### PR TITLE
Prepare locations dataset

### DIFF
--- a/jobs/prepare_locations.py
+++ b/jobs/prepare_locations.py
@@ -49,7 +49,7 @@ def main(workplace_source, cqc_location_source, cqc_provider_source, destination
 
     print(f"Reading CQC locations parquet from {cqc_location_source}")
     cqc_df = spark.read.parquet(
-        cqc_source).select(required_cqc_fields)
+        cqc_location_source).select(required_cqc_fields)
 
     print(f"Reading CQC providers parquet from {cqc_provider_source}")
     cqc_provider_df = spark.read.parquet(

--- a/jobs/prepare_locations.py
+++ b/jobs/prepare_locations.py
@@ -263,13 +263,25 @@ def collect_arguments():
     parser = argparse.ArgumentParser()
 
     parser.add_argument(
-        "--workplace_source", help="Source s3 directory for ASCWDS workplace dataset", required=True)
+        "--workplace_source",
+        help="Source s3 directory for ASCWDS workplace dataset",
+        required=True
+    )
     parser.add_argument(
-        "--cqc_location_source", help="Source s3 directory for CQC locations api dataset", required=True)
+        "--cqc_location_source",
+        help="Source s3 directory for CQC locations api dataset",
+        required=True
+    )
     parser.add_argument(
-        "--cqc_provider_source", help="Source s3 directory for CQC providers api dataset", required=True)
+        "--cqc_provider_source",
+        help="Source s3 directory for CQC providers api dataset",
+        required=True
+    )
     parser.add_argument(
-        "--destination", help="A destination directory for outputting cqc locations, if not provided shall default to S3 todays date.", required=True)
+        "--destination",
+        help="A destination directory for outputting cqc locations, if not provided shall default to S3 todays date.",
+        required=True
+    )
 
     args, unknown = parser.parse_known_args()
 

--- a/jobs/prepare_locations.py
+++ b/jobs/prepare_locations.py
@@ -63,12 +63,13 @@ def main(workplace_source, cqc_source, destination):
 
 
 def remove_duplicates(input_df):
-    print(f"Removing duplicates...")
+    print("Removing duplicates...")
     return input_df.drop_duplicates(subset=["locationid", "import_date"])
 
 
 def clean(input_df):
-    print(f"Cleaning...")
+    print("Cleaning...")
+
     # Standardise negative and 0 values as None.
     input_df = input_df.replace('0', None).replace('-1', None)
 
@@ -83,7 +84,7 @@ def clean(input_df):
 
 
 def filter_nulls(input_df):
-    print(f"Filtering nulls...")
+    print("Filtering nulls...")
     # Remove rows with null for wkrrecs and totalstaff
     input_df = input_df.filter("wkrrecs is not null or totalstaff is not null")
 
@@ -94,7 +95,7 @@ def filter_nulls(input_df):
 
 
 def calculate_jobcount(input_df):
-    print(f"Calculating jobcount...")
+    print("Calculating jobcount...")
     # Add null/empty jobcount column
     input_df = input_df.withColumn("jobcount", lit(None).cast(IntegerType()))
 

--- a/jobs/prepare_locations.py
+++ b/jobs/prepare_locations.py
@@ -60,12 +60,8 @@ def main(workplace_source, cqc_location_source, cqc_provider_source, destination
 
     output_df = calculate_jobcount(output_df)
 
-    # print(f"Exporting as parquet to {destination}")
-    # utils.write_to_parquet(workplaces_df, destination)
-
-    print(f"Exporting as csv to {destination}")
-    output_df.coalesce(1).write.format(
-        "com.databricks.spark.csv").save(destination, header="true")
+    print(f"Exporting as parquet to {destination}")
+    utils.write_to_parquet(output_df, destination)
 
 
 def remove_duplicates(input_df):

--- a/jobs/prepare_locations.py
+++ b/jobs/prepare_locations.py
@@ -32,12 +32,7 @@ required_cqc_fields = [
     "postalcode",
     "carehome",
     "constituency",
-    "localauthority",
-    "year",
-    "month",
-    "day",
-    "import_date",
-    "version"
+    "localauthority"
 ]
 
 
@@ -51,7 +46,7 @@ def main(workplace_source, cqc_source, destination):
     workplaces_df = clean(workplaces_df)
     workplaces_df = filter_nulls(workplaces_df)
 
-    print(f"Reading CQC parquet from {workplace_source}")
+    print(f"Reading CQC parquet from {cqc_source}")
     cqc_df = spark.read.parquet(
         cqc_source).select(required_cqc_fields)
 

--- a/jobs/prepare_locations.py
+++ b/jobs/prepare_locations.py
@@ -29,10 +29,10 @@ required_cqc_fields = [
     "dormancy",
     "numberofbeds",
     "region",
-    "postalcode"
+    "postalcode",
     "carehome",
     "constituency",
-    "localauthority"
+    "localauthority",
     "year",
     "month",
     "day",
@@ -51,6 +51,7 @@ def main(workplace_source, cqc_source, destination):
     workplaces_df = clean(workplaces_df)
     workplaces_df = filter_nulls(workplaces_df)
 
+    print(f"Reading CQC parquet from {workplace_source}")
     cqc_df = spark.read.parquet(
         cqc_source).select(required_cqc_fields)
 
@@ -69,10 +70,12 @@ def main(workplace_source, cqc_source, destination):
 
 
 def remove_duplicates(input_df):
+    print(f"Removing duplicates...")
     return input_df.drop_duplicates(subset=["locationid", "import_date"])
 
 
 def clean(input_df):
+    print(f"Cleaning...")
     # Standardise negative and 0 values as None.
     input_df = input_df.replace('0', None).replace('-1', None)
 
@@ -87,6 +90,7 @@ def clean(input_df):
 
 
 def filter_nulls(input_df):
+    print(f"Filtering nulls...")
     # Remove rows with null for wkrrecs and totalstaff
     input_df = input_df.filter("wkrrecs is not null or totalstaff is not null")
 
@@ -97,6 +101,7 @@ def filter_nulls(input_df):
 
 
 def calculate_jobcount(input_df):
+    print(f"Calculating jobcount...")
     # Add null/empty jobcount column
     input_df = input_df.withColumn("jobcount", lit(None).cast(IntegerType()))
 

--- a/jobs/prepare_locations.py
+++ b/jobs/prepare_locations.py
@@ -6,13 +6,6 @@ from pyspark.sql.functions import abs, coalesce, greatest, lit, max, when, col
 from pyspark.sql.types import IntegerType
 from utils import utils
 
-# Read in most recent cqc_locations_api bulk dataset
-# Read in provided ascwds locations dataset
-# Perform cleaning  DONE
-# Filter nulls      DONE
-# Join CQC to ASCWDS
-# Predict job counts
-
 required_workplace_fields = [
     "locationid",
     "providerid",
@@ -232,3 +225,23 @@ def calculate_jobcount(input_df):
     input_df = input_df.drop(*columns_to_drop)
 
     return input_df
+
+
+def collect_arguments():
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument(
+        "--workplace_source", help="Source s3 directory for ASCWDS workplace dataset", required=True)
+    parser.add_argument(
+        "--cqc_source", help="Source s3 directory for CQC locations api dataset", required=True)
+    parser.add_argument(
+        "--destination", help="A destination directory for outputting cqc locations, if not provided shall default to S3 todays date.", required=True)
+
+    args, unknown = parser.parse_known_args()
+
+    return args.workplace_source, args.cqc_source, args.destination
+
+
+if __name__ == "__main__":
+    workplace_source, cqc_source, destination, = collect_arguments()
+    main(workplace_source, cqc_source, destination)

--- a/jobs/prepare_locations.py
+++ b/jobs/prepare_locations.py
@@ -89,7 +89,6 @@ def calculate_jobcount(input_df):
     ).otherwise(col("jobcount")))
 
     # Estimate job count from beds
-
     input_df = input_df.withColumn("bed_estimate_jobcount", when(
         (
             col("jobcount").isNull() &
@@ -124,6 +123,34 @@ def calculate_jobcount(input_df):
                 )
             )
         ), (col("totalstaff") + col("wkrrecs")) / 2
+    ).otherwise(col("jobcount")))
+
+    # if totalstaff within 10% or < 5: return totalstaff
+    input_df = input_df.withColumn("jobcount", when(
+        (
+            col("jobcount").isNull() &
+            col("bed_estimate_jobcount").isNotNull() &
+            (
+
+                (col("totalstaff_diff") < 5) | (
+                    col("totalstaff_percentage_diff") < 0.1)
+
+            )
+        ), col("totalstaff")
+    ).otherwise(col("jobcount")))
+
+    # if wkrrecs within 10% or < 5: return wkrrecs
+    input_df = input_df.withColumn("jobcount", when(
+        (
+            col("jobcount").isNull() &
+            col("bed_estimate_jobcount").isNotNull() &
+            (
+
+                (col("wkrrecs_diff") < 5) | (
+                    col("wkrrecs_percentage_diff") < 0.1)
+
+            )
+        ), col("wkrrecs")
     ).otherwise(col("jobcount")))
 
     return input_df

--- a/jobs/prepare_locations.py
+++ b/jobs/prepare_locations.py
@@ -1,0 +1,85 @@
+import argparse
+from datetime import date
+
+from pyspark.sql.dataframe import DataFrame
+from pyspark.sql.functions import abs, coalesce, greatest, lit, max
+from pyspark.sql.types import IntegerType
+from utils import utils
+
+
+def clean(input_df):
+    # Standardise negative and 0 values as None.
+    input_df = input_df.replace('0', None).replace('-1', None)
+
+    # Cast integers to string
+    input_df = input_df.withColumn(
+        "totalstaff", input_df["totalstaff"].cast(IntegerType()))
+
+    input_df = input_df.withColumn(
+        "wkrrecs", input_df["wkrrecs"].cast(IntegerType()))
+
+    return input_df
+
+
+def filter_nulls(input_df):
+    # Remove rows with null for wkrrecs and totalstaff
+    input_df = input_df.filter("wkrrecs is not null or totalstaff is not null")
+
+    # Remove rows with null locationId
+    input_df = input_df.na.drop(subset=["locationid"])
+
+    return input_df
+
+
+def calculate_jobcount(input_df):
+    # Add null jobcount column
+    input_df = input_df.withColumn("jobcount", lit(None).cast(IntegerType()))
+
+    # totalstaff = wkrrrecs: Take totalstaff
+    input_df = (
+        input_df
+        .filter("jobcount is null")
+        .filter("wkrrecs=totalstaff and wkrrecs is not null and totalstaff is not null")
+        .withColumn("jobcount", input_df.totalstaff)
+    )
+
+    # Either wkrrecs or totalstaff is null: return first not null
+    input_df = (
+        input_df
+        .filter("jobcount is null")
+        .filter("wkrrecs is null or totalstaff is null")
+        .withColumn("jobcount", coalesce(input_df.totalstaff, input_df.wkrrecs))
+    )
+
+    # Abs difference between totalstaff & wkrrecs < 5 or < 10% take average:
+    input_df = input_df.withColumn('abs_difference', abs(
+        input_df.totalstaff - input_df.wkrrecs))
+
+    input_df = (
+        input_df
+        .filter("jobcount is null")
+        .filter("abs_difference < 8 or abs_difference/totalstaff < 0.15")
+        .withColumn("jobcount", (input_df.totalstaff + input_df.wkrrecs)/2)
+    )
+
+    input_df = input_df.drop("abs_difference")
+
+    # totalstaff or wkrrecs < 3: return max
+    input_df = (
+        input_df
+        .filter("jobcount is null")
+        .filter("totalstaff < 3 or wkrrecs < 3")
+        .withColumn("jobcount", greatest(input_df.totalstaff, input_df.wkrrecs))
+    )
+
+    # Estimate job count from beds
+
+    bed_estimate_df = input_df.filter(
+        "numberofbeds is not null and numberofbeds > 0")
+
+    input_df = (
+        input_df
+        .filter("jobcount is null")
+        .filter("numberofbeds > 0")
+        .withColumn("bed_estimate_jobcount", 8.40975704621392 + bed_estimate_df.numberofbeds * 1.0010753137758377001)
+    )

--- a/jobs/prepare_locations.py
+++ b/jobs/prepare_locations.py
@@ -36,6 +36,9 @@ required_cqc_fields = [
     "localauthority"
 ]
 
+MIN_ABSOLUTE_DIFFERENCE = 5
+MIN_PERCENTAGE_DIFFERENCE = 0.1
+
 
 def main(workplace_source, cqc_location_source, cqc_provider_source, destination):
     spark = utils.get_spark()
@@ -137,8 +140,8 @@ def calculate_jobcount_abs_difference_within_range(input_df):
         (
             col("jobcount").isNull() &
             (
-                (col("abs_difference") < 5) | (
-                    col("abs_difference") / col("totalstaff") < 0.1)
+                (col("abs_difference") < MIN_ABSOLUTE_DIFFERENCE) | (
+                    col("abs_difference") / col("totalstaff") < MIN_PERCENTAGE_DIFFERENCE)
             )
         ), (col("totalstaff") + col("wkrrecs")) / 2
     ).otherwise(col("jobcount")))
@@ -188,12 +191,12 @@ def calculate_jobcount_estimate_from_beds(input_df):
             col("bed_estimate_jobcount").isNotNull() &
             (
                 (
-                    (col("totalstaff_diff") < 5) | (
-                        col("totalstaff_percentage_diff") < 0.1)
+                    (col("totalstaff_diff") < MIN_ABSOLUTE_DIFFERENCE) | (
+                        col("totalstaff_percentage_diff") < MIN_PERCENTAGE_DIFFERENCE)
                 ) &
                 (
-                    (col("wkrrecs_diff") < 5) | (
-                        col("wkrrecs_percentage_diff") < 0.1)
+                    (col("wkrrecs_diff") < MIN_ABSOLUTE_DIFFERENCE) | (
+                        col("wkrrecs_percentage_diff") < MIN_PERCENTAGE_DIFFERENCE)
                 )
             )
         ), (col("totalstaff") + col("wkrrecs")) / 2
@@ -206,8 +209,8 @@ def calculate_jobcount_estimate_from_beds(input_df):
             col("bed_estimate_jobcount").isNotNull() &
             (
 
-                (col("totalstaff_diff") < 5) | (
-                    col("totalstaff_percentage_diff") < 0.1)
+                (col("totalstaff_diff") < MIN_ABSOLUTE_DIFFERENCE) | (
+                    col("totalstaff_percentage_diff") < MIN_PERCENTAGE_DIFFERENCE)
 
             )
         ), col("totalstaff")
@@ -220,8 +223,8 @@ def calculate_jobcount_estimate_from_beds(input_df):
             col("bed_estimate_jobcount").isNotNull() &
             (
 
-                (col("wkrrecs_diff") < 5) | (
-                    col("wkrrecs_percentage_diff") < 0.1)
+                (col("wkrrecs_diff") < MIN_ABSOLUTE_DIFFERENCE) | (
+                    col("wkrrecs_percentage_diff") < MIN_PERCENTAGE_DIFFERENCE)
 
             )
         ), col("wkrrecs")

--- a/jobs/prepare_locations.py
+++ b/jobs/prepare_locations.py
@@ -29,7 +29,7 @@ required_cqc_fields = [
     "dormancy",
     "numberofbeds",
     "region",
-    "postalcode",
+    "postalcode"
     "carehome",
     "constituency",
     "localauthority"

--- a/jobs/prepare_locations.py
+++ b/jobs/prepare_locations.py
@@ -47,6 +47,7 @@ def main(workplace_source, cqc_source, destination):
     workplaces_df = spark.read.parquet(
         workplace_source).select(required_workplace_fields)
 
+    workplaces_df = remove_duplicates(workplaces_df)
     workplaces_df = clean(workplaces_df)
     workplaces_df = filter_nulls(workplaces_df)
 
@@ -65,6 +66,10 @@ def main(workplace_source, cqc_source, destination):
     print(f"Exporting as csv to {destination}")
     output_df.coalesce(1).write.format(
         "com.databricks.spark.csv").save(destination, header="true")
+
+
+def remove_duplicates(input_df):
+    return input_df.drop_duplicates(subset=["locationid", "import_date"])
 
 
 def clean(input_df):

--- a/jobs/prepare_locations.py
+++ b/jobs/prepare_locations.py
@@ -54,8 +54,6 @@ def main(workplace_source, cqc_source, destination):
 
     output_df = calculate_jobcount(output_df)
 
-    output_df.show(20, False)
-
     # print(f"Exporting as parquet to {destination}")
     # utils.write_to_parquet(workplaces_df, destination)
 

--- a/main.tf
+++ b/main.tf
@@ -158,6 +158,29 @@ resource "aws_glue_job" "ingest_ascwds_dataset" {
   }
 }
 
+resource "aws_glue_job" "prepare_locations_job" {
+  name              = "prepare_locations_job"
+  role_arn          = aws_iam_role.glue_service_iam_role.arn
+  glue_version      = "2.0"
+  worker_type       = "Standard"
+  number_of_workers = 2
+  execution_property {
+    max_concurrent_runs = 5
+  }
+
+  command {
+    script_location = "${var.scripts_location}prepare_locations.py"
+  }
+
+  default_arguments = {
+    "--extra-py-files" : "s3://sfc-data-engineering/scripts/dependencies/dependencies.zip"
+    "--TempDir"          = var.glue_temp_dir
+    "--workplace_source" = ""
+    "--cqc_source"       = ""
+    "--destination"      = ""
+  }
+}
+
 resource "aws_glue_job" "bulk_cqc_providers_download_job" {
   name              = "bulk_cqc_providers_download_job"
   role_arn          = aws_iam_role.glue_service_iam_role.arn

--- a/main.tf
+++ b/main.tf
@@ -174,10 +174,11 @@ resource "aws_glue_job" "prepare_locations_job" {
 
   default_arguments = {
     "--extra-py-files" : "s3://sfc-data-engineering/scripts/dependencies/dependencies.zip"
-    "--TempDir"          = var.glue_temp_dir
-    "--workplace_source" = ""
-    "--cqc_source"       = ""
-    "--destination"      = ""
+    "--TempDir"             = var.glue_temp_dir
+    "--workplace_source"    = ""
+    "--cqc_location_source" = ""
+    "--cqc_provider_source" = ""
+    "--destination"         = ""
   }
 }
 

--- a/tests/unit/test_prepare_locations.py
+++ b/tests/unit/test_prepare_locations.py
@@ -81,7 +81,6 @@ class PrepareLocationsTests(unittest.TestCase):
 
         jobcount_df = prepare_locations.calculate_jobcount(df)
         jobcount_df_list = jobcount_df.collect()
-        jobcount_df.show()
 
         self.assertEqual(jobcount_df_list[0]["jobcount"], 0.0)
         self.assertEqual(jobcount_df_list[1]["jobcount"], 500.0)

--- a/tests/unit/test_prepare_locations.py
+++ b/tests/unit/test_prepare_locations.py
@@ -45,7 +45,10 @@ class PrepareLocationsTests(unittest.TestCase):
         df = self.spark.createDataFrame(rows, columns)
 
         cleaned_df = prepare_locations.clean(df)
+        cleaned_df_list = cleaned_df.collect()
         self.assertEqual(cleaned_df.count(), 6)
+        self.assertEqual(cleaned_df_list[0]["totalstaff"], None)
+        self.assertEqual(cleaned_df_list[1]["totalstaff"], 500)
 
 
 if __name__ == '__main__':

--- a/tests/unit/test_prepare_locations.py
+++ b/tests/unit/test_prepare_locations.py
@@ -13,6 +13,23 @@ class PrepareLocationsTests(unittest.TestCase):
             .appName("test_prepare_locations") \
             .getOrCreate()
 
+    def test_remove_duplicates(self):
+        columns = ["locationid", "import_date"]
+        rows = [
+            ("1-000000001", "01-12-2022"),
+            ("1-000000001", "01-12-2022"),
+            ("1-000000001", "01-12-2021"),
+            ("1-000000001", "01-12-2021"),
+            ("1-000000002", "01-12-2022"),
+            ("1-000000002", "01-12-2021")
+        ]
+        df = self.spark.createDataFrame(rows, columns)
+
+        filtered_df = prepare_locations.remove_duplicates(df)
+        self.assertEqual(filtered_df.count(), 4)
+        self.assertEqual(filtered_df.select("locationid").rdd.flatMap(lambda x: x).collect(), [
+                         "1-000000001", "1-000000001", "1-000000002", "1-000000002"])
+
     def test_filter_nulls(self):
         columns = ["locationid", "wkrrecs", "totalstaff"]
         rows = [

--- a/tests/unit/test_prepare_locations.py
+++ b/tests/unit/test_prepare_locations.py
@@ -13,42 +13,41 @@ class PrepareLocationsTests(unittest.TestCase):
             .appName("test_prepare_locations") \
             .getOrCreate()
 
-    # def test_filter_nulls(self):
+    def test_filter_nulls(self):
+        columns = ["locationid", "wkrrecs", "totalstaff"]
+        rows = [
+            ("1-000000001", None, 20),
+            ("1-000000002", 500, 500),
+            ("1-000000003", 100, None),
+            ("1-000000004", None, None),
+            ("1-000000005", 25, 75),
+            (None, 1, 0),
+        ]
+        df = self.spark.createDataFrame(rows, columns)
 
-    #     columns = ["locationid", "wkrrecs", "totalstaff"]
-    #     rows = [
-    #         ("1-000000001", None, 20),
-    #         ("1-000000002", 500, 500),
-    #         ("1-000000003", 100, None),
-    #         ("1-000000004", None, None),
-    #         ("1-000000005", 25, 75),
-    #         (None, 1, 0),
-    #     ]
-    #     df = self.spark.createDataFrame(rows, columns)
+        filtered_df = prepare_locations.filter_nulls(df)
+        self.assertEqual(filtered_df.count(), 4)
+        self.assertEqual(filtered_df.select("locationid").rdd.flatMap(lambda x: x).collect(), [
+                         "1-000000001", "1-000000002", "1-000000003", "1-000000005"])
 
-    #     filtered_df = prepare_locations.filter_nulls(df)
-    #     self.assertEqual(filtered_df.count(), 4)
-    #     self.assertEqual(filtered_df.select("locationid").rdd.flatMap(lambda x: x).collect(), [
-    #                      "1-000000001", "1-000000002", "1-000000003", "1-000000005"])
+    def test_clean(self):
 
-    # def test_clean(self):
+        columns = ["locationid", "wkrrecs", "totalstaff"]
+        rows = [
+            ("1-000000001", None, "0"),
+            ("1-000000002", "500", "500"),
+            ("1-000000003", "100", "-1"),
+            ("1-000000004", None, "0"),
+            ("1-000000005", "25", "75"),
+            (None, "1", "0"),
+        ]
+        df = self.spark.createDataFrame(rows, columns)
 
-    #     columns = ["locationid", "wkrrecs", "totalstaff"]
-    #     rows = [
-    #         ("1-000000001", None, "0"),
-    #         ("1-000000002", "500", "500"),
-    #         ("1-000000003", "100", "-1"),
-    #         ("1-000000004", None, "0"),
-    #         ("1-000000005", "25", "75"),
-    #         (None, "1", "0"),
-    #     ]
-    #     df = self.spark.createDataFrame(rows, columns)
-
-    #     cleaned_df = prepare_locations.clean(df)
-    #     cleaned_df_list = cleaned_df.collect()
-    #     self.assertEqual(cleaned_df.count(), 6)
-    #     self.assertEqual(cleaned_df_list[0]["totalstaff"], None)
-    #     self.assertEqual(cleaned_df_list[1]["totalstaff"], 500)
+        cleaned_df = prepare_locations.clean(df)
+        cleaned_df_list = cleaned_df.collect()
+        self.assertEqual(cleaned_df.count(), 6)
+        self.assertEqual(cleaned_df_list[0]["totalstaff"], None)
+        self.assertEqual(cleaned_df_list[1]["totalstaff"], 500)
 
     def test_calculate_jobcount(self):
         columns = ["locationid", "wkrrecs", "totalstaff", "numberofbeds"]

--- a/tests/unit/test_prepare_locations.py
+++ b/tests/unit/test_prepare_locations.py
@@ -13,42 +13,62 @@ class PrepareLocationsTests(unittest.TestCase):
             .appName("test_prepare_locations") \
             .getOrCreate()
 
-    def test_filter_nulls(self):
+    # def test_filter_nulls(self):
 
-        columns = ["locationid", "wkrrecs", "totalstaff"]
+    #     columns = ["locationid", "wkrrecs", "totalstaff"]
+    #     rows = [
+    #         ("1-000000001", None, 20),
+    #         ("1-000000002", 500, 500),
+    #         ("1-000000003", 100, None),
+    #         ("1-000000004", None, None),
+    #         ("1-000000005", 25, 75),
+    #         (None, 1, 0),
+    #     ]
+    #     df = self.spark.createDataFrame(rows, columns)
+
+    #     filtered_df = prepare_locations.filter_nulls(df)
+    #     self.assertEqual(filtered_df.count(), 4)
+    #     self.assertEqual(filtered_df.select("locationid").rdd.flatMap(lambda x: x).collect(), [
+    #                      "1-000000001", "1-000000002", "1-000000003", "1-000000005"])
+
+    # def test_clean(self):
+
+    #     columns = ["locationid", "wkrrecs", "totalstaff"]
+    #     rows = [
+    #         ("1-000000001", None, "0"),
+    #         ("1-000000002", "500", "500"),
+    #         ("1-000000003", "100", "-1"),
+    #         ("1-000000004", None, "0"),
+    #         ("1-000000005", "25", "75"),
+    #         (None, "1", "0"),
+    #     ]
+    #     df = self.spark.createDataFrame(rows, columns)
+
+    #     cleaned_df = prepare_locations.clean(df)
+    #     cleaned_df_list = cleaned_df.collect()
+    #     self.assertEqual(cleaned_df.count(), 6)
+    #     self.assertEqual(cleaned_df_list[0]["totalstaff"], None)
+    #     self.assertEqual(cleaned_df_list[1]["totalstaff"], 500)
+
+    def test_calculate_jobcount(self):
+        columns = ["locationid", "wkrrecs", "totalstaff", "numberofbeds"]
         rows = [
-            ("1-000000001", None, 20),
-            ("1-000000002", 500, 500),
-            ("1-000000003", 100, None),
-            ("1-000000004", None, None),
-            ("1-000000005", 25, 75),
-            (None, 1, 0),
+            ("1-000000001", None, 0, 0),
+            ("1-000000002", 500, 500, 490),
+            ("1-000000003", 100, None, 10),
+            ("1-000000004", None, 10, 12),
+            ("1-000000005", 25, 75, 40),
+            ("1-000000006", 30, 60, 40),
+            ("1-000000007", 600, 900, 150),
+            ("1-000000008", 10, 12, None),
+            ("1-000000009", 1, 23, None),
+            ("1-000000010", 90, 102, 85)
         ]
         df = self.spark.createDataFrame(rows, columns)
 
-        filtered_df = prepare_locations.filter_nulls(df)
-        self.assertEqual(filtered_df.count(), 4)
-        self.assertEqual(filtered_df.select("locationid").rdd.flatMap(lambda x: x).collect(), [
-                         "1-000000001", "1-000000002", "1-000000003", "1-000000005"])
-
-    def test_clean(self):
-
-        columns = ["locationid", "wkrrecs", "totalstaff"]
-        rows = [
-            ("1-000000001", None, "0"),
-            ("1-000000002", "500", "500"),
-            ("1-000000003", "100", "-1"),
-            ("1-000000004", None, "0"),
-            ("1-000000005", "25", "75"),
-            (None, "1", "0"),
-        ]
-        df = self.spark.createDataFrame(rows, columns)
-
-        cleaned_df = prepare_locations.clean(df)
-        cleaned_df_list = cleaned_df.collect()
-        self.assertEqual(cleaned_df.count(), 6)
-        self.assertEqual(cleaned_df_list[0]["totalstaff"], None)
-        self.assertEqual(cleaned_df_list[1]["totalstaff"], 500)
+        jobcount_df = prepare_locations.calculate_jobcount(df)
+        jobcount_df_list = jobcount_df.collect()
+        jobcount_df.show()
 
 
 if __name__ == '__main__':

--- a/tests/unit/test_prepare_locations.py
+++ b/tests/unit/test_prepare_locations.py
@@ -1,0 +1,52 @@
+import unittest
+from jobs import format_fields
+from jobs import prepare_locations
+from pyspark.sql import SparkSession
+from pathlib import Path
+import shutil
+
+
+class PrepareLocationsTests(unittest.TestCase):
+
+    def setUp(self):
+        self.spark = SparkSession.builder \
+            .appName("test_prepare_locations") \
+            .getOrCreate()
+
+    def test_filter_nulls(self):
+
+        columns = ["locationid", "wkrrecs", "totalstaff"]
+        rows = [
+            ("1-000000001", None, 20),
+            ("1-000000002", 500, 500),
+            ("1-000000003", 100, None),
+            ("1-000000004", None, None),
+            ("1-000000005", 25, 75),
+            (None, 1, 0),
+        ]
+        df = self.spark.createDataFrame(rows, columns)
+
+        filtered_df = prepare_locations.filter_nulls(df)
+        self.assertEqual(filtered_df.count(), 4)
+        self.assertEqual(filtered_df.select("locationid").rdd.flatMap(lambda x: x).collect(), [
+                         "1-000000001", "1-000000002", "1-000000003", "1-000000005"])
+
+    def test_clean(self):
+
+        columns = ["locationid", "wkrrecs", "totalstaff"]
+        rows = [
+            ("1-000000001", None, "0"),
+            ("1-000000002", "500", "500"),
+            ("1-000000003", "100", "-1"),
+            ("1-000000004", None, "0"),
+            ("1-000000005", "25", "75"),
+            (None, "1", "0"),
+        ]
+        df = self.spark.createDataFrame(rows, columns)
+
+        cleaned_df = prepare_locations.clean(df)
+        self.assertEqual(cleaned_df.count(), 6)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This PR aims to provide a new spark job intended to be run on a glue cluster that is responsible for the following:
- Joining relevant fields from ASCWDS and CQC for use in later modelling
- Create a new feature `jobcount` to replace `wkrrecs` and `totalstaff`. `jobcount` will be used for all models moving forward as the sole value indicating number of jobs at a given location.
-  Clean up null values and format integer fields