### PR TITLE
Fix bulk download cqc location job

### DIFF
--- a/jobs/bulk_download_cqc_locations.py
+++ b/jobs/bulk_download_cqc_locations.py
@@ -1,4 +1,4 @@
-from utils import cqc_location_api as cqc
+from utils import cqc_api as cqc
 from utils import utils
 from schemas.cqc_location_schema import LOCATION_SCHEMA
 from datetime import date


### PR DESCRIPTION
Our cqc location bulk download job failed this month due to a bad import:
![image](https://user-images.githubusercontent.com/6236228/152772693-61c8b3ba-97ee-4fbd-860a-cc757e9359ed.png)

This pr fixes this