### PR TITLE
Black formatter

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
 jobs:
   test:
     docker:
-      - image: circleci/python:3.9.7
+      - image: circleci/python:3.9.6
     resource_class: small
 
     steps:
@@ -48,7 +48,7 @@ jobs:
 
   deploy:
     docker:
-      - image: circleci/python:3.9.7
+      - image: circleci/python:3.9.6
     resource_class: small
 
     steps:

--- a/Pipfile
+++ b/Pipfile
@@ -14,6 +14,8 @@ requests = "*"
 ratelimit = "*"
 spark = "*"
 
-[dev-packages]
+
+[dev - packages]
 pylint = "2.11.1"
 autopep8 = "1.6.0"
+black = "*"

--- a/Pipfile
+++ b/Pipfile
@@ -4,7 +4,7 @@ verify_ssl = true
 name = "pypi"
 
 [requires]
-python_full_version = "3.9.7"
+python_full_version = "3.9.6"
 
 [packages]
 pyspark = "3.2.0"

--- a/Pipfile
+++ b/Pipfile
@@ -14,7 +14,6 @@ requests = "*"
 ratelimit = "*"
 spark = "*"
 
-
 [dev-packages]
 pylint = "2.11.1"
 autopep8 = "1.6.0"

--- a/Pipfile
+++ b/Pipfile
@@ -15,7 +15,7 @@ ratelimit = "*"
 spark = "*"
 
 
-[dev - packages]
+[dev-packages]
 pylint = "2.11.1"
 autopep8 = "1.6.0"
 black = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,252 +1,356 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "997274163945b121cfffaed5a11fa4535f032fb818839f7d1489a3e65ad309c4"
+            "sha256": "309bd9f4c5d41d0ac0fc7bc5160cc15c7b8c134378fbd1da89844d7fa1c82129"
         },
         "pipfile-spec": 6,
-        "requires": {
-            "python_full_version": "3.9.7"
-        },
+        "requires": {"python_full_version": "3.9.7"},
         "sources": [
             {
                 "name": "pypi",
                 "url": "https://pypi.python.org/simple",
-                "verify_ssl": true
+                "verify_ssl": true,
             }
-        ]
+        ],
     },
     "default": {
-        "boto3": {
+        "black": {
             "hashes": [
-                "sha256:2fb05cbe81b9ce11d9394fc6c4ffa5fd1cceb114dc1d2887dc61081707e44522",
-                "sha256:aa4efdb811476a9e6c6fdf7c4595e3aa4258834351d2f3af1d97c87c1180e3be"
+                "sha256:07e5c049442d7ca1a2fc273c79d1aecbbf1bc858f62e8184abe1ad175c4f7cc2",
+                "sha256:0e21e1f1efa65a50e3960edd068b6ae6d64ad6235bd8bfea116a03b21836af71",
+                "sha256:1297c63b9e1b96a3d0da2d85d11cd9bf8664251fd69ddac068b98dc4f34f73b6",
+                "sha256:228b5ae2c8e3d6227e4bde5920d2fc66cc3400fde7bcc74f480cb07ef0b570d5",
+                "sha256:2d6f331c02f0f40aa51a22e479c8209d37fcd520c77721c034517d44eecf5912",
+                "sha256:2ff96450d3ad9ea499fc4c60e425a1439c2120cbbc1ab959ff20f7c76ec7e866",
+                "sha256:3524739d76b6b3ed1132422bf9d82123cd1705086723bc3e235ca39fd21c667d",
+                "sha256:35944b7100af4a985abfcaa860b06af15590deb1f392f06c8683b4381e8eeaf0",
+                "sha256:373922fc66676133ddc3e754e4509196a8c392fec3f5ca4486673e685a421321",
+                "sha256:5fa1db02410b1924b6749c245ab38d30621564e658297484952f3d8a39fce7e8",
+                "sha256:6f2f01381f91c1efb1451998bd65a129b3ed6f64f79663a55fe0e9b74a5f81fd",
+                "sha256:742ce9af3086e5bd07e58c8feb09dbb2b047b7f566eb5f5bc63fd455814979f3",
+                "sha256:7835fee5238fc0a0baf6c9268fb816b5f5cd9b8793423a75e8cd663c48d073ba",
+                "sha256:8871fcb4b447206904932b54b567923e5be802b9b19b744fdff092bd2f3118d0",
+                "sha256:a7c0192d35635f6fc1174be575cb7915e92e5dd629ee79fdaf0dcfa41a80afb5",
+                "sha256:b1a5ed73ab4c482208d20434f700d514f66ffe2840f63a6252ecc43a9bc77e8a",
+                "sha256:c8226f50b8c34a14608b848dc23a46e5d08397d009446353dad45e04af0c8e28",
+                "sha256:ccad888050f5393f0d6029deea2a33e5ae371fd182a697313bdbd835d3edaf9c",
+                "sha256:dae63f2dbf82882fa3b2a3c49c32bffe144970a573cd68d247af6560fc493ae1",
+                "sha256:e2f69158a7d120fd641d1fa9a921d898e20d52e44a74a6fbbcc570a62a6bc8ab",
+                "sha256:efbadd9b52c060a8fc3b9658744091cb33c31f830b3f074422ed27bad2b18e8f",
+                "sha256:f5660feab44c2e3cb24b2419b998846cbb01c23c7fe645fee45087efa3da2d61",
+                "sha256:fdb8754b453fb15fad3f72cd9cad3e16776f0964d67cf30ebcbf10327a3777a3",
             ],
             "index": "pypi",
-            "version": "==1.20.21"
+            "version": "==22.1.0",
+        },
+        "boto3": {
+            "hashes": [
+                "sha256:1a272a1dd36414b1626a47bb580425203be0b5a34caa117f38a5e18adf21f918",
+                "sha256:8129ad42cc0120d1c63daa18512d6f0b1439e385b2b6e0fe987f116bdf795546",
+            ],
+            "index": "pypi",
+            "version": "==1.20.54",
         },
         "botocore": {
             "hashes": [
-                "sha256:853828e871dff588d92b383a3cf5e93861e180b9ed43135e36c2e139a72e030e",
-                "sha256:d7f8e82cba38aa1e66015cab0a5ca3204503e90afc4695e97228e28329a14c04"
+                "sha256:06ae8076c4dcf3d72bec4d37e5f2dce4a92a18a8cdaa3bfaa6e3b7b5e30a8d7e",
+                "sha256:4bb9ba16cccee5f5a2602049bc3e2db6865346b2550667f3013bdf33b0a01ceb",
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==1.23.21"
+            "version": "==1.23.54",
         },
         "certifi": {
             "hashes": [
                 "sha256:78884e7c1d4b00ce3cea67b44566851c4343c120abd683433ce934a68ea58872",
-                "sha256:d62a0163eb4c2344ac042ab2bdf75399a71a2d8c7d47eac2e2ee91b9d6339569"
+                "sha256:d62a0163eb4c2344ac042ab2bdf75399a71a2d8c7d47eac2e2ee91b9d6339569",
             ],
-            "version": "==2021.10.8"
+            "version": "==2021.10.8",
         },
         "charset-normalizer": {
             "hashes": [
-                "sha256:1eecaa09422db5be9e29d7fc65664e6c33bd06f9ced7838578ba40d58bdf3721",
-                "sha256:b0b883e8e874edfdece9c28f314e3dd5badf067342e42fb162203335ae61aa2c"
+                "sha256:2857e29ff0d34db842cd7ca3230549d1a697f96ee6d3fb071cfa6c7393832597",
+                "sha256:6881edbebdb17b39b4eaaa821b438bf6eddffb4468cf344f09f89def34a8b1df",
             ],
             "markers": "python_version >= '3'",
-            "version": "==2.0.9"
+            "version": "==2.0.12",
+        },
+        "click": {
+            "hashes": [
+                "sha256:353f466495adaeb40b6b5f592f9f91cb22372351c84caeb068132442a4518ef3",
+                "sha256:410e932b050f5eed773c4cda94de75971c89cdb3155a72a0831139a79e5ecb5b",
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==8.0.3",
+        },
+        "colorama": {
+            "hashes": [
+                "sha256:5941b2b48a20143d2267e95b1c2a7603ce057ee39fd88e7329b0c292aa16869b",
+                "sha256:9f47eda37229f68eee03b24b9748937c7dc3868f906e8ba69fbcbdd3bc5dc3e2",
+            ],
+            "markers": "platform_system == 'Windows'",
+            "version": "==0.4.4",
         },
         "idna": {
             "hashes": [
                 "sha256:84d9dd047ffa80596e0f246e2eab0b391788b0503584e8945f2368256d2735ff",
-                "sha256:9d643ff0a55b762d5cdb124b8eaa99c66322e2157b69160bc32796e824360e6d"
+                "sha256:9d643ff0a55b762d5cdb124b8eaa99c66322e2157b69160bc32796e824360e6d",
             ],
             "markers": "python_version >= '3'",
-            "version": "==3.3"
+            "version": "==3.3",
         },
         "jmespath": {
             "hashes": [
                 "sha256:b85d0567b8666149a93172712e68920734333c0ce7e89b78b3e987f71e5ed4f9",
-                "sha256:cdf6525904cc597730141d61b36f2e4b8ecc257c420fa2f4549bac2c2d0cb72f"
+                "sha256:cdf6525904cc597730141d61b36f2e4b8ecc257c420fa2f4549bac2c2d0cb72f",
             ],
             "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==0.10.0"
+            "version": "==0.10.0",
         },
         "mock": {
             "hashes": [
                 "sha256:122fcb64ee37cfad5b3f48d7a7d51875d7031aaf3d8be7c42e2bee25044eee62",
-                "sha256:7d3fbbde18228f4ff2f1f119a45cdffa458b4c0dee32eb4d2bb2f82554bac7bc"
+                "sha256:7d3fbbde18228f4ff2f1f119a45cdffa458b4c0dee32eb4d2bb2f82554bac7bc",
             ],
             "index": "pypi",
-            "version": "==4.0.3"
+            "version": "==4.0.3",
+        },
+        "mypy-extensions": {
+            "hashes": [
+                "sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d",
+                "sha256:2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8",
+            ],
+            "version": "==0.4.3",
+        },
+        "pathspec": {
+            "hashes": [
+                "sha256:7d15c4ddb0b5c802d161efc417ec1a2558ea2653c2e8ad9c19098201dc1c993a",
+                "sha256:e564499435a2673d586f6b2130bb5b95f04a3ba06f81b8f895b651a3c76aabb1",
+            ],
+            "version": "==0.9.0",
+        },
+        "platformdirs": {
+            "hashes": [
+                "sha256:30671902352e97b1eafd74ade8e4a694782bd3471685e78c32d0fdfd3aa7e7bb",
+                "sha256:8ec11dfba28ecc0715eb5fb0147a87b1bf325f349f3da9aab2cd6b50b96b692b",
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==2.5.0",
         },
         "py4j": {
             "hashes": [
-                "sha256:624f97c363b8dd84822bc666b12fa7f7d97824632b2ff3d852cc491359ce7615",
-                "sha256:bf0485388e415ff26710d2dc719cb0ede16cf1164b1ee757e0ebb2e98c471521"
+                "sha256:04f5b06917c0c8a81ab34121dda09a2ba1f74e96d59203c821d5cb7d28c35363",
+                "sha256:0d92844da4cb747155b9563c44fc322c9a1562b3ef0979ae692dbde732d784dd",
             ],
-            "version": "==0.10.9.2"
+            "version": "==0.10.9.3",
         },
         "pyspark": {
             "hashes": [
-                "sha256:bfea06179edbfb4bc76a0f470bd3c38e12f00e1023e3ad0373558d07cff102ab"
+                "sha256:0b81359262ec6e9ac78c353344e7de026027d140c6def949ff0d80ab70f89a54"
             ],
             "index": "pypi",
-            "version": "==3.2.0"
+            "version": "==3.2.1",
         },
         "python-dateutil": {
             "hashes": [
                 "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86",
-                "sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"
+                "sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9",
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==2.8.2"
+            "version": "==2.8.2",
         },
         "ratelimit": {
             "hashes": [
                 "sha256:af8a9b64b821529aca09ebaf6d8d279100d766f19e90b5059ac6a718ca6dee42"
             ],
             "index": "pypi",
-            "version": "==2.2.1"
+            "version": "==2.2.1",
         },
         "requests": {
             "hashes": [
-                "sha256:6c1246513ecd5ecd4528a0906f910e8f0f9c6b8ec72030dc9fd154dc1a6efd24",
-                "sha256:b8aa58f8cf793ffd8782d3d8cb19e66ef36f7aba4353eec859e74678b01b07a7"
+                "sha256:68d7c56fd5a8999887728ef304a6d12edc7be74f1cfa47714fc8b414525c9a61",
+                "sha256:f22fa1e554c9ddfd16e6e41ac79759e17be9e492b3587efa038054674760e72d",
             ],
             "index": "pypi",
-            "version": "==2.26.0"
+            "version": "==2.27.1",
         },
         "s3transfer": {
             "hashes": [
-                "sha256:50ed823e1dc5868ad40c8dc92072f757aa0e653a192845c94a3b676f4a62da4c",
-                "sha256:9c1dc369814391a6bda20ebbf4b70a0f34630592c9aa520856bf384916af2803"
+                "sha256:25c140f5c66aa79e1ac60be50dcd45ddc59e83895f062a3aab263b870102911f",
+                "sha256:69d264d3e760e569b78aaa0f22c97e955891cd22e32b10c51f784eeda4d9d10a",
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==0.5.0"
+            "version": "==0.5.1",
         },
         "six": {
             "hashes": [
                 "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926",
-                "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
+                "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254",
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==1.16.0"
+            "version": "==1.16.0",
         },
         "spark": {
             "hashes": [
                 "sha256:df499b57d30178c6d32dbda2af188b9833a261a70ccd262126ed7b415d9e36d1"
             ],
             "index": "pypi",
-            "version": "==0.2.1"
+            "version": "==0.2.1",
+        },
+        "tomli": {
+            "hashes": [
+                "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc",
+                "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f",
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==2.0.1",
+        },
+        "typing-extensions": {
+            "hashes": [
+                "sha256:1a9462dcc3347a79b1f1c0271fbe79e844580bb598bafa1ed208b94da3cdcd42",
+                "sha256:21c85e0fe4b9a155d0799430b0ad741cdce7e359660ccbd8b530613e8df88ce2",
+            ],
+            "markers": "python_version < '3.10'",
+            "version": "==4.1.1",
         },
         "urllib3": {
             "hashes": [
-                "sha256:4987c65554f7a2dbf30c18fd48778ef124af6fab771a377103da0585e2336ece",
-                "sha256:c4fdf4019605b6e5423637e01bc9fe4daef873709a7973e195ceba0a62bbc844"
+                "sha256:000ca7f471a233c2251c6c7023ee85305721bfdf18621ebff4fd17a8653427ed",
+                "sha256:0e7c33d9a63e7ddfcb86780aac87befc2fbddf46c58dbb487e0855f7ceec283c",
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'",
-            "version": "==1.26.7"
-        }
+            "version": "==1.26.8",
+        },
     },
     "develop": {
         "astroid": {
             "hashes": [
-                "sha256:5939cf55de24b92bda00345d4d0659d01b3c7dafb5055165c330bc7c568ba273",
-                "sha256:776ca0b748b4ad69c00bfe0fff38fa2d21c338e12c84aa9715ee0d473c422778"
+                "sha256:1efdf4e867d4d8ba4a9f6cf9ce07cd182c4c41de77f23814feb27ca93ca9d877",
+                "sha256:506daabe5edffb7e696ad82483ad0228245a9742ed7d2d8c9cdb31537decf9f6",
             ],
-            "markers": "python_version ~= '3.6'",
-            "version": "==2.9.0"
+            "markers": "python_full_version >= '3.6.2'",
+            "version": "==2.9.3",
         },
         "autopep8": {
             "hashes": [
                 "sha256:44f0932855039d2c15c4510d6df665e4730f2b8582704fa48f9c55bd3e17d979",
-                "sha256:ed77137193bbac52d029a52c59bec1b0629b5a186c495f1eb21b126ac466083f"
+                "sha256:ed77137193bbac52d029a52c59bec1b0629b5a186c495f1eb21b126ac466083f",
             ],
             "index": "pypi",
-            "version": "==1.6.0"
+            "version": "==1.6.0",
+        },
+        "colorama": {
+            "hashes": [
+                "sha256:5941b2b48a20143d2267e95b1c2a7603ce057ee39fd88e7329b0c292aa16869b",
+                "sha256:9f47eda37229f68eee03b24b9748937c7dc3868f906e8ba69fbcbdd3bc5dc3e2",
+            ],
+            "markers": "platform_system == 'Windows'",
+            "version": "==0.4.4",
         },
         "isort": {
             "hashes": [
                 "sha256:6f62d78e2f89b4500b080fe3a81690850cd254227f27f75c3a0c491a1f351ba7",
-                "sha256:e8443a5e7a020e9d7f97f1d7d9cd17c88bcb3bc7e218bf9cf5095fe550be2951"
+                "sha256:e8443a5e7a020e9d7f97f1d7d9cd17c88bcb3bc7e218bf9cf5095fe550be2951",
             ],
             "markers": "python_version < '4.0' and python_full_version >= '3.6.1'",
-            "version": "==5.10.1"
+            "version": "==5.10.1",
         },
         "lazy-object-proxy": {
             "hashes": [
-                "sha256:17e0967ba374fc24141738c69736da90e94419338fd4c7c7bef01ee26b339653",
-                "sha256:1fee665d2638491f4d6e55bd483e15ef21f6c8c2095f235fef72601021e64f61",
-                "sha256:22ddd618cefe54305df49e4c069fa65715be4ad0e78e8d252a33debf00f6ede2",
-                "sha256:24a5045889cc2729033b3e604d496c2b6f588c754f7a62027ad4437a7ecc4837",
-                "sha256:410283732af311b51b837894fa2f24f2c0039aa7f220135192b38fcc42bd43d3",
-                "sha256:4732c765372bd78a2d6b2150a6e99d00a78ec963375f236979c0626b97ed8e43",
-                "sha256:489000d368377571c6f982fba6497f2aa13c6d1facc40660963da62f5c379726",
-                "sha256:4f60460e9f1eb632584c9685bccea152f4ac2130e299784dbaf9fae9f49891b3",
-                "sha256:5743a5ab42ae40caa8421b320ebf3a998f89c85cdc8376d6b2e00bd12bd1b587",
-                "sha256:85fb7608121fd5621cc4377a8961d0b32ccf84a7285b4f1d21988b2eae2868e8",
-                "sha256:9698110e36e2df951c7c36b6729e96429c9c32b3331989ef19976592c5f3c77a",
-                "sha256:9d397bf41caad3f489e10774667310d73cb9c4258e9aed94b9ec734b34b495fd",
-                "sha256:b579f8acbf2bdd9ea200b1d5dea36abd93cabf56cf626ab9c744a432e15c815f",
-                "sha256:b865b01a2e7f96db0c5d12cfea590f98d8c5ba64ad222300d93ce6ff9138bcad",
-                "sha256:bf34e368e8dd976423396555078def5cfc3039ebc6fc06d1ae2c5a65eebbcde4",
-                "sha256:c6938967f8528b3668622a9ed3b31d145fab161a32f5891ea7b84f6b790be05b",
-                "sha256:d1c2676e3d840852a2de7c7d5d76407c772927addff8d742b9808fe0afccebdf",
-                "sha256:d7124f52f3bd259f510651450e18e0fd081ed82f3c08541dffc7b94b883aa981",
-                "sha256:d900d949b707778696fdf01036f58c9876a0d8bfe116e8d220cfd4b15f14e741",
-                "sha256:ebfd274dcd5133e0afae738e6d9da4323c3eb021b3e13052d8cbd0e457b1256e",
-                "sha256:ed361bb83436f117f9917d282a456f9e5009ea12fd6de8742d1a4752c3017e93",
-                "sha256:f5144c75445ae3ca2057faac03fda5a902eff196702b0a24daf1d6ce0650514b"
+                "sha256:043651b6cb706eee4f91854da4a089816a6606c1428fd391573ef8cb642ae4f7",
+                "sha256:07fa44286cda977bd4803b656ffc1c9b7e3bc7dff7d34263446aec8f8c96f88a",
+                "sha256:12f3bb77efe1367b2515f8cb4790a11cffae889148ad33adad07b9b55e0ab22c",
+                "sha256:2052837718516a94940867e16b1bb10edb069ab475c3ad84fd1e1a6dd2c0fcfc",
+                "sha256:2130db8ed69a48a3440103d4a520b89d8a9405f1b06e2cc81640509e8bf6548f",
+                "sha256:39b0e26725c5023757fc1ab2a89ef9d7ab23b84f9251e28f9cc114d5b59c1b09",
+                "sha256:46ff647e76f106bb444b4533bb4153c7370cdf52efc62ccfc1a28bdb3cc95442",
+                "sha256:4dca6244e4121c74cc20542c2ca39e5c4a5027c81d112bfb893cf0790f96f57e",
+                "sha256:553b0f0d8dbf21890dd66edd771f9b1b5f51bd912fa5f26de4449bfc5af5e029",
+                "sha256:677ea950bef409b47e51e733283544ac3d660b709cfce7b187f5ace137960d61",
+                "sha256:6a24357267aa976abab660b1d47a34aaf07259a0c3859a34e536f1ee6e76b5bb",
+                "sha256:6a6e94c7b02641d1311228a102607ecd576f70734dc3d5e22610111aeacba8a0",
+                "sha256:6aff3fe5de0831867092e017cf67e2750c6a1c7d88d84d2481bd84a2e019ec35",
+                "sha256:6ecbb350991d6434e1388bee761ece3260e5228952b1f0c46ffc800eb313ff42",
+                "sha256:7096a5e0c1115ec82641afbdd70451a144558ea5cf564a896294e346eb611be1",
+                "sha256:70ed0c2b380eb6248abdef3cd425fc52f0abd92d2b07ce26359fcbc399f636ad",
+                "sha256:8561da8b3dd22d696244d6d0d5330618c993a215070f473b699e00cf1f3f6443",
+                "sha256:85b232e791f2229a4f55840ed54706110c80c0a210d076eee093f2b2e33e1bfd",
+                "sha256:898322f8d078f2654d275124a8dd19b079080ae977033b713f677afcfc88e2b9",
+                "sha256:8f3953eb575b45480db6568306893f0bd9d8dfeeebd46812aa09ca9579595148",
+                "sha256:91ba172fc5b03978764d1df5144b4ba4ab13290d7bab7a50f12d8117f8630c38",
+                "sha256:9d166602b525bf54ac994cf833c385bfcc341b364e3ee71e3bf5a1336e677b55",
+                "sha256:a57d51ed2997e97f3b8e3500c984db50a554bb5db56c50b5dab1b41339b37e36",
+                "sha256:b9e89b87c707dd769c4ea91f7a31538888aad05c116a59820f28d59b3ebfe25a",
+                "sha256:bb8c5fd1684d60a9902c60ebe276da1f2281a318ca16c1d0a96db28f62e9166b",
+                "sha256:c19814163728941bb871240d45c4c30d33b8a2e85972c44d4e63dd7107faba44",
+                "sha256:c4ce15276a1a14549d7e81c243b887293904ad2d94ad767f42df91e75fd7b5b6",
+                "sha256:c7a683c37a8a24f6428c28c561c80d5f4fd316ddcf0c7cab999b15ab3f5c5c69",
+                "sha256:d609c75b986def706743cdebe5e47553f4a5a1da9c5ff66d76013ef396b5a8a4",
+                "sha256:d66906d5785da8e0be7360912e99c9188b70f52c422f9fc18223347235691a84",
+                "sha256:dd7ed7429dbb6c494aa9bc4e09d94b778a3579be699f9d67da7e6804c422d3de",
+                "sha256:df2631f9d67259dc9620d831384ed7732a198eb434eadf69aea95ad18c587a28",
+                "sha256:e368b7f7eac182a59ff1f81d5f3802161932a41dc1b1cc45c1f757dc876b5d2c",
+                "sha256:e40f2013d96d30217a51eeb1db28c9ac41e9d0ee915ef9d00da639c5b63f01a1",
+                "sha256:f769457a639403073968d118bc70110e7dce294688009f5c24ab78800ae56dc8",
+                "sha256:fccdf7c2c5821a8cbd0a9440a456f5050492f2270bd54e94360cac663398739b",
+                "sha256:fd45683c3caddf83abbb1249b653a266e7069a09f486daa8863fb0e7496a9fdb",
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'",
-            "version": "==1.6.0"
+            "markers": "python_version >= '3.6'",
+            "version": "==1.7.1",
         },
         "mccabe": {
             "hashes": [
                 "sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42",
-                "sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f"
+                "sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f",
             ],
-            "version": "==0.6.1"
+            "version": "==0.6.1",
         },
         "platformdirs": {
             "hashes": [
-                "sha256:367a5e80b3d04d2428ffa76d33f124cf11e8fff2acdaa9b43d545f5c7d661ef2",
-                "sha256:8868bbe3c3c80d42f20156f22e7131d2fb321f5bc86a2a345375c6481a67021d"
+                "sha256:30671902352e97b1eafd74ade8e4a694782bd3471685e78c32d0fdfd3aa7e7bb",
+                "sha256:8ec11dfba28ecc0715eb5fb0147a87b1bf325f349f3da9aab2cd6b50b96b692b",
             ],
-            "markers": "python_version >= '3.6'",
-            "version": "==2.4.0"
+            "markers": "python_version >= '3.7'",
+            "version": "==2.5.0",
         },
         "pycodestyle": {
             "hashes": [
                 "sha256:720f8b39dde8b293825e7ff02c475f3077124006db4f440dcbc9a20b76548a20",
-                "sha256:eddd5847ef438ea1c7870ca7eb78a9d47ce0cdb4851a5523949f2601d0cbbe7f"
+                "sha256:eddd5847ef438ea1c7870ca7eb78a9d47ce0cdb4851a5523949f2601d0cbbe7f",
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
-            "version": "==2.8.0"
+            "version": "==2.8.0",
         },
         "pylint": {
             "hashes": [
                 "sha256:9d945a73640e1fec07ee34b42f5669b770c759acd536ec7b16d7e4b87a9c9ff9",
-                "sha256:daabda3f7ed9d1c60f52d563b1b854632fd90035bcf01443e234d3dc794e3b74"
+                "sha256:daabda3f7ed9d1c60f52d563b1b854632fd90035bcf01443e234d3dc794e3b74",
             ],
             "index": "pypi",
-            "version": "==2.12.2"
+            "version": "==2.12.2",
         },
         "setuptools": {
             "hashes": [
-                "sha256:6d10741ff20b89cd8c6a536ee9dc90d3002dec0226c78fb98605bfb9ef8a7adf",
-                "sha256:d144f85102f999444d06f9c0e8c737fd0194f10f2f7e5fdb77573f6e2fa4fad0"
+                "sha256:716f9d20b4c3513d1720245eb1dac009b40c9694c88e940e54b67b8b65d09493",
+                "sha256:d181db00651bce5268b8f559795053d5e8f645e4dbafac6d262b22d7e72e19eb",
             ],
-            "markers": "python_version >= '3.6'",
-            "version": "==59.5.0"
+            "markers": "python_version >= '3.7'",
+            "version": "==60.9.0",
         },
         "toml": {
             "hashes": [
                 "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b",
-                "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"
+                "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f",
             ],
             "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==0.10.2"
+            "version": "==0.10.2",
         },
         "typing-extensions": {
             "hashes": [
-                "sha256:4ca091dea149f945ec56afb48dae714f21e8692ef22a395223bcd328961b6a0e",
-                "sha256:7f001e5ac290a0c0401508864c7ec868be4e701886d5b573a9528ed3973d9d3b"
+                "sha256:1a9462dcc3347a79b1f1c0271fbe79e844580bb598bafa1ed208b94da3cdcd42",
+                "sha256:21c85e0fe4b9a155d0799430b0ad741cdce7e359660ccbd8b530613e8df88ce2",
             ],
             "markers": "python_version < '3.10'",
-            "version": "==4.0.1"
+            "version": "==4.1.1",
         },
         "wrapt": {
             "hashes": [
@@ -300,10 +404,10 @@
                 "sha256:f122ccd12fdc69628786d0c947bdd9cb2733be8f800d88b5a37c57f1f1d73c10",
                 "sha256:f99c0489258086308aad4ae57da9e8ecf9e1f3f30fa35d5e170b4d4896554d80",
                 "sha256:f9c51d9af9abb899bd34ace878fbec8bf357b3194a10c4e8e0a25512826ef056",
-                "sha256:fd76c47f20984b43d93de9a82011bb6e5f8325df6c9ed4d8310029a55fa361ea"
+                "sha256:fd76c47f20984b43d93de9a82011bb6e5f8325df6c9ed4d8310029a55fa361ea",
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
-            "version": "==1.13.3"
-        }
-    }
+            "version": "==1.13.3",
+        },
+    },
 }

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,19 +1,162 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "309bd9f4c5d41d0ac0fc7bc5160cc15c7b8c134378fbd1da89844d7fa1c82129"
+            "sha256": "fc995b321f6ca63d4811c9473584c67dca22a4ee9a8c29b35f30e6d63f86a52e"
         },
         "pipfile-spec": 6,
-        "requires": {"python_full_version": "3.9.7"},
+        "requires": {
+            "python_full_version": "3.9.6"
+        },
         "sources": [
             {
                 "name": "pypi",
                 "url": "https://pypi.python.org/simple",
-                "verify_ssl": true,
+                "verify_ssl": true
             }
-        ],
+        ]
     },
     "default": {
+        "boto3": {
+            "hashes": [
+                "sha256:25a76b7b530a124d9e526c62ff2b7da5782315195badb9a6273714898d689820",
+                "sha256:cc40566dec3f48611a82ace07b29489848e9bd35a51e3e992d1902a3c037e9fc"
+            ],
+            "index": "pypi",
+            "version": "==1.21.0"
+        },
+        "botocore": {
+            "hashes": [
+                "sha256:2bf4463513bd89817aa5d7341ed81c7c76d906e6c70672c8762d64ecf3275771",
+                "sha256:47723cef6112f451630bf2446cfd6be2782cc1d6b1b92acb12ff00797588c5f3"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==1.24.0"
+        },
+        "certifi": {
+            "hashes": [
+                "sha256:78884e7c1d4b00ce3cea67b44566851c4343c120abd683433ce934a68ea58872",
+                "sha256:d62a0163eb4c2344ac042ab2bdf75399a71a2d8c7d47eac2e2ee91b9d6339569"
+            ],
+            "version": "==2021.10.8"
+        },
+        "charset-normalizer": {
+            "hashes": [
+                "sha256:2857e29ff0d34db842cd7ca3230549d1a697f96ee6d3fb071cfa6c7393832597",
+                "sha256:6881edbebdb17b39b4eaaa821b438bf6eddffb4468cf344f09f89def34a8b1df"
+            ],
+            "markers": "python_version >= '3'",
+            "version": "==2.0.12"
+        },
+        "idna": {
+            "hashes": [
+                "sha256:84d9dd047ffa80596e0f246e2eab0b391788b0503584e8945f2368256d2735ff",
+                "sha256:9d643ff0a55b762d5cdb124b8eaa99c66322e2157b69160bc32796e824360e6d"
+            ],
+            "markers": "python_version >= '3'",
+            "version": "==3.3"
+        },
+        "jmespath": {
+            "hashes": [
+                "sha256:b85d0567b8666149a93172712e68920734333c0ce7e89b78b3e987f71e5ed4f9",
+                "sha256:cdf6525904cc597730141d61b36f2e4b8ecc257c420fa2f4549bac2c2d0cb72f"
+            ],
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2'",
+            "version": "==0.10.0"
+        },
+        "mock": {
+            "hashes": [
+                "sha256:122fcb64ee37cfad5b3f48d7a7d51875d7031aaf3d8be7c42e2bee25044eee62",
+                "sha256:7d3fbbde18228f4ff2f1f119a45cdffa458b4c0dee32eb4d2bb2f82554bac7bc"
+            ],
+            "index": "pypi",
+            "version": "==4.0.3"
+        },
+        "py4j": {
+            "hashes": [
+                "sha256:04f5b06917c0c8a81ab34121dda09a2ba1f74e96d59203c821d5cb7d28c35363",
+                "sha256:0d92844da4cb747155b9563c44fc322c9a1562b3ef0979ae692dbde732d784dd"
+            ],
+            "version": "==0.10.9.3"
+        },
+        "pyspark": {
+            "hashes": [
+                "sha256:0b81359262ec6e9ac78c353344e7de026027d140c6def949ff0d80ab70f89a54"
+            ],
+            "index": "pypi",
+            "version": "==3.2.1"
+        },
+        "python-dateutil": {
+            "hashes": [
+                "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86",
+                "sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
+            "version": "==2.8.2"
+        },
+        "ratelimit": {
+            "hashes": [
+                "sha256:af8a9b64b821529aca09ebaf6d8d279100d766f19e90b5059ac6a718ca6dee42"
+            ],
+            "index": "pypi",
+            "version": "==2.2.1"
+        },
+        "requests": {
+            "hashes": [
+                "sha256:68d7c56fd5a8999887728ef304a6d12edc7be74f1cfa47714fc8b414525c9a61",
+                "sha256:f22fa1e554c9ddfd16e6e41ac79759e17be9e492b3587efa038054674760e72d"
+            ],
+            "index": "pypi",
+            "version": "==2.27.1"
+        },
+        "s3transfer": {
+            "hashes": [
+                "sha256:25c140f5c66aa79e1ac60be50dcd45ddc59e83895f062a3aab263b870102911f",
+                "sha256:69d264d3e760e569b78aaa0f22c97e955891cd22e32b10c51f784eeda4d9d10a"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==0.5.1"
+        },
+        "six": {
+            "hashes": [
+                "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926",
+                "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
+            "version": "==1.16.0"
+        },
+        "spark": {
+            "hashes": [
+                "sha256:df499b57d30178c6d32dbda2af188b9833a261a70ccd262126ed7b415d9e36d1"
+            ],
+            "index": "pypi",
+            "version": "==0.2.1"
+        },
+        "urllib3": {
+            "hashes": [
+                "sha256:000ca7f471a233c2251c6c7023ee85305721bfdf18621ebff4fd17a8653427ed",
+                "sha256:0e7c33d9a63e7ddfcb86780aac87befc2fbddf46c58dbb487e0855f7ceec283c"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'",
+            "version": "==1.26.8"
+        }
+    },
+    "develop": {
+        "astroid": {
+            "hashes": [
+                "sha256:1efdf4e867d4d8ba4a9f6cf9ce07cd182c4c41de77f23814feb27ca93ca9d877",
+                "sha256:506daabe5edffb7e696ad82483ad0228245a9742ed7d2d8c9cdb31537decf9f6"
+            ],
+            "markers": "python_full_version >= '3.6.2'",
+            "version": "==2.9.3"
+        },
+        "autopep8": {
+            "hashes": [
+                "sha256:44f0932855039d2c15c4510d6df665e4730f2b8582704fa48f9c55bd3e17d979",
+                "sha256:ed77137193bbac52d029a52c59bec1b0629b5a186c495f1eb21b126ac466083f"
+            ],
+            "index": "pypi",
+            "version": "==1.6.0"
+        },
         "black": {
             "hashes": [
                 "sha256:07e5c049442d7ca1a2fc273c79d1aecbbf1bc858f62e8184abe1ad175c4f7cc2",
@@ -38,221 +181,34 @@
                 "sha256:e2f69158a7d120fd641d1fa9a921d898e20d52e44a74a6fbbcc570a62a6bc8ab",
                 "sha256:efbadd9b52c060a8fc3b9658744091cb33c31f830b3f074422ed27bad2b18e8f",
                 "sha256:f5660feab44c2e3cb24b2419b998846cbb01c23c7fe645fee45087efa3da2d61",
-                "sha256:fdb8754b453fb15fad3f72cd9cad3e16776f0964d67cf30ebcbf10327a3777a3",
+                "sha256:fdb8754b453fb15fad3f72cd9cad3e16776f0964d67cf30ebcbf10327a3777a3"
             ],
             "index": "pypi",
-            "version": "==22.1.0",
-        },
-        "boto3": {
-            "hashes": [
-                "sha256:1a272a1dd36414b1626a47bb580425203be0b5a34caa117f38a5e18adf21f918",
-                "sha256:8129ad42cc0120d1c63daa18512d6f0b1439e385b2b6e0fe987f116bdf795546",
-            ],
-            "index": "pypi",
-            "version": "==1.20.54",
-        },
-        "botocore": {
-            "hashes": [
-                "sha256:06ae8076c4dcf3d72bec4d37e5f2dce4a92a18a8cdaa3bfaa6e3b7b5e30a8d7e",
-                "sha256:4bb9ba16cccee5f5a2602049bc3e2db6865346b2550667f3013bdf33b0a01ceb",
-            ],
-            "markers": "python_version >= '3.6'",
-            "version": "==1.23.54",
-        },
-        "certifi": {
-            "hashes": [
-                "sha256:78884e7c1d4b00ce3cea67b44566851c4343c120abd683433ce934a68ea58872",
-                "sha256:d62a0163eb4c2344ac042ab2bdf75399a71a2d8c7d47eac2e2ee91b9d6339569",
-            ],
-            "version": "==2021.10.8",
-        },
-        "charset-normalizer": {
-            "hashes": [
-                "sha256:2857e29ff0d34db842cd7ca3230549d1a697f96ee6d3fb071cfa6c7393832597",
-                "sha256:6881edbebdb17b39b4eaaa821b438bf6eddffb4468cf344f09f89def34a8b1df",
-            ],
-            "markers": "python_version >= '3'",
-            "version": "==2.0.12",
+            "version": "==22.1.0"
         },
         "click": {
             "hashes": [
                 "sha256:353f466495adaeb40b6b5f592f9f91cb22372351c84caeb068132442a4518ef3",
-                "sha256:410e932b050f5eed773c4cda94de75971c89cdb3155a72a0831139a79e5ecb5b",
+                "sha256:410e932b050f5eed773c4cda94de75971c89cdb3155a72a0831139a79e5ecb5b"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==8.0.3",
+            "version": "==8.0.3"
         },
         "colorama": {
             "hashes": [
                 "sha256:5941b2b48a20143d2267e95b1c2a7603ce057ee39fd88e7329b0c292aa16869b",
-                "sha256:9f47eda37229f68eee03b24b9748937c7dc3868f906e8ba69fbcbdd3bc5dc3e2",
+                "sha256:9f47eda37229f68eee03b24b9748937c7dc3868f906e8ba69fbcbdd3bc5dc3e2"
             ],
-            "markers": "platform_system == 'Windows'",
-            "version": "==0.4.4",
-        },
-        "idna": {
-            "hashes": [
-                "sha256:84d9dd047ffa80596e0f246e2eab0b391788b0503584e8945f2368256d2735ff",
-                "sha256:9d643ff0a55b762d5cdb124b8eaa99c66322e2157b69160bc32796e824360e6d",
-            ],
-            "markers": "python_version >= '3'",
-            "version": "==3.3",
-        },
-        "jmespath": {
-            "hashes": [
-                "sha256:b85d0567b8666149a93172712e68920734333c0ce7e89b78b3e987f71e5ed4f9",
-                "sha256:cdf6525904cc597730141d61b36f2e4b8ecc257c420fa2f4549bac2c2d0cb72f",
-            ],
-            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==0.10.0",
-        },
-        "mock": {
-            "hashes": [
-                "sha256:122fcb64ee37cfad5b3f48d7a7d51875d7031aaf3d8be7c42e2bee25044eee62",
-                "sha256:7d3fbbde18228f4ff2f1f119a45cdffa458b4c0dee32eb4d2bb2f82554bac7bc",
-            ],
-            "index": "pypi",
-            "version": "==4.0.3",
-        },
-        "mypy-extensions": {
-            "hashes": [
-                "sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d",
-                "sha256:2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8",
-            ],
-            "version": "==0.4.3",
-        },
-        "pathspec": {
-            "hashes": [
-                "sha256:7d15c4ddb0b5c802d161efc417ec1a2558ea2653c2e8ad9c19098201dc1c993a",
-                "sha256:e564499435a2673d586f6b2130bb5b95f04a3ba06f81b8f895b651a3c76aabb1",
-            ],
-            "version": "==0.9.0",
-        },
-        "platformdirs": {
-            "hashes": [
-                "sha256:30671902352e97b1eafd74ade8e4a694782bd3471685e78c32d0fdfd3aa7e7bb",
-                "sha256:8ec11dfba28ecc0715eb5fb0147a87b1bf325f349f3da9aab2cd6b50b96b692b",
-            ],
-            "markers": "python_version >= '3.7'",
-            "version": "==2.5.0",
-        },
-        "py4j": {
-            "hashes": [
-                "sha256:04f5b06917c0c8a81ab34121dda09a2ba1f74e96d59203c821d5cb7d28c35363",
-                "sha256:0d92844da4cb747155b9563c44fc322c9a1562b3ef0979ae692dbde732d784dd",
-            ],
-            "version": "==0.10.9.3",
-        },
-        "pyspark": {
-            "hashes": [
-                "sha256:0b81359262ec6e9ac78c353344e7de026027d140c6def949ff0d80ab70f89a54"
-            ],
-            "index": "pypi",
-            "version": "==3.2.1",
-        },
-        "python-dateutil": {
-            "hashes": [
-                "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86",
-                "sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9",
-            ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==2.8.2",
-        },
-        "ratelimit": {
-            "hashes": [
-                "sha256:af8a9b64b821529aca09ebaf6d8d279100d766f19e90b5059ac6a718ca6dee42"
-            ],
-            "index": "pypi",
-            "version": "==2.2.1",
-        },
-        "requests": {
-            "hashes": [
-                "sha256:68d7c56fd5a8999887728ef304a6d12edc7be74f1cfa47714fc8b414525c9a61",
-                "sha256:f22fa1e554c9ddfd16e6e41ac79759e17be9e492b3587efa038054674760e72d",
-            ],
-            "index": "pypi",
-            "version": "==2.27.1",
-        },
-        "s3transfer": {
-            "hashes": [
-                "sha256:25c140f5c66aa79e1ac60be50dcd45ddc59e83895f062a3aab263b870102911f",
-                "sha256:69d264d3e760e569b78aaa0f22c97e955891cd22e32b10c51f784eeda4d9d10a",
-            ],
-            "markers": "python_version >= '3.6'",
-            "version": "==0.5.1",
-        },
-        "six": {
-            "hashes": [
-                "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926",
-                "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254",
-            ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==1.16.0",
-        },
-        "spark": {
-            "hashes": [
-                "sha256:df499b57d30178c6d32dbda2af188b9833a261a70ccd262126ed7b415d9e36d1"
-            ],
-            "index": "pypi",
-            "version": "==0.2.1",
-        },
-        "tomli": {
-            "hashes": [
-                "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc",
-                "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f",
-            ],
-            "markers": "python_version >= '3.7'",
-            "version": "==2.0.1",
-        },
-        "typing-extensions": {
-            "hashes": [
-                "sha256:1a9462dcc3347a79b1f1c0271fbe79e844580bb598bafa1ed208b94da3cdcd42",
-                "sha256:21c85e0fe4b9a155d0799430b0ad741cdce7e359660ccbd8b530613e8df88ce2",
-            ],
-            "markers": "python_version < '3.10'",
-            "version": "==4.1.1",
-        },
-        "urllib3": {
-            "hashes": [
-                "sha256:000ca7f471a233c2251c6c7023ee85305721bfdf18621ebff4fd17a8653427ed",
-                "sha256:0e7c33d9a63e7ddfcb86780aac87befc2fbddf46c58dbb487e0855f7ceec283c",
-            ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'",
-            "version": "==1.26.8",
-        },
-    },
-    "develop": {
-        "astroid": {
-            "hashes": [
-                "sha256:1efdf4e867d4d8ba4a9f6cf9ce07cd182c4c41de77f23814feb27ca93ca9d877",
-                "sha256:506daabe5edffb7e696ad82483ad0228245a9742ed7d2d8c9cdb31537decf9f6",
-            ],
-            "markers": "python_full_version >= '3.6.2'",
-            "version": "==2.9.3",
-        },
-        "autopep8": {
-            "hashes": [
-                "sha256:44f0932855039d2c15c4510d6df665e4730f2b8582704fa48f9c55bd3e17d979",
-                "sha256:ed77137193bbac52d029a52c59bec1b0629b5a186c495f1eb21b126ac466083f",
-            ],
-            "index": "pypi",
-            "version": "==1.6.0",
-        },
-        "colorama": {
-            "hashes": [
-                "sha256:5941b2b48a20143d2267e95b1c2a7603ce057ee39fd88e7329b0c292aa16869b",
-                "sha256:9f47eda37229f68eee03b24b9748937c7dc3868f906e8ba69fbcbdd3bc5dc3e2",
-            ],
-            "markers": "platform_system == 'Windows'",
-            "version": "==0.4.4",
+            "markers": "sys_platform == 'win32'",
+            "version": "==0.4.4"
         },
         "isort": {
             "hashes": [
                 "sha256:6f62d78e2f89b4500b080fe3a81690850cd254227f27f75c3a0c491a1f351ba7",
-                "sha256:e8443a5e7a020e9d7f97f1d7d9cd17c88bcb3bc7e218bf9cf5095fe550be2951",
+                "sha256:e8443a5e7a020e9d7f97f1d7d9cd17c88bcb3bc7e218bf9cf5095fe550be2951"
             ],
-            "markers": "python_version < '4.0' and python_full_version >= '3.6.1'",
-            "version": "==5.10.1",
+            "markers": "python_full_version >= '3.6.1' and python_version < '4.0'",
+            "version": "==5.10.1"
         },
         "lazy-object-proxy": {
             "hashes": [
@@ -292,65 +248,87 @@
                 "sha256:e40f2013d96d30217a51eeb1db28c9ac41e9d0ee915ef9d00da639c5b63f01a1",
                 "sha256:f769457a639403073968d118bc70110e7dce294688009f5c24ab78800ae56dc8",
                 "sha256:fccdf7c2c5821a8cbd0a9440a456f5050492f2270bd54e94360cac663398739b",
-                "sha256:fd45683c3caddf83abbb1249b653a266e7069a09f486daa8863fb0e7496a9fdb",
+                "sha256:fd45683c3caddf83abbb1249b653a266e7069a09f486daa8863fb0e7496a9fdb"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==1.7.1",
+            "version": "==1.7.1"
         },
         "mccabe": {
             "hashes": [
                 "sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42",
-                "sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f",
+                "sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f"
             ],
-            "version": "==0.6.1",
+            "version": "==0.6.1"
+        },
+        "mypy-extensions": {
+            "hashes": [
+                "sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d",
+                "sha256:2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8"
+            ],
+            "version": "==0.4.3"
+        },
+        "pathspec": {
+            "hashes": [
+                "sha256:7d15c4ddb0b5c802d161efc417ec1a2558ea2653c2e8ad9c19098201dc1c993a",
+                "sha256:e564499435a2673d586f6b2130bb5b95f04a3ba06f81b8f895b651a3c76aabb1"
+            ],
+            "version": "==0.9.0"
         },
         "platformdirs": {
             "hashes": [
                 "sha256:30671902352e97b1eafd74ade8e4a694782bd3471685e78c32d0fdfd3aa7e7bb",
-                "sha256:8ec11dfba28ecc0715eb5fb0147a87b1bf325f349f3da9aab2cd6b50b96b692b",
+                "sha256:8ec11dfba28ecc0715eb5fb0147a87b1bf325f349f3da9aab2cd6b50b96b692b"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==2.5.0",
+            "version": "==2.5.0"
         },
         "pycodestyle": {
             "hashes": [
                 "sha256:720f8b39dde8b293825e7ff02c475f3077124006db4f440dcbc9a20b76548a20",
-                "sha256:eddd5847ef438ea1c7870ca7eb78a9d47ce0cdb4851a5523949f2601d0cbbe7f",
+                "sha256:eddd5847ef438ea1c7870ca7eb78a9d47ce0cdb4851a5523949f2601d0cbbe7f"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
-            "version": "==2.8.0",
+            "version": "==2.8.0"
         },
         "pylint": {
             "hashes": [
                 "sha256:9d945a73640e1fec07ee34b42f5669b770c759acd536ec7b16d7e4b87a9c9ff9",
-                "sha256:daabda3f7ed9d1c60f52d563b1b854632fd90035bcf01443e234d3dc794e3b74",
+                "sha256:daabda3f7ed9d1c60f52d563b1b854632fd90035bcf01443e234d3dc794e3b74"
             ],
             "index": "pypi",
-            "version": "==2.12.2",
+            "version": "==2.12.2"
         },
         "setuptools": {
             "hashes": [
                 "sha256:716f9d20b4c3513d1720245eb1dac009b40c9694c88e940e54b67b8b65d09493",
-                "sha256:d181db00651bce5268b8f559795053d5e8f645e4dbafac6d262b22d7e72e19eb",
+                "sha256:d181db00651bce5268b8f559795053d5e8f645e4dbafac6d262b22d7e72e19eb"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==60.9.0",
+            "version": "==60.9.0"
         },
         "toml": {
             "hashes": [
                 "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b",
-                "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f",
+                "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"
             ],
-            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==0.10.2",
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2'",
+            "version": "==0.10.2"
+        },
+        "tomli": {
+            "hashes": [
+                "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc",
+                "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==2.0.1"
         },
         "typing-extensions": {
             "hashes": [
                 "sha256:1a9462dcc3347a79b1f1c0271fbe79e844580bb598bafa1ed208b94da3cdcd42",
-                "sha256:21c85e0fe4b9a155d0799430b0ad741cdce7e359660ccbd8b530613e8df88ce2",
+                "sha256:21c85e0fe4b9a155d0799430b0ad741cdce7e359660ccbd8b530613e8df88ce2"
             ],
             "markers": "python_version < '3.10'",
-            "version": "==4.1.1",
+            "version": "==4.1.1"
         },
         "wrapt": {
             "hashes": [
@@ -404,10 +382,10 @@
                 "sha256:f122ccd12fdc69628786d0c947bdd9cb2733be8f800d88b5a37c57f1f1d73c10",
                 "sha256:f99c0489258086308aad4ae57da9e8ecf9e1f3f30fa35d5e170b4d4896554d80",
                 "sha256:f9c51d9af9abb899bd34ace878fbec8bf357b3194a10c4e8e0a25512826ef056",
-                "sha256:fd76c47f20984b43d93de9a82011bb6e5f8325df6c9ed4d8310029a55fa361ea",
+                "sha256:fd76c47f20984b43d93de9a82011bb6e5f8325df6c9ed4d8310029a55fa361ea"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
-            "version": "==1.13.3",
-        },
-    },
+            "version": "==1.13.3"
+        }
+    }
 }

--- a/environment/constants.py
+++ b/environment/constants.py
@@ -1,0 +1,4 @@
+PIR_BASE_PATH = "s3://sfc-data-engineering/domain=CQC/dataset=pir/"
+ASCWDS_WORKPLACE_BASE_PATH = "s3://sfc-data-engineering/domain=ASCWDS/dataset=workplace"
+CQC_LOCATIONS_BASE_PATH = "s3://sfc-data-engineering/domain=CQC/dataset=locations-api/"
+CQC_PROVIDERS_BASE_PATH = "s3://sfc-data-engineering/domain=CQC/dataset=providers-api/"

--- a/jobs/bleh.py
+++ b/jobs/bleh.py
@@ -1,0 +1,2 @@
+def something_ntatE_THEIE():
+    print("Something")

--- a/jobs/bulk_download_cqc_locations.py
+++ b/jobs/bulk_download_cqc_locations.py
@@ -8,7 +8,9 @@ import argparse
 def main(destination):
     print("Collecting all locations from API")
     spark = utils.get_spark()
-    for paginated_locations in cqc.get_all_objects(stream=True, object_type="locations", object_identifier="locationId"):
+    for paginated_locations in cqc.get_all_objects(
+        stream=True, object_type="locations", object_identifier="locationId"
+    ):
 
         df = spark.createDataFrame(paginated_locations, LOCATION_SCHEMA)
         utils.write_to_parquet(df, destination, True)
@@ -20,7 +22,10 @@ def collect_arguments():
     parser = argparse.ArgumentParser()
 
     parser.add_argument(
-        "--destination", help="A destination directory for outputting cqc locations, if not provided shall default to S3 todays date.", required=False)
+        "--destination",
+        help="A destination directory for outputting cqc locations, if not provided shall default to S3 todays date.",
+        required=False,
+    )
 
     args, unknown = parser.parse_known_args()
 
@@ -32,6 +37,7 @@ if __name__ == "__main__":
     if not destination:
         todays_date = date.today()
         destination = utils.generate_s3_dir_date_path(
-            domain="CQC", dataset="locations-api", date=todays_date)
+            domain="CQC", dataset="locations-api", date=todays_date
+        )
 
     main(destination)

--- a/jobs/bulk_download_cqc_providers.py
+++ b/jobs/bulk_download_cqc_providers.py
@@ -9,7 +9,9 @@ from utils import utils
 def main(destination):
     print("Collecting all providers from API")
     spark = utils.get_spark()
-    for paginated_providers in cqc.get_all_objects(stream=True, object_type="providers", object_identifier="providerId"):
+    for paginated_providers in cqc.get_all_objects(
+        stream=True, object_type="providers", object_identifier="providerId"
+    ):
         # May need schema as second parameter
         df = spark.createDataFrame(paginated_providers, PROVIDER_SCHEMA)
         utils.write_to_parquet(df, destination, True)
@@ -21,7 +23,10 @@ def collect_arguments():
     parser = argparse.ArgumentParser()
 
     parser.add_argument(
-        "--destination", help="A destination directory for outputting cqc providers, if not provided shall default to S3 todays date.", required=False)
+        "--destination",
+        help="A destination directory for outputting cqc providers, if not provided shall default to S3 todays date.",
+        required=False,
+    )
 
     args, unknown = parser.parse_known_args()
 
@@ -33,6 +38,7 @@ if __name__ == "__main__":
     if not destination:
         todays_date = date.today()
         destination = utils.generate_s3_dir_date_path(
-            domain="CQC", dataset="providers-api", date=todays_date)
+            domain="CQC", dataset="providers-api", date=todays_date
+        )
 
     main(destination)

--- a/jobs/csv_to_parquet.py
+++ b/jobs/csv_to_parquet.py
@@ -16,11 +16,19 @@ def main(source, destination, delimiter):
 def collect_arguments():
     parser = argparse.ArgumentParser()
     parser.add_argument(
-        "--source", help="A CSV file used as source input", required=True)
+        "--source", help="A CSV file used as source input", required=True
+    )
     parser.add_argument(
-        "--destination", help="A destination directory for outputting parquet files", required=True)
+        "--destination",
+        help="A destination directory for outputting parquet files",
+        required=True,
+    )
     parser.add_argument(
-        "--delimiter", help="Specify a custom field delimiter", required=False, default=",")
+        "--delimiter",
+        help="Specify a custom field delimiter",
+        required=False,
+        default=",",
+    )
 
     args, unknown = parser.parse_known_args()
 
@@ -30,7 +38,7 @@ def collect_arguments():
     return args.source, args.destination, args.delimiter
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     print("Spark job 'csv_to_parquet' starting...")
     print(f"Job parameters: {sys.argv}")
 

--- a/jobs/denormalise_ascwds_dataset.py
+++ b/jobs/denormalise_ascwds_dataset.py
@@ -29,7 +29,7 @@ worker_fields_required = [
     "salary",
     "hrlyrate",
     "pay_changedate",
-    "pay_savedate"
+    "pay_savedate",
 ]
 workplace_fields_required = [
     "establishmentid",
@@ -40,7 +40,7 @@ workplace_fields_required = [
     "totalstaff",
     "totalstarters",
     "totalleavers",
-    "totalvacancies"
+    "totalvacancies",
 ]
 
 join_on_field = "establishmentid"
@@ -48,9 +48,9 @@ join_type = "inner"
 
 
 def main(worker_source, workplace_source, destination):
-    spark = SparkSession.builder \
-        .appName("sfc_data_engineering_csv_to_parquet") \
-        .getOrCreate()
+    spark = SparkSession.builder.appName(
+        "sfc_data_engineering_csv_to_parquet"
+    ).getOrCreate()
 
     worker_df = read_parquet(spark, worker_source)
     workplace_df = read_parquet(spark, workplace_source)
@@ -61,7 +61,8 @@ def main(worker_source, workplace_source, destination):
 
 def denormalise(df1, df2):
     joined_df = df1.select(worker_fields_required).join(
-        df2.select(workplace_fields_required), join_on_field, join_type)
+        df2.select(workplace_fields_required), join_on_field, join_type
+    )
 
     return joined_df
 
@@ -80,18 +81,27 @@ def read_parquet(spark, source):
 def collect_arguments():
     parser = argparse.ArgumentParser()
     parser.add_argument(
-        "--worker_source", help="A source parquet dir containing worker related rows", required=True)
+        "--worker_source",
+        help="A source parquet dir containing worker related rows",
+        required=True,
+    )
     parser.add_argument(
-        "--workplace_source", help="A source parquet dir containing workplace related rows", required=True)
+        "--workplace_source",
+        help="A source parquet dir containing workplace related rows",
+        required=True,
+    )
     parser.add_argument(
-        "--destination", help="A destination directory for outputting parquet files", required=True)
+        "--destination",
+        help="A destination directory for outputting parquet files",
+        required=True,
+    )
 
     args, unknown = parser.parse_known_args()
 
     return args.worker_source, args.workplace_source, args.destination
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     print("Spark job 'format_fields' starting...")
     print(f"Job parameters: {sys.argv}")
     worker_source, workplace_source, destination = collect_arguments()

--- a/jobs/flatten_cqc_locations.py
+++ b/jobs/flatten_cqc_locations.py
@@ -20,11 +20,19 @@ def flatten_specialisms(df):
 def collect_arguments():
     parser = argparse.ArgumentParser()
     parser.add_argument(
-        "--source", help="A CSV file used as source input", required=True)
+        "--source", help="A CSV file used as source input", required=True
+    )
     parser.add_argument(
-        "--destination", help="A destination directory for outputting parquet files", required=True)
+        "--destination",
+        help="A destination directory for outputting parquet files",
+        required=True,
+    )
     parser.add_argument(
-        "--delimiter", help="Specify a custom field delimiter", required=False, default=",")
+        "--delimiter",
+        help="Specify a custom field delimiter",
+        required=False,
+        default=",",
+    )
 
     args, unknown = parser.parse_known_args()
 
@@ -34,7 +42,7 @@ def collect_arguments():
     return args.source, args.destination, args.delimiter
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     print("Spark job 'csv_to_parquet' starting...")
     print(f"Job parameters: {sys.argv}")
 

--- a/jobs/format_fields.py
+++ b/jobs/format_fields.py
@@ -4,7 +4,6 @@ import argparse
 import sys
 
 
-
 def main(source, destination):
     df = read_parquet(source)
     df = format_date_fields(df)
@@ -12,9 +11,9 @@ def main(source, destination):
 
 
 def read_parquet(source):
-    spark = SparkSession.builder \
-        .appName("sfc_data_engineering_csv_to_parquet") \
-        .getOrCreate()
+    spark = SparkSession.builder.appName(
+        "sfc_data_engineering_csv_to_parquet"
+    ).getOrCreate()
 
     df = spark.read.parquet(source)
 
@@ -28,16 +27,20 @@ def write_parquet(df, destination):
 def collect_arguments():
     parser = argparse.ArgumentParser()
     parser.add_argument(
-        "--source", help="A parquet file used as source input", required=True)
+        "--source", help="A parquet file used as source input", required=True
+    )
     parser.add_argument(
-        "--destination", help="A destination directory for outputting parquet files", required=True)
+        "--destination",
+        help="A destination directory for outputting parquet files",
+        required=True,
+    )
 
     args, unknown = parser.parse_known_args()
 
     return args.source, args.destination
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     print("Spark job 'format_fields' starting...")
     print(f"Job parameters: {sys.argv}")
 

--- a/jobs/ingest_ascwds_dataset.py
+++ b/jobs/ingest_ascwds_dataset.py
@@ -21,11 +21,19 @@ def main(source, destination, delimiter):
 def collect_arguments():
     parser = argparse.ArgumentParser()
     parser.add_argument(
-        "--source", help="A CSV file used as source input", required=True)
+        "--source", help="A CSV file used as source input", required=True
+    )
     parser.add_argument(
-        "--destination", help="A destination directory for outputting parquet files", required=True)
+        "--destination",
+        help="A destination directory for outputting parquet files",
+        required=True,
+    )
     parser.add_argument(
-        "--delimiter", help="Specify a custom field delimiter", required=False, default=DEFAULT_DELIMITER)
+        "--delimiter",
+        help="Specify a custom field delimiter",
+        required=False,
+        default=DEFAULT_DELIMITER,
+    )
 
     args, unknown = parser.parse_known_args()
 
@@ -35,7 +43,7 @@ def collect_arguments():
     return args.source, args.destination, args.delimiter
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     print("Spark job 'ingest_ascwds_dataset' starting...")
     print(f"Job parameters: {sys.argv}")
 

--- a/jobs/prepare_locations.py
+++ b/jobs/prepare_locations.py
@@ -5,6 +5,7 @@ from pyspark.sql.dataframe import DataFrame
 from pyspark.sql.functions import abs, coalesce, greatest, lit, max, when, col, to_date
 from pyspark.sql.types import IntegerType
 from utils import utils
+from environment import constants
 
 required_workplace_fields = [
     "locationid",
@@ -12,7 +13,7 @@ required_workplace_fields = [
     "providerid",
     "totalstaff",
     "wkrrecs",
-    "import_date"
+    "import_date",
 ]
 
 required_cqc_fields = [
@@ -30,44 +31,44 @@ required_cqc_fields = [
     "carehome",
     "constituency",
     "localauthority",
-    "import_date"
+    "import_date",
 ]
 
 MIN_ABSOLUTE_DIFFERENCE = 5
 MIN_PERCENTAGE_DIFFERENCE = 0.1
-ASCWDS_WORKPLACE_BASE_PATH = "s3://sfc-data-engineering/domain=ASCWDS/dataset=workplace"
-CQC_LOCATIONS_BASE_PATH = "s3://sfc-data-engineering/domain=CQC/dataset=locations-api/"
-CQC_PROVIDERS_BASE_PATH = "s3://sfc-data-engineering/domain=CQC/dataset=providers-api/"
 
 
 def main(workplace_source, cqc_location_source, cqc_provider_source, destination):
     spark = utils.get_spark()
     print(f"Reading workplaces parquet from {workplace_source}")
-    workplaces_df = spark.read.option("basePath", ASCWDS_WORKPLACE_BASE_PATH).parquet(
-        workplace_source).select(required_workplace_fields)
+    workplaces_df = (
+        spark.read.option("basePath", constants.ASCWDS_WORKPLACE_BASE_PATH)
+        .parquet(workplace_source)
+        .select(required_workplace_fields)
+    )
 
-    workplaces_df = format_date(
-        workplaces_df, "import_date", "ascwds_workplace_import_date")
+    workplaces_df = format_date(workplaces_df, "import_date", "ascwds_workplace_import_date")
     workplaces_df = remove_duplicates(workplaces_df)
     workplaces_df = clean(workplaces_df)
     workplaces_df = filter_nulls(workplaces_df)
 
     print(f"Reading CQC locations parquet from {cqc_location_source}")
-    cqc_df = spark.read.option("basePath", CQC_LOCATIONS_BASE_PATH).parquet(
-        cqc_location_source).select(required_cqc_fields)
+    cqc_df = (
+        spark.read.option("basePath", constants.CQC_LOCATIONS_BASE_PATH)
+        .parquet(cqc_location_source)
+        .select(required_cqc_fields)
+    )
 
     cqc_df = format_date(cqc_df, "import_date", "cqc_locations_import_date")
 
     print(f"Reading CQC providers parquet from {cqc_provider_source}")
-    cqc_provider_df = spark.read.option("basePath", CQC_PROVIDERS_BASE_PATH).parquet(
-        cqc_provider_source).select(
-            "providerid",
-            col("name").alias("provider_name"),
-            col("import_date")
+    cqc_provider_df = (
+        spark.read.option("basePath", constants.CQC_PROVIDERS_BASE_PATH)
+        .parquet(cqc_provider_source)
+        .select("providerid", col("name").alias("provider_name"), col("import_date"))
     )
 
-    cqc_provider_df = format_date(
-        cqc_provider_df, "import_date", "cqc_providers_import_date")
+    cqc_provider_df = format_date(cqc_provider_df, "import_date", "cqc_providers_import_date")
 
     output_df = cqc_df.join(workplaces_df, "locationid", "left")
     output_df = output_df.join(cqc_provider_df, "providerid", "left")
@@ -79,11 +80,9 @@ def main(workplace_source, cqc_location_source, cqc_provider_source, destination
 
 
 def format_date(input_df, date_column, new_date_column):
-    input_df = input_df.withColumnRenamed(
-        date_column, new_date_column)
+    input_df = input_df.withColumnRenamed(date_column, new_date_column)
 
-    input_df = input_df.withColumn(new_date_column, to_date(
-        col(new_date_column).cast("string"), "yyyyMMdd"))
+    input_df = input_df.withColumn(new_date_column, to_date(col(new_date_column).cast("string"), "yyyyMMdd"))
 
     return input_df
 
@@ -97,14 +96,12 @@ def clean(input_df):
     print("Cleaning...")
 
     # Standardise negative and 0 values as None.
-    input_df = input_df.replace('0', None).replace('-1', None)
+    input_df = input_df.replace("0", None).replace("-1", None)
 
     # Cast integers to string
-    input_df = input_df.withColumn(
-        "totalstaff", input_df["totalstaff"].cast(IntegerType()))
+    input_df = input_df.withColumn("totalstaff", input_df["totalstaff"].cast(IntegerType()))
 
-    input_df = input_df.withColumn(
-        "wkrrecs", input_df["wkrrecs"].cast(IntegerType()))
+    input_df = input_df.withColumn("wkrrecs", input_df["wkrrecs"].cast(IntegerType()))
 
     return input_df
 
@@ -122,49 +119,54 @@ def filter_nulls(input_df):
 
 def calculate_jobcount_totalstaff_equal_wkrrecs(input_df):
     # totalstaff = wkrrrecs: Take totalstaff
-    return input_df.withColumn("jobcount", when(
-        (
-            col("jobcount").isNull() &
-            (col("wkrrecs") == col("totalstaff")) &
-            col("totalstaff").isNotNull() &
-            col("wkrrecs").isNotNull()
-        ), col("totalstaff")
-    ).otherwise(col("jobcount")))
+    return input_df.withColumn(
+        "jobcount",
+        when(
+            (
+                col("jobcount").isNull()
+                & (col("wkrrecs") == col("totalstaff"))
+                & col("totalstaff").isNotNull()
+                & col("wkrrecs").isNotNull()
+            ),
+            col("totalstaff"),
+        ).otherwise(col("jobcount")),
+    )
 
 
 def calculate_jobcount_coalesce_totalstaff_wkrrecs(input_df):
     # Either wkrrecs or totalstaff is null: return first not null
-    return input_df.withColumn("jobcount", when(
-        (
-            col("jobcount").isNull() &
+    return input_df.withColumn(
+        "jobcount",
+        when(
             (
-                (
-                    col("totalstaff").isNull() &
-                    col("wkrrecs").isNotNull()
-                ) |
-                (
-                    col("totalstaff").isNotNull() &
-                    col("wkrrecs").isNull()
+                col("jobcount").isNull()
+                & (
+                    (col("totalstaff").isNull() & col("wkrrecs").isNotNull())
+                    | (col("totalstaff").isNotNull() & col("wkrrecs").isNull())
                 )
-            )
-        ), coalesce(input_df.totalstaff, input_df.wkrrecs)
-    ).otherwise(coalesce(col("jobcount"))))
+            ),
+            coalesce(input_df.totalstaff, input_df.wkrrecs),
+        ).otherwise(coalesce(col("jobcount"))),
+    )
 
 
 def calculate_jobcount_abs_difference_within_range(input_df):
     # Abs difference between totalstaff & wkrrecs < 5 or < 10% take average:
-    input_df = input_df.withColumn('abs_difference', abs(
-        input_df.totalstaff - input_df.wkrrecs))
+    input_df = input_df.withColumn("abs_difference", abs(input_df.totalstaff - input_df.wkrrecs))
 
-    input_df = input_df.withColumn("jobcount", when(
-        (
-            col("jobcount").isNull() &
+    input_df = input_df.withColumn(
+        "jobcount",
+        when(
             (
-                (col("abs_difference") < MIN_ABSOLUTE_DIFFERENCE) | (
-                    col("abs_difference") / col("totalstaff") < MIN_PERCENTAGE_DIFFERENCE)
-            )
-        ), (col("totalstaff") + col("wkrrecs")) / 2
-    ).otherwise(col("jobcount")))
+                col("jobcount").isNull()
+                & (
+                    (col("abs_difference") < MIN_ABSOLUTE_DIFFERENCE)
+                    | (col("abs_difference") / col("totalstaff") < MIN_PERCENTAGE_DIFFERENCE)
+                )
+            ),
+            (col("totalstaff") + col("wkrrecs")) / 2,
+        ).otherwise(col("jobcount")),
+    )
 
     input_df = input_df.drop("abs_difference")
 
@@ -173,82 +175,92 @@ def calculate_jobcount_abs_difference_within_range(input_df):
 
 def calculate_jobcount_handle_tiny_values(input_df):
     # totalstaff or wkrrecs < 3: return max
-    return input_df.withColumn("jobcount", when(
-        (
-            col("jobcount").isNull() &
-            (
-                (col("totalstaff") < 3) | (col("wkrrecs") < 3)
-            )
-        ), greatest(col("totalstaff"), col("wkrrecs"))
-    ).otherwise(col("jobcount")))
+    return input_df.withColumn(
+        "jobcount",
+        when(
+            (col("jobcount").isNull() & ((col("totalstaff") < 3) | (col("wkrrecs") < 3))),
+            greatest(col("totalstaff"), col("wkrrecs")),
+        ).otherwise(col("jobcount")),
+    )
 
 
 def calculate_jobcount_estimate_from_beds(input_df):
     beds_to_jobcount_intercept = 8.40975704621392
     beds_to_jobcount_coefficient = 1.0010753137758377001
-    input_df = input_df.withColumn("bed_estimate_jobcount", when(
-        (
-            col("jobcount").isNull() &
-            (col("numberofbeds") > 0)
-        ), (beds_to_jobcount_intercept + (col("numberofbeds") * beds_to_jobcount_coefficient))
-    ).otherwise(None))
+    input_df = input_df.withColumn(
+        "bed_estimate_jobcount",
+        when(
+            (col("jobcount").isNull() & (col("numberofbeds") > 0)),
+            (beds_to_jobcount_intercept + (col("numberofbeds") * beds_to_jobcount_coefficient)),
+        ).otherwise(None),
+    )
 
     # Determine differences
-    input_df = input_df.withColumn("totalstaff_diff", abs(
-        input_df.totalstaff - input_df.bed_estimate_jobcount))
-    input_df = input_df.withColumn("wkrrecs_diff", abs(
-        input_df.wkrrecs - input_df.bed_estimate_jobcount))
-    input_df = input_df.withColumn("totalstaff_percentage_diff", abs(
-        input_df.totalstaff_diff/input_df.bed_estimate_jobcount))
-    input_df = input_df.withColumn("wkrrecs_percentage_diff", abs(
-        input_df.wkrrecs/input_df.bed_estimate_jobcount))
+    input_df = input_df.withColumn("totalstaff_diff", abs(input_df.totalstaff - input_df.bed_estimate_jobcount))
+    input_df = input_df.withColumn("wkrrecs_diff", abs(input_df.wkrrecs - input_df.bed_estimate_jobcount))
+    input_df = input_df.withColumn(
+        "totalstaff_percentage_diff",
+        abs(input_df.totalstaff_diff / input_df.bed_estimate_jobcount),
+    )
+    input_df = input_df.withColumn(
+        "wkrrecs_percentage_diff",
+        abs(input_df.wkrrecs / input_df.bed_estimate_jobcount),
+    )
 
     # Bounding predictions to certain locations with differences in range
     # if totalstaff and wkrrecs within 10% or < 5: return avg(totalstaff + wkrrds)
-    input_df = input_df.withColumn("jobcount", when(
-        (
-            col("jobcount").isNull() &
-            col("bed_estimate_jobcount").isNotNull() &
+    input_df = input_df.withColumn(
+        "jobcount",
+        when(
             (
-                (
-                    (col("totalstaff_diff") < MIN_ABSOLUTE_DIFFERENCE) | (
-                        col("totalstaff_percentage_diff") < MIN_PERCENTAGE_DIFFERENCE)
-                ) &
-                (
-                    (col("wkrrecs_diff") < MIN_ABSOLUTE_DIFFERENCE) | (
-                        col("wkrrecs_percentage_diff") < MIN_PERCENTAGE_DIFFERENCE)
+                col("jobcount").isNull()
+                & col("bed_estimate_jobcount").isNotNull()
+                & (
+                    (
+                        (col("totalstaff_diff") < MIN_ABSOLUTE_DIFFERENCE)
+                        | (col("totalstaff_percentage_diff") < MIN_PERCENTAGE_DIFFERENCE)
+                    )
+                    & (
+                        (col("wkrrecs_diff") < MIN_ABSOLUTE_DIFFERENCE)
+                        | (col("wkrrecs_percentage_diff") < MIN_PERCENTAGE_DIFFERENCE)
+                    )
                 )
-            )
-        ), (col("totalstaff") + col("wkrrecs")) / 2
-    ).otherwise(col("jobcount")))
+            ),
+            (col("totalstaff") + col("wkrrecs")) / 2,
+        ).otherwise(col("jobcount")),
+    )
 
     # if totalstaff within 10% or < 5: return totalstaff
-    input_df = input_df.withColumn("jobcount", when(
-        (
-            col("jobcount").isNull() &
-            col("bed_estimate_jobcount").isNotNull() &
+    input_df = input_df.withColumn(
+        "jobcount",
+        when(
             (
-
-                (col("totalstaff_diff") < MIN_ABSOLUTE_DIFFERENCE) | (
-                    col("totalstaff_percentage_diff") < MIN_PERCENTAGE_DIFFERENCE)
-
-            )
-        ), col("totalstaff")
-    ).otherwise(col("jobcount")))
+                col("jobcount").isNull()
+                & col("bed_estimate_jobcount").isNotNull()
+                & (
+                    (col("totalstaff_diff") < MIN_ABSOLUTE_DIFFERENCE)
+                    | (col("totalstaff_percentage_diff") < MIN_PERCENTAGE_DIFFERENCE)
+                )
+            ),
+            col("totalstaff"),
+        ).otherwise(col("jobcount")),
+    )
 
     # if wkrrecs within 10% or < 5: return wkrrecs
-    input_df = input_df.withColumn("jobcount", when(
-        (
-            col("jobcount").isNull() &
-            col("bed_estimate_jobcount").isNotNull() &
+    input_df = input_df.withColumn(
+        "jobcount",
+        when(
             (
-
-                (col("wkrrecs_diff") < MIN_ABSOLUTE_DIFFERENCE) | (
-                    col("wkrrecs_percentage_diff") < MIN_PERCENTAGE_DIFFERENCE)
-
-            )
-        ), col("wkrrecs")
-    ).otherwise(col("jobcount")))
+                col("jobcount").isNull()
+                & col("bed_estimate_jobcount").isNotNull()
+                & (
+                    (col("wkrrecs_diff") < MIN_ABSOLUTE_DIFFERENCE)
+                    | (col("wkrrecs_percentage_diff") < MIN_PERCENTAGE_DIFFERENCE)
+                )
+            ),
+            col("wkrrecs"),
+        ).otherwise(col("jobcount")),
+    )
 
     # Drop temporary columns
     columns_to_drop = [
@@ -256,7 +268,7 @@ def calculate_jobcount_estimate_from_beds(input_df):
         "totalstaff_diff",
         "wkrrecs_diff",
         "totalstaff_percentage_diff",
-        "wkrrecs_percentage_diff"
+        "wkrrecs_percentage_diff",
     ]
 
     input_df = input_df.drop(*columns_to_drop)
@@ -285,30 +297,39 @@ def collect_arguments():
     parser.add_argument(
         "--workplace_source",
         help="Source s3 directory for ASCWDS workplace dataset",
-        required=True
+        required=True,
     )
     parser.add_argument(
         "--cqc_location_source",
         help="Source s3 directory for CQC locations api dataset",
-        required=True
+        required=True,
     )
     parser.add_argument(
         "--cqc_provider_source",
         help="Source s3 directory for CQC providers api dataset",
-        required=True
+        required=True,
     )
     parser.add_argument(
         "--destination",
         help="A destination directory for outputting cqc locations, if not provided shall default to S3 todays date.",
-        required=True
+        required=True,
     )
 
     args, unknown = parser.parse_known_args()
 
-    return args.workplace_source, args.cqc_location_source, args.cqc_provider_source, args.destination
+    return (
+        args.workplace_source,
+        args.cqc_location_source,
+        args.cqc_provider_source,
+        args.destination,
+    )
 
 
 if __name__ == "__main__":
-    workplace_source, cqc_location_source, cqc_provider_source, destination, = collect_arguments()
-    main(workplace_source, cqc_location_source,
-         cqc_provider_source, destination)
+    (
+        workplace_source,
+        cqc_location_source,
+        cqc_provider_source,
+        destination,
+    ) = collect_arguments()
+    main(workplace_source, cqc_location_source, cqc_provider_source, destination)

--- a/schemas/cqc_location_schema.py
+++ b/schemas/cqc_location_schema.py
@@ -1,135 +1,216 @@
 from pyspark.sql.types import *
 
-LOCATION_SCHEMA = StructType(fields=[
-    StructField('locationId', StringType(), True),
-    StructField('providerId', StringType(), True),
-    StructField('organisationType', StringType(), True),
-    StructField('type', StringType(), True),
-    StructField('name', StringType(), True),
-    StructField('onspdCcgCode', StringType(), True),
-    StructField('onspdCcgName', StringType(), True),
-    StructField('odsCode', StringType(), True),
-    StructField('uprn', StringType(), True),
-    StructField('registrationStatus', StringType(), True),
-    StructField('registrationDate', StringType(), True),
-    StructField('deregistrationDate', StringType(), True),
-    StructField('dormancy', StringType(), True),
-    StructField('numberOfBeds', IntegerType(), True),
-    StructField('website', StringType(), True),
-    StructField('postalAddressLine1', StringType(), True),
-    StructField('postalAddressTownCity', StringType(), True),
-    StructField('postalAddressCounty', StringType(), True),
-    StructField('region', StringType(), True),
-    StructField('postalCode', StringType(), True),
-    StructField('onspdLatitude', FloatType(), True),
-    StructField('onspdLongitude', FloatType(), True),
-    StructField('careHome', StringType(), True),
-    StructField('inspectionDirectorate', StringType(), True),
-    StructField('mainPhoneNumber', StringType(), True),
-    StructField('constituency', StringType(), True),
-    StructField('localAuthority', StringType(), True),
-    StructField('lastInspection', StructType([
-        StructField('date', StringType(), True)
-    ]), True),
-    StructField('lastReport', StructType([
+LOCATION_SCHEMA = StructType(
+    fields=[
+        StructField("locationId", StringType(), True),
+        StructField("providerId", StringType(), True),
+        StructField("organisationType", StringType(), True),
+        StructField("type", StringType(), True),
+        StructField("name", StringType(), True),
+        StructField("onspdCcgCode", StringType(), True),
+        StructField("onspdCcgName", StringType(), True),
+        StructField("odsCode", StringType(), True),
+        StructField("uprn", StringType(), True),
+        StructField("registrationStatus", StringType(), True),
+        StructField("registrationDate", StringType(), True),
+        StructField("deregistrationDate", StringType(), True),
+        StructField("dormancy", StringType(), True),
+        StructField("numberOfBeds", IntegerType(), True),
+        StructField("website", StringType(), True),
+        StructField("postalAddressLine1", StringType(), True),
+        StructField("postalAddressTownCity", StringType(), True),
+        StructField("postalAddressCounty", StringType(), True),
+        StructField("region", StringType(), True),
+        StructField("postalCode", StringType(), True),
+        StructField("onspdLatitude", FloatType(), True),
+        StructField("onspdLongitude", FloatType(), True),
+        StructField("careHome", StringType(), True),
+        StructField("inspectionDirectorate", StringType(), True),
+        StructField("mainPhoneNumber", StringType(), True),
+        StructField("constituency", StringType(), True),
+        StructField("localAuthority", StringType(), True),
         StructField(
-            'publicationDate', StringType(), True)
-    ]), True),
-    StructField(
-        'relationships', ArrayType(
-            StructType([
-                StructField('relatedLocationId', StringType(), True),
-                StructField('relatedLocationName', StringType(), True),
-                StructField('type', StringType(), True),
-                StructField('reason', StringType(), True),
-            ])
-        ), True),
-    # StructField('locationTypes', ArrayType(), False),
-    StructField(
-        'regulatedActivities', ArrayType(
-            StructType([
-                StructField('name', StringType(), True),
-                StructField('code', StringType(), True),
-                StructField('contacts', ArrayType(
-                    StructType([
-                            StructField('personTitle',
-                                        StringType(), True),
-                            StructField('personGivenName',
-                                        StringType(), True),
-                            StructField('personFamilyName',
-                                        StringType(), True),
-                            StructField('personRoles', StringType(), True),
-                            ])
-                ), True),
-            ])
-        )
-    ),
-    StructField(
-        'gacServiceTypes', ArrayType(
-            StructType([
-                StructField('name', StringType(), True),
-                StructField('description', StringType(), True),
-            ])
-        )
-    ),
-    StructField(
-        'inspectionCategories', ArrayType(
-            StructType([
-                StructField('code', StringType(), True),
-                StructField('primary', StringType(), True),
-                StructField('name', StringType(), True),
-            ])
-        ), True),
-    StructField(
-        'specialisms', ArrayType(
-            StructType([
-                StructField('name', StringType(), True),
-            ])
-        ), True),
-    # StructField('inspectionAreas', ArrayType(), True),
-    StructField('currentRatings', StructType([
-        StructField('overall', StructType([
-                StructField("rating", StringType(), True),
-                StructField("reportDate", StringType(), True),
-                StructField("reportLinkId", StringType(), True),
-                StructField(
-                    'keyQuestionRatings', ArrayType(
-                        StructType([
-                            StructField('name', StringType(), True),
-                            StructField('rating', StringType(), True),
-                            StructField('reportDate', StringType(), True),
-                            StructField('reportLinkId', StringType(), True),
-                        ])
+            "lastInspection",
+            StructType([StructField("date", StringType(), True)]),
+            True,
+        ),
+        StructField(
+            "lastReport",
+            StructType([StructField("publicationDate", StringType(), True)]),
+            True,
+        ),
+        StructField(
+            "relationships",
+            ArrayType(
+                StructType(
+                    [
+                        StructField("relatedLocationId", StringType(), True),
+                        StructField("relatedLocationName", StringType(), True),
+                        StructField("type", StringType(), True),
+                        StructField("reason", StringType(), True),
+                    ]
+                )
+            ),
+            True,
+        ),
+        # StructField('locationTypes', ArrayType(), False),
+        StructField(
+            "regulatedActivities",
+            ArrayType(
+                StructType(
+                    [
+                        StructField("name", StringType(), True),
+                        StructField("code", StringType(), True),
+                        StructField(
+                            "contacts",
+                            ArrayType(
+                                StructType(
+                                    [
+                                        StructField("personTitle", StringType(), True),
+                                        StructField(
+                                            "personGivenName", StringType(), True
+                                        ),
+                                        StructField(
+                                            "personFamilyName", StringType(), True
+                                        ),
+                                        StructField("personRoles", StringType(), True),
+                                    ]
+                                )
+                            ),
+                            True,
+                        ),
+                    ]
+                )
+            ),
+        ),
+        StructField(
+            "gacServiceTypes",
+            ArrayType(
+                StructType(
+                    [
+                        StructField("name", StringType(), True),
+                        StructField("description", StringType(), True),
+                    ]
+                )
+            ),
+        ),
+        StructField(
+            "inspectionCategories",
+            ArrayType(
+                StructType(
+                    [
+                        StructField("code", StringType(), True),
+                        StructField("primary", StringType(), True),
+                        StructField("name", StringType(), True),
+                    ]
+                )
+            ),
+            True,
+        ),
+        StructField(
+            "specialisms",
+            ArrayType(
+                StructType(
+                    [
+                        StructField("name", StringType(), True),
+                    ]
+                )
+            ),
+            True,
+        ),
+        # StructField('inspectionAreas', ArrayType(), True),
+        StructField(
+            "currentRatings",
+            StructType(
+                [
+                    StructField(
+                        "overall",
+                        StructType(
+                            [
+                                StructField("rating", StringType(), True),
+                                StructField("reportDate", StringType(), True),
+                                StructField("reportLinkId", StringType(), True),
+                                StructField(
+                                    "keyQuestionRatings",
+                                    ArrayType(
+                                        StructType(
+                                            [
+                                                StructField("name", StringType(), True),
+                                                StructField(
+                                                    "rating", StringType(), True
+                                                ),
+                                                StructField(
+                                                    "reportDate", StringType(), True
+                                                ),
+                                                StructField(
+                                                    "reportLinkId", StringType(), True
+                                                ),
+                                            ]
+                                        )
+                                    ),
+                                ),
+                                StructField("reportDate", StringType(), True),
+                            ]
+                        ),
+                        True,
                     )
+                ]
+            ),
+            True,
+        ),
+        StructField(
+            "historicRatings",
+            ArrayType(
+                StructType(
+                    [
+                        StructField("organisationId", StringType(), True),
+                        StructField("reportLinkId", StringType(), True),
+                        StructField("reportDate", StringType(), True),
+                        StructField(
+                            "overall",
+                            StructType(
+                                [
+                                    StructField("rating", StringType(), True),
+                                    StructField(
+                                        "keyQuestionRatings",
+                                        ArrayType(
+                                            StructType(
+                                                [
+                                                    StructField(
+                                                        "name", StringType(), True
+                                                    ),
+                                                    StructField(
+                                                        "rating", StringType(), True
+                                                    ),
+                                                ]
+                                            ),
+                                            True,
+                                        ),
+                                        True,
+                                    ),
+                                ]
+                            ),
+                            True,
+                        ),
+                    ]
                 ),
-                StructField("reportDate", StringType(), True),
-                ]), True)
-    ]), True),
-    StructField('historicRatings', ArrayType(
-        StructType([
-            StructField("organisationId", StringType(), True),
-            StructField("reportLinkId", StringType(), True),
-            StructField("reportDate", StringType(), True),
-            StructField('overall', StructType([
-                StructField("rating", StringType(), True),
-                StructField(
-                        'keyQuestionRatings', ArrayType(
-                            StructType([
-                                StructField('name', StringType(), True),
-                                StructField('rating', StringType(), True),
-                            ]), True), True),
-            ]), True),
-        ]), True)
-    ),
-    StructField(
-        'reports', ArrayType(
-            StructType([
-                StructField('linkId', StringType(), True),
-                StructField('reportDate', StringType(), True),
-                StructField('reportUri', StringType(), True),
-                StructField('firstVisitDate', StringType(), True),
-                StructField('reportType', StringType(), True),
-            ])
-        ), True
-    ),
-])
+                True,
+            ),
+        ),
+        StructField(
+            "reports",
+            ArrayType(
+                StructType(
+                    [
+                        StructField("linkId", StringType(), True),
+                        StructField("reportDate", StringType(), True),
+                        StructField("reportUri", StringType(), True),
+                        StructField("firstVisitDate", StringType(), True),
+                        StructField("reportType", StringType(), True),
+                    ]
+                )
+            ),
+            True,
+        ),
+    ]
+)

--- a/schemas/cqc_provider_schema.py
+++ b/schemas/cqc_provider_schema.py
@@ -1,30 +1,33 @@
 from pyspark.sql.types import *
 
-PROVIDER_SCHEMA = StructType(fields=[
-    StructField('providerId', StringType(), True),
-    StructField(
-        'locationIds', ArrayType(
-            StringType(),
-        )
-    ),
-    StructField('organisationType', StringType(), True),
-    StructField('ownershipType', StringType(), True),
-    StructField('type', StringType(), True),
-    StructField('uprn', StringType(), True),
-    StructField('name', StringType(), True),
-    StructField('registrationStatus', StringType(), True),
-    StructField('registrationDate', StringType(), True),
-    StructField('deregistrationDate', StringType(), True),
-    StructField('postalAddressLine1', StringType(), True),
-    StructField('postalAddressTownCity', StringType(), True),
-    StructField('postalAddressCounty', StringType(), True),
-    StructField('region', StringType(), True),
-    StructField('postalCode', StringType(), True),
-    StructField('onspdLatitude', FloatType(), True),
-    StructField('onspdLongitude', FloatType(), True),
-    StructField('mainPhoneNumber', StringType(), True),
-    StructField('companiesHouseNumber', StringType(), True),
-    StructField('inspectionDirectorate', StringType(), True),
-    StructField('constituency', StringType(), True),
-    StructField('localAuthority', StringType(), True)
-])
+PROVIDER_SCHEMA = StructType(
+    fields=[
+        StructField("providerId", StringType(), True),
+        StructField(
+            "locationIds",
+            ArrayType(
+                StringType(),
+            ),
+        ),
+        StructField("organisationType", StringType(), True),
+        StructField("ownershipType", StringType(), True),
+        StructField("type", StringType(), True),
+        StructField("uprn", StringType(), True),
+        StructField("name", StringType(), True),
+        StructField("registrationStatus", StringType(), True),
+        StructField("registrationDate", StringType(), True),
+        StructField("deregistrationDate", StringType(), True),
+        StructField("postalAddressLine1", StringType(), True),
+        StructField("postalAddressTownCity", StringType(), True),
+        StructField("postalAddressCounty", StringType(), True),
+        StructField("region", StringType(), True),
+        StructField("postalCode", StringType(), True),
+        StructField("onspdLatitude", FloatType(), True),
+        StructField("onspdLongitude", FloatType(), True),
+        StructField("mainPhoneNumber", StringType(), True),
+        StructField("companiesHouseNumber", StringType(), True),
+        StructField("inspectionDirectorate", StringType(), True),
+        StructField("constituency", StringType(), True),
+        StructField("localAuthority", StringType(), True),
+    ]
+)

--- a/tests/integration/test_cqc_api_integration.py
+++ b/tests/integration/test_cqc_api_integration.py
@@ -10,7 +10,6 @@ LOCATION_ID_REGEX = r"[0-9]-[0-9]{11}"
 
 
 class TestCQCLocationAPIIntegration(unittest.TestCase):
-
     def setUp(self):
         pass
 
@@ -30,15 +29,14 @@ class TestCQCLocationAPIIntegration(unittest.TestCase):
         page = 1
         url = f"https://api.cqc.org.uk/public/v1/locations"
 
-        locations = cqc.get_page_objects(
-            url, page, "locations", "locationId", 5)
+        locations = cqc.get_page_objects(url, page, "locations", "locationId", 5)
         self.assertEqual(len(locations), 5)
 
         regex = re.compile(LOCATION_ID_REGEX)
         for location in locations:
-            self.assertTrue(regex.match(location['locationId']))
+            self.assertTrue(regex.match(location["locationId"]))
             self.assertIsNotNone(location["providerId"])
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/unit/test_cqc_location_api.py
+++ b/tests/unit/test_cqc_location_api.py
@@ -5,45 +5,46 @@ import unittest
 
 
 class TestCQCLocationAPI(unittest.TestCase):
-
     def setUp(self):
         pass
 
     def tearDown(self):
         pass
 
-    @mock.patch('utils.cqc_api.call_api')
+    @mock.patch("utils.cqc_api.call_api")
     def test_get_location(self, mock_call_api):
         mock_call_api.return_value = {"locationId": "test_id"}
 
-        location_body = {
-            "locationId": "test_id"
-        }
+        location_body = {"locationId": "test_id"}
 
         result = cqc.get_object("test_id", "locations")
         self.assertEqual(result, location_body)
 
-    @mock.patch('utils.cqc_api.call_api')
-    @mock.patch('utils.cqc_api.get_object')
+    @mock.patch("utils.cqc_api.call_api")
+    @mock.patch("utils.cqc_api.get_object")
     def test_get_page_locations(self, mock_get_object, mock_call_api):
-        mock_call_api.return_value = {"locations": [
-            {"locationId": "test_id"},
-            {"locationId": "test_id_2"},
-            {"locationId": "test_id_3"},
-        ]}
+        mock_call_api.return_value = {
+            "locations": [
+                {"locationId": "test_id"},
+                {"locationId": "test_id_2"},
+                {"locationId": "test_id_3"},
+            ]
+        }
 
-        mock_get_object.return_value(
-            {"locationId": "get_location_return_id"})
+        mock_get_object.return_value({"locationId": "get_location_return_id"})
 
-        result = cqc.get_page_objects(
-            "test_url", 1, "locations", "locationId")
+        result = cqc.get_page_objects("test_url", 1, "locations", "locationId")
 
-        mock_call_api.assert_called_once_with(
-            "test_url", {'page': 1, 'perPage': 500})
+        mock_call_api.assert_called_once_with("test_url", {"page": 1, "perPage": 500})
 
         mock_get_object.assert_has_calls(
-            [mock.call("test_id", "locations"), mock.call("test_id_2", "locations"), mock.call("test_id_3", "locations")])
+            [
+                mock.call("test_id", "locations"),
+                mock.call("test_id_2", "locations"),
+                mock.call("test_id_3", "locations"),
+            ]
+        )
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/unit/test_denormalise_ascwds_dataset.py
+++ b/tests/unit/test_denormalise_ascwds_dataset.py
@@ -10,9 +10,9 @@ class TestDenormaliseASCWDSDataset(unittest.TestCase):
     test_csv_joinable_path = "tests/test_data/joinable.csv"
 
     def setUp(self):
-        spark = SparkSession.builder \
-            .appName("sfc_data_engineering_denormalise_ascwds_dataset") \
-            .getOrCreate()
+        spark = SparkSession.builder.appName(
+            "sfc_data_engineering_denormalise_ascwds_dataset"
+        ).getOrCreate()
 
         self.df1 = spark.read.csv(self.test_csv_path, header=True)
         self.df2 = spark.read.csv(self.test_csv_joinable_path, header=True)
@@ -20,9 +20,15 @@ class TestDenormaliseASCWDSDataset(unittest.TestCase):
     def tearDown(self):
         pass
 
-    @patch('jobs.denormalise_ascwds_dataset.worker_fields_required', ["col_a", "col_b", "col_c", "date_col"])
-    @patch('jobs.denormalise_ascwds_dataset.workplace_fields_required', ["col_a",  "col_d", "col_date_2"])
-    @patch('jobs.denormalise_ascwds_dataset.join_on_field', "col_a")
+    @patch(
+        "jobs.denormalise_ascwds_dataset.worker_fields_required",
+        ["col_a", "col_b", "col_c", "date_col"],
+    )
+    @patch(
+        "jobs.denormalise_ascwds_dataset.workplace_fields_required",
+        ["col_a", "col_d", "col_date_2"],
+    )
+    @patch("jobs.denormalise_ascwds_dataset.join_on_field", "col_a")
     def test_denormalise_datasets(self):
 
         self.assertEqual(len(self.df1.columns), 4)
@@ -35,18 +41,22 @@ class TestDenormaliseASCWDSDataset(unittest.TestCase):
         self.assertEqual(len(df.columns), 6)
         self.assertEqual(df.count(), 3)
 
-    @patch('jobs.denormalise_ascwds_dataset.worker_fields_required', ["col_a", "date_col"])
-    @patch('jobs.denormalise_ascwds_dataset.workplace_fields_required', ["col_a", "col_d", "col_date_2"])
-    @patch('jobs.denormalise_ascwds_dataset.join_on_field', "col_a")
+    @patch(
+        "jobs.denormalise_ascwds_dataset.worker_fields_required", ["col_a", "date_col"]
+    )
+    @patch(
+        "jobs.denormalise_ascwds_dataset.workplace_fields_required",
+        ["col_a", "col_d", "col_date_2"],
+    )
+    @patch("jobs.denormalise_ascwds_dataset.join_on_field", "col_a")
     def test_denormalise_datasets_returns_subset_of_columns(self):
 
         df = denormalise_ascwds_dataset.denormalise(self.df1, self.df2)
 
         self.assertEqual(len(df.columns), 4)
-        self.assertEqual(
-            df.columns, ["col_a", "date_col", "col_d", "col_date_2"])
+        self.assertEqual(df.columns, ["col_a", "date_col", "col_d", "col_date_2"])
         self.assertEqual(df.count(), 3)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -8,14 +8,14 @@ from pyspark.sql import SparkSession
 
 class UtilsTests(unittest.TestCase):
 
-    test_csv_path = 'tests/test_data/example_csv.csv'
-    test_csv_custom_delim_path = 'tests/test_data/example_csv_custom_delimiter.csv'
+    test_csv_path = "tests/test_data/example_csv.csv"
+    test_csv_custom_delim_path = "tests/test_data/example_csv_custom_delimiter.csv"
     tmp_dir = "tmp-out"
 
     def setUp(self):
-        spark = SparkSession.builder \
-            .appName("sfc_data_engineering_csv_to_parquet") \
-            .getOrCreate()
+        spark = SparkSession.builder.appName(
+            "sfc_data_engineering_csv_to_parquet"
+        ).getOrCreate()
         self.df = spark.read.csv(self.test_csv_path, header=True)
 
     def tearDown(self):
@@ -23,18 +23,17 @@ class UtilsTests(unittest.TestCase):
             shutil.rmtree(self.tmp_dir)
         except OSError as e:
             pass  # Ignore dir does not exist
-        
-        
-        
-        
 
     def test_generate_s3_dir_date_path(self):
 
         dec_first_21 = datetime(2021, 12, 1)
         dir_path = utils.generate_s3_dir_date_path(
-            "test_domain", "test_dateset", dec_first_21)
+            "test_domain", "test_dateset", dec_first_21
+        )
         self.assertEqual(
-            dir_path, "s3://sfc-data-engineering/domain=test_domain/dataset=test_dateset/version=1.0.0/year=2021/month=12/day=01/import_date=20211201")
+            dir_path,
+            "s3://sfc-data-engineering/domain=test_domain/dataset=test_dateset/version=1.0.0/year=2021/month=12/day=01/import_date=20211201",
+        )
 
     def test_read_csv(self):
         df = utils.read_csv(self.test_csv_path)
@@ -42,8 +41,7 @@ class UtilsTests(unittest.TestCase):
         self.assertEqual(df.count(), 3)
 
     def test_read_with_custom_delimiter(self):
-        df = utils.read_csv(
-            self.test_csv_custom_delim_path, "|")
+        df = utils.read_csv(self.test_csv_custom_delim_path, "|")
 
         self.assertEqual(df.columns, ["col_a", "col_b", "col_c"])
         self.assertEqual(df.count(), 3)
@@ -58,9 +56,10 @@ class UtilsTests(unittest.TestCase):
     def test_format_date_fields(self):
         self.assertEqual(self.df.select("date_col").first()[0], "28/11/1993")
         formatted_df = utils.format_date_fields(self.df)
-        self.assertEqual(str(formatted_df.select(
-            "date_col").first()[0]), "1993-11-28 00:00:00")
+        self.assertEqual(
+            str(formatted_df.select("date_col").first()[0]), "1993-11-28 00:00:00"
+        )
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/utils/cqc_api.py
+++ b/utils/cqc_api.py
@@ -1,4 +1,3 @@
-
 from schemas.cqc_location_schema import LOCATION_SCHEMA
 from pyspark import SparkConf
 from pyspark.context import SparkContext
@@ -43,10 +42,10 @@ def get_all_objects(stream, object_type, object_identifier, per_page=DEFAULT_PAG
     print(f"Beginning CQC bulk download of {object_type}...")
 
     for page_number in range(1, total_pages + 1):
-        print(
-            f"Collecting {object_type} from API page {page_number}/{total_pages}")
+        print(f"Collecting {object_type} from API page {page_number}/{total_pages}")
         page_locations = get_page_objects(
-            url, page_number, object_type, object_identifier)
+            url, page_number, object_type, object_identifier
+        )
 
         if stream:
             yield page_locations
@@ -57,7 +56,9 @@ def get_all_objects(stream, object_type, object_identifier, per_page=DEFAULT_PAG
         return all_objects
 
 
-def get_page_objects(url, page_number, object_type, object_identifier, per_page=DEFAULT_PAGE_SIZE):
+def get_page_objects(
+    url, page_number, object_type, object_identifier, per_page=DEFAULT_PAGE_SIZE
+):
 
     page_objects = []
     response_body = call_api(url, {"page": page_number, "perPage": per_page})

--- a/utils/generate_s3_upload_directories.py
+++ b/utils/generate_s3_upload_directories.py
@@ -3,7 +3,7 @@ import boto3
 
 def generate_ASCWDS_directories():
     directories = []
-    for dataset in ['worker', 'workplace']:
+    for dataset in ["worker", "workplace"]:
         for year in range(2010, 2030):
             for month in range(1, 13):
                 for day in range(1, 32):
@@ -25,13 +25,13 @@ def generate_historical_CQC_directories():
 
 
 def main():
-    s3 = boto3.client('s3')
+    s3 = boto3.client("s3")
     bucket_name = "sfc-data-engineering-raw"
 
     directories = generate_historical_CQC_directories()
     for directory in directories:
-        s3.put_object(Bucket=bucket_name, Key=(directory+'/'))
+        s3.put_object(Bucket=bucket_name, Key=(directory + "/"))
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -14,9 +14,7 @@ class SetupSpark(object):
         return self.spark
 
     def setupSpark(self):
-        spark = SparkSession.builder \
-            .appName("sfc_data_engineering") \
-            .getOrCreate()
+        spark = SparkSession.builder.appName("sfc_data_engineering").getOrCreate()
 
         return spark
 
@@ -38,15 +36,15 @@ def generate_s3_dir_date_path(domain, dataset, date):
 def write_to_parquet(df, output_dir, append=False):
 
     if append:
-        df.write.mode('append').parquet(output_dir)
+        df.write.mode("append").parquet(output_dir)
     else:
         df.write.parquet(output_dir)
 
 
 def read_csv(source, delimiter=","):
-    spark = SparkSession.builder \
-        .appName("sfc_data_engineering_csv_to_parquet") \
-        .getOrCreate()
+    spark = SparkSession.builder.appName(
+        "sfc_data_engineering_csv_to_parquet"
+    ).getOrCreate()
 
     df = spark.read.option("delimiter", delimiter).csv(source, header=True)
 
@@ -54,11 +52,9 @@ def read_csv(source, delimiter=","):
 
 
 def format_date_fields(df, date_column_identifier="date", raw_date_format="dd/MM/yyyy"):
-    date_columns = [
-        column for column in df.columns if date_column_identifier in column]
+    date_columns = [column for column in df.columns if date_column_identifier in column]
 
     for date_column in date_columns:
-        df = df.withColumn(date_column, to_timestamp(
-            date_column, raw_date_format))
+        df = df.withColumn(date_column, to_timestamp(date_column, raw_date_format))
 
     return df


### PR DESCRIPTION
Black: https://github.com/psf/black - the uncompromising code formatter.

This PR adds the black dependency and formats the entire project - hence it being such a large pr!

Auto formats our code (with a little bit of vscode configuration. Here's my settings.json for example:
```
{
  "python.pythonPath": "C:\\Users\\adamp\\.virtualenvs\\DataEngineering-nH3w3qds\\Scripts\\python.exe",
  "python.envFile": "${workspaceFolder}/.env",
  "python.linting.flake8Enabled": true,
  "python.linting.enabled": true,
  "python.formatting.provider": "black",
  "python.formatting.blackPath": "C:\\Users\\adamp\\.virtualenvs\\DataEngineering-nH3w3qds\\Scripts\\black.exe",
  "editor.formatOnSave": true,
  "python.linting.pylintEnabled": false,
  "python.formatting.blackArgs": ["--line-length=120"],
  "python.linting.flake8Args": [
      "--max-line-length=120",
      "--ignore=E402,F841,F401,E302,E305,W503",
  ],
  "editor.defaultFormatter": "ms-python.python"
}
```

I also downgraded python to 3.9.6 the latest available release on pyenv