### PR TITLE
providerid now imports from CQC instead of ASCWDS

### DIFF
--- a/jobs/prepare_locations.py
+++ b/jobs/prepare_locations.py
@@ -43,7 +43,6 @@ def get_ascwds_workplace_df(workplace_source, base_path=constants.ASCWDS_WORKPLA
         .select(
             col("locationid"),
             col("establishmentid"),
-            col("providerid"),
             col("totalstaff").alias("total_staff"),
             col("wkrrecs").alias("worker_record_count"),
             col("import_date").alias("ascwds_workplace_import_date"),
@@ -74,6 +73,7 @@ def get_cqc_location_df(cqc_location_source, base_path=constants.CQC_LOCATIONS_B
         .parquet(cqc_location_source)
         .select(
             col("locationid"),
+            col("providerid"),
             col("organisationtype").alias("organisation_type"),
             col("type").alias("location_type"),
             col("name").alias("location_name"),

--- a/tests/unit/test_prepare_locations.py
+++ b/tests/unit/test_prepare_locations.py
@@ -37,10 +37,9 @@ class PrepareLocationsTests(unittest.TestCase):
 
         self.assertEqual(workplace_df.columns[0], "locationid")
         self.assertEqual(workplace_df.columns[1], "establishmentid")
-        self.assertEqual(workplace_df.columns[2], "providerid")
-        self.assertEqual(workplace_df.columns[3], "total_staff")
-        self.assertEqual(workplace_df.columns[4], "worker_record_count")
-        self.assertEqual(workplace_df.columns[5], "ascwds_workplace_import_date")
+        self.assertEqual(workplace_df.columns[2], "total_staff")
+        self.assertEqual(workplace_df.columns[3], "worker_record_count")
+        self.assertEqual(workplace_df.columns[4], "ascwds_workplace_import_date")
 
     def test_get_pir_dataframe(self):
         path = "tests/test_data/domain=CQC/dataset=pir/version=0.0.1/format=parquet"


### PR DESCRIPTION
there are 2 trello tickets related to this - both relate to dodgy looking providerids appearing in the dataset_locations_prepared which has knock on effects - turns out we were using providerid from ASCWDS which is manually entered by workplaces and not the providerid contained in the CQC dataset

https://trello.com/c/qKN1Xrak/216-general-locationids-appearing-as-providerids-in-datasetlocationsprepared-in-error
https://trello.com/c/i8KuvS7B/225-general-issue-incorrect-providerids-appearing-in-datasetlocationsprepared