### PR TITLE
Fix main deployment pipeline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,9 +107,6 @@ workflows:
           filters:
             branches:
               only: main
-      - deploy-dependencies:
-          requires:
-            - test
       - terraform-plan:
           requires:
             - test
@@ -120,6 +117,9 @@ workflows:
       - terraform-apply:
           requires:
             - plan-approval
+      - deploy-dependencies:
+          requires:
+            - terraform-apply
 
   
   test-plan-and-deploy-to-dev:    

--- a/terraform/pipeline/step-function.tf
+++ b/terraform/pipeline/step-function.tf
@@ -7,7 +7,7 @@ resource "aws_sfn_state_machine" "ethnicity-breakdown-state-machine" {
 
 
 resource "aws_iam_role" "step_function_iam_role" {
-  name               = "${terraform.workspace}-AWSStepFunction-data-engineering-role"
+  name               = "${terraform.workspace}-AWSStepFunction-role"
   assume_role_policy = data.aws_iam_policy_document.step_function_iam_policy.json
 }
 


### PR DESCRIPTION
Move the job dependency to after terraform plan - code isn't stored after tests resulting in the zipping of dependencies failing 