### PR TITLE
removed duplicate reportDate and 2 commented out fields

### DIFF
--- a/schemas/cqc_location_schema.py
+++ b/schemas/cqc_location_schema.py
@@ -53,7 +53,6 @@ LOCATION_SCHEMA = StructType(
             ),
             True,
         ),
-        # StructField('locationTypes', ArrayType(), False),
         StructField(
             "regulatedActivities",
             ArrayType(
@@ -114,7 +113,6 @@ LOCATION_SCHEMA = StructType(
             ),
             True,
         ),
-        # StructField('inspectionAreas', ArrayType(), True),
         StructField(
             "currentRatings",
             StructType(
@@ -139,7 +137,6 @@ LOCATION_SCHEMA = StructType(
                                         )
                                     ),
                                 ),
-                                StructField("reportDate", StringType(), True),
                             ]
                         ),
                         True,


### PR DESCRIPTION
accidental duplicate reportDate causes us a lot of problems - me/Adam fixed it in my CQC import PR but we haven't pushed to main yet so the schema gets replaced with the old version whenever anyone else publishes a PR

putting this in to change the main branch permanently