### PR TITLE
Format branch names before using them to create AWS resources

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,6 +79,15 @@ jobs:
           command: |
             cd terraform/pipeline
             terraform apply -auto-approve tfapply
+      - run:
+          name: save pipeline resources bucket name
+          command: |
+            cd terraform/pipeline
+            echo $(terraform output --raw pipeline_resources_bucket_name) > pipeline_resources_bucket_name
+
+      - persist_to_workspace:
+          root: .
+          paths: ./terraform/pipeline/pipeline_resources_bucket_name
   
   deploy-dependencies:
     docker:
@@ -96,7 +105,7 @@ jobs:
       - aws-s3/sync:
           aws-region: AWS_REGION
           from: dependencies
-          to: 's3://sfc-${CIRCLE_BRANCH}-pipeline-resources/dependencies'
+          to: "s3://$(cat terraform/pipeline/pipeline_resources_bucket_name)/dependencies"
 
           
 workflows:

--- a/terraform/modules/glue-crawler/glue-crawler.tf
+++ b/terraform/modules/glue-crawler/glue-crawler.tf
@@ -1,6 +1,6 @@
 resource "aws_glue_crawler" "crawler" {
   database_name = var.workspace_glue_database_name
-  name          = "${terraform.workspace}-data_engineering_${var.dataset_for_crawler}"
+  name          = "${local.workspace_prefix}-data_engineering_${var.dataset_for_crawler}"
   role          = var.glue_role.arn
   schedule      = var.schedule
 
@@ -9,7 +9,7 @@ resource "aws_glue_crawler" "crawler" {
   }
 
   s3_target {
-    path = "s3://sfc-${terraform.workspace}-datasets/domain=${var.dataset_for_crawler}/"
+    path = "s3://sfc-${local.workspace_prefix}-datasets/domain=${var.dataset_for_crawler}/"
   }
 
   schema_change_policy {

--- a/terraform/modules/glue-crawler/locals.tf
+++ b/terraform/modules/glue-crawler/locals.tf
@@ -1,0 +1,3 @@
+locals {
+  workspace_prefix = lower(replace(terraform.workspace, "/[^a-zA-Z0-9]+/", "-"))
+}

--- a/terraform/modules/glue-crawler/locals.tf
+++ b/terraform/modules/glue-crawler/locals.tf
@@ -1,3 +1,3 @@
 locals {
-  workspace_prefix = lower(replace(terraform.workspace, "/[^a-zA-Z0-9]+/", "-"))
+  workspace_prefix = substr(lower(replace(terraform.workspace, "/[^a-zA-Z0-9]+/", "-")), 0, 40)
 }

--- a/terraform/modules/glue-crawler/optional-inputs.tf
+++ b/terraform/modules/glue-crawler/optional-inputs.tf
@@ -2,5 +2,5 @@ variable "schedule" {
   description = "An optional schedule in CRON format to execute the crawler"
   type        = string
   default     = null
-  
+
 }

--- a/terraform/modules/glue-job/locals.tf
+++ b/terraform/modules/glue-job/locals.tf
@@ -1,3 +1,6 @@
 locals {
-  job_name = "${terraform.workspace}-${replace(var.script_name, ".py", "")}_job"
+  workspace_prefix = lower(replace(terraform.workspace, "/[^a-zA-Z0-9]+/", "-"))
+  name             = "${local.workspace_prefix}-${replace(var.script_name, ".py", "")}"
+  job_name         = "${local.name}_job"
+  trigger_name     = "${local.name}_trigger"
 }

--- a/terraform/modules/glue-job/locals.tf
+++ b/terraform/modules/glue-job/locals.tf
@@ -1,5 +1,5 @@
 locals {
-  workspace_prefix = lower(replace(terraform.workspace, "/[^a-zA-Z0-9]+/", "-"))
+  workspace_prefix = substr(lower(replace(terraform.workspace, "/[^a-zA-Z0-9]+/", "-")), 0, 40)
   name             = "${local.workspace_prefix}-${replace(var.script_name, ".py", "")}"
   job_name         = "${local.name}_job"
   trigger_name     = "${local.name}_trigger"

--- a/terraform/modules/glue-job/outputs.tf
+++ b/terraform/modules/glue-job/outputs.tf
@@ -1,7 +1,7 @@
 output "job_name" {
   value = aws_glue_job.glue_job.name
 }
+
 output "job_arn" {
   value = aws_glue_job.glue_job.arn
 }
-

--- a/terraform/modules/glue-job/trigger.tf
+++ b/terraform/modules/glue-job/trigger.tf
@@ -1,6 +1,6 @@
 resource "aws_glue_trigger" "glue_job_trigger" {
   count    = terraform.workspace == "main" && var.trigger ? 1 : 0
-  name     = "${terraform.workspace}-${var.script_name}-trigger"
+  name     = local.trigger_name
   schedule = var.trigger_schedule
   type     = "SCHEDULED"
 

--- a/terraform/modules/s3-bucket/inputs.tf
+++ b/terraform/modules/s3-bucket/inputs.tf
@@ -1,5 +1,5 @@
 variable "bucket_name" {
-  description = "Name of the python script to run"
+  description = "Name of the S3 bucket"
   type        = string
 }
 

--- a/terraform/modules/s3-bucket/s3.tf
+++ b/terraform/modules/s3-bucket/s3.tf
@@ -1,5 +1,5 @@
 resource "aws_s3_bucket" "s3_bucket" {
-  bucket        = "sfc-${terraform.workspace}-${var.bucket_name}"
+  bucket        = "sfc-${var.bucket_name}"
   force_destroy = var.empty_bucket_on_destroy
 }
 

--- a/terraform/pipeline/glue.tf
+++ b/terraform/pipeline/glue.tf
@@ -1,6 +1,6 @@
 resource "aws_glue_catalog_database" "glue_catalog_database" {
-  name        = "${terraform.workspace}-${var.glue_database_name}"
-  description = "Database for all datasets belonging to the ${terraform.workspace} environment."
+  name        = "${local.workspace_prefix}-${var.glue_database_name}"
+  description = "Database for all datasets belonging to the ${local.workspace_prefix} environment."
 }
 
 module "csv_to_parquet_job" {
@@ -106,14 +106,14 @@ module "ascwds_crawler" {
   source                       = "../modules/glue-crawler"
   dataset_for_crawler          = "ASCWDS"
   glue_role                    = aws_iam_role.sfc_glue_service_iam_role
-  workspace_glue_database_name = "${terraform.workspace}-${var.glue_database_name}"
+  workspace_glue_database_name = "${local.workspace_prefix}-${var.glue_database_name}"
 }
 
 module "data_engineering_crawler" {
   source                       = "../modules/glue-crawler"
   dataset_for_crawler          = "data_engineering"
   glue_role                    = aws_iam_role.sfc_glue_service_iam_role
-  workspace_glue_database_name = "${terraform.workspace}-${var.glue_database_name}"
+  workspace_glue_database_name = "${local.workspace_prefix}-${var.glue_database_name}"
 }
 
 module "cqc_crawler" {
@@ -121,5 +121,5 @@ module "cqc_crawler" {
   dataset_for_crawler          = "CQC"
   glue_role                    = aws_iam_role.sfc_glue_service_iam_role
   schedule                     = "cron(00 07 * * ? *)"
-  workspace_glue_database_name = "${terraform.workspace}-${var.glue_database_name}"
+  workspace_glue_database_name = "${local.workspace_prefix}-${var.glue_database_name}"
 }

--- a/terraform/pipeline/iam.tf
+++ b/terraform/pipeline/iam.tf
@@ -1,5 +1,5 @@
 resource "aws_iam_role" "sfc_glue_service_iam_role" {
-  name               = "${terraform.workspace}-glue_service_iam_role"
+  name               = "${local.workspace_prefix}-glue_service_iam_role"
   assume_role_policy = data.aws_iam_policy_document.glue_service_assume_role_policy.json
 }
 
@@ -21,9 +21,9 @@ resource "aws_iam_role_policy_attachment" "AWSGlueServiceRole_policy_attachment"
 
 
 resource "aws_iam_policy" "glue_crawler_logging_policy" {
-  name        = "${terraform.workspace}-logging_policy"
+  name        = "${local.workspace_prefix}-logging_policy"
   path        = "/"
-  description = "Iam logging policy crawlers on ${terraform.workspace} environment"
+  description = "Iam logging policy crawlers on ${local.workspace_prefix} environment"
 
   policy = jsonencode({
 
@@ -50,9 +50,9 @@ resource "aws_iam_role_policy_attachment" "glue_crawler_logging_policy_attachmen
 }
 
 resource "aws_iam_policy" "glue_job_s3_data_engineering_policy" {
-  name        = "${terraform.workspace}-glue_job_bucket_access_policy"
+  name        = "${local.workspace_prefix}-glue_job_bucket_access_policy"
   path        = "/"
-  description = "Iam policy for the all glue jobs on workspace: ${terraform.workspace}"
+  description = "Iam policy for the all glue jobs on workspace: ${local.workspace_prefix}"
 
   policy = jsonencode({
 
@@ -81,9 +81,9 @@ resource "aws_iam_role_policy_attachment" "glue_job_s3_policy_attachment" {
 }
 
 resource "aws_iam_policy" "glue_jobs_read_raw_s3_data_policy" {
-  name        = "${terraform.workspace}-glue_job_read_raw_s3_bucket_access_policy"
+  name        = "${local.workspace_prefix}-glue_job_read_raw_s3_bucket_access_policy"
   path        = "/"
-  description = "Iam policy for the all glue jobs on workspace: ${terraform.workspace} to read the raw data"
+  description = "Iam policy for the all glue jobs on workspace: ${local.workspace_prefix} to read the raw data"
 
   policy = jsonencode({
 

--- a/terraform/pipeline/main.tf
+++ b/terraform/pipeline/main.tf
@@ -14,3 +14,7 @@ terraform {
 
   }
 }
+
+locals {
+  workspace_prefix = lower(replace(terraform.workspace, "/[^a-zA-Z0-9]+/", "-"))
+}

--- a/terraform/pipeline/main.tf
+++ b/terraform/pipeline/main.tf
@@ -16,5 +16,5 @@ terraform {
 }
 
 locals {
-  workspace_prefix = lower(replace(terraform.workspace, "/[^a-zA-Z0-9]+/", "-"))
+  workspace_prefix = substr(lower(replace(terraform.workspace, "/[^a-zA-Z0-9]+/", "-")), 0, 40)
 }

--- a/terraform/pipeline/outputs.tf
+++ b/terraform/pipeline/outputs.tf
@@ -1,0 +1,3 @@
+output "pipeline_resources_bucket_name" {
+    value = module.pipeline_resources.bucket_name
+}

--- a/terraform/pipeline/s3.tf
+++ b/terraform/pipeline/s3.tf
@@ -1,11 +1,11 @@
 module "pipeline_resources" {
   source                  = "../modules/s3-bucket"
-  bucket_name             = "pipeline-resources"
+  bucket_name             = "${local.workspace_prefix}-pipeline-resources"
   empty_bucket_on_destroy = true
 }
 
 module "datasets_bucket" {
   source                  = "../modules/s3-bucket"
-  bucket_name             = "datasets"
+  bucket_name             = "${local.workspace_prefix}-datasets"
   empty_bucket_on_destroy = false
 }

--- a/terraform/pipeline/step-function.tf
+++ b/terraform/pipeline/step-function.tf
@@ -1,5 +1,5 @@
 resource "aws_sfn_state_machine" "ethnicity-breakdown-state-machine" {
-  name       = "${terraform.workspace}-EthnicityBreakdownPipeline"
+  name       = "${local.workspace_prefix}-EthnicityBreakdownPipeline"
   role_arn   = aws_iam_role.step_function_iam_role.arn
   type       = "STANDARD"
   definition = templatefile("EthnicityBreakdownPipeline-StepFunction.json", {})
@@ -7,7 +7,7 @@ resource "aws_sfn_state_machine" "ethnicity-breakdown-state-machine" {
 
 
 resource "aws_iam_role" "step_function_iam_role" {
-  name               = "${terraform.workspace}-AWSStepFunction-role"
+  name               = "${local.workspace_prefix}-AWSStepFunction-role"
   assume_role_policy = data.aws_iam_policy_document.step_function_iam_policy.json
 }
 
@@ -23,7 +23,7 @@ data "aws_iam_policy_document" "step_function_iam_policy" {
 }
 
 resource "aws_iam_policy" "step_function_iam_policy" {
-  name        = "${terraform.workspace}-step_function_iam_policy"
+  name        = "${local.workspace_prefix}-step_function_iam_policy"
   path        = "/"
   description = "IAM Policy for step functions"
 


### PR DESCRIPTION
There are conditions on some AWS resource names that were causing errors if branch names were too long or had unaccepted characters (like underscores in S3 bucket names).
Formatting includes
- Lowercasing
- Replacing any non-alphanumeric character with a dash
- Trimming the name to max 40 characters

https://trello.com/c/67U2Ch7y/317-format-branch-names-when-creating-terraform-resources-in-workspaces-to-avoid-deployment-errors
