### PR TITLE
Trigger asc wds ingestion when CSV files are uploaded to S3

### DIFF
--- a/terraform/pipeline/eventbridge.tf
+++ b/terraform/pipeline/eventbridge.tf
@@ -1,6 +1,6 @@
 resource "aws_cloudwatch_event_rule" "ascwds_csv_added" {
   is_enabled  = terraform.workspace == "main" ? true : false
-  name        = "ascwds-csv-added"
+  name        = "${local.workspace_prefix}-ascwds-csv-added"
   description = "Captures when a new ASC WDS worker or workspace CSV is uploaded to sfc-data-engineering-raw bucket"
 
   event_pattern = <<EOF
@@ -59,7 +59,7 @@ resource "aws_iam_role_policy_attachment" "start_state_machines" {
 
 resource "aws_cloudwatch_event_target" "trigger_transform_ascwds_state_machine" {
   rule      = aws_cloudwatch_event_rule.ascwds_csv_added.name
-  target_id = "StartTransformASCWDSStateMachine"
+  target_id = "${local.workspace_prefix}-StartTransformASCWDSStateMachine"
   arn       = aws_sfn_state_machine.transform_ascwds_state_machine.arn
   role_arn  = aws_iam_role.start_state_machines.arn
 

--- a/terraform/pipeline/eventbridge.tf
+++ b/terraform/pipeline/eventbridge.tf
@@ -1,4 +1,5 @@
 resource "aws_cloudwatch_event_rule" "ascwds_csv_added" {
+  is_enabled  = terraform.workspace == "main" ? true : false
   name        = "ascwds-csv-added"
   description = "Captures when a new ASC WDS worker or workspace CSV is uploaded to sfc-data-engineering-raw bucket"
 

--- a/terraform/pipeline/eventbridge.tf
+++ b/terraform/pipeline/eventbridge.tf
@@ -1,0 +1,80 @@
+resource "aws_cloudwatch_event_rule" "ascwds_csv_added" {
+  name        = "ascwds-csv-added"
+  description = "Captures when a new ASC WDS worker or workspace CSV is uploaded to sfc-data-engineering-raw bucket"
+
+  event_pattern = <<EOF
+{
+  "source": ["aws.s3"],
+  "detail-type": ["Object Created"],
+  "detail": {
+    "bucket": {
+      "name": ["sfc-data-engineering-raw"]
+    },
+    "object": {
+      "key": [ {"prefix": "domain=ASCWDS/dataset=worker" }, {"prefix": "domain=ASCWDS/dataset=workplace" }  ]
+    }
+  }
+}
+EOF
+}
+
+resource "aws_iam_policy" "start_state_machines" {
+  name = "${local.workspace_prefix}-start-state-machines"
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect   = "Allow"
+        Action   = ["states:StartExecution"]
+        Resource = [aws_sfn_state_machine.transform_ascwds_state_machine.arn]
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role" "start_state_machines" {
+  name = "${local.workspace_prefix}-start-state-machines"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "events.amazonaws.com"
+      },
+      "Effect": "Allow"
+    }
+  ]
+}
+EOF 
+}
+
+resource "aws_iam_role_policy_attachment" "start_state_machines" {
+  role       = aws_iam_role.start_state_machines.name
+  policy_arn = aws_iam_policy.start_state_machines.arn
+}
+
+resource "aws_cloudwatch_event_target" "trigger_transform_ascwds_state_machine" {
+  rule      = aws_cloudwatch_event_rule.ascwds_csv_added.name
+  target_id = "StartTransformASCWDSStateMachine"
+  arn       = aws_sfn_state_machine.transform_ascwds_state_machine.arn
+  role_arn  = aws_iam_role.start_state_machines.arn
+
+  input_transformer {
+    input_paths = {
+      bucket_name = "$.detail.bucket.name",
+      key         = "$.detail.object.key",
+    }
+    input_template = <<EOF
+    {
+        "jobs": {
+            "ingest_ascwds_dataset" : {
+                "source": "s3://<bucket_name>/<key>"
+            }
+        }
+    }
+    EOF
+  }
+}

--- a/terraform/pipeline/outputs.tf
+++ b/terraform/pipeline/outputs.tf
@@ -1,3 +1,3 @@
 output "pipeline_resources_bucket_name" {
-    value = module.pipeline_resources.bucket_name
+  value = module.pipeline_resources.bucket_name
 }

--- a/terraform/pipeline/step-function.tf
+++ b/terraform/pipeline/step-function.tf
@@ -27,9 +27,7 @@ resource "aws_sfn_state_machine" "transform_ascwds_state_machine" {
   type     = "STANDARD"
   definition = templatefile("step-functions/TransformASCWDS-StepFunction.json", {
     ingest_ascwds_job_name               = module.ingest_ascwds_dataset_job.job_name
-    prepare_locations_job_name           = module.prepare_locations_job.job_name
     data_engineering_ascwds_crawler_name = module.ascwds_crawler.crawler_name
-    data_engineering_crawler_name        = module.data_engineering_crawler.crawler_name
     dataset_bucket_name                  = module.datasets_bucket.bucket_name
   })
 

--- a/terraform/pipeline/step-functions/TransformASCWDS-StepFunction.json
+++ b/terraform/pipeline/step-functions/TransformASCWDS-StepFunction.json
@@ -20,60 +20,12 @@
                     "Next": "Fail"
                 }
             ],
-            "Next": "Parallel",
-            "ResultPath": "$.jobs.prepare_locations_job",
-            "ResultSelector": {
-                "destination": "s3://${dataset_bucket_name}/domain=data_engineering/dataset=locations_prepared/version=1.0.1/",
-                "pir_source": "s3://sfc-main-datasets/domain=CQC/dataset=pir/version=0.0.3/",
-                "workplace_source": "s3://${dataset_bucket_name}/domain=ASCWDS/dataset=workplace/version=1.0.0/",
-                "cqc_provider_source": "s3://sfc-main-datasets/domain=CQC/dataset=providers-api/version=1.0.0/",
-                "cqc_location_source": "s3://sfc-main-datasets/domain=CQC/dataset=locations-api/version=1.0.0/"
-              }
+            "Next": "Run Data Engineering ASC WDS Crawler"
         },
-        "Parallel": {
-            "Type": "Parallel",
-            "Next": "Run Data Engineering Crawler",
-            "ResultPath": null,
-            "Branches": [
-                {
-                    "StartAt": "Run ASCWDS Crawler",
-                    "States": {
-                        "Run ASCWDS Crawler": {
-                            "Type": "Task",
-                            "Parameters": {
-                                "Name": "${data_engineering_ascwds_crawler_name}"
-                            },
-                            "Resource": "arn:aws:states:::aws-sdk:glue:startCrawler",
-                            "End": true
-                        }
-                    }
-                },
-                {
-                    "StartAt": "Prepare Locations",
-                    "States": {
-                        "Prepare Locations": {
-                            "Type": "Task",
-                            "Resource": "arn:aws:states:::glue:startJobRun.sync",
-                            "Parameters": {
-                                "JobName": "${prepare_locations_job_name}",
-                                "Arguments": {
-                                    "--destination.$": "$.jobs.prepare_locations_job.destination",
-                                    "--pir_source.$": "$.jobs.prepare_locations_job.pir_source",
-                                    "--workplace_source.$": "$.jobs.prepare_locations_job.workplace_source",
-                                    "--cqc_provider_source.$": "$.jobs.prepare_locations_job.cqc_provider_source",
-                                    "--cqc_location_source.$": "$.jobs.prepare_locations_job.cqc_location_source"
-                                }
-                            },
-                            "End": true
-                        }
-                    }
-                }
-            ]
-        },
-        "Run Data Engineering Crawler": {
+        "Run Data Engineering ASC WDS Crawler": {
             "Type": "Task",
             "Parameters": {
-                "Name": "${data_engineering_crawler_name}"
+                "Name": "${data_engineering_ascwds_crawler_name}"
             },
             "Resource": "arn:aws:states:::aws-sdk:glue:startCrawler",
             "Next": "Success"

--- a/terraform/pipeline/step-functions/TransformASCWDS-StepFunction.json
+++ b/terraform/pipeline/step-functions/TransformASCWDS-StepFunction.json
@@ -1,0 +1,88 @@
+{
+    "Comment": "A description of my state machine",
+    "StartAt": "Ingest ASCWDS",
+    "States": {
+        "Ingest ASCWDS": {
+            "Type": "Task",
+            "Resource": "arn:aws:states:::glue:startJobRun.sync",
+            "Parameters": {
+                "JobName": "${ingest_ascwds_job_name}",
+                "Arguments": {
+                    "--destination.$": "$.jobs.ingest_ascwds_dataset.destination",
+                    "--source.$": "$.jobs.ingest_ascwds_dataset.source"
+                }
+            },
+            "Catch": [
+                {
+                    "ErrorEquals": [
+                        "States.ALL"
+                    ],
+                    "Next": "Fail"
+                }
+            ],
+            "Next": "Parallel",
+            "ResultPath": "$.jobs.prepare_locations_job",
+            "ResultSelector": {
+                "destination": "s3://${dataset_bucket_name}/domain=data_engineering/dataset=locations_prepared/version=1.0.1/",
+                "pir_source": "s3://sfc-main-datasets/domain=CQC/dataset=pir/version=0.0.3/",
+                "workplace_source": "s3://${dataset_bucket_name}/domain=ASCWDS/dataset=workplace/version=1.0.0/",
+                "cqc_provider_source": "s3://sfc-main-datasets/domain=CQC/dataset=providers-api/version=1.0.0/",
+                "cqc_location_source": "s3://sfc-main-datasets/domain=CQC/dataset=locations-api/version=1.0.0/"
+              }
+        },
+        "Parallel": {
+            "Type": "Parallel",
+            "Next": "Run Data Engineering Crawler",
+            "ResultPath": null,
+            "Branches": [
+                {
+                    "StartAt": "Run ASCWDS Crawler",
+                    "States": {
+                        "Run ASCWDS Crawler": {
+                            "Type": "Task",
+                            "Parameters": {
+                                "Name": "${data_engineering_ascwds_crawler_name}"
+                            },
+                            "Resource": "arn:aws:states:::aws-sdk:glue:startCrawler",
+                            "End": true
+                        }
+                    }
+                },
+                {
+                    "StartAt": "Prepare Locations",
+                    "States": {
+                        "Prepare Locations": {
+                            "Type": "Task",
+                            "Resource": "arn:aws:states:::glue:startJobRun.sync",
+                            "Parameters": {
+                                "JobName": "${prepare_locations_job_name}",
+                                "Arguments": {
+                                    "--destination.$": "$.jobs.prepare_locations_job.destination",
+                                    "--pir_source.$": "$.jobs.prepare_locations_job.pir_source",
+                                    "--workplace_source.$": "$.jobs.prepare_locations_job.workplace_source",
+                                    "--cqc_provider_source.$": "$.jobs.prepare_locations_job.cqc_provider_source",
+                                    "--cqc_location_source.$": "$.jobs.prepare_locations_job.cqc_location_source"
+                                }
+                            },
+                            "End": true
+                        }
+                    }
+                }
+            ]
+        },
+        "Run Data Engineering Crawler": {
+            "Type": "Task",
+            "Parameters": {
+                "Name": "${data_engineering_crawler_name}"
+            },
+            "Resource": "arn:aws:states:::aws-sdk:glue:startCrawler",
+            "Next": "Success"
+        },
+        "Success": {
+            "Type": "Succeed"
+        },
+        "Fail": {
+            "Type": "Fail"
+        }
+    }
+}

--- a/terraform/pipeline/step-functions/TransformASCWDS-StepFunction.json
+++ b/terraform/pipeline/step-functions/TransformASCWDS-StepFunction.json
@@ -8,7 +8,7 @@
             "Parameters": {
                 "JobName": "${ingest_ascwds_job_name}",
                 "Arguments": {
-                    "--destination.$": "$.jobs.ingest_ascwds_dataset.destination",
+                    "--destination": "s3://${dataset_bucket_name}/domain=ASCWDS/",
                     "--source.$": "$.jobs.ingest_ascwds_dataset.source"
                 }
             },


### PR DESCRIPTION
# Description

When a file is uploaded to the `sfc-data-engineering-raw` S3 bucket it will send a notification to eventbridge.
An event bridge rule, set up in this PR,  will invoke when it receives a notification that a worker or workplace file has been uploaded (It checks the S3 object prefix looks like `domain=ASCWDS/dataset=worker`).
When invoked the rule triggers a step function, with the path of the uploaded file as an input.
The step function runs the ingest ASC WDS glue job & then a crawler.
