### PR TITLE
Mark that state machines depend on the step function role

### DIFF
--- a/terraform/pipeline/step-function.tf
+++ b/terraform/pipeline/step-function.tf
@@ -15,6 +15,10 @@ resource "aws_sfn_state_machine" "ethnicity-breakdown-state-machine" {
     include_execution_data = true
     level                  = "ERROR"
   }
+
+  depends_on = [
+    aws_iam_role.step_function_iam_role
+  ]
 }
 
 resource "aws_cloudwatch_log_group" "state_machines" {
@@ -36,6 +40,10 @@ resource "aws_sfn_state_machine" "transform_ascwds_state_machine" {
     include_execution_data = true
     level                  = "ERROR"
   }
+
+  depends_on = [
+    aws_iam_role.step_function_iam_role
+  ]
 }
 
 resource "aws_iam_role" "step_function_iam_role" {


### PR DESCRIPTION
# Description
This was failing the apply step with an Acces Denied when the functionality of the state machines and the role were updated in tandem. 


As evidenced on [this workflow run](https://app.circleci.com/pipelines/github/NMDSdevopsServiceAdm/DataEngineering/779/workflows/fc11187d-bda6-43cd-b0d6-81cc6d7e3e28)