### PR TITLE
Github actions to trigger a circle ci workflow to destroy terraform

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,19 @@
 version: 2.1
 
+parameters:
+  GHA_Actor:
+    type: string
+    default: ""
+  GHA_Action:
+    type: string
+    default: ""
+  GHA_Event:
+    type: string
+    default: ""
+  GHA_Meta:
+    type: string
+    default: ""
+
 orbs:
   aws-s3: circleci/aws-s3@3.0
 
@@ -107,10 +121,31 @@ jobs:
           from: dependencies
           to: "s3://$(cat terraform/pipeline/pipeline_resources_bucket_name)/dependencies"
 
-          
+  terraform-destroy:
+    working_directory: /tmp/project
+    docker:
+      - image: docker.mirror.hashicorp.services/hashicorp/terraform:1.2.1
+    resource_class: small
+    steps:
+      - checkout
+      - run:
+          name: Print github actions vars
+          command: |
+            echo << pipeline.parameters.GHA_Meta >>
+      # - run:
+      #     name: terraform destroy
+      #     command: |
+      #       cd terraform/pipeline
+      #       terraform init -input=false
+      #       terraform workspace select << pipeline.parameters.GHA_Meta >>
+      #       terraform destroy -auto-approve
+      #       terraform workspace select default
+      #       terraform workspace delete << pipeline.parameters.GHA_Meta >>
+
 workflows:
   version: 2
   test-plan-approve-and-deploy-to-main:
+    unless: << pipeline.parameters.GHA_Action >>
     jobs:
       - test:
           filters:
@@ -131,7 +166,8 @@ workflows:
             - terraform-apply
 
   
-  test-plan-and-deploy-to-dev:    
+  test-plan-and-deploy-to-dev:
+    unless: << pipeline.parameters.GHA_Action >>
     jobs:
       - test:
           filters:
@@ -146,3 +182,8 @@ workflows:
       - deploy-dependencies:
           requires:
             - terraform-apply
+
+  delete-development-environment:
+    when: << pipeline.parameters.GHA_Action >>
+    jobs:
+      - terraform-destroy

--- a/.github/workflows/delete-development-environments.yml
+++ b/.github/workflows/delete-development-environments.yml
@@ -14,4 +14,4 @@ jobs:
         with:
           GHA_Meta: ${{ github.event.ref }}
         env:
-          CCI_TOKEN: ${{ secrets.CCI_TOKEN }}
+          CCI_TOKEN: ${{ secrets.CIRCLECI_TOKEN }}

--- a/.github/workflows/delete-development-environments.yml
+++ b/.github/workflows/delete-development-environments.yml
@@ -1,0 +1,17 @@
+name: delete-dev-envs
+
+on: [ delete ]
+
+jobs:
+  trigger-circleci-delete:
+    runs-on: ubuntu-latest
+    steps:
+      - name: print branch details
+        run: echo "ref - ${{ github.event.ref }}, ref_type - ${{ github.event.ref_type }}"
+
+      - name: Trigger circle CI delete development environment workflow
+        uses: CircleCI-Public/trigger-circleci-pipeline-action@v1.0.5
+        with:
+          GHA_Meta: ${{ github.event.ref }}
+        env:
+          CCI_TOKEN: ${{ secrets.CCI_TOKEN }}


### PR DESCRIPTION
Circle CI doesn't have an option to hook into branch deletion events on its own, so using github actions as an intermediary.

This PR creates a GitHub action that's triggered on a branch being deleted. 
The Github action will trigger a circle ci workflow pipeline, we pass the branch name to the pipeline via the `GHA_Meta` parameter. ([docs for the orb that does this](https://github.com/marketplace/actions/trigger-circleci-pipeline)). 
In the circle CI pipeline conditionals have been added to only run a new delete dev environments workflow if it's triggered in this way.
This workflow will run terraform destroy and delete the workspace.

I've commented out the step to destroy the terraform and have printed some info in Github actions and circleci to check it's hooked up properly first.
