### PR TITLE
Add count for services offered when feature engineering for locations

### DIFF
--- a/jobs/locations_feature_engineering.py
+++ b/jobs/locations_feature_engineering.py
@@ -1,0 +1,37 @@
+import argparse
+
+from utils import utils
+import pyspark.sql.functions as F
+
+
+def main(prepared_locations_source):
+    spark = utils.get_spark()
+
+    locations_df = spark.read.option("basePath", prepared_locations_source).parquet(
+        prepared_locations_source
+    )
+
+    locations_df = locations_df.withColumn(
+        "service_count", F.size(locations_df.services_offered)
+    )
+
+    return locations_df
+
+
+def collect_arguments():
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument(
+        "--prepared_locations_source",
+        help="Source S3 directory for data engineering prepared locations dataset",
+        required=True,
+    )
+    args, _ = parser.parse_known_args()
+
+    return args.prepared_locations_source
+
+
+if __name__ == "__main__":
+    (prepared_locations_source) = collect_arguments()
+
+    main(prepared_locations_source)

--- a/tests/test_file_generator.py
+++ b/tests/test_file_generator.py
@@ -561,6 +561,24 @@ def generate_ascwds_worker_file(output_destination):
     return df
 
 
+def generate_prepared_locations_file_parquet(output_destination):
+    spark = utils.get_spark()
+    columns = ["location_id", "services_offered"]
+
+    rows = [
+        ("1-1783948", ["Domiciliary care service", "Supported living service"]),
+        ("1-1334987222", ["Domiciliary care service"]),
+        ("1-348374832", ["Domiciliary care service", "Extra Care housing services"]),
+    ]
+
+    df = spark.createDataFrame(rows, columns)
+
+    if output_destination:
+        df.coalesce(1).write.mode("overwrite").parquet(output_destination)
+
+    return df
+
+
 def generate_locationid_and_providerid_file(output_destination):
     spark = utils.get_spark()
     columns = ["providerId", "locationId", "other_cols"]

--- a/tests/unit/test_locations_feature_engineering.py
+++ b/tests/unit/test_locations_feature_engineering.py
@@ -1,0 +1,32 @@
+import unittest
+import shutil
+
+from pyspark.sql import SparkSession
+from jobs.locations_feature_engineering import main
+from tests.test_file_generator import generate_prepared_locations_file_parquet
+
+
+class LocationsFeatureEngineeringTests(unittest.TestCase):
+    PREPARED_LOCATIONS_TEST_DATA = (
+        "tests/test_data/domain=data_engineering/dataset=prepared_locations"
+    )
+
+    def setUp(self):
+        self.spark = SparkSession.builder.appName(
+            "test_locations_feature_engineering"
+        ).getOrCreate()
+        generate_prepared_locations_file_parquet(self.PREPARED_LOCATIONS_TEST_DATA)
+        return super().setUp()
+
+    def tearDown(self) -> None:
+        shutil.rmtree(self.PREPARED_LOCATIONS_TEST_DATA)
+        return super().tearDown()
+
+    def test_main_adds_service_count_column(self):
+        df = main(self.PREPARED_LOCATIONS_TEST_DATA)
+        self.assertIn("service_count", df.columns)
+
+        rows = df.collect()
+
+        self.assertEqual(rows[0].service_count, 2)
+        self.assertEqual(rows[1].service_count, 1)


### PR DESCRIPTION
# Description
[Trello](https://trello.com/c/yA3U9fTn/322-epic2-a-prepare-data-to-apply-model-feature-engineering-and-vectorise-columns)

A job script for locations feature engineering that reads in the prepared locations and adds a column with a count of the number of services a location offers.

# Developer checklist
- [x] Unit test
- [x] Linked to Trello ticket
- [ ] Documentation up to date
