### PR TITLE
Run terraform destroy and then delete workspace on branch delete

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -152,18 +152,18 @@ jobs:
     steps:
       - checkout
       - run:
-          name: Print github actions vars
+          name: terraform destroy
           command: |
-            echo << pipeline.parameters.GHA_Meta >>
-      # - run:
-      #     name: terraform destroy
-      #     command: |
-      #       cd terraform/pipeline
-      #       terraform init -input=false
-      #       terraform workspace select << pipeline.parameters.GHA_Meta >>
-      #       terraform destroy -auto-approve
-      #       terraform workspace select default
-      #       terraform workspace delete << pipeline.parameters.GHA_Meta >>
+            cd terraform/pipeline
+            terraform init -input=false
+            terraform workspace select << pipeline.parameters.GHA_Meta >>
+            terraform destroy -auto-approve
+      - run:
+          name: delete workspace
+          command: |
+            cd terraform/pipeline
+            terraform workspace select default
+            terraform workspace delete << pipeline.parameters.GHA_Meta >>
 
 workflows:
   version: 2

--- a/.github/workflows/delete-development-environments.yml
+++ b/.github/workflows/delete-development-environments.yml
@@ -6,9 +6,8 @@ jobs:
   trigger-circleci-delete:
     runs-on: ubuntu-latest
     steps:
-      - name: print branch details
-        run: echo "ref - ${{ github.event.ref }}, ref_type - ${{ github.event.ref_type }}"
-
+      - name: print branch name
+        run: echo "Calling Cicle CI pipeline with parameter GHA_Meta - ${{ github.event.ref }}"
       - name: Trigger circle CI delete development environment workflow
         uses: CircleCI-Public/trigger-circleci-pipeline-action@v1.0.5
         with:


### PR DESCRIPTION
[Trello](https://trello.com/c/FN4iE08m/330-run-destroy-development-resources-when-github-branches-are-deleted)

# Description
Now adding in the code to delete the dev resources, after successfully testing that the branch name was being passed in as a parameter to the circle ci pipeline and that the delete development environments workflow is only triggered on branch delete.


