### PR TITLE
A couple of tweaks to region formatting in feature engineering

### DIFF
--- a/jobs/locations_feature_engineering.py
+++ b/jobs/locations_feature_engineering.py
@@ -1,4 +1,5 @@
 import argparse
+import re
 
 import pyspark.sql.functions as F
 from pyspark.ml.feature import VectorAssembler
@@ -35,7 +36,9 @@ def explode_regions(locations_df):
     distinct_region_rows = locations_df.select("region").distinct().na.drop().collect()
     regions = []
     for row in distinct_region_rows:
+        non_lower_alpha = re.compile("[^a-z_]")
         region_column_name = row.region.replace(" ", "_").lower()
+        region_column_name = re.sub(non_lower_alpha, "", region_column_name)
         regions.append(region_column_name)
 
         locations_df = locations_df.withColumn(

--- a/jobs/locations_feature_engineering.py
+++ b/jobs/locations_feature_engineering.py
@@ -32,7 +32,7 @@ def main(prepared_locations_source, destination=None):
 
 
 def explode_regions(locations_df):
-    distinct_region_rows = locations_df.select("region").distinct().collect()
+    distinct_region_rows = locations_df.select("region").distinct().na.drop().collect()
     regions = []
     for row in distinct_region_rows:
         region_column_name = row.region.replace(" ", "_").lower()

--- a/terraform/pipeline/glue.tf
+++ b/terraform/pipeline/glue.tf
@@ -55,8 +55,8 @@ module "locations_feature_engineering_job" {
   datasets_bucket = module.datasets_bucket
 
   job_parameters = {
-    "--prepared_locations_source" = "${module.datasets_bucket.bucket_uri}/domain=data_engineering/dataset=locations_prepared/"
-    "--destination"               = ""
+    "--prepared_locations_source" = "${module.datasets_bucket.bucket_uri}/domain=data_engineering/dataset=locations_prepared/version=1.0.0/"
+    "--destination"               = "${module.datasets_bucket.bucket_uri}/domain=data_engineering/dataset=locations_ml_features/version=1.0.0/"
   }
 }
 

--- a/tests/test_file_generator.py
+++ b/tests/test_file_generator.py
@@ -599,7 +599,7 @@ def generate_prepared_locations_file_parquet(output_destination):
         ("1-1060912125","20220112", "Yorkshire and The Humbler", 2, True, ["Acute services with overnight beds"]),
         ("1-107095666","20220301", "Yorkshire and The Humbler", 2, True, ["Specialist college service","Community based services for people who misuse substances","Urgent care services'"]),
         ("1-108369587","20220308", "South West", 2, True, ["Specialist college service"]),
-        ("1-10758359583","20220308", "Yorkshire and The Humbler", 2, True, ["Mobile doctors service"]),
+        ("1-10758359583","20220308", None, 2, True, ["Mobile doctors service"]),
         ("1-108387554","20220381", "Yorkshire and The Humbler", 2, True, ["Doctors treatment service", "Hospice services at home"]),
         ("1-10894414510","20220308", "Yorkshire and The Humbler", 2, True, ["Care home service with nursing"]),
         ("1-108950835","20220315", "Merseyside", 2, True, ["Care home service without nursing'"]),

--- a/tests/test_file_generator.py
+++ b/tests/test_file_generator.py
@@ -603,7 +603,7 @@ def generate_prepared_locations_file_parquet(output_destination):
         ("1-108387554","20220381", "Yorkshire and The Humbler", 2, True, ["Doctors treatment service", "Hospice services at home"]),
         ("1-10894414510","20220308", "Yorkshire and The Humbler", 2, True, ["Care home service with nursing"]),
         ("1-108950835","20220315", "Merseyside", 2, True, ["Care home service without nursing'"]),
-        ("1-108967195","20220422", "Merseyside", 2, True, ["Domiciliary care service"]),
+        ("1-108967195","20220422", "(pseudo) Wales", 2, True, ["Domiciliary care service"]),
     ]
     # fmt: on
 

--- a/tests/unit/test_locations_feature_engineering.py
+++ b/tests/unit/test_locations_feature_engineering.py
@@ -108,15 +108,17 @@ class LocationsFeatureEngineeringTests(unittest.TestCase):
         self.assertIn("south_east", regions)
         self.assertIn("south_west", regions)
         self.assertIn("yorkshire_and_the_humbler", regions)
+        self.assertIn("pseudo_wales", regions)
 
         self.assertNotIn("South East", regions)
         self.assertNotIn("South West", regions)
         self.assertNotIn("Yorkshire and The Humbler", regions)
+        self.assertNotIn("(pseudo) Wales", regions)
 
     def test_explode_regions_returns_distinct_regions(self):
         _, regions = locations_feature_engineering.explode_regions(self.test_df)
 
-        self.assertEqual(len(regions), 5)
+        self.assertEqual(len(regions), 6)
 
     def test_explode_regions_creates_a_column_for_each_region(self):
         df, regions = locations_feature_engineering.explode_regions(self.test_df)


### PR DESCRIPTION
[Trello](https://trello.com/b/WVIoMpEh/data-engineering)
# Description
Based on testing the glue jobs against the full data set, the following changes have been made
- Handles null values in the region field
- Removes any non alpha (plus _) character from region (this is to accommodate for `(pseudo) Wales`, but I think James has handled these in a different way so I'll check with him when he's back)
- I also added the full paths for destination/ source datasets as default arguments in glue so you don't have to add it whilst testing.

# Developer checklist
- [x] Unit test
- [x] Linked to Trello ticket
