### PR TITLE
empty development s3 buckets on tf destroy

### DIFF
--- a/terraform/pipeline/main.tf
+++ b/terraform/pipeline/main.tf
@@ -15,7 +15,8 @@ terraform {
 }
 
 locals {
-  workspace_prefix = substr(lower(replace(terraform.workspace, "/[^a-zA-Z0-9]+/", "-")), 0, 30)
+  workspace_prefix           = substr(lower(replace(terraform.workspace, "/[^a-zA-Z0-9]+/", "-")), 0, 30)
+  is_development_environment = local.workspace_prefix != "main"
 }
 
 data "aws_caller_identity" "current" {}

--- a/terraform/pipeline/s3.tf
+++ b/terraform/pipeline/s3.tf
@@ -1,11 +1,11 @@
 module "pipeline_resources" {
   source                  = "../modules/s3-bucket"
   bucket_name             = "${local.workspace_prefix}-pipeline-resources"
-  empty_bucket_on_destroy = true
+  empty_bucket_on_destroy = local.is_development_environment
 }
 
 module "datasets_bucket" {
   source                  = "../modules/s3-bucket"
   bucket_name             = "${local.workspace_prefix}-datasets"
-  empty_bucket_on_destroy = false
+  empty_bucket_on_destroy = local.is_development_environment
 }


### PR DESCRIPTION
# Description

By default, you can't delete S3 buckets with objects inside them using terraform, which makes sense for our main environment but not the development ones.

This enables terraform to empty S3 buckets before deleting them on our development environments so that they can be easily torn down after merging a branch.


