### PR TITLE
Full read access to main datasets from development workspaces

### DIFF
--- a/terraform/pipeline/iam.tf
+++ b/terraform/pipeline/iam.tf
@@ -97,7 +97,7 @@ resource "aws_iam_policy" "glue_jobs_read_raw_s3_data_policy" {
         ],
         "Resource" : [
           "arn:aws:s3:::sfc-data-engineering-raw/*",
-          "arn:aws:s3:::sfc-main-datasets/domain=CQC*"
+          "arn:aws:s3:::sfc-main-datasets/*"
         ]
       }
     ]


### PR DESCRIPTION
So that we can test against full datasets on our branch workspaces