### PR TITLE
Estimate all jobs

### DIFF
--- a/jobs/estimate_job_counts.py
+++ b/jobs/estimate_job_counts.py
@@ -44,6 +44,7 @@ def main(
             PIR_SERVICE_USERS,
             NUMBER_OF_BEDS,
             SNAPSHOT_DATE,
+            JOB_COUNT,
         )
         .filter(f"{REGISTRATION_STATUS} = 'Registered'")
     )
@@ -224,9 +225,9 @@ def insert_predictions_into_locations(locations_df, predictions_df):
 
     locations_with_predictions = locations_with_predictions.withColumn(
         ESTIMATE_JOB_COUNT,
-        F.when(F.col("prediction").isNotNull(), F.col("prediction")).otherwise(
-            F.col(ESTIMATE_JOB_COUNT)
-        ),
+        F.when(
+            F.col(ESTIMATE_JOB_COUNT).isNotNull(), F.col(ESTIMATE_JOB_COUNT)
+        ).otherwise(F.col("prediction")),
     )
 
     locations_df = locations_with_predictions.drop(F.col("prediction"))

--- a/jobs/estimate_job_counts.py
+++ b/jobs/estimate_job_counts.py
@@ -46,8 +46,7 @@ def main(
             SNAPSHOT_DATE,
         )
         .filter(
-            f"{REGISTRATION_STATUS} = 'Registered' \
-            and {SNAPSHOT_DATE} = {snapshot_date}"
+            f"{REGISTRATION_STATUS} = 'Registered'"
         )
     )
 

--- a/terraform/pipeline/glue.tf
+++ b/terraform/pipeline/glue.tf
@@ -87,7 +87,7 @@ module "job_role_breakdown_job" {
   }
 }
 
-module "estimate_2021_jobs_job" {
+module "estimate_job_counts_job" {
   source          = "../modules/glue-job"
   script_name     = "estimate_job_counts.py"
   glue_role       = aws_iam_role.sfc_glue_service_iam_role

--- a/terraform/pipeline/step-function.tf
+++ b/terraform/pipeline/step-function.tf
@@ -5,7 +5,7 @@ resource "aws_sfn_state_machine" "ethnicity-breakdown-state-machine" {
   definition = templatefile("step-functions/EthnicityBreakdownPipeline-StepFunction.json", {
     ingest_ascwds_job_name               = module.ingest_ascwds_dataset_job.job_name
     prepare_locations_job_name           = module.prepare_locations_job.job_name
-    estimate_2021_jobs_job_name          = module.estimate_2021_jobs_job.job_name
+    estimate_2021_jobs_job_name          = module.estimate_job_counts_job.job_name
     data_engineering_ascwds_crawler_name = module.ascwds_crawler.crawler_name
     data_engineering_crawler_name        = module.data_engineering_crawler.crawler_name
   })

--- a/tests/unit/test_estimate_job_counts.py
+++ b/tests/unit/test_estimate_job_counts.py
@@ -42,7 +42,7 @@ class EstimateJobCountTests(unittest.TestCase):
         self.assertEqual(df[3]["primary_service_type"], "non-residential")
 
     def test_model_populate_known_2021_jobs(self):
-        columns = ["locationid", "job_count_2021", "estimate_job_count_2021"]
+        columns = ["locationid", "job_count_2021", "estimate_job_count"]
         rows = [
             ("1-000000001", 1, None),
             ("1-000000002", None, None),
@@ -55,17 +55,17 @@ class EstimateJobCountTests(unittest.TestCase):
         self.assertEqual(df.count(), 4)
 
         df = df.collect()
-        self.assertEqual(df[0]["estimate_job_count_2021"], 1)
-        self.assertEqual(df[1]["estimate_job_count_2021"], None)
-        self.assertEqual(df[2]["estimate_job_count_2021"], 4)
-        self.assertEqual(df[3]["estimate_job_count_2021"], 10)
+        self.assertEqual(df[0]["estimate_job_count"], 1)
+        self.assertEqual(df[1]["estimate_job_count"], None)
+        self.assertEqual(df[2]["estimate_job_count"], 4)
+        self.assertEqual(df[3]["estimate_job_count"], 10)
 
     def test_model_non_res_historical(self):
         columns = [
             "locationid",
             "primary_service_type",
             "last_known_job_count",
-            "estimate_job_count_2021",
+            "estimate_job_count",
         ]
         rows = [
             ("1-000000001", "non-residential", 10, None),
@@ -79,10 +79,10 @@ class EstimateJobCountTests(unittest.TestCase):
         self.assertEqual(df.count(), 4)
 
         df = df.collect()
-        self.assertEqual(df[0]["estimate_job_count_2021"], 10.3)
-        self.assertEqual(df[1]["estimate_job_count_2021"], None)
-        self.assertEqual(df[2]["estimate_job_count_2021"], 20.6)
-        self.assertEqual(df[3]["estimate_job_count_2021"], 10)
+        self.assertEqual(df[0]["estimate_job_count"], 10.3)
+        self.assertEqual(df[1]["estimate_job_count"], None)
+        self.assertEqual(df[2]["estimate_job_count"], 20.6)
+        self.assertEqual(df[3]["estimate_job_count"], 10)
 
     def test_model_non_res_historical_pir(self):
         columns = [
@@ -90,7 +90,7 @@ class EstimateJobCountTests(unittest.TestCase):
             "primary_service_type",
             "last_known_job_count",
             "pir_service_users",
-            "estimate_job_count_2021",
+            "estimate_job_count",
         ]
         rows = [
             ("1-000000001", "non-residential", 10, 5, None),
@@ -104,16 +104,16 @@ class EstimateJobCountTests(unittest.TestCase):
         self.assertEqual(df.count(), 4)
 
         df = df.collect()
-        self.assertEqual(df[0]["estimate_job_count_2021"], 27.391)
-        self.assertEqual(df[1]["estimate_job_count_2021"], None)
-        self.assertEqual(df[2]["estimate_job_count_2021"], 29.735999999999997)
-        self.assertEqual(df[3]["estimate_job_count_2021"], 10)
+        self.assertEqual(df[0]["estimate_job_count"], 27.391)
+        self.assertEqual(df[1]["estimate_job_count"], None)
+        self.assertEqual(df[2]["estimate_job_count"], 29.735999999999997)
+        self.assertEqual(df[3]["estimate_job_count"], 10)
 
     def test_model_non_res_default(self):
         columns = [
             "locationid",
             "primary_service_type",
-            "estimate_job_count_2021",
+            "estimate_job_count",
         ]
         rows = [
             ("1-000000001", "non-residential", None),
@@ -127,10 +127,10 @@ class EstimateJobCountTests(unittest.TestCase):
         self.assertEqual(df.count(), 4)
 
         df = df.collect()
-        self.assertEqual(df[0]["estimate_job_count_2021"], 54.09)
-        self.assertEqual(df[1]["estimate_job_count_2021"], None)
-        self.assertEqual(df[2]["estimate_job_count_2021"], 54.09)
-        self.assertEqual(df[3]["estimate_job_count_2021"], 10)
+        self.assertEqual(df[0]["estimate_job_count"], 54.09)
+        self.assertEqual(df[1]["estimate_job_count"], None)
+        self.assertEqual(df[2]["estimate_job_count"], 54.09)
+        self.assertEqual(df[3]["estimate_job_count"], 10)
 
     def generate_features_df(self):
         # fmt: off
@@ -167,7 +167,7 @@ class EstimateJobCountTests(unittest.TestCase):
             "locationid",
             "primary_service_type",
             "last_known_job_count",
-            "estimate_job_count_2021",
+            "estimate_job_count",
             "carehome",
             "region",
             "number_of_beds",
@@ -207,8 +207,8 @@ class EstimateJobCountTests(unittest.TestCase):
             df["locationid"] == "1-000000002"
         ).collect()[0]
 
-        self.assertIsNotNone(expected_location_with_prediction.estimate_job_count_2021)
-        self.assertIsNone(expected_location_without_prediction.estimate_job_count_2021)
+        self.assertIsNotNone(expected_location_with_prediction.estimate_job_count)
+        self.assertIsNone(expected_location_without_prediction.estimate_job_count)
 
     def test_insert_predictions_into_locations_doesnt_remove_existing_estimates(self):
         locations_df = self.generate_locations_df()
@@ -219,9 +219,9 @@ class EstimateJobCountTests(unittest.TestCase):
         expected_location_with_prediction = df.where(
             df["locationid"] == "1-000000004"
         ).collect()[0]
-        self.assertEqual(expected_location_with_prediction.estimate_job_count_2021, 10)
+        self.assertEqual(expected_location_with_prediction.estimate_job_count, 10)
 
-    def test_insert_predictions_into_locations_inserts_prediction_when_locationid_matches(
+    def test_insert_predictions_into_locations_does_so_when_locationid_matches(
         self,
     ):
         locations_df = self.generate_locations_df()
@@ -235,10 +235,8 @@ class EstimateJobCountTests(unittest.TestCase):
         expected_location_without_prediction = df.where(
             df["locationid"] == "1-000000003"
         ).collect()[0]
-        self.assertEqual(
-            expected_location_with_prediction.estimate_job_count_2021, 56.89
-        )
-        self.assertIsNone(expected_location_without_prediction.estimate_job_count_2021)
+        self.assertEqual(expected_location_with_prediction.estimate_job_count, 56.89)
+        self.assertIsNone(expected_location_without_prediction.estimate_job_count)
 
     def test_insert_predictions_into_locations_only_inserts_for_matching_snapshots(
         self,
@@ -251,7 +249,7 @@ class EstimateJobCountTests(unittest.TestCase):
         expected_location_without_prediction = df.where(
             (df["locationid"] == "1-000000001") & (df["snapshot_date"] == "2022-02-20")
         ).collect()[0]
-        self.assertIsNone(expected_location_without_prediction.estimate_job_count_2021)
+        self.assertIsNone(expected_location_without_prediction.estimate_job_count)
 
     def test_insert_predictions_into_locations_removes_all_columns_from_predictions_df(
         self,
@@ -268,7 +266,7 @@ class EstimateJobCountTests(unittest.TestCase):
             "primary_service_type",
             "pir_service_users",
             "number_of_beds",
-            "estimate_job_count_2021",
+            "estimate_job_count",
         ]
         rows = [
             ("1-000000001", "Care home with nursing", 10, 10, None),
@@ -282,17 +280,17 @@ class EstimateJobCountTests(unittest.TestCase):
         self.assertEqual(df.count(), 4)
 
         df = df.collect()
-        self.assertEqual(df[0]["estimate_job_count_2021"], 13.544000000000002)
-        self.assertEqual(df[1]["estimate_job_count_2021"], None)
-        self.assertEqual(df[2]["estimate_job_count_2021"], None)
-        self.assertEqual(df[3]["estimate_job_count_2021"], 10)
+        self.assertEqual(df[0]["estimate_job_count"], 13.544000000000002)
+        self.assertEqual(df[1]["estimate_job_count"], None)
+        self.assertEqual(df[2]["estimate_job_count"], None)
+        self.assertEqual(df[3]["estimate_job_count"], 10)
 
     def test_model_care_home_with_nursing_cqc_beds(self):
         columns = [
             "locationid",
             "primary_service_type",
             "number_of_beds",
-            "estimate_job_count_2021",
+            "estimate_job_count",
         ]
         rows = [
             ("1-000000001", "Care home with nursing", 10, None),
@@ -306,10 +304,10 @@ class EstimateJobCountTests(unittest.TestCase):
         self.assertEqual(df.count(), 4)
 
         df = df.collect()
-        self.assertEqual(df[0]["estimate_job_count_2021"], 14.420000000000002)
-        self.assertEqual(df[1]["estimate_job_count_2021"], None)
-        self.assertEqual(df[2]["estimate_job_count_2021"], 8.405000000000001)
-        self.assertEqual(df[3]["estimate_job_count_2021"], 10)
+        self.assertEqual(df[0]["estimate_job_count"], 14.420000000000002)
+        self.assertEqual(df[1]["estimate_job_count"], None)
+        self.assertEqual(df[2]["estimate_job_count"], 8.405000000000001)
+        self.assertEqual(df[3]["estimate_job_count"], 10)
 
     def test_model_care_home_without_nursing_cqc_beds_and_pir(self):
         columns = [
@@ -317,7 +315,7 @@ class EstimateJobCountTests(unittest.TestCase):
             "primary_service_type",
             "pir_service_users",
             "number_of_beds",
-            "estimate_job_count_2021",
+            "estimate_job_count",
         ]
         rows = [
             ("1-000000001", "Care home without nursing", 10, 5, None),
@@ -331,17 +329,17 @@ class EstimateJobCountTests(unittest.TestCase):
         self.assertEqual(df.count(), 4)
 
         df = df.collect()
-        self.assertEqual(df[0]["estimate_job_count_2021"], 16.467)
-        self.assertEqual(df[1]["estimate_job_count_2021"], None)
-        self.assertEqual(df[2]["estimate_job_count_2021"], None)
-        self.assertEqual(df[3]["estimate_job_count_2021"], 10)
+        self.assertEqual(df[0]["estimate_job_count"], 16.467)
+        self.assertEqual(df[1]["estimate_job_count"], None)
+        self.assertEqual(df[2]["estimate_job_count"], None)
+        self.assertEqual(df[3]["estimate_job_count"], 10)
 
     def test_model_care_home_without_nursing_cqc_beds(self):
         columns = [
             "locationid",
             "primary_service_type",
             "number_of_beds",
-            "estimate_job_count_2021",
+            "estimate_job_count",
         ]
         rows = [
             ("1-000000001", "Care home without nursing", 10, None),
@@ -355,10 +353,10 @@ class EstimateJobCountTests(unittest.TestCase):
         self.assertEqual(df.count(), 4)
 
         df = df.collect()
-        self.assertEqual(df[0]["estimate_job_count_2021"], 19.417)
-        self.assertEqual(df[1]["estimate_job_count_2021"], None)
-        self.assertEqual(df[2]["estimate_job_count_2021"], 27.543)
-        self.assertEqual(df[3]["estimate_job_count_2021"], 10)
+        self.assertEqual(df[0]["estimate_job_count"], 19.417)
+        self.assertEqual(df[1]["estimate_job_count"], None)
+        self.assertEqual(df[2]["estimate_job_count"], 27.543)
+        self.assertEqual(df[3]["estimate_job_count"], 10)
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_estimate_job_counts.py
+++ b/tests/unit/test_estimate_job_counts.py
@@ -218,7 +218,8 @@ class EstimateJobCountTests(unittest.TestCase):
         columns = [ "locationid", "primary_service_type", "job_count", "carehome", "region", "number_of_beds", "snapshot_date", "prediction" ]
 
         rows = [
-            ("1-000000001", "Care home with nursing", 10, "Y", "South West", 67, "2022-03-29", 56.89)
+            ("1-000000001", "Care home with nursing", 10, "Y", "South West", 67, "2022-03-29", 56.89),
+            ("1-000000004", "non-residential", 10, "N", None, 0, "2022-03-29", 12.34),
         ]
         # fmt: on
         return self.spark.createDataFrame(


### PR DESCRIPTION
[Trello](https://trello.com/c/tTX25vvy/335-epic2-update-estimate-2021-jobs-to-estimate-jobs-all-time)
# Description

- Renaming all variables and column names to not reference 2021 anymore
- Removing columns for `job_count_2019`, `job_count_2020` & `job_count_2021`
- Using the value of `job_count` for `estimate_job_count` if it exist for the location in the snapshot
- Setting the `last_known_job_count` as the job_count in the snapshot most recent to the current one where job count is populated.
- Also noticed that the estimated_job_count worked out by the model was overwriting an actual job_count, so fixed this.  

# How to test

# Developer checklist
- [x] Unit test
- [x] Linked to Trello ticket
