### PR TITLE
Increase resources for prepare locations

### DIFF
--- a/terraform/modules/glue-job/glue.tf
+++ b/terraform/modules/glue-job/glue.tf
@@ -2,8 +2,8 @@ resource "aws_glue_job" "glue_job" {
   name              = local.job_name
   role_arn          = var.glue_role.arn
   glue_version      = var.glue_version
-  worker_type       = "Standard"
-  number_of_workers = 2
+  worker_type       = var.worker_type
+  number_of_workers = var.number_of_workers
   max_retries       = 0
 
   execution_property {

--- a/terraform/modules/glue-job/optional-inputs.tf
+++ b/terraform/modules/glue-job/optional-inputs.tf
@@ -25,3 +25,15 @@ variable "glue_version" {
     error_message = "Must be one of 1.0, 2.0 of 3.0"
   }
 }
+
+variable "worker_type" {
+  description = "Glue worker type"
+  default     = "Standard"
+  type        = string
+}
+
+variable "number_of_workers" {
+  description = "Number of glue workers"
+  default     = 2
+  type        = number
+}

--- a/terraform/modules/glue-job/optional-inputs.tf
+++ b/terraform/modules/glue-job/optional-inputs.tf
@@ -30,10 +30,20 @@ variable "worker_type" {
   description = "Glue worker type"
   default     = "Standard"
   type        = string
+
+  validation {
+    condition     = contains(["Standard", "G.1X", "G.2X"], var.worker_type)
+    error_message = "Must be one of Standard, G.1X or G.2X"
+  }
 }
 
 variable "number_of_workers" {
   description = "Number of glue workers"
   default     = 2
   type        = number
+
+  validation {
+    condition     = var.number_of_workers >= 2
+    error_message = "Must be at least 2"
+  }
 }

--- a/terraform/pipeline/glue.tf
+++ b/terraform/pipeline/glue.tf
@@ -32,11 +32,14 @@ module "ingest_ascwds_dataset_job" {
 }
 
 module "prepare_locations_job" {
-  source          = "../modules/glue-job"
-  script_name     = "prepare_locations.py"
-  glue_role       = aws_iam_role.sfc_glue_service_iam_role
-  resource_bucket = module.pipeline_resources
-  datasets_bucket = module.datasets_bucket
+  source            = "../modules/glue-job"
+  script_name       = "prepare_locations.py"
+  glue_role         = aws_iam_role.sfc_glue_service_iam_role
+  glue_version      = "3.0"
+  worker_type       = "G.2X"
+  number_of_workers = 6
+  resource_bucket   = module.pipeline_resources
+  datasets_bucket   = module.datasets_bucket
 
   job_parameters = {
     "--workplace_source"    = "${module.datasets_bucket.bucket_uri}/domain=ASCWDS/dataset=workplace/"


### PR DESCRIPTION
# Description
- Update glue job terraform module to allow the number of workers and worker type to be configurable.
- Increases the number of workers for the prepare locations job and gives it workers with more memory
- Upgraded glue version of prepare locations job

With the current resource allocation, the prepare locations job can't handle running against all the data with all versions.
