### PR TITLE
Partition output data from prepare locations. 

### DIFF
--- a/jobs/prepare_locations.py
+++ b/jobs/prepare_locations.py
@@ -2,7 +2,7 @@ import argparse
 import builtins
 
 import pyspark.sql.functions as F
-from pyspark.sql.types import StringType, IntegerType, StructField, StructType
+from pyspark.sql.types import IntegerType
 from pyspark.sql.utils import AnalysisException
 
 from utils import utils
@@ -334,30 +334,6 @@ def generate_closest_date_matrix(
         )
 
     return date_matrix
-
-
-def date_matrix_to_df(matrix):
-    spark = utils.get_spark()
-    schema = StructType(
-        [
-            StructField("snapshot_date", StringType(), True),
-            StructField("asc_workplace_date", StringType(), True),
-            StructField("cqc_location_date", StringType(), True),
-            StructField("cqc_provider_date", StringType(), True),
-            StructField("pir_date", StringType(), True),
-        ]
-    )
-    matrix = [
-        (
-            row["snapshot_date"],
-            row["asc_workplace_date"],
-            row["cqc_location_date"],
-            row["cqc_provider_date"],
-            row["pir_date"],
-        )
-        for row in matrix
-    ]
-    return spark.createDataFrame(data=matrix, schema=schema)
 
 
 def clean(input_df):

--- a/jobs/prepare_locations.py
+++ b/jobs/prepare_locations.py
@@ -11,7 +11,9 @@ from pyspark.sql.functions import (
     max,
     when,
 )
+import pyspark.sql.functions as F
 from pyspark.sql.types import StringType, IntegerType, StructField, StructType
+from pyspark.sql.utils import AnalysisException
 from datetime import datetime
 
 from utils import utils
@@ -31,10 +33,17 @@ def main(
     print("Building locations prepared dataset")
     master_df = None
 
-    complete_ascwds_workplace_df = get_ascwds_workplace_df(workplace_source)
-    complete_cqc_location_df = get_cqc_location_df(cqc_location_source)
-    complete_cqc_provider_df = get_cqc_provider_df(cqc_provider_source)
-    complete_pir_df = get_pir_df(pir_source)
+    max_snapshot_date_processed = get_max_snapshot_of_locations_prepared(destination)
+    complete_ascwds_workplace_df = get_ascwds_workplace_df(
+        workplace_source, since_date=max_snapshot_date_processed
+    )
+    complete_cqc_location_df = get_cqc_location_df(
+        cqc_location_source, since_date=max_snapshot_date_processed
+    )
+    complete_cqc_provider_df = get_cqc_provider_df(
+        cqc_provider_source, since_date=max_snapshot_date_processed
+    )
+    complete_pir_df = get_pir_df(pir_source, since_date=max_snapshot_date_processed)
 
     date_matrix = generate_closest_date_matrix(
         complete_ascwds_workplace_df,
@@ -83,7 +92,6 @@ def main(
         output_df = output_df.withColumn(
             "snapshot_date", F.lit(snapshot_date_row["snapshot_date"])
         )
-        output_df = utils.format_import_date(output_df, fieldname="snapshot_date")
         output_df = output_df.withColumn(
             "snapshot_year", col("snapshot_date").substr(1, 4)
         )
@@ -93,6 +101,7 @@ def main(
         output_df = output_df.withColumn(
             "snapshot_day", col("snapshot_date").substr(7, 2)
         )
+        output_df = utils.format_import_date(output_df, fieldname="snapshot_date")
 
         output_df = output_df.select(
             "snapshot_date",
@@ -139,7 +148,6 @@ def main(
                 append=True,
                 partitionKeys=["snapshot_year", "snapshot_month", "snapshot_day"],
             )
-        else:
             if master_df is None:
                 master_df = output_df
             else:
@@ -147,8 +155,22 @@ def main(
     return master_df
 
 
-def get_max_snapshot_of_locations_prepared():
-    return ""
+def get_max_snapshot_of_locations_prepared(destination):
+    spark = utils.get_spark()
+    try:
+        previous_snpashots = spark.read.option("basePath", destination).parquet(
+            destination
+        )
+    except AnalysisException:
+        return None
+
+    max_year = previous_snpashots.select(F.max("snapshot_year")).first()[0]
+    previous_snpashots = previous_snpashots.where(F.col("snapshot_year") == max_year)
+    max_month = previous_snpashots.select(F.max("snapshot_month")).first()[0]
+    previous_snpashots = previous_snpashots.where(F.col("snapshot_month") == max_month)
+    max_day = previous_snpashots.select(F.max("snapshot_day")).first()[0]
+
+    return f"{max_year}{max_month:0>2}{max_day:0>2}"
 
 
 def get_ascwds_workplace_df(workplace_source, since_date=None):
@@ -225,8 +247,7 @@ def get_cqc_location_df(cqc_location_source, since_date=None):
 def filter_out_import_dates_older_than(df, date):
     if date is None:
         return df
-    since_date = date.strftime("%Y%m%d")
-    return df.filter(col("import_date") > since_date)
+    return df.filter(col("import_date") > date)
 
 
 def get_cqc_provider_df(cqc_provider_source, since_date=None):

--- a/jobs/prepare_locations.py
+++ b/jobs/prepare_locations.py
@@ -1,7 +1,21 @@
 import argparse
 import builtins
 
-import pyspark.sql.functions as F
+from pyspark.sql.functions import (
+    abs,
+    add_months,
+    coalesce,
+    col,
+    greatest,
+    lit,
+    lower,
+    max,
+    when,
+    year,
+    month,
+    dayofmonth,
+    lpad,
+)
 from pyspark.sql.types import DateType, IntegerType, StructField, StructType
 
 from utils import utils
@@ -72,6 +86,13 @@ def main(
         output_df = output_df.withColumn(
             "snapshot_date", F.lit(snapshot_date_row["snapshot_date"])
         )
+        output_df = output_df.withColumn("snapshot_year", year(col("snapshot_date")))
+        output_df = output_df.withColumn(
+            "snapshot_month", lpad(month(col("snapshot_date")), 2, "0")
+        )
+        output_df = output_df.withColumn(
+            "snapshot_day", lpad(dayofmonth(col("snapshot_date")), 2, "0")
+        )
 
         if master_df is None:
             master_df = output_df
@@ -80,6 +101,9 @@ def main(
 
     master_df = master_df.select(
         "snapshot_date",
+        "snapshot_year",
+        "snapshot_month",
+        "snapshot_day",
         "ascwds_workplace_import_date",
         "cqc_locations_import_date",
         "cqc_providers_import_date",
@@ -110,7 +134,11 @@ def main(
 
     if destination:
         print(f"Exporting as parquet to {destination}")
-        utils.write_to_parquet(master_df, destination)
+        utils.write_to_parquet(
+            master_df,
+            destination,
+            partitionKeys=["snapshot_year", "snapshot_month", "snapshot_day"],
+        )
     else:
         return master_df
 

--- a/jobs/prepare_locations.py
+++ b/jobs/prepare_locations.py
@@ -154,11 +154,9 @@ def get_max_snapshot_of_locations_prepared(destination):
         return None
 
     max_year = previous_snpashots.select(F.max("snapshot_year")).first()[0]
-    previous_snpashots = previous_snpashots.where(F.F.col("snapshot_year") == max_year)
+    previous_snpashots = previous_snpashots.where(F.col("snapshot_year") == max_year)
     max_month = previous_snpashots.select(F.max("snapshot_month")).first()[0]
-    previous_snpashots = previous_snpashots.where(
-        F.F.col("snapshot_month") == max_month
-    )
+    previous_snpashots = previous_snpashots.where(F.col("snapshot_month") == max_month)
     max_day = previous_snpashots.select(F.max("snapshot_day")).first()[0]
 
     return f"{max_year}{max_month:0>2}{max_day:0>2}"

--- a/terraform/modules/glue-job/glue.tf
+++ b/terraform/modules/glue-job/glue.tf
@@ -18,5 +18,6 @@ resource "aws_glue_job" "glue_job" {
       "--extra-py-files"                   = "${var.resource_bucket.bucket_uri}/dependencies/dependencies.zip"
       "--TempDir"                          = "${var.resource_bucket.bucket_uri}/temp/"
       "--enable-continuous-cloudwatch-log" = "true"
+      "--enable-auto-scaling"              = var.worker_type == "Standard" ? "false" : "true"
   })
 }

--- a/terraform/pipeline/glue.tf
+++ b/terraform/pipeline/glue.tf
@@ -42,11 +42,11 @@ module "prepare_locations_job" {
   datasets_bucket   = module.datasets_bucket
 
   job_parameters = {
-    "--workplace_source"    = "${module.datasets_bucket.bucket_uri}/domain=ASCWDS/dataset=workplace/"
-    "--cqc_location_source" = "${module.datasets_bucket.bucket_uri}/domain=CQC/dataset=locations-api/"
-    "--cqc_provider_source" = "${module.datasets_bucket.bucket_uri}/domain=CQC/dataset=providers-api/"
-    "--pir_source"          = "${module.datasets_bucket.bucket_uri}/domain=CQC/dataset=pir/"
-    "--destination"         = ""
+    "--workplace_source"    = "s3://sfc-main-datasets/domain=ASCWDS/dataset=workplace/"
+    "--cqc_location_source" = "s3://sfc-main-datasets/domain=CQC/dataset=locations-api/"
+    "--cqc_provider_source" = "s3://sfc-main-datasets/domain=CQC/dataset=providers-api/"
+    "--pir_source"          = "s3://sfc-main-datasets/domain=CQC/dataset=pir/"
+    "--destination"         = "${module.datasets_bucket.bucket_uri}/domain=data_engineering/dataset=locations_prepared/version=1.0.0/"
   }
 }
 

--- a/terraform/pipeline/glue.tf
+++ b/terraform/pipeline/glue.tf
@@ -42,10 +42,10 @@ module "prepare_locations_job" {
   datasets_bucket   = module.datasets_bucket
 
   job_parameters = {
-    "--workplace_source"    = "s3://sfc-main-datasets/domain=ASCWDS/dataset=workplace/"
-    "--cqc_location_source" = "s3://sfc-main-datasets/domain=CQC/dataset=locations-api/"
-    "--cqc_provider_source" = "s3://sfc-main-datasets/domain=CQC/dataset=providers-api/"
-    "--pir_source"          = "s3://sfc-main-datasets/domain=CQC/dataset=pir/"
+    "--workplace_source"    = "${module.datasets_bucket.bucket_uri}/domain=ASCWDS/dataset=workplace/"
+    "--cqc_location_source" = "${module.datasets_bucket.bucket_uri}/domain=CQC/dataset=locations-api/"
+    "--cqc_provider_source" = "${module.datasets_bucket.bucket_uri}/domain=CQC/dataset=providers-api/"
+    "--pir_source"          = "${module.datasets_bucket.bucket_uri}/domain=CQC/dataset=pir/"
     "--destination"         = "${module.datasets_bucket.bucket_uri}/domain=data_engineering/dataset=locations_prepared/version=1.0.0/"
   }
 }

--- a/tests/test_file_generator.py
+++ b/tests/test_file_generator.py
@@ -193,57 +193,14 @@ def generate_ethnicity_census_lsoa_csv(output_destination):
         "Black/African/Caribbean/Black British",
         "Other ethnic group",
     ]
-
+    # fmt: off
     rows = [
-        (
-            "E01000001 : Area name 001A",
-            "876",
-            "767",
-            "608",
-            "18",
-            "141",
-            "15",
-            "74",
-            "4",
-            "16",
-        ),
-        (
-            "E01000002 : Area name 001B",
-            "830",
-            "763",
-            "630",
-            "13",
-            "120",
-            "16",
-            "45",
-            "2",
-            "4",
-        ),
-        (
-            "E01000003 : Area name 001C",
-            "817",
-            "678",
-            "533",
-            "26",
-            "119",
-            "22",
-            "84",
-            "20",
-            "13",
-        ),
-        (
-            "E01000005 : Area name 001E",
-            "467",
-            "311",
-            "222",
-            "11",
-            "78",
-            "23",
-            "77",
-            "37",
-            "19",
-        ),
+        ("E01000001 : Area name 001A", "876", "767", "608", "18", "141", "15", "74", "4", "16"),
+        ("E01000002 : Area name 001B","830","763","630","13","120","16","45","2","4"),
+        ("E01000003 : Area name 001C","817","678","533","26","119","22","84","20","13"),
+        ("E01000005 : Area name 001E","467","311","222","11","78","23","77","37","19"),
     ]
+    # fmt: on
 
     df = spark.createDataFrame(rows, columns)
 
@@ -312,21 +269,21 @@ def generate_cqc_locations_file(output_destination):
 
     # fmt: off
     rows = [
-        ("1-000000001", 1, "location", "Social Care Org", "name of organisation", "Registered", "2011-02-15", None, "N", 50, "Yorkshire & Humberside", "OX29 9UB", "Y", "Rochester and Strood", "Medway", [{"name": "Nursing homes", "description": "Care home service with nursing"}], "20220101"),
-        ("1-000000002", 2, "location", "Social Care Org", "name of organisation", "Registered", "2011-02-15", None, "N", 50, "South East", "OX29 9UB", "Y", "Rochester and Strood", "Medway", [{"name": "Nursing homes", "description": "Care home service with nursing"}], "20220101"),
-        ("1-000000003", 3, "location", "Social Care Org", "name of organisation", "Registered", "2011-02-15", None, "N", 50, "South East", "OX29 9UB", "Y", "Rochester and Strood", "Medway", [{"name": "Nursing homes", "description": "Care home service without nursing"}], "20220101"),
-        ("1-000000004", 4, "location", "Social Care Org", "name of organisation", "Registered", "2011-02-15", None, "Y", 50, "Yorkshire & Humberside", "OX29 9UB", "Y", "Rochester and Strood", "Medway", [{"name": "Nursing homes", "description": "Care home service without nursing"}], "20220101"),
-        ("1-000000005", 4, "location", "Social Care Org", "name of organisation", "Registered", "2011-02-15", None, "N", 50, "South East", "OX29 9UB", "Y", "Rochester and Strood", "Medway", [{"name": "Nursing homes", "description": "Care home service without nursing"}], "20220101"),
-        ("1-000000006", 5, "location", "Social Care Org", "name of organisation", "Registered", "2011-02-15", None, "N", 50, "South East", "OX29 9UB", "Y", "Rochester and Strood", "Medway", [{"name": "Nursing homes", "description": "Care home service without nursing"}], "20220101"),
-        ("1-000000007", 5, "location", "Social Care Org", "name of organisation", "Registered", "2011-02-15", None, "N", 50, "Yorkshire and The Humber", "OX29 9UB", "Y", "Rochester and Strood", "Medway", [{"name": "Nursing homes", "description": "Care home service without nursing"}], "20220101"),
-        ("1-000000008", 6, "location", "Social Care Org", "name of organisation", "Registered", "2011-02-15", None, "N", 50, "South East", "OX29 9UB", "Y", "Rochester and Strood", "Medway", [{"name": "Nursing homes", "description": "Care home service without nursing"}], "20220101"),
-        ("1-000000009", 7, "location", "Social Care Org", "name of organisation", "Registered", "2011-02-15", None, "Y", 50, "South East", "OX29 9UB", "Y", "Rochester and Strood", "Medway", [{"name": "Nursing homes", "description": "Care home service without nursing"}], "20220101"),
-        ("1-000000010", 8, "location", "Social Care Org", "name of organisation", "Registered", "2011-02-15", None, "N", 50, "South East", "OX29 9UB", "Y", "Rochester and Strood", "Medway", [{"name": "Nursing homes", "description": "Care home service with nursing"}], "20220101"),
-        ("1-000000011", 9, "location", "Social Care Org", "name of organisation", "Registered", "2011-02-15", None, "N", 50, "South East", "OX29 9UB", "Y", "Rochester and Strood", "Medway", [{"name": "Nursing homes", "description": "Care home service with nursing"}], "20220101"),
-        ("1-000000012", 9, "location", "Social Care Org", "name of organisation", "Registered", "2011-02-15", None, "N", 50, "South East", "OX29 9UB", "Y", "Rochester and Strood", "Medway", [{"name": "Nursing homes", "description": "Care home service with nursing"}], "20220101"),
-        ("1-000000013", 10, "location", "Social Care Org", "name of organisation", "Deregistered", "2011-02-15", "2015-01-01", "N", 50, "South East", "OX29 9UB", "Y", "Rochester and Strood", "Medway", [{"name": "Nursing homes", "description": "Care home service with nursing"}], "20220101"),
-        ("1-000000014", 11, "location", "Social Care Org", "name of organisation", "Registered", "2011-02-15", None, "N", 50, "South East", "OX29 9UB", "Y", "Rochester and Strood", "Medway", [{"name": "Nursing homes", "description": "Care home service with nursing"}], "20220101"),
-        ("1-000000015", 12, "location", "Not social care", "name of organisation", "Registered", "2011-02-15", None, "N", 50, "South East", "OX29 9UB", "Y", "Rochester and Strood", "Medway", [{"name": "Nursing homes", "description": "Care home service with nursing"}], "20220101"),
+        ("1-000000001", 1, "location", "Social Care Org", "name of organisation", "Registered", "2011-02-15", None, "N", 50, "Yorkshire & Humberside", "OX29 9UB", "Y", "Rochester and Strood", "Medway", [{"name": "Nursing homes", "description": "Care home service with nursing"}], "20200101"),
+        ("1-000000002", 2, "location", "Social Care Org", "name of organisation", "Registered", "2011-02-15", None, "N", 50, "South East", "OX29 9UB", "Y", "Rochester and Strood", "Medway", [{"name": "Nursing homes", "description": "Care home service with nursing"}], "20190101"),
+        ("1-000000003", 3, "location", "Social Care Org", "name of organisation", "Registered", "2011-02-15", None, "N", 50, "South East", "OX29 9UB", "Y", "Rochester and Strood", "Medway", [{"name": "Nursing homes", "description": "Care home service without nursing"}], "20200101"),
+        ("1-000000004", 4, "location", "Social Care Org", "name of organisation", "Registered", "2011-02-15", None, "Y", 50, "Yorkshire & Humberside", "OX29 9UB", "Y", "Rochester and Strood", "Medway", [{"name": "Nursing homes", "description": "Care home service without nursing"}], "20190101"),
+        ("1-000000005", 4, "location", "Social Care Org", "name of organisation", "Registered", "2011-02-15", None, "N", 50, "South East", "OX29 9UB", "Y", "Rochester and Strood", "Medway", [{"name": "Nursing homes", "description": "Care home service without nursing"}], "20190101"),
+        ("1-000000006", 5, "location", "Social Care Org", "name of organisation", "Registered", "2011-02-15", None, "N", 50, "South East", "OX29 9UB", "Y", "Rochester and Strood", "Medway", [{"name": "Nursing homes", "description": "Care home service without nursing"}], "20190101"),
+        ("1-000000007", 5, "location", "Social Care Org", "name of organisation", "Registered", "2011-02-15", None, "N", 50, "Yorkshire and The Humber", "OX29 9UB", "Y", "Rochester and Strood", "Medway", [{"name": "Nursing homes", "description": "Care home service without nursing"}], "20190101"),
+        ("1-000000008", 6, "location", "Social Care Org", "name of organisation", "Registered", "2011-02-15", None, "N", 50, "South East", "OX29 9UB", "Y", "Rochester and Strood", "Medway", [{"name": "Nursing homes", "description": "Care home service without nursing"}], "20190101"),
+        ("1-000000009", 7, "location", "Social Care Org", "name of organisation", "Registered", "2011-02-15", None, "Y", 50, "South East", "OX29 9UB", "Y", "Rochester and Strood", "Medway", [{"name": "Nursing homes", "description": "Care home service without nursing"}], "20190101"),
+        ("1-000000010", 8, "location", "Social Care Org", "name of organisation", "Registered", "2011-02-15", None, "N", 50, "South East", "OX29 9UB", "Y", "Rochester and Strood", "Medway", [{"name": "Nursing homes", "description": "Care home service with nursing"}], "20200101"),
+        ("1-000000011", 9, "location", "Social Care Org", "name of organisation", "Registered", "2011-02-15", None, "N", 50, "South East", "OX29 9UB", "Y", "Rochester and Strood", "Medway", [{"name": "Nursing homes", "description": "Care home service with nursing"}], "20200101"),
+        ("1-000000012", 9, "location", "Social Care Org", "name of organisation", "Registered", "2011-02-15", None, "N", 50, "South East", "OX29 9UB", "Y", "Rochester and Strood", "Medway", [{"name": "Nursing homes", "description": "Care home service with nursing"}], "20200101"),
+        ("1-000000013", 10, "location", "Social Care Org", "name of organisation", "Deregistered", "2011-02-15", "2015-01-01", "N", 50, "South East", "OX29 9UB", "Y", "Rochester and Strood", "Medway", [{"name": "Nursing homes", "description": "Care home service with nursing"}], "20200101"),
+        ("1-000000014", 11, "location", "Social Care Org", "name of organisation", "Registered", "2011-02-15", None, "N", 50, "South East", "OX29 9UB", "Y", "Rochester and Strood", "Medway", [{"name": "Nursing homes", "description": "Care home service with nursing"}], "20200101"),
+        ("1-000000015", 12, "location", "Not social care", "name of organisation", "Registered", "2011-02-15", None, "N", 50, "South East", "OX29 9UB", "Y", "Rochester and Strood", "Medway", [{"name": "Nursing homes", "description": "Care home service with nursing"}], "20200101"),
         ("1-000000001", 1, "location", "Social Care Org", "name of organisation", "Registered", "2011-02-15", None, "Y", 50, "South East", "OX29 9UB", "Y", "Rochester and Strood", "Medway", [{"name": "Nursing homes", "description": "Care home service with nursing"}], "20210101"),
         ("1-000000002", 2, "location", "Social Care Org", "name of organisation", "Registered", "2011-02-15", None, "N", 50, "Yorkshire and The Humber", "OX29 9UB", "Y", "Rochester and Strood", "Medway", [{"name": "Nursing homes", "description": "Care home service with nursing"}], "20210101"),
         ("1-000000003", 3, "location", "Social Care Org", "name of organisation", "Registered", "2011-02-15", None, "N", 50, "South East", "OX29 9UB", "Y", "Rochester and Strood", "Medway", [{"name": "Nursing homes", "description": "Care home service without nursing"}], "20210101"),
@@ -336,12 +293,12 @@ def generate_cqc_locations_file(output_destination):
         ("1-000000007", 5, "location", "Social Care Org", "name of organisation", "Registered", "2011-02-15", None, "N", 50, "Yorkshire and The Humber", "OX29 9UB", "Y", "Rochester and Strood", "Medway", [{"name": "Nursing homes", "description": "Care home service without nursing"}], "20210101"),
         ("1-000000008", 6, "location", "Social Care Org", "name of organisation", "Registered", "2011-02-15", None, "N", 50, "South East", "OX29 9UB", "Y", "Rochester and Strood", "Medway", [{"name": "Nursing homes", "description": "Care home service without nursing"}], "20210101"),
         ("1-000000009", 7, "location", "Social Care Org", "name of organisation", "Registered", "2011-02-15", None, "Y", 50, "South East", "OX29 9UB", "Y", "Rochester and Strood", "Medway", [{"name": "Nursing homes", "description": "Care home service without nursing"}], "20210101"),
-        ("1-000000010", 8, "location", "Social Care Org", "name of organisation", "Registered", "2011-02-15", None, "N", 50, "South East", "OX29 9UB", "Y", "Rochester and Strood", "Medway", [{"name": "Nursing homes", "description": "Care home service with nursing"}], "20210101"),
-        ("1-000000011", 9, "location", "Social Care Org", "name of organisation", "Registered", "2011-02-15", None, "N", 50, "South East", "OX29 9UB", "Y", "Rochester and Strood", "Medway", [{"name": "Nursing homes", "description": "Care home service with nursing"}], "20210101"),
-        ("1-000000012", 9, "location", "Social Care Org", "name of organisation", "Registered", "2011-02-15", None, "N", 50, "South East", "OX29 9UB", "Y", "Rochester and Strood", "Medway", [{"name": "Nursing homes", "description": "Care home service with nursing"}], "20210101"),
-        ("1-000000013", 10, "location", "Social Care Org", "name of organisation", "Deregistered", "2011-02-15", "2015-01-01", "N", 50, "South East", "OX29 9UB", "Y", "Rochester and Strood", "Medway", [{"name": "Nursing homes", "description": "Care home service with nursing"}], "20210101"),
-        ("1-000000014", 11, "location", "Social Care Org", "name of organisation", "Registered", "2011-02-15", None, "N", 50, "South East", "OX29 9UB", "Y", "Rochester and Strood", "Medway", [{"name": "Nursing homes", "description": "Care home service with nursing"}], "20210101"),
-        ("1-000000015", 12, "location", "Not social care", "name of organisation", "Registered", "2011-02-15", None, "N", 50, "South East", "OX29 9UB", "Y", "Rochester and Strood", "Medway", [{"name": "Nursing homes", "description": "Care home service with nursing"}], "20210101"),
+        ("1-000000010", 8, "location", "Social Care Org", "name of organisation", "Registered", "2011-02-15", None, "N", 50, "South East", "OX29 9UB", "Y", "Rochester and Strood", "Medway", [{"name": "Nursing homes", "description": "Care home service with nursing"}], "20220101"),
+        ("1-000000011", 9, "location", "Social Care Org", "name of organisation", "Registered", "2011-02-15", None, "N", 50, "South East", "OX29 9UB", "Y", "Rochester and Strood", "Medway", [{"name": "Nursing homes", "description": "Care home service with nursing"}], "20220101"),
+        ("1-000000012", 9, "location", "Social Care Org", "name of organisation", "Registered", "2011-02-15", None, "N", 50, "South East", "OX29 9UB", "Y", "Rochester and Strood", "Medway", [{"name": "Nursing homes", "description": "Care home service with nursing"}], "20220101"),
+        ("1-000000013", 10, "location", "Social Care Org", "name of organisation", "Deregistered", "2011-02-15", "2015-01-01", "N", 50, "South East", "OX29 9UB", "Y", "Rochester and Strood", "Medway", [{"name": "Nursing homes", "description": "Care home service with nursing"}], "20220101"),
+        ("1-000000014", 11, "location", "Social Care Org", "name of organisation", "Registered", "2011-02-15", None, "N", 50, "South East", "OX29 9UB", "Y", "Rochester and Strood", "Medway", [{"name": "Nursing homes", "description": "Care home service with nursing"}], "20220101"),
+        ("1-000000015", 12, "location", "Not social care", "name of organisation", "Registered", "2011-02-15", None, "N", 50, "South East", "OX29 9UB", "Y", "Rochester and Strood", "Medway", [{"name": "Nursing homes", "description": "Care home service with nursing"}], "20220101"),
     ]
     # fmt: on
 
@@ -365,7 +322,7 @@ def generate_cqc_providers_file(output_destination):
     )
 
     rows = [
-        (1, "new provider name 1", "20220105"),
+        (1, "new provider name 1", "20220605"),
         (2, "provider name 2", "20220105"),
         (3, "provider name 3", "20220105"),
         (1, "provider name 1", "20210105"),
@@ -402,8 +359,8 @@ def generate_pir_file(output_destination):
     )
 
     rows = [
-        ("1-000000001", 20, "20220105"),
-        ("1-000000002", 10, "20220105"),
+        ("1-000000001", 20, "20220605"),
+        ("1-000000002", 10, "20220605"),
         ("1-000000003", 16, "20220105"),
         ("1-000000004", 29, "20220105"),
         ("1-000000005", 93, "20220105"),
@@ -443,20 +400,20 @@ def generate_ascwds_workplace_file(output_destination):
     ]
 
     rows = [
+        ("1-000000001", "101", 14, 16, "20200101", "1", date(2021, 2, 1), 0),
+        ("1-000000002", "102", 76, 65, "20200101", "1", date(2021, 4, 1), 1),
+        ("1-000000003", "103", 34, 34, "20200101", "2", date(2021, 3, 1), 0),
+        ("1-000000004", "104", 234, 265, "20190101", "2", date(2021, 4, 1), 0),
+        ("1-000000005", "105", 62, 65, "20190101", "3", date(2021, 10, 1), 0),
+        ("1-000000006", "106", 77, 77, "20190101", "3", date(2020, 3, 1), 1),
+        ("1-000000007", "107", 51, 42, "20190101", "3", date(2021, 5, 1), 0),
+        ("1-000000008", "108", 36, 34, "20190101", "4", date(2021, 7, 1), 0),
+        ("1-000000009", "109", 34, 32, "20190101", "5", date(2021, 12, 1), 0),
+        ("1-0000000010", "110", 14, 20, "20190101", "6", date(2021, 3, 1), 0),
         ("1-000000001", "101", 14, 16, "20220101", "1", date(2021, 2, 1), 0),
         ("1-000000002", "102", 76, 65, "20220101", "1", date(2021, 4, 1), 1),
         ("1-000000003", "103", 34, 34, "20220101", "2", date(2021, 3, 1), 0),
         ("1-000000004", "104", 234, 265, "20220101", "2", date(2021, 4, 1), 0),
-        ("1-000000005", "105", 62, 65, "20220101", "3", date(2021, 10, 1), 0),
-        ("1-000000006", "106", 77, 77, "20220101", "3", date(2020, 3, 1), 1),
-        ("1-000000007", "107", 51, 42, "20220101", "3", date(2021, 5, 1), 0),
-        ("1-000000008", "108", 36, 34, "20220101", "4", date(2021, 7, 1), 0),
-        ("1-000000009", "109", 34, 32, "20220101", "5", date(2021, 12, 1), 0),
-        ("1-0000000010", "110", 14, 20, "20220101", "6", date(2021, 3, 1), 0),
-        ("1-000000001", "101", 14, 16, "20210101", "1", date(2021, 2, 1), 0),
-        ("1-000000002", "102", 76, 65, "20210101", "1", date(2021, 4, 1), 1),
-        ("1-000000003", "103", 34, 34, "20210101", "2", date(2021, 3, 1), 0),
-        ("1-000000004", "104", 234, 265, "20210101", "2", date(2021, 4, 1), 0),
         ("1-000000005", "105", 62, 65, "20210101", "3", date(2021, 10, 1), 0),
         ("1-000000006", "106", 77, 77, "20210101", "3", date(2020, 3, 1), 1),
         ("1-000000007", "107", 51, 42, "20210101", "3", date(2021, 5, 1), 0),

--- a/tests/test_file_generator.py
+++ b/tests/test_file_generator.py
@@ -6,7 +6,6 @@ from pyspark.sql.types import (
     StringType,
     ArrayType,
     IntegerType,
-    DateType,
     LongType,
     BooleanType,
 )
@@ -584,20 +583,17 @@ def generate_prepared_locations_file_parquet(
     output_destination, partitions=["2022", "03", "08"], append=False
 ):
     spark = utils.get_spark()
-
-    schema = StructType(
-        [
-            StructField("locationid", StringType(), True),
-            StructField("snapshot_date", StringType(), True),
-            StructField("region", StringType(), True),
-            StructField("number_of_beds", LongType(), True),
-            StructField("dormancy", BooleanType(), True),
-            StructField("services_offered", ArrayType(StringType(), True), True),
-            StructField("snapshot_year", StringType(), True),
-            StructField("snapshot_month", StringType(), True),
-            StructField("snapshot_day", StringType(), True),
-        ]
-    )
+    columns = [
+        "locationid",
+        "snapshot_date",
+        "region",
+        "number_of_beds",
+        "dormancy",
+        "services_offered",
+        "snapshot_year",
+        "snapshot_month",
+        "snapshot_day",
+    ]
 
     # fmt: off
     rows = [
@@ -618,7 +614,7 @@ def generate_prepared_locations_file_parquet(
     ]
     # fmt: on
 
-    df = spark.createDataFrame(rows, schema)
+    df = spark.createDataFrame(rows, columns)
 
     df = df.withColumn("snapshot_date", F.to_date(df.snapshot_date, "yyyyMMdd"))
     if append:

--- a/tests/unit/test_locations_feature_engineering.py
+++ b/tests/unit/test_locations_feature_engineering.py
@@ -42,8 +42,9 @@ class LocationsFeatureEngineeringTests(unittest.TestCase):
         self.assertIn("service_21", df.columns)
 
         rows = df.collect()
+        test_row = next(row for row in rows if row.locationid == "1-348374832")
 
-        self.assertEqual(rows[2].service_10, 1)
+        self.assertEqual(test_row.service_10, 1)
 
     def test_main_adds_vectorized_column(self):
         df = locations_feature_engineering.main(self.PREPARED_LOCATIONS_TEST_DATA)
@@ -61,10 +62,16 @@ class LocationsFeatureEngineeringTests(unittest.TestCase):
         df = locations_feature_engineering.main(self.PREPARED_LOCATIONS_TEST_DATA)
         self.assertIn("date_diff", df.columns)
 
-        rows = df.collect()
+        results = df.collect()
+        test_date_diff_1 = next(
+            row.date_diff for row in results if row.locationid == "1-107095666"
+        )
+        test_date_diff_2 = next(
+            row.date_diff for row in results if row.locationid == "1-108967195"
+        )
 
-        self.assertEqual(rows[7].date_diff, 52)
-        self.assertEqual(rows[12].date_diff, 0)
+        self.assertEqual(test_date_diff_1, 52)
+        self.assertEqual(test_date_diff_2, 0)
 
     # OTHER METHODS TEST
 

--- a/tests/unit/test_prepare_locations.py
+++ b/tests/unit/test_prepare_locations.py
@@ -72,6 +72,9 @@ class PrepareLocationsTests(unittest.TestCase):
             output_df.columns,
             [
                 "snapshot_date",
+                "snapshot_year",
+                "snapshot_month",
+                "snapshot_day",
                 "ascwds_workplace_import_date",
                 "cqc_locations_import_date",
                 "cqc_providers_import_date",

--- a/tests/unit/test_prepare_locations.py
+++ b/tests/unit/test_prepare_locations.py
@@ -18,6 +18,7 @@ from tests.test_file_generator import (
     generate_cqc_locations_file,
     generate_cqc_providers_file,
     generate_pir_file,
+    generate_prepared_locations_file_parquet,
 )
 
 
@@ -27,6 +28,7 @@ class PrepareLocationsTests(unittest.TestCase):
     TEST_CQC_LOCATION_FILE = "tests/test_data/domain=cqc/dataset=location"
     TEST_CQC_PROVIDERS_FILE = "tests/test_data/domain=cqc/dataset=providers"
     TEST_PIR_FILE = "tests/test_data/domain=cqc/dataset=pir"
+    DESTINATION = "tests/test_data/domain=data_engineering/dataset=locations_prepared/version=1.0.0"
 
     calculate_jobs_schema = StructType(
         [
@@ -55,7 +57,8 @@ class PrepareLocationsTests(unittest.TestCase):
             shutil.rmtree(self.TEST_CQC_LOCATION_FILE)
             shutil.rmtree(self.TEST_CQC_PROVIDERS_FILE)
             shutil.rmtree(self.TEST_PIR_FILE)
-        except OSError():
+            shutil.rmtree(self.DESTINATION)
+        except OSError:
             pass  # Ignore dir does not exist
 
     def test_main_successfully_runs(self):
@@ -64,6 +67,7 @@ class PrepareLocationsTests(unittest.TestCase):
             self.TEST_CQC_LOCATION_FILE,
             self.TEST_CQC_PROVIDERS_FILE,
             self.TEST_PIR_FILE,
+            self.DESTINATION,
         )
 
         self.assertIsNotNone(output_df)
@@ -106,8 +110,9 @@ class PrepareLocationsTests(unittest.TestCase):
 
     def test_get_ascwds_workplace_df(self):
         workplace_df = prepare_locations.get_ascwds_workplace_df(
-            self.TEST_ASCWDS_WORKPLACE_FILE, date(2020, 1, 1)
+            self.TEST_ASCWDS_WORKPLACE_FILE, "20200101"
         )
+
         self.assertEqual(workplace_df.columns[0], "locationid")
         self.assertEqual(workplace_df.columns[1], "establishmentid")
         self.assertEqual(workplace_df.columns[2], "total_staff")
@@ -117,7 +122,7 @@ class PrepareLocationsTests(unittest.TestCase):
 
     def test_get_cqc_location_df(self):
         cqc_location_df = prepare_locations.get_cqc_location_df(
-            self.TEST_CQC_LOCATION_FILE, date(2020, 1, 1)
+            self.TEST_CQC_LOCATION_FILE, "20200101"
         )
 
         self.assertEqual(cqc_location_df.columns[0], "locationid")
@@ -127,7 +132,7 @@ class PrepareLocationsTests(unittest.TestCase):
 
     def test_get_cqc_provider_df(self):
         cqc_provider_df = prepare_locations.get_cqc_provider_df(
-            self.TEST_CQC_PROVIDERS_FILE, date(2021, 1, 5)
+            self.TEST_CQC_PROVIDERS_FILE, "20210105"
         )
 
         self.assertEqual(cqc_provider_df.columns[0], "providerid")
@@ -136,7 +141,7 @@ class PrepareLocationsTests(unittest.TestCase):
         self.assertEqual(cqc_provider_df.count(), 3)
 
     def test_get_pir_df(self):
-        pir_df = prepare_locations.get_pir_df(self.TEST_PIR_FILE, date(2021, 1, 5))
+        pir_df = prepare_locations.get_pir_df(self.TEST_PIR_FILE, "20210105")
 
         self.assertEqual(pir_df.count(), 8)
         self.assertEqual(len(pir_df.columns), 3)
@@ -188,7 +193,7 @@ class PrepareLocationsTests(unittest.TestCase):
 
     def test_get_unique_import_dates_from_cqc_location_dataset(self):
         cqc_location_df = prepare_locations.get_cqc_location_df(
-            self.TEST_CQC_LOCATION_FILE, date(2021, 1, 1)
+            self.TEST_CQC_LOCATION_FILE, "20210101"
         )
 
         result = prepare_locations.get_unique_import_dates(cqc_location_df)
@@ -446,6 +451,30 @@ class PrepareLocationsTests(unittest.TestCase):
         dormancy_count = cqc_locations.filter(cqc_locations.dormancy).count()
 
         self.assertEqual(dormancy_count, 5)
+
+    def test_get_max_snapshot_of_destiantion_returns_none_if_no_data(self):
+        max = prepare_locations.get_max_snapshot_of_locations_prepared(self.DESTINATION)
+
+        self.assertIsNone(max)
+
+    def test_get_max_snapshot_of_destination_returns_only_partition(self):
+        generate_prepared_locations_file_parquet(
+            self.DESTINATION, partitions=["2022", "01", "01"]
+        )
+
+        max = prepare_locations.get_max_snapshot_of_locations_prepared(self.DESTINATION)
+        self.assertEqual(max, "20220101")
+
+    def test_get_max_snapshot_of_destination_returns_max_partition(self):
+        generate_prepared_locations_file_parquet(
+            self.DESTINATION, partitions=["2022", "01", "01"], append=True
+        )
+        generate_prepared_locations_file_parquet(
+            self.DESTINATION, partitions=["2021", "02", "01"], append=True
+        )
+
+        max = prepare_locations.get_max_snapshot_of_locations_prepared(self.DESTINATION)
+        self.assertEqual(max, "20220101")
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_prepare_locations.py
+++ b/tests/unit/test_prepare_locations.py
@@ -40,8 +40,7 @@ class PrepareLocationsTests(unittest.TestCase):
         ]
     )
 
-    @classmethod
-    def setUpClass(self):
+    def setUp(self):
         self.spark = SparkSession.builder.appName(
             "test_prepare_locations"
         ).getOrCreate()
@@ -50,8 +49,7 @@ class PrepareLocationsTests(unittest.TestCase):
         generate_cqc_providers_file(self.TEST_CQC_PROVIDERS_FILE)
         generate_pir_file(self.TEST_PIR_FILE)
 
-    @classmethod
-    def tearDownClass(self):
+    def tearDown(self):
         try:
             shutil.rmtree(self.TEST_ASCWDS_WORKPLACE_FILE)
             shutil.rmtree(self.TEST_CQC_LOCATION_FILE)

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -465,7 +465,7 @@ class UtilsTests(unittest.TestCase):
         df = utils.format_import_date(self.test_workplace_df)
 
         self.assertEqual(df.schema["import_date"].dataType, DateType())
-        self.assertEqual(str(df.select("import_date").first()[0]), "2022-01-01")
+        self.assertEqual(str(df.select("import_date").first()[0]), "2020-01-01")
 
 
 if __name__ == "__main__":

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -85,7 +85,7 @@ def generate_s3_main_datasets_dir_date_path(domain, dataset, date):
 def write_to_parquet(df, output_dir, append=False, partitionKeys=[]):
 
     if append:
-        df.write.mode("append").parquet(output_dir)
+        df.write.mode("append").partitionBy(*partitionKeys).parquet(output_dir)
     else:
         df.write.partitionBy(*partitionKeys).parquet(output_dir)
 

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -82,12 +82,12 @@ def generate_s3_main_datasets_dir_date_path(domain, dataset, date):
     return output_dir
 
 
-def write_to_parquet(df, output_dir, append=False):
+def write_to_parquet(df, output_dir, append=False, partitionKeys=[]):
 
     if append:
         df.write.mode("append").parquet(output_dir)
     else:
-        df.write.parquet(output_dir)
+        df.write.partitionBy(*partitionKeys).parquet(output_dir)
 
 
 def read_csv(source, delimiter=","):


### PR DESCRIPTION
[Trello](https://trello.com/c/BgxSkZOG/340-epic4-add-date-partitions-to-data-outputs-from-transformations)
# Description
- When writing out the prepared location data partition data by `snapshot_year`, `snapshot_month`, `snapshot_day`. 
- The job will also check what the previous highest snapshot date is and only process newer snapshots than this date. 

# Developer checklist
- [x] Unit test
- [x] Linked to Trello ticket
