### PR TITLE
Partitioning output data for locations features engineering

### DIFF
--- a/jobs/locations_feature_engineering.py
+++ b/jobs/locations_feature_engineering.py
@@ -13,6 +13,8 @@ def main(prepared_locations_source, destination=None):
     locations_df = spark.read.option("basePath", prepared_locations_source).parquet(
         prepared_locations_source
     )
+    max_snapshot = utils.get_max_snapshot_partitions(destination)
+    locations_df = filter_records_since_snapshot_date(locations_df, max_snapshot)
 
     locations_df = locations_df.withColumn(
         "service_count", F.size(locations_df.services_offered)
@@ -27,9 +29,33 @@ def main(prepared_locations_source, destination=None):
 
     if destination:
         print(f"Exporting as parquet to {destination}")
-        utils.write_to_parquet(locations_df, destination)
-    else:
+        utils.write_to_parquet(
+            locations_df,
+            destination,
+            append=True,
+            partitionKeys=["snapshot_year", "snapshot_month", "snapshot_day"],
+        )
+    return locations_df
+
+
+def filter_records_since_snapshot_date(locations_df, max_snapshot):
+    if not max_snapshot:
         return locations_df
+    max_snapshot_date = f"{max_snapshot[0]}{max_snapshot[1]:0>2}{max_snapshot[2]:0>2}"
+    print(f"max snapshot previously processed: {max_snapshot_date}")
+    locations_df = locations_df.withColumn(
+        "snapshot_full_date",
+        F.concat(
+            locations_df.snapshot_year.cast("string"),
+            F.lpad(locations_df.snapshot_month.cast("string"), 2, "0"),
+            F.lpad(locations_df.snapshot_day.cast("string"), 2, "0"),
+        ),
+    )
+    locations_df = locations_df.where(
+        locations_df["snapshot_full_date"] > max_snapshot_date
+    )
+    locations_df.drop("snapshot_full_date")
+    return locations_df
 
 
 def format_region(region):

--- a/jobs/prepare_locations.py
+++ b/jobs/prepare_locations.py
@@ -2,7 +2,7 @@ import argparse
 import builtins
 
 import pyspark.sql.functions as F
-from pyspark.sql.types import StringType, IntegerType, StructField, StructType
+from pyspark.sql.types import IntegerType
 from pyspark.sql.utils import AnalysisException
 
 from utils import utils
@@ -334,30 +334,6 @@ def generate_closest_date_matrix(
         )
 
     return date_matrix
-
-
-def date_matrix_to_df(matrix):
-    spark = utils.get_spark()
-    schema = StructType(
-        [
-            StructField("snapshot_date", StringType(), True),
-            StructField("asc_workplace_date", StringType(), True),
-            StructField("cqc_location_date", StringType(), True),
-            StructField("cqc_provider_date", StringType(), True),
-            StructField("pir_date", StringType(), True),
-        ]
-    )
-    matrix = [
-        (
-            row["snapshot_date"],
-            row["asc_workplace_date"],
-            row["cqc_location_date"],
-            row["cqc_provider_date"],
-            row["pir_date"],
-        )
-        for row in matrix
-    ]
-    return spark.createDataFrame(data=matrix, schema=schema)
 
 
 def clean(input_df):

--- a/jobs/prepare_locations.py
+++ b/jobs/prepare_locations.py
@@ -3,7 +3,6 @@ import builtins
 
 import pyspark.sql.functions as F
 from pyspark.sql.types import IntegerType
-from pyspark.sql.utils import AnalysisException
 
 from utils import utils
 

--- a/jobs/prepare_locations.py
+++ b/jobs/prepare_locations.py
@@ -154,11 +154,9 @@ def get_max_snapshot_of_locations_prepared(destination):
         return None
 
     max_year = previous_snpashots.select(F.max("snapshot_year")).first()[0]
-    previous_snpashots = previous_snpashots.where(F.F.col("snapshot_year") == max_year)
+    previous_snpashots = previous_snpashots.where(F.col("snapshot_year") == max_year)
     max_month = previous_snpashots.select(F.max("snapshot_month")).first()[0]
-    previous_snpashots = previous_snpashots.where(
-        F.F.col("snapshot_month") == max_month
-    )
+    previous_snpashots = previous_snpashots.where(F.col("snapshot_month") == max_month)
     max_day = previous_snpashots.select(F.max("snapshot_day")).first()[0]
 
     return f"{max_year}{max_month:0>2}{max_day:0>2}"

--- a/terraform/modules/glue-job/glue.tf
+++ b/terraform/modules/glue-job/glue.tf
@@ -19,5 +19,6 @@ resource "aws_glue_job" "glue_job" {
       "--TempDir"                          = "${var.resource_bucket.bucket_uri}/temp/"
       "--enable-continuous-cloudwatch-log" = "true"
       "--enable-auto-scaling"              = var.worker_type == "Standard" ? "false" : "true"
+      "--conf"                             = "spark.sql.sources.partitionColumnTypeInference.enabled=false"
   })
 }

--- a/tests/test_file_generator.py
+++ b/tests/test_file_generator.py
@@ -579,8 +579,31 @@ def generate_flexible_worker_file_hourly_rate(salary, salaryint, hrlyrate, hrs_w
     return df
 
 
+def generate_location_features_file_parquet(output_destination=None):
+    spark = utils.get_spark()
+    # fmt: off
+    feature_columns = [ "locationid", "job_count", "carehome", "region", "snapshot_year", "snapshot_month", "snapshot_day", "snapshot_date" ]
+
+    feature_rows = [
+        ("1-000000001", 10, "Y", "South West", "2022", "02", "28", "2022-03-29"),
+        ("1-000000002", 10, "N", "Merseyside", "2022", "02", "28", "2022-03-29"),
+        ("1-000000003", 20, None, "Merseyside", "2022", "02", "28", "2022-03-29"),
+        ("1-000000004", 10, "N", None, "2022", "02", "28", "2022-03-29"),
+    ]
+    # fmt: on
+    df = spark.createDataFrame(
+        feature_rows,
+        schema=feature_columns,
+    )
+    if output_destination:
+        df.write.mode("overwrite").partitionBy(
+            "snapshot_year", "snapshot_month", "snapshot_day"
+        ).parquet(output_destination)
+    return df
+
+
 def generate_prepared_locations_file_parquet(
-    output_destination, partitions=["2022", "03", "08"], append=False
+    output_destination=None, partitions=["2022", "03", "08"], append=False
 ):
     spark = utils.get_spark()
     columns = [

--- a/tests/test_file_generator.py
+++ b/tests/test_file_generator.py
@@ -6,8 +6,6 @@ from pyspark.sql.types import (
     StringType,
     ArrayType,
     IntegerType,
-    LongType,
-    BooleanType,
 )
 import pyspark.sql.functions as F
 

--- a/tests/test_file_generator.py
+++ b/tests/test_file_generator.py
@@ -6,6 +6,7 @@ from pyspark.sql.types import (
     StringType,
     ArrayType,
     IntegerType,
+    DateType,
     LongType,
     BooleanType,
 )
@@ -583,17 +584,20 @@ def generate_prepared_locations_file_parquet(
     output_destination, partitions=["2022", "03", "08"], append=False
 ):
     spark = utils.get_spark()
-    columns = [
-        "locationid",
-        "snapshot_date",
-        "region",
-        "number_of_beds",
-        "dormancy",
-        "services_offered",
-        "snapshot_year",
-        "snapshot_month",
-        "snapshot_day",
-    ]
+
+    schema = StructType(
+        [
+            StructField("locationid", StringType(), True),
+            StructField("snapshot_date", StringType(), True),
+            StructField("region", StringType(), True),
+            StructField("number_of_beds", LongType(), True),
+            StructField("dormancy", BooleanType(), True),
+            StructField("services_offered", ArrayType(StringType(), True), True),
+            StructField("snapshot_year", StringType(), True),
+            StructField("snapshot_month", StringType(), True),
+            StructField("snapshot_day", StringType(), True),
+        ]
+    )
 
     # fmt: off
     rows = [
@@ -614,7 +618,7 @@ def generate_prepared_locations_file_parquet(
     ]
     # fmt: on
 
-    df = spark.createDataFrame(rows, columns)
+    df = spark.createDataFrame(rows, schema)
 
     df = df.withColumn("snapshot_date", F.to_date(df.snapshot_date, "yyyyMMdd"))
     if append:

--- a/tests/test_file_generator.py
+++ b/tests/test_file_generator.py
@@ -6,7 +6,6 @@ from pyspark.sql.types import (
     StringType,
     ArrayType,
     IntegerType,
-    DateType,
     LongType,
     BooleanType,
 )
@@ -584,20 +583,17 @@ def generate_prepared_locations_file_parquet(
     output_destination, partitions=["2022", "03", "08"], append=False
 ):
     spark = utils.get_spark()
-
-    schema = StructType(
-        [
-            StructField("locationid", StringType(), True),
-            StructField("snapshot_date", StringType(), True),
-            StructField("region", StringType(), True),
-            StructField("number_of_beds", LongType(), True),
-            StructField("dormancy", BooleanType(), True),
-            StructField("services_offered", ArrayType(StringType(), True), True),
-            StructField("snapshot_year", StringType(), True),
-            StructField("snapshot_month", StringType(), True),
-            StructField("snapshot_day", StringType(), True),
-        ]
-    )
+    columns = [
+        "locationid",
+        "snapshot_date",
+        "region",
+        "number_of_beds",
+        "dormancy",
+        "services_offered",
+        "snapshot_year",
+        "snapshot_month",
+        "snapshot_day",
+    ]
 
     # fmt: off
     rows = [
@@ -618,7 +614,7 @@ def generate_prepared_locations_file_parquet(
     ]
     # fmt: on
 
-    df = spark.createDataFrame(rows, schema)
+    df = spark.createDataFrame(rows, columns)
 
     df = df.withColumn("snapshot_date", F.to_date(df.snapshot_date, "yyyyMMdd"))
     if append:

--- a/tests/unit/test_prepare_locations.py
+++ b/tests/unit/test_prepare_locations.py
@@ -108,7 +108,7 @@ class PrepareLocationsTests(unittest.TestCase):
 
     def test_get_ascwds_workplace_df(self):
         workplace_df = prepare_locations.get_ascwds_workplace_df(
-            self.TEST_ASCWDS_WORKPLACE_FILE, date(2020, 1, 1)
+            self.TEST_ASCWDS_WORKPLACE_FILE, "20200101"
         )
 
         self.assertEqual(workplace_df.columns[0], "locationid")
@@ -120,7 +120,7 @@ class PrepareLocationsTests(unittest.TestCase):
 
     def test_get_cqc_location_df(self):
         cqc_location_df = prepare_locations.get_cqc_location_df(
-            self.TEST_CQC_LOCATION_FILE, date(2020, 1, 1)
+            self.TEST_CQC_LOCATION_FILE, "20200101"
         )
 
         self.assertEqual(cqc_location_df.columns[0], "locationid")
@@ -130,7 +130,7 @@ class PrepareLocationsTests(unittest.TestCase):
 
     def test_get_cqc_provider_df(self):
         cqc_provider_df = prepare_locations.get_cqc_provider_df(
-            self.TEST_CQC_PROVIDERS_FILE, date(2021, 1, 5)
+            self.TEST_CQC_PROVIDERS_FILE, "20210105"
         )
 
         self.assertEqual(cqc_provider_df.columns[0], "providerid")
@@ -139,7 +139,7 @@ class PrepareLocationsTests(unittest.TestCase):
         self.assertEqual(cqc_provider_df.count(), 3)
 
     def test_get_pir_df(self):
-        pir_df = prepare_locations.get_pir_df(self.TEST_PIR_FILE, date(2021, 1, 5))
+        pir_df = prepare_locations.get_pir_df(self.TEST_PIR_FILE, "20210105")
 
         self.assertEqual(pir_df.count(), 8)
         self.assertEqual(len(pir_df.columns), 3)
@@ -191,7 +191,7 @@ class PrepareLocationsTests(unittest.TestCase):
 
     def test_get_unique_import_dates_from_cqc_location_dataset(self):
         cqc_location_df = prepare_locations.get_cqc_location_df(
-            self.TEST_CQC_LOCATION_FILE, date(2021, 1, 1)
+            self.TEST_CQC_LOCATION_FILE, "20210101"
         )
 
         result = prepare_locations.get_unique_import_dates(cqc_location_df)

--- a/tests/unit/test_prepare_locations.py
+++ b/tests/unit/test_prepare_locations.py
@@ -450,30 +450,6 @@ class PrepareLocationsTests(unittest.TestCase):
 
         self.assertEqual(dormancy_count, 5)
 
-    def test_get_max_snapshot_of_destiantion_returns_none_if_no_data(self):
-        max = prepare_locations.get_max_snapshot_of_locations_prepared(self.DESTINATION)
-
-        self.assertIsNone(max)
-
-    def test_get_max_snapshot_of_destination_returns_only_partition(self):
-        generate_prepared_locations_file_parquet(
-            self.DESTINATION, partitions=["2022", "01", "01"]
-        )
-
-        max = prepare_locations.get_max_snapshot_of_locations_prepared(self.DESTINATION)
-        self.assertEqual(max, "20220101")
-
-    def test_get_max_snapshot_of_destination_returns_max_partition(self):
-        generate_prepared_locations_file_parquet(
-            self.DESTINATION, partitions=["2022", "01", "01"], append=True
-        )
-        generate_prepared_locations_file_parquet(
-            self.DESTINATION, partitions=["2021", "02", "01"], append=True
-        )
-
-        max = prepare_locations.get_max_snapshot_of_locations_prepared(self.DESTINATION)
-        self.assertEqual(max, "20220101")
-
 
 if __name__ == "__main__":
     unittest.main(warnings="ignore")

--- a/tests/unit/test_prepare_locations.py
+++ b/tests/unit/test_prepare_locations.py
@@ -18,7 +18,6 @@ from tests.test_file_generator import (
     generate_cqc_locations_file,
     generate_cqc_providers_file,
     generate_pir_file,
-    generate_prepared_locations_file_parquet,
 )
 
 

--- a/tests/unit/test_prepare_locations.py
+++ b/tests/unit/test_prepare_locations.py
@@ -108,7 +108,7 @@ class PrepareLocationsTests(unittest.TestCase):
 
     def test_get_ascwds_workplace_df(self):
         workplace_df = prepare_locations.get_ascwds_workplace_df(
-            self.TEST_ASCWDS_WORKPLACE_FILE, "20200101"
+            self.TEST_ASCWDS_WORKPLACE_FILE, date(2020, 1, 1)
         )
 
         self.assertEqual(workplace_df.columns[0], "locationid")
@@ -120,7 +120,7 @@ class PrepareLocationsTests(unittest.TestCase):
 
     def test_get_cqc_location_df(self):
         cqc_location_df = prepare_locations.get_cqc_location_df(
-            self.TEST_CQC_LOCATION_FILE, "20200101"
+            self.TEST_CQC_LOCATION_FILE, date(2020, 1, 1)
         )
 
         self.assertEqual(cqc_location_df.columns[0], "locationid")
@@ -130,7 +130,7 @@ class PrepareLocationsTests(unittest.TestCase):
 
     def test_get_cqc_provider_df(self):
         cqc_provider_df = prepare_locations.get_cqc_provider_df(
-            self.TEST_CQC_PROVIDERS_FILE, "20210105"
+            self.TEST_CQC_PROVIDERS_FILE, date(2021, 1, 5)
         )
 
         self.assertEqual(cqc_provider_df.columns[0], "providerid")
@@ -139,7 +139,7 @@ class PrepareLocationsTests(unittest.TestCase):
         self.assertEqual(cqc_provider_df.count(), 3)
 
     def test_get_pir_df(self):
-        pir_df = prepare_locations.get_pir_df(self.TEST_PIR_FILE, "20210105")
+        pir_df = prepare_locations.get_pir_df(self.TEST_PIR_FILE, date(2021, 1, 5))
 
         self.assertEqual(pir_df.count(), 8)
         self.assertEqual(len(pir_df.columns), 3)
@@ -191,7 +191,7 @@ class PrepareLocationsTests(unittest.TestCase):
 
     def test_get_unique_import_dates_from_cqc_location_dataset(self):
         cqc_location_df = prepare_locations.get_cqc_location_df(
-            self.TEST_CQC_LOCATION_FILE, "20210101"
+            self.TEST_CQC_LOCATION_FILE, date(2021, 1, 1)
         )
 
         result = prepare_locations.get_unique_import_dates(cqc_location_df)


### PR DESCRIPTION
[Trello](https://trello.com/c/BgxSkZOG/340-epic4-add-date-partitions-to-data-outputs-from-transformations)
# Description
- Partition the output data by `snapshot_year`, `snapshot_month`, `snapshot_day`
- Only process snapshots since the last job run

# Developer checklist
- [x] Unit test
- [x] Linked to Trello ticket
