### PR TITLE
Ingest ONS data with lookup tables

### DIFF
--- a/jobs/ingest_ons_data.py
+++ b/jobs/ingest_ons_data.py
@@ -1,0 +1,74 @@
+import sys
+
+import pyspark.sql.functions as F
+from pyspark.sql.utils import AnalysisException
+
+
+from utils import utils
+
+POSTCODE_DIR_PREFIX = "dataset=postcode-directory"
+POSTCODE_LOOKUP_DIR_PREFIX = "dataset=postcode-directory-field-lookups"
+
+
+def main(source, destination):
+    spark = utils.get_spark()
+
+    ingest_new_import_dates(
+        spark, f"{source}{POSTCODE_DIR_PREFIX}/", f"{destination}{POSTCODE_DIR_PREFIX}/"
+    )
+    all_fields = utils.get_s3_sub_folders_for_path(
+        f"{source}{POSTCODE_LOOKUP_DIR_PREFIX}/"
+    )
+
+    print(
+        f"found lookup tables for {all_fields} in {source}{POSTCODE_LOOKUP_DIR_PREFIX}"
+    )
+
+    for field in all_fields:
+        print(f"Ingesting lookup table for {field}")
+        ingest_new_import_dates(
+            spark,
+            f"{source}{POSTCODE_LOOKUP_DIR_PREFIX}/{field}/",
+            f"{destination}{POSTCODE_LOOKUP_DIR_PREFIX}/{field}/",
+        )
+
+    return
+
+
+def ingest_new_import_dates(spark, source, destination):
+    print(f"Reading CSV from {source}")
+    data_to_import = spark.read.option("header", True).csv(source)
+    previously_imported_dates = get_previous_import_dates(spark, destination)
+
+    if previously_imported_dates:
+        data_to_import = data_to_import.join(
+            previously_imported_dates,
+            data_to_import.import_date
+            == previously_imported_dates.already_imported_date,
+            "leftouter",
+        ).where(previously_imported_dates.already_imported_date.isNull())
+    print(f"Writing CSV to {destination}")
+    data_to_import.write.mode("append").partitionBy(
+        "year", "month", "day", "import_date"
+    ).parquet(destination)
+    return data_to_import
+
+
+def get_previous_import_dates(spark, destination):
+    try:
+        df = spark.read.parquet(destination)
+    except AnalysisException:
+        return None
+
+    return df.select(F.col("import_date").alias("already_imported_date")).distinct()
+
+
+if __name__ == "__main__":
+    print("Spark job 'inges_ons_data' starting...")
+    print(f"Job parameters: {sys.argv}")
+
+    ons_source, ons_destination = utils.collect_arguments(
+        ("--source", "S3 path to the ONS raw data domain"),
+        ("--destination", "S3 path to save output data"),
+    )
+    main(ons_source, ons_destination)

--- a/terraform/modules/glue-crawler/glue-crawler.tf
+++ b/terraform/modules/glue-crawler/glue-crawler.tf
@@ -1,6 +1,6 @@
 resource "aws_glue_crawler" "crawler" {
   database_name = var.workspace_glue_database_name
-  name          = "${local.workspace_prefix}-data_engineering_${var.dataset_for_crawler}"
+  name          = "${local.workspace_prefix}-data_engineering_${var.dataset_for_crawler}${var.name_postfix}"
   role          = var.glue_role.arn
   schedule      = var.schedule
 
@@ -9,7 +9,8 @@ resource "aws_glue_crawler" "crawler" {
   }
 
   s3_target {
-    path = "s3://sfc-${local.workspace_prefix}-datasets/domain=${var.dataset_for_crawler}/"
+    path       = "s3://sfc-${local.workspace_prefix}-datasets/domain=${var.dataset_for_crawler}/"
+    exclusions = var.exclusions
   }
 
   schema_change_policy {
@@ -17,11 +18,12 @@ resource "aws_glue_crawler" "crawler" {
     update_behavior = "UPDATE_IN_DATABASE"
   }
 
+
   configuration = jsonencode(
     {
       "Version" = 1.0,
       "Grouping" = {
-        "TableLevelConfiguration" = 3,
+        "TableLevelConfiguration" = var.table_level,
         "TableGroupingPolicy"     = "CombineCompatibleSchemas"
       }
     }

--- a/terraform/modules/glue-crawler/optional-inputs.tf
+++ b/terraform/modules/glue-crawler/optional-inputs.tf
@@ -4,3 +4,21 @@ variable "schedule" {
   default     = null
 
 }
+
+variable "exclusions" {
+  description = "An optional list of glob pattern to exclude from the crawl"
+  type        = list(string)
+  default     = null
+}
+
+variable "table_level" {
+  description = "Level in the S3 path at which to create tables. Default is set to 3 inline with bucket/domain/dataset structrue."
+  type        = number
+  default     = 3
+}
+
+variable "name_postfix" {
+  description = "Optional postfix to add to the crawler name"
+  type        = string
+  default     = ""
+}

--- a/terraform/pipeline/glue.tf
+++ b/terraform/pipeline/glue.tf
@@ -37,7 +37,7 @@ module "ingest_ons_data_job" {
   glue_role       = aws_iam_role.sfc_glue_service_iam_role
   resource_bucket = module.pipeline_resources
   datasets_bucket = module.datasets_bucket
-  version         = "3.0"
+  glue_version    = "3.0"
 
   job_parameters = {
     "--source"      = ""
@@ -192,4 +192,15 @@ module "ons_crawler" {
   dataset_for_crawler          = "ONS"
   glue_role                    = aws_iam_role.sfc_glue_service_iam_role
   workspace_glue_database_name = "${local.workspace_prefix}-${var.glue_database_name}"
+  exclusions                   = ["dataset=postcode-directory-field-lookups/**"]
+}
+
+module "ons_lookups_crawler" {
+  source                       = "../modules/glue-crawler"
+  dataset_for_crawler          = "ONS"
+  name_postfix                 = "_lookups"
+  glue_role                    = aws_iam_role.sfc_glue_service_iam_role
+  workspace_glue_database_name = "${local.workspace_prefix}-${var.glue_database_name}"
+  exclusions                   = ["dataset=postcode-directory/**"]
+  table_level                  = 4
 }

--- a/terraform/pipeline/glue.tf
+++ b/terraform/pipeline/glue.tf
@@ -31,6 +31,20 @@ module "ingest_ascwds_dataset_job" {
   }
 }
 
+module "ingest_ons_data_job" {
+  source          = "../modules/glue-job"
+  script_name     = "ingest_ons_data.py"
+  glue_role       = aws_iam_role.sfc_glue_service_iam_role
+  resource_bucket = module.pipeline_resources
+  datasets_bucket = module.datasets_bucket
+  version         = "3.0"
+
+  job_parameters = {
+    "--source"      = ""
+    "--destination" = "${module.datasets_bucket.bucket_uri}/domain=ONS/"
+  }
+}
+
 module "prepare_locations_job" {
   source            = "../modules/glue-job"
   script_name       = "prepare_locations.py"

--- a/terraform/pipeline/glue.tf
+++ b/terraform/pipeline/glue.tf
@@ -172,3 +172,10 @@ module "cqc_crawler" {
   schedule                     = "cron(00 07 * * ? *)"
   workspace_glue_database_name = "${local.workspace_prefix}-${var.glue_database_name}"
 }
+
+module "ons_crawler" {
+  source                       = "../modules/glue-crawler"
+  dataset_for_crawler          = "ONS"
+  glue_role                    = aws_iam_role.sfc_glue_service_iam_role
+  workspace_glue_database_name = "${local.workspace_prefix}-${var.glue_database_name}"
+}

--- a/tests/test_file_generator.py
+++ b/tests/test_file_generator.py
@@ -388,6 +388,23 @@ def generate_pir_file(output_destination):
     return df
 
 
+def generate_ons_data(output_destination):
+    spark = utils.get_spark()
+    # fmt: off
+    columns = ["pcd", "nhser", "year", "month", "day", "import_date"]
+    rows = [
+        ("SW9 0LL", "E40000003", "2021", "02", "01", "20210201"),
+        ("BH1 1QZ", "E40000006", "2021", "02", "01", "20210201"),
+        ("PO6 2EQ", "E40000005", "2021", "02", "01", "20210201"),
+    ]
+    # fmt: on
+
+    df = spark.createDataFrame(rows, columns)
+    if output_destination:
+        df.coalesce(1).write.mode("overwrite").parquet(output_destination)
+    return df
+
+
 def generate_ascwds_workplace_file(output_destination):
     spark = utils.get_spark()
     columns = [

--- a/tests/unit/test_ingest_ons_data.py
+++ b/tests/unit/test_ingest_ons_data.py
@@ -1,0 +1,165 @@
+import shutil
+import unittest
+from pathlib import Path
+import warnings
+
+from pyspark.sql import SparkSession
+from unittest.mock import patch
+
+from jobs import ingest_ons_data
+
+
+class IngestIngestONSDataTests(unittest.TestCase):
+    DATA_SOURCE = "tests/test_data/tmp/domain=ONS/"
+    LOOKUPS_SOURCE = (
+        "tests/test_data/tmp/domain=ONS/dataset=postcode-directory-field-lookups/"
+    )
+    DESTINATION = "tests/test_data/tmp/output/domain=ONS/"
+
+    def setUp(self):
+        self.spark = (
+            SparkSession.builder.appName("sfc_data_engineering_test_ingest_ons_dataset")
+            .config("spark.sql.sources.partitionColumnTypeInference.enabled", False)
+            .getOrCreate()
+        )
+        warnings.simplefilter("ignore", ResourceWarning)
+
+    def tearDown(self):
+        try:
+            shutil.rmtree(self.DESTINATION)
+            shutil.rmtree(self.DATA_SOURCE)
+            shutil.rmtree(self.LOOKUPS_SOURCE)
+        except OSError:
+            pass
+
+    def generate_ons_test_csv_file(
+        self, output_destination, partitions=("2021", "02", "01")
+    ):
+        columns = ["pcd", "nhser", "year", "month", "day", "import_date"]
+        # fmt: off
+        rows = [
+            ("SW9 0LL", "E40000003", partitions[0], partitions[1], partitions[2], partitions[0] + partitions[1] + partitions[2]),
+            ("BH1 1QZ", "E40000006", partitions[0], partitions[1], partitions[2], partitions[0] + partitions[1] + partitions[2]),
+            ("PO6 2EQ", "E40000005", partitions[0], partitions[1], partitions[2], partitions[0] + partitions[1] + partitions[2]),
+        ]
+        # fmt: on
+
+        df = self.spark.createDataFrame(rows, columns)
+        if output_destination:
+            df.coalesce(1).write.option("header", True).mode("overwrite").partitionBy(
+                "year", "month", "day", "import_date"
+            ).csv(output_destination)
+
+    def write_csv(self, path, lines):
+        p = Path(path)
+        p.mkdir(parents=True, exist_ok=True)
+        f = open(
+            f"{path}data.csv",
+            "w",
+        )
+        for line in lines:
+            f.write(line + "\n")
+        f.close()
+
+    def generate_region_lookup_csv(self, output_destination):
+        lines = [
+            "RGN20CD,RGN20CDO,RGN20NM,RGN20NMW",
+            "E12000001,A,North East,Gogledd Ddwyrain",
+            "E12000002,B,North West,Gogledd Orllewin",
+            "E12000003,D,Yorkshire and The Humber,Swydd Efrog a Humber",
+            "E12000004,E,East Midlands,Dwyrain y Canolbarth",
+            "E12000005,F,West Midlands,Gorllewin y Canolbarth",
+        ]
+        region_file_path = f"{output_destination}field=rgn/year=2021/month=01/day=01/import_date=20210101/"
+        self.write_csv(region_file_path, lines)
+
+    def generate_nhs_region_lookup_csv(self, output_destination):
+        lines = [
+            "NHSER19CD,NHSER19CDH,NHSER19NM",
+            "E40000003,Y56,London",
+            "E40000005,Y59,South East",
+            "E40000006,Y58,South West",
+            "E40000007,Y61,East of England",
+            "E40000008,Y60,Midlands",
+            "E40000009,Y63,North East and Yorkshire",
+            "E40000010,Y62,North West",
+        ]
+        nhs_region_file_path = f"{output_destination}field=nhser/year=2021/month=01/day=01/import_date=20210101/"
+        self.write_csv(nhs_region_file_path, lines)
+
+    @patch("utils.utils.get_s3_sub_folders_for_path")
+    def test_main_imports_one_csv_file(self, get_subfolder_mock):
+        get_subfolder_mock.return_value = []
+        self.generate_ons_test_csv_file(
+            f"{self.DATA_SOURCE}/dataset=postcode-directory/"
+        )
+
+        ingest_ons_data.main(self.DATA_SOURCE, self.DESTINATION)
+
+        ons_data = self.spark.read.parquet(
+            f"{self.DESTINATION}/dataset=postcode-directory/"
+        )
+        self.assertEqual(ons_data.count(), 3)
+        ons_data_row = ons_data.collect()[0]
+        self.assertEqual(ons_data_row.import_date, "20210201")
+
+    @patch("utils.utils.get_s3_sub_folders_for_path")
+    def test_main_wont_import_data_already_imported(self, get_subfolder_mock):
+        get_subfolder_mock.return_value = []
+        self.generate_ons_test_csv_file(
+            f"{self.DATA_SOURCE}/dataset=postcode-directory/"
+        )
+
+        ingest_ons_data.main(self.DATA_SOURCE, self.DESTINATION)
+        ingest_ons_data.main(self.DATA_SOURCE, self.DESTINATION)
+
+        ons_data = self.spark.read.parquet(
+            f"{self.DESTINATION}/dataset=postcode-directory/"
+        )
+        self.assertEqual(ons_data.count(), 3)
+
+    @patch("utils.utils.get_s3_sub_folders_for_path")
+    def test_main_will_import_new_data(self, get_subfolder_mock):
+        get_subfolder_mock.return_value = []
+        self.generate_ons_test_csv_file(
+            f"{self.DATA_SOURCE}/dataset=postcode-directory/"
+        )
+
+        ingest_ons_data.main(self.DATA_SOURCE, self.DESTINATION)
+        self.generate_ons_test_csv_file(
+            f"{self.DATA_SOURCE}/dataset=postcode-directory/", ("2022", "01", "02")
+        )
+        ingest_ons_data.main(self.DATA_SOURCE, self.DESTINATION)
+
+        ons_data = self.spark.read.parquet(
+            f"{self.DESTINATION}/dataset=postcode-directory/"
+        )
+        self.assertEqual(ons_data.count(), 6)
+        ons_data_partitions = ons_data.select("import_date").distinct().collect()
+        self.assertEqual(len(ons_data_partitions), 2)
+
+    @patch("utils.utils.get_s3_sub_folders_for_path")
+    def test_imports_supporting_lookup_files_for_import_date(self, get_subfolder_mock):
+        get_subfolder_mock.return_value = ["field=rgn", "field=nhser"]
+        self.generate_ons_test_csv_file(
+            f"{self.DATA_SOURCE}/dataset=postcode-directory/"
+        )
+        self.generate_nhs_region_lookup_csv(self.LOOKUPS_SOURCE)
+        self.generate_region_lookup_csv(self.LOOKUPS_SOURCE)
+
+        ingest_ons_data.main(self.DATA_SOURCE, self.DESTINATION)
+        rgn_lookup = self.spark.read.parquet(
+            f"{self.DESTINATION}/dataset=postcode-directory-field-lookups/field=rgn/"
+        )
+        nhser_lookup = self.spark.read.parquet(
+            f"{self.DESTINATION}/dataset=postcode-directory-field-lookups/field=nhser/"
+        )
+
+        self.assertEqual(rgn_lookup.count(), 5)
+        self.assertEqual(nhser_lookup.count(), 7)
+
+        rgn_lookup_row = rgn_lookup.collect()[0]
+        nhser_lookup_row = nhser_lookup.collect()[0]
+
+        self.assertEqual(rgn_lookup_row.import_date, "20210101")
+        self.assertEqual(nhser_lookup_row.import_date, "20210101")


### PR DESCRIPTION
[Trello](https://trello.com/c/kWyv4ybS/339-add-ons-region-into-the-prepared-locations-data)
# Description
A glue job to save all ONS CSVs at a source location as parquet files in the datasets bucket and then do the same with any lookup CSVs. The job will check which import_dates have already been saved in the destination and ignore those.

The ONS csv must be saved in the subdirectory `/dataset=postcode-directory/year=2022/...` and the field lookup CSVs must be save in a sub directory for each field, for example `/dataset=postcode-directory-field-lookups/field=rgm/year=2022/...`.

Also added crawlers to crawl both of these datasets.

# Developer checklist
- [x] Unit test
- [x] Linked to Trello ticket
