### PR TITLE
Job to denormalise ONS data using lookup tables

### DIFF
--- a/jobs/denormalise_ons_data.py
+++ b/jobs/denormalise_ons_data.py
@@ -1,0 +1,99 @@
+import sys
+
+import pyspark.sql.functions as F
+from pyspark.sql.utils import AnalysisException
+
+
+from utils import utils
+
+
+def main(ons_source, lookup_source, destination):
+    spark = utils.get_spark()
+    ons_data = get_previoulsy_unimported_data(spark, ons_source, destination)
+    field_replacement_col_info = [
+        # field_name, coded_column_name, named_column_name
+        ("rgn", "RGN20CD", "RGN20NM"),
+        ("nhser", "NHSER19CD", "NHSER19NM"),
+        ("ccg", "ccg21cd", "ccg21nm"),
+        ("ctry", "ctry12cd", "ctry12nm"),
+        ("imd", "lsoa11cd", "lsoa11nm"),
+        ("lsoa11", "lsoa11cd", "lsoa11nm"),
+        ("msoa11", "msoa11cd", "msoa11nm"),
+        ("oslaua", "lad21cd", "lad21nm"),
+        ("ru11ind", "RU11IND", "RU11NM"),
+    ]
+    for col_info in field_replacement_col_info:
+        ons_data = replace_field_from_lookup(
+            spark, lookup_source, ons_data, col_info[0], col_info[1], col_info[2]
+        )
+
+    ons_data.write.mode("append").partitionBy(
+        "year", "month", "day", "import_date"
+    ).parquet(destination)
+
+
+def replace_field_from_lookup(
+    spark, lookup_source, ons_data, field_name, coded_column_name, named_column_name
+):
+    lookup = spark.read.parquet(f"{lookup_source}field={field_name}/")
+    if coded_column_name == "RU11IND":
+        lookup = lookup.withColumnRenamed("RU11IND", "RU11INDCD")
+        coded_column_name = "RU11INDCD"
+    lookup = lookup.alias(field_name)
+
+    ons_data_with_lookup = ons_data.join(
+        lookup,
+        (ons_data[field_name] == lookup[coded_column_name])
+        & (ons_data.import_date == lookup.import_date),
+        "leftouter",
+    )
+    ons_data_with_lookup = ons_data_with_lookup.withColumn(
+        field_name,
+        F.when(
+            lookup[named_column_name].isNotNull(), lookup[named_column_name]
+        ).otherwise(None),
+    )
+    ons_data_with_lookup = remove_joined_columns(
+        ons_data_with_lookup, lookup.columns, field_name
+    )
+    return ons_data_with_lookup
+
+
+def remove_joined_columns(data, columns, alias):
+    for col in columns:
+        data = data.drop(F.col(f"{alias}.{col}"))
+    return data
+
+
+def get_previoulsy_unimported_data(spark, source, destination):
+    ons_data = spark.read.parquet(source)
+    previously_imported_dates = get_previous_import_dates(spark, destination)
+
+    if previously_imported_dates:
+        ons_data = ons_data.join(
+            previously_imported_dates,
+            ons_data.import_date == previously_imported_dates.already_imported_date,
+            "leftouter",
+        ).where(previously_imported_dates.already_imported_date.isNull())
+    return ons_data
+
+
+def get_previous_import_dates(spark, destination):
+    try:
+        df = spark.read.parquet(destination)
+    except AnalysisException:
+        return None
+
+    return df.select(F.col("import_date").alias("already_imported_date")).distinct()
+
+
+if __name__ == "__main__":
+    print("Spark job 'inges_ons_data' starting...")
+    print(f"Job parameters: {sys.argv}")
+
+    ons_source, ons_lookup_source, ons_destination = utils.collect_arguments(
+        ("--ons_source", "S3 path to the ONS data"),
+        ("--lookup_source", "S3 path to the ONS lookup"),
+        ("--destination", "S3 path to save output data"),
+    )
+    main(ons_source, ons_lookup_source, ons_destination)

--- a/jobs/denormalise_ons_data.py
+++ b/jobs/denormalise_ons_data.py
@@ -9,7 +9,7 @@ from utils import utils
 
 def main(ons_source, lookup_source, destination):
     spark = utils.get_spark()
-    ons_data = get_previoulsy_unimported_data(spark, ons_source, destination)
+    ons_data = get_previously_unimported_data(spark, ons_source, destination)
     field_replacement_col_info = [
         # field_name, coded_column_name, named_column_name
         ("rgn", "RGN20CD", "RGN20NM"),
@@ -65,7 +65,7 @@ def remove_joined_columns(data, columns, alias):
     return data
 
 
-def get_previoulsy_unimported_data(spark, source, destination):
+def get_previously_unimported_data(spark, source, destination):
     ons_data = spark.read.parquet(source)
     previously_imported_dates = get_previous_import_dates(spark, destination)
 
@@ -88,7 +88,7 @@ def get_previous_import_dates(spark, destination):
 
 
 if __name__ == "__main__":
-    print("Spark job 'inges_ons_data' starting...")
+    print("Spark job 'denormalise_ons_data' starting...")
     print(f"Job parameters: {sys.argv}")
 
     ons_source, ons_lookup_source, ons_destination = utils.collect_arguments(

--- a/terraform/pipeline/glue.tf
+++ b/terraform/pipeline/glue.tf
@@ -45,6 +45,21 @@ module "ingest_ons_data_job" {
   }
 }
 
+module "denormalise_ons_data_job" {
+  source          = "../modules/glue-job"
+  script_name     = "denormalise_ons_data.py"
+  glue_role       = aws_iam_role.sfc_glue_service_iam_role
+  resource_bucket = module.pipeline_resources
+  datasets_bucket = module.datasets_bucket
+  glue_version    = "3.0"
+
+  job_parameters = {
+    "--ons_source"    = "${module.datasets_bucket.bucket_uri}/domain=ONS/dataset=postcode-directory/"
+    "--lookup_source" = "${module.datasets_bucket.bucket_uri}/domain=ONS/dataset=postcode-directory-field-lookups/"
+    "--destination"   = "${module.datasets_bucket.bucket_uri}/domain=ONS/dataset=postcode-directory-denormalised/"
+  }
+}
+
 module "prepare_locations_job" {
   source            = "../modules/glue-job"
   script_name       = "prepare_locations.py"

--- a/tests/unit/test_denormalise_ons_data.py
+++ b/tests/unit/test_denormalise_ons_data.py
@@ -81,7 +81,6 @@ class TestDenormaliseONSDataTests(unittest.TestCase):
         self.create_lookup_df(("E06000001", "Hartlepool"), ["lad21cd", "lad21nm"], "oslaua")
         self.create_lookup_df(("B1", "(England/Wales) Urban minor conurbation"), ["RU11IND", "RU11NM"], "ru11ind")
 
-        # field_ru11ind ?
         # fmt: on
 
     def test_main_writes_data_to_the_output(self):

--- a/tests/unit/test_denormalise_ons_data.py
+++ b/tests/unit/test_denormalise_ons_data.py
@@ -1,0 +1,187 @@
+import shutil
+import unittest
+import warnings
+
+from pyspark.sql import SparkSession
+
+from jobs import denormalise_ons_data
+
+
+class TestDenormaliseONSDataTests(unittest.TestCase):
+    DATA_SOURCE = "tests/test_data/tmp/domain=ONS/dataset=postcode-directory/"
+    LOOKUPS_SOURCE = (
+        "tests/test_data/tmp/domain=ONS/dataset=postcode-directory-field-lookups/"
+    )
+    DESTINATION = (
+        "tests/test_data/tmp/output/domain=ONS/dataset=post-directory-denormalised/"
+    )
+    PARTITION_COLS = ["year", "month", "day", "import_date"]
+
+    def setUp(self):
+        self.spark = (
+            SparkSession.builder.appName("sfc_data_engineering_test_denorm_ons_dataset")
+            .config("spark.sql.sources.partitionColumnTypeInference.enabled", False)
+            .getOrCreate()
+        )
+        self.generate_ons_raw_data_file(self.DATA_SOURCE)
+        self.generate_lookups()
+        warnings.simplefilter("ignore", ResourceWarning)
+
+    def tearDown(self):
+        try:
+            shutil.rmtree(self.DESTINATION)
+        except OSError:
+            pass
+        try:
+            shutil.rmtree(self.DATA_SOURCE)
+        except OSError:
+            pass
+        try:
+            shutil.rmtree(self.LOOKUPS_SOURCE)
+        except OSError:
+            pass
+
+    def generate_ons_raw_data_file(
+        self, output_destination, partitions=("2021", "02", "01")
+    ):
+        import_date = partitions[0] + partitions[1] + partitions[2]
+        # fmt: off
+        columns = ["pcd", "rgn", "nhser", "ccg", "ctry", "imd", "lsoa11", "msoa11", "oslaua", "ru11ind"] + self.PARTITION_COLS
+        partitions = (*partitions, import_date)
+        rows = [
+            ("SW9 0LL", "E12000001", "E40000003", "E38000006", "E92000001", "E01021988", "95AA01S1", "E02000001", "E06000001", "B1") + partitions,
+        ]
+        # fmt: on
+
+        df = self.spark.createDataFrame(rows, columns)
+        if output_destination:
+            df.coalesce(1).write.mode("overwrite").partitionBy(
+                "year", "month", "day", "import_date"
+            ).parquet(output_destination)
+
+    def create_lookup_df(self, row, columns, field):
+        columns = columns + self.PARTITION_COLS
+        rows = [row + ("2021", "02", "01", "20210201")]
+        df = self.spark.createDataFrame(rows, columns)
+
+        df.coalesce(1).write.mode("overwrite").partitionBy(
+            "year", "month", "day", "import_date"
+        ).parquet(f"{self.LOOKUPS_SOURCE}field={field}/")
+
+    def generate_lookups(self):
+
+        # fmt: off
+        self.create_lookup_df(("E12000001", "North East"), ["RGN20CD", "RGN20NM"], "rgn")
+        self.create_lookup_df(("E40000003", "London"), ["NHSER19CD", "NHSER19NM"], "nhser")
+        self.create_lookup_df(("E38000006", "NHS Barnsley CCG"), ["ccg21cd", "ccg21nm"], "ccg")
+        self.create_lookup_df(("E92000001", "England"), ["ctry12cd", "ctry12nm"], "ctry")
+        self.create_lookup_df(("E01021988", "Tendring 018A"), ["lsoa11cd", "lsoa11nm"], "imd")
+        self.create_lookup_df(("95AA01S1", "Aldergrove 1"), ["lsoa11cd", "lsoa11nm"], "lsoa11")
+        self.create_lookup_df(("E02000001", "City of London 001"), ["msoa11cd", "msoa11nm"], "msoa11")
+        self.create_lookup_df(("E06000001", "Hartlepool"), ["lad21cd", "lad21nm"], "oslaua")
+        self.create_lookup_df(("B1", "(England/Wales) Urban minor conurbation"), ["RU11IND", "RU11NM"], "ru11ind")
+
+        # field_ru11ind ?
+        # fmt: on
+
+    def test_main_writes_data_to_the_output(self):
+        denormalise_ons_data.main(
+            self.DATA_SOURCE, self.LOOKUPS_SOURCE, self.DESTINATION
+        )
+
+        ons_data = self.spark.read.parquet(self.DESTINATION)
+        self.assertEqual(ons_data.count(), 1)
+
+    def test_main_wont_import_data_already_imported(self):
+        denormalise_ons_data.main(
+            self.DATA_SOURCE, self.LOOKUPS_SOURCE, self.DESTINATION
+        )
+        denormalise_ons_data.main(
+            self.DATA_SOURCE, self.LOOKUPS_SOURCE, self.DESTINATION
+        )
+
+        ons_data = self.spark.read.parquet(self.DESTINATION)
+        self.assertEqual(ons_data.count(), 1)
+
+    def test_replaces_rgn_field_with_lookup_values(self):
+        denormalise_ons_data.main(
+            self.DATA_SOURCE, self.LOOKUPS_SOURCE, self.DESTINATION
+        )
+
+        ons_data = self.spark.read.parquet(self.DESTINATION)
+        ons_data_row = ons_data.collect()[0]
+        self.assertEqual(ons_data_row.rgn, "North East")
+
+    def test_replaces_nhser_field_with_lookup_values(self):
+        denormalise_ons_data.main(
+            self.DATA_SOURCE, self.LOOKUPS_SOURCE, self.DESTINATION
+        )
+
+        ons_data = self.spark.read.parquet(self.DESTINATION)
+        ons_data_row = ons_data.collect()[0]
+        self.assertEqual(ons_data_row.nhser, "London")
+
+    def test_replaces_ccg_field_with_lookup_values(self):
+        denormalise_ons_data.main(
+            self.DATA_SOURCE, self.LOOKUPS_SOURCE, self.DESTINATION
+        )
+
+        ons_data = self.spark.read.parquet(self.DESTINATION)
+        ons_data_row = ons_data.collect()[0]
+        self.assertEqual(ons_data_row.ccg, "NHS Barnsley CCG")
+
+    def test_replaces_ctry_field_with_lookup_values(self):
+        denormalise_ons_data.main(
+            self.DATA_SOURCE, self.LOOKUPS_SOURCE, self.DESTINATION
+        )
+
+        ons_data = self.spark.read.parquet(self.DESTINATION)
+        ons_data_row = ons_data.collect()[0]
+        self.assertEqual(ons_data_row.ctry, "England")
+
+    def test_replaces_imd_field_with_lookup_values(self):
+        denormalise_ons_data.main(
+            self.DATA_SOURCE, self.LOOKUPS_SOURCE, self.DESTINATION
+        )
+
+        ons_data = self.spark.read.parquet(self.DESTINATION)
+        ons_data_row = ons_data.collect()[0]
+        self.assertEqual(ons_data_row.imd, "Tendring 018A")
+
+    def test_replaces_lsoa11_field_with_lookup_values(self):
+        denormalise_ons_data.main(
+            self.DATA_SOURCE, self.LOOKUPS_SOURCE, self.DESTINATION
+        )
+
+        ons_data = self.spark.read.parquet(self.DESTINATION)
+        ons_data_row = ons_data.collect()[0]
+        self.assertEqual(ons_data_row.lsoa11, "Aldergrove 1")
+
+    def test_replaces_msoa11_field_with_lookup_values(self):
+        denormalise_ons_data.main(
+            self.DATA_SOURCE, self.LOOKUPS_SOURCE, self.DESTINATION
+        )
+
+        ons_data = self.spark.read.parquet(self.DESTINATION)
+        ons_data_row = ons_data.collect()[0]
+        self.assertEqual(ons_data_row.msoa11, "City of London 001")
+
+    def test_replaces_oslaua_field_with_lookup_values(self):
+        denormalise_ons_data.main(
+            self.DATA_SOURCE, self.LOOKUPS_SOURCE, self.DESTINATION
+        )
+
+        ons_data = self.spark.read.parquet(self.DESTINATION)
+        ons_data_row = ons_data.collect()[0]
+        self.assertEqual(ons_data_row.oslaua, "Hartlepool")
+
+    def test_replaces_ru11ind_field_with_lookup_values(self):
+        denormalise_ons_data.main(
+            self.DATA_SOURCE, self.LOOKUPS_SOURCE, self.DESTINATION
+        )
+
+        ons_data = self.spark.read.parquet(self.DESTINATION)
+        ons_data_row = ons_data.collect()[0]
+        self.assertEqual(
+            ons_data_row.ru11ind, "(England/Wales) Urban minor conurbation"
+        )


### PR DESCRIPTION
[Trello](https://trello.com/c/kWyv4ybS/339-add-ons-region-into-the-prepared-locations-data)
# Description
A glue job to denormalise some fields in the ONS data. It will replace coded values in the following fields with their human-readable names in a lookup table.
- pcd
- rgn
- nhser
- ccg
- ctry
- imd
- lsoa11
- msoa11
- oslaua
- ru11ind


# Developer checklist
- [x] Unit test
- [x] Linked to Trello ticket

