### PR TITLE
Rename pir service users col

### DIFF
--- a/jobs/estimate_job_counts.py
+++ b/jobs/estimate_job_counts.py
@@ -3,13 +3,7 @@ from datetime import date
 import sys
 
 import pyspark.sql.functions as F
-from pyspark.sql.types import (
-    IntegerType,
-    StructType,
-    StructField,
-    StringType,
-    FloatType,
-)
+from pyspark.sql.types import IntegerType
 from pyspark.ml.regression import GBTRegressionModel
 from pyspark.ml.evaluation import RegressionEvaluator
 from pyspark.sql import Window
@@ -26,7 +20,7 @@ LOCATION_ID = "locationid"
 LAST_KNOWN_JOB_COUNT = "last_known_job_count"
 ESTIMATE_JOB_COUNT = "estimate_job_count"
 PRIMARY_SERVICE_TYPE = "primary_service_type"
-PIR_SERVICE_USERS = "pir_service_users"
+PEOPLE_DIRECTLY_EMPLOYED = "people_directly_employed"
 NUMBER_OF_BEDS = "number_of_beds"
 REGISTRATION_STATUS = "registration_status"
 LOCATION_TYPE = "location_type"
@@ -53,7 +47,7 @@ def main(
         .select(
             LOCATION_ID,
             SERVICES_OFFERED,
-            PIR_SERVICE_USERS,
+            PEOPLE_DIRECTLY_EMPLOYED,
             NUMBER_OF_BEDS,
             SNAPSHOT_DATE,
             JOB_COUNT,
@@ -218,9 +212,9 @@ def model_non_res_historical_pir(df):
             (
                 F.col(ESTIMATE_JOB_COUNT).isNull()
                 & (F.col(PRIMARY_SERVICE_TYPE) == "non-residential")
-                & F.col(PIR_SERVICE_USERS).isNotNull()
+                & F.col(PEOPLE_DIRECTLY_EMPLOYED).isNotNull()
             ),
-            (25.046 + (0.469 * F.col(PIR_SERVICE_USERS))),
+            (25.046 + (0.469 * F.col(PEOPLE_DIRECTLY_EMPLOYED))),
         ).otherwise(F.col(ESTIMATE_JOB_COUNT)),
     )
     return df
@@ -360,12 +354,12 @@ def model_care_home_with_nursing_pir_and_cqc_beds(df):
             (
                 F.col(ESTIMATE_JOB_COUNT).isNull()
                 & (F.col(PRIMARY_SERVICE_TYPE) == "Care home with nursing")
-                & F.col(PIR_SERVICE_USERS).isNotNull()
+                & F.col(PEOPLE_DIRECTLY_EMPLOYED).isNotNull()
                 & F.col(NUMBER_OF_BEDS).isNotNull()
             ),
             (
                 (0.773 * F.col(NUMBER_OF_BEDS))
-                + (0.551 * F.col(PIR_SERVICE_USERS))
+                + (0.551 * F.col(PEOPLE_DIRECTLY_EMPLOYED))
                 + 0.304
             ),
         ).otherwise(F.col(ESTIMATE_JOB_COUNT)),
@@ -410,13 +404,13 @@ def model_care_home_without_nursing_cqc_beds_and_pir(df):
             (
                 F.col(ESTIMATE_JOB_COUNT).isNull()
                 & (F.col(PRIMARY_SERVICE_TYPE) == "Care home without nursing")
-                & F.col(PIR_SERVICE_USERS).isNotNull()
+                & F.col(PEOPLE_DIRECTLY_EMPLOYED).isNotNull()
                 & F.col(NUMBER_OF_BEDS).isNotNull()
             ),
             (
                 10.652
                 + (0.571 * F.col(NUMBER_OF_BEDS))
-                + (0.296 * F.col(PIR_SERVICE_USERS))
+                + (0.296 * F.col(PEOPLE_DIRECTLY_EMPLOYED))
             ),
         ).otherwise(F.col(ESTIMATE_JOB_COUNT)),
     )

--- a/jobs/prepare_locations.py
+++ b/jobs/prepare_locations.py
@@ -120,7 +120,7 @@ def main(
             "dormancy",
             "number_of_beds",
             "services_offered",
-            "pir_service_users",
+            "people_directly_employed",
             "job_count",
             "region",
             "postal_code",
@@ -260,7 +260,7 @@ def get_pir_df(pir_source, since_date=None):
                 "how_many_people_are_directly_employed"
                 "_and_deliver_regulated_activities_at_"
                 "your_service_as_part_of_their_daily_duties"
-            ).alias("pir_service_users"),
+            ).alias("people_directly_employed"),
             F.col("import_date"),
         )
     )

--- a/tests/test_file_generator.py
+++ b/tests/test_file_generator.py
@@ -673,7 +673,7 @@ def generate_prepared_locations_file_parquet(
         "number_of_beds",
         "dormancy",
         "services_offered",
-        "pir_service_users",
+        "people_directly_employed",
         "job_count",
         "local_authority",
         "snapshot_year",

--- a/tests/unit/test_estimate_job_counts.py
+++ b/tests/unit/test_estimate_job_counts.py
@@ -226,7 +226,7 @@ class EstimateJobCountTests(unittest.TestCase):
             "locationid",
             "primary_service_type",
             "last_known_job_count",
-            "pir_service_users",
+            "people_directly_employed",
             "estimate_job_count",
         ]
         rows = [
@@ -439,7 +439,7 @@ class EstimateJobCountTests(unittest.TestCase):
         columns = [
             "locationid",
             "primary_service_type",
-            "pir_service_users",
+            "people_directly_employed",
             "number_of_beds",
             "estimate_job_count",
         ]
@@ -488,7 +488,7 @@ class EstimateJobCountTests(unittest.TestCase):
         columns = [
             "locationid",
             "primary_service_type",
-            "pir_service_users",
+            "people_directly_employed",
             "number_of_beds",
             "estimate_job_count",
         ]

--- a/tests/unit/test_prepare_locations.py
+++ b/tests/unit/test_prepare_locations.py
@@ -95,7 +95,7 @@ class PrepareLocationsTests(unittest.TestCase):
                 "dormancy",
                 "number_of_beds",
                 "services_offered",
-                "pir_service_users",
+                "people_directly_employed",
                 "job_count",
                 "region",
                 "postal_code",
@@ -144,7 +144,7 @@ class PrepareLocationsTests(unittest.TestCase):
         self.assertEqual(len(pir_df.columns), 3)
 
         self.assertEqual(pir_df.columns[0], "locationid")
-        self.assertEqual(pir_df.columns[1], "pir_service_users")
+        self.assertEqual(pir_df.columns[1], "people_directly_employed")
         self.assertEqual(pir_df.columns[2], "import_date")
 
     def test_get_date_closest_to_search_date_returns_correct_date(self):


### PR DESCRIPTION
[Trello](https://trello.com/c/aPQZ1J57)

# Description
- Renamed `how_many_people_are_directly_employed_and_deliver_regulated_activities_at_your_service_as_part_of_their_daily_duties` to `people_directly_employed` instead of `pir_service_users` as it makes more sense

# Developer checklist
- [ ] Unit test
- [ ] Linked to Trello ticket
