### PR TITLE
Drop duplicates when importing CQC data

### DIFF
--- a/jobs/bulk_download_cqc_locations.py
+++ b/jobs/bulk_download_cqc_locations.py
@@ -13,10 +13,11 @@ def main(destination):
     for paginated_locations in cqc.get_all_objects(
         stream=True, object_type="locations", object_identifier="locationId"
     ):
+        locations_df = spark.createDataFrame(paginated_locations, LOCATION_SCHEMA)
         if df:
-            df = df.union(paginated_locations)
+            df = df.union(locations_df)
         else:
-            df = spark.createDataFrame(paginated_locations, LOCATION_SCHEMA)
+            df = locations_df
 
     df = df.dropDuplicates(["locationId"])
     utils.write_to_parquet(df, destination, True)


### PR DESCRIPTION
[Trello](https://trello.com/c/MGeY4mHE/311-investigate-and-resolve-duplicate-cqc-data-update-import-job-to-remove-at-ingest)
# Description

When ingesting CQC location data, combine the full dataset and then drop any duplicate location IDs

# Developer checklist
- [x] Linked to Trello ticket
