### PR TITLE
Use dataframe with only the date columns to work out start & end dates

### DIFF
--- a/jobs/worker_tracking.py
+++ b/jobs/worker_tracking.py
@@ -50,16 +50,18 @@ def main(
         return start_worker_df
 
 
-def max_import_date_in_two_datasets(workplace_df, worker_df):
-    workplace_df = workplace_df.join(worker_df, ["import_date"], "inner")
+def max_import_date_in_two_datasets(workplace_dates_df, worker_dates_df):
+    combined_dates = workplace_dates_df.join(worker_dates_df, ["import_date"], "inner")
 
-    max_import_date = workplace_df.select(F.max(F.col("import_date")).alias("max"))
+    max_import_date = combined_dates.select(F.max(F.col("import_date")).alias("max"))
 
     return max_import_date.first().max
 
 
-def get_start_period_import_date(workplace_df, worker_df, end_period_import_date):
-    import_date = workplace_df.join(worker_df, ["import_date"], "inner")
+def get_start_period_import_date(
+    workplace_dates_df, worker_dates_df, end_period_import_date
+):
+    import_date = workplace_dates_df.join(worker_dates_df, ["import_date"], "inner")
 
     max_import_date_as_date = datetime.strptime(end_period_import_date, "%Y%m%d")
 
@@ -75,11 +77,19 @@ def get_start_period_import_date(workplace_df, worker_df, end_period_import_date
 
 
 def get_start_and_end_period_import_dates(workplace_df, worker_df):
-    end_period_import_date = max_import_date_in_two_datasets(workplace_df, worker_df)
+    workplace_dates = workplace_df.select("import_date").distinct()
+    worker_dates = worker_df.select("import_date").distinct()
+    end_period_import_date = max_import_date_in_two_datasets(
+        workplace_dates, worker_dates
+    )
+
+    print(f"End period date calculated as: {end_period_import_date}")
 
     start_period_import_date = get_start_period_import_date(
-        workplace_df, worker_df, end_period_import_date
+        workplace_dates, worker_dates, end_period_import_date
     )
+
+    print(f"Start period date calculated as: {start_period_import_date}")
 
     return start_period_import_date, end_period_import_date
 

--- a/terraform/pipeline/glue.tf
+++ b/terraform/pipeline/glue.tf
@@ -87,10 +87,11 @@ module "worker_tracking_job" {
   resource_bucket = module.pipeline_resources
   datasets_bucket = module.datasets_bucket
 
+
   job_parameters = {
     "--source_ascwds_workplace" = "${module.datasets_bucket.bucket_uri}/domain=ASCWDS/dataset=workplace/"
     "--source_ascwds_worker"    = "${module.datasets_bucket.bucket_uri}/domain=ASCWDS/dataset=worker/"
-    "--destination"             = ""
+    "--destination"             = "${module.datasets_bucket.bucket_uri}/domain=data_engineering/dataset=worker_tracked/"
   }
 }
 


### PR DESCRIPTION
# Description

Dropping all the columns apart from import date to calculate the start and end dates for the worker tracking job massively improves the performance of the job.
