### PR TITLE
Stop the ONS lookup crawler from crawling the denormalised ONS date

### DIFF
--- a/terraform/pipeline/glue.tf
+++ b/terraform/pipeline/glue.tf
@@ -219,6 +219,6 @@ module "ons_lookups_crawler" {
   name_postfix                 = "_lookups"
   glue_role                    = aws_iam_role.sfc_glue_service_iam_role
   workspace_glue_database_name = "${local.workspace_prefix}-${var.glue_database_name}"
-  exclusions                   = ["dataset=postcode-directory/**"]
+  exclusions                   = ["dataset=postcode-directory/**", "dataset=postcode-directory-denormalised/**"]
   table_level                  = 4
 }


### PR DESCRIPTION
# Description
The lookups crawler should only be crawling the ONS lookup tables, there is another crawler that crawls ONS data & denormalised ONS data
