### PR TITLE
Notifications on pipeline failure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,5 +57,5 @@ terraform.tfvars
 *.pyc
 .DS_Store
 
-# ------ lambda aritfacts ---- #
+# ------ lambda artefacts ---- #
 lambdas/**.zip

--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,6 @@ terraform.tfvars
 .python-version
 *.pyc
 .DS_Store
+
+# ------ lambda aritfacts ---- #
+lambdas/**.zip

--- a/lambdas/error_notifications/error_notifications.py
+++ b/lambdas/error_notifications/error_notifications.py
@@ -1,0 +1,88 @@
+import boto3
+import os
+import json
+
+
+def get_monitoring_url(job_run_id, job_name):
+    return "https://eu-west-2.console.aws.amazon.com/gluestudio/home?region=eu-west-2#/job/{job_name}/run/{job_run_id}?from=monitoring".format(
+        job_name=job_name, job_run_id=job_run_id
+    )
+
+
+def get_state_machine_execution_url(execution_id):
+    return "https://eu-west-2.console.aws.amazon.com/states/home?region=eu-west-2#/v2/executions/details/{execution_id}".format(
+        execution_id=execution_id
+    )
+
+
+def glue_job_failure_message(statemachine_name, error, execution_details_url):
+    error_json = json.loads(error)
+    message = error_json["ErrorMessage"]
+    jr_id = error_json["Id"]
+    jr_name = error_json["JobName"]
+    glue_job_monitoring = get_monitoring_url(jr_id, jr_name)
+
+    email_message = (
+        f"Execution of the step function {statemachine_name} has failed. "
+        f"The failure occured on glue job {jr_name} with error: \n\n"
+        f"{message} \n\n"
+        f"View the run details of the glue job here: {glue_job_monitoring} \n\n"
+        "View the execution details for the state function here: "
+        f"{execution_details_url} \n"
+    )
+    return email_message
+
+
+def generic_failure_message(statemachine_name, error, execution_details_url):
+    message = (
+        f"Execution of the step function {statemachine_name} has failed woth error. \n\n"
+        f"{error} \n\n"
+        f"View the execution details for the state function here: {execution_details_url} \n"
+    )
+    return message
+
+
+def send_sns_notification(snsTopicArn, message_params, sns_client):
+    error = message_params["Error"]
+    execution_id = message_params["ExecutionId"]
+    statemachine_name = message_params["StateMachineName"]
+    execution_details_url = get_state_machine_execution_url(execution_id)
+
+    try:
+        message = glue_job_failure_message(
+            statemachine_name, error, execution_details_url
+        )
+    except json.decoder.JSONDecodeError:
+        message = generic_failure_message(
+            statemachine_name, error, execution_details_url
+        )
+
+    response = sns_client.publish(
+        TopicArn=snsTopicArn,
+        Message=message,
+        Subject="Failed pipeline execution notification",
+    )
+
+    return response
+
+
+def success_callback(token, sns_resposne, sf_client):
+    sf_client.send_task_success(taskToken=token, output=json.dumps(sns_resposne))
+
+
+def failure_callback(token, error, cause, sf_client):
+    sf_client.send_task_failure(taskToken=token, error=error, cause=cause)
+
+
+def main(event, _, sns_client=None, sf_client=None):
+    if not sns_client:
+        sns_client = boto3.client("sns")
+    if not sf_client:
+        sf_client = boto3.client("stepfunctions")
+
+    snsTopicArn = os.getenv("SNS_TOPIC_ARN")
+    try:
+        sns_response = send_sns_notification(snsTopicArn, event, sns_client)
+        success_callback(event["CallbackToken"], sns_response, sf_client)
+    except Exception as err:
+        failure_callback(event["CallbackToken"], f"{type(err)}", f"{err}", sf_client)

--- a/lambdas/error_notifications/error_notifications.py
+++ b/lambdas/error_notifications/error_notifications.py
@@ -35,7 +35,7 @@ def glue_job_failure_message(statemachine_name, error, execution_details_url):
 
 def generic_failure_message(statemachine_name, error, execution_details_url):
     message = (
-        f"Execution of the step function {statemachine_name} has failed woth error. \n\n"
+        f"Execution of the step function {statemachine_name} has failed with error. \n\n"
         f"{error} \n\n"
         f"View the execution details for the state function here: {execution_details_url} \n"
     )
@@ -66,8 +66,8 @@ def send_sns_notification(snsTopicArn, message_params, sns_client):
     return response
 
 
-def success_callback(token, sns_resposne, sf_client):
-    sf_client.send_task_success(taskToken=token, output=json.dumps(sns_resposne))
+def success_callback(token, sns_response, sf_client):
+    sf_client.send_task_success(taskToken=token, output=json.dumps(sns_response))
 
 
 def failure_callback(token, error, cause, sf_client):

--- a/terraform/pipeline/lambda.tf
+++ b/terraform/pipeline/lambda.tf
@@ -13,11 +13,10 @@ resource "aws_s3_object" "error_notification_lambda" {
 }
 
 resource "aws_lambda_function" "error_notification_lambda" {
-  role          = aws_iam_role.error_notification_lambda.arn
-  handler       = "error_notifications.main"
-  runtime       = "python3.9"
-  function_name = "${local.workspace_prefix}-glue-failure-notification"
-  #   filename        = "../../lambdas/error_notifications"
+  role             = aws_iam_role.error_notification_lambda.arn
+  handler          = "error_notifications.main"
+  runtime          = "python3.9"
+  function_name    = "${local.workspace_prefix}-glue-failure-notification"
   s3_bucket        = module.pipeline_resources.bucket_name
   s3_key           = aws_s3_object.error_notification_lambda.key
   source_code_hash = data.archive_file.error_notification_lambda.output_base64sha256

--- a/terraform/pipeline/lambda.tf
+++ b/terraform/pipeline/lambda.tf
@@ -1,0 +1,106 @@
+data "archive_file" "error_notification_lambda" {
+  type        = "zip"
+  source_dir  = "../../lambdas/error_notifications"
+  output_path = "../../lambdas/error_notifications.zip"
+}
+
+resource "aws_s3_object" "error_notification_lambda" {
+  bucket      = module.pipeline_resources.bucket_name
+  key         = "lambda-scripts/error_notifications.py"
+  source      = data.archive_file.error_notification_lambda.output_path
+  acl         = "private"
+  source_hash = data.archive_file.error_notification_lambda.output_base64sha256
+}
+
+resource "aws_lambda_function" "error_notification_lambda" {
+  role          = aws_iam_role.error_notification_lambda.arn
+  handler       = "error_notifications.main"
+  runtime       = "python3.9"
+  function_name = "${local.workspace_prefix}-glue-failure-notification"
+  #   filename        = "../../lambdas/error_notifications"
+  s3_bucket        = module.pipeline_resources.bucket_name
+  s3_key           = aws_s3_object.error_notification_lambda.key
+  source_code_hash = data.archive_file.error_notification_lambda.output_base64sha256
+
+  environment {
+    variables = {
+      SNS_TOPIC_ARN = aws_sns_topic.pipeline_failures.arn
+    }
+  }
+}
+
+data "aws_iam_policy_document" "error_notification_lambda_assume_role" {
+  statement {
+    actions = [
+      "sts:AssumeRole"
+    ]
+    principals {
+      identifiers = [
+        "lambda.amazonaws.com"
+      ]
+      type = "Service"
+    }
+  }
+}
+
+resource "aws_iam_role" "error_notification_lambda" {
+  name               = "${local.workspace_prefix}-error-notification-lambda"
+  assume_role_policy = data.aws_iam_policy_document.error_notification_lambda_assume_role.json
+}
+
+data "aws_iam_policy_document" "error_notification_lambda" {
+  statement {
+    actions = [
+      "logs:CreateLogGroup",
+      "logs:CreateLogStream",
+      "logs:PutLogEvents",
+    ]
+    effect = "Allow"
+    resources = [
+      "arn:aws:logs:*:*:*"
+    ]
+  }
+
+  statement {
+    actions = [
+      "states:SendTaskSuccess",
+      "states:SendTaskFailure"
+    ]
+    effect = "Allow"
+    resources = [
+      "*"
+    ]
+  }
+
+  statement {
+    actions = [
+      "SNS:ListTopics",
+      "SNS:ListTagsForResource"
+    ]
+    effect = "Allow"
+    resources = [
+      "*"
+    ]
+  }
+
+  statement {
+    actions = [
+      "SNS:Publish"
+    ]
+    effect = "Allow"
+    resources = [
+      aws_sns_topic.pipeline_failures.arn
+    ]
+  }
+}
+
+resource "aws_iam_policy" "error_notification_lambda" {
+  name   = "${local.workspace_prefix}-error-notification-lambda"
+  policy = data.aws_iam_policy_document.error_notification_lambda.json
+}
+
+resource "aws_iam_role_policy_attachment" "error_notification_lambda" {
+  role       = aws_iam_role.error_notification_lambda.name
+  policy_arn = aws_iam_policy.error_notification_lambda.arn
+}
+

--- a/terraform/pipeline/sns.tf
+++ b/terraform/pipeline/sns.tf
@@ -1,0 +1,9 @@
+resource "aws_sns_topic" "pipeline_failures" {
+  name = "${local.workspace_prefix}-pipeline-failures"
+}
+
+resource "aws_sns_topic_subscription" "pipeline_failures_test_email" {
+  endpoint  = "test@madetech.com"
+  protocol  = "email"
+  topic_arn = aws_sns_topic.pipeline_failures.arn
+}

--- a/terraform/pipeline/sns.tf
+++ b/terraform/pipeline/sns.tf
@@ -1,9 +1,3 @@
 resource "aws_sns_topic" "pipeline_failures" {
   name = "${local.workspace_prefix}-pipeline-failures"
 }
-
-resource "aws_sns_topic_subscription" "pipeline_failures_test_email" {
-  endpoint  = "test@madetech.com"
-  protocol  = "email"
-  topic_arn = aws_sns_topic.pipeline_failures.arn
-}

--- a/terraform/pipeline/step-function.tf
+++ b/terraform/pipeline/step-function.tf
@@ -13,6 +13,7 @@ resource "aws_sfn_state_machine" "data-engineering-state-machine" {
     pipeline_resources_bucket_uri          = module.pipeline_resources.bucket_uri
     dataset_bucket_uri                     = module.datasets_bucket.bucket_uri
     pipeline_failure_sns_topic             = aws_sns_topic.pipeline_failures.arn
+    pipeline_failure_lambda_function_arn   = aws_lambda_function.error_notification_lambda.arn
   })
 
   logging_configuration {
@@ -164,6 +165,13 @@ resource "aws_iam_policy" "step_function_iam_policy" {
           "SNS:Publish"
         ],
         "Resource" : "${aws_sns_topic.pipeline_failures.arn}"
+      },
+      {
+        "Effect" : "Allow",
+        "Action" : [
+          "lambda:InvokeFunction"
+        ],
+        "Resource" : "${aws_lambda_function.error_notification_lambda.arn}*"
       }
     ]
   })

--- a/terraform/pipeline/step-function.tf
+++ b/terraform/pipeline/step-function.tf
@@ -12,6 +12,7 @@ resource "aws_sfn_state_machine" "data-engineering-state-machine" {
     data_engineering_crawler_name          = module.data_engineering_crawler.crawler_name
     pipeline_resources_bucket_uri          = module.pipeline_resources.bucket_uri
     dataset_bucket_uri                     = module.datasets_bucket.bucket_uri
+    pipeline_failure_sns_topic             = aws_sns_topic.pipeline_failures.arn
   })
 
   logging_configuration {
@@ -156,6 +157,13 @@ resource "aws_iam_policy" "step_function_iam_policy" {
           "events:DescribeRule",
         ],
         "Resource" : "arn:aws:events:eu-west-2:${data.aws_caller_identity.current.account_id}:rule/StepFunctions*"
+      },
+      {
+        "Effect" : "Allow",
+        "Action" : [
+          "SNS:Publish"
+        ],
+        "Resource" : "${aws_sns_topic.pipeline_failures.arn}"
       }
     ]
   })

--- a/terraform/pipeline/step-functions/DataEngineeringPipeline-StepFunction.json
+++ b/terraform/pipeline/step-functions/DataEngineeringPipeline-StepFunction.json
@@ -1,155 +1,158 @@
 {
   "Comment": "A description of my state machine",
-  "StartAt": "Run prepare locations job",
+  "StartAt": "All Transformations",
   "States": {
-    "Run prepare locations job": {
-      "Type": "Task",
-      "Resource": "arn:aws:states:::glue:startJobRun.sync",
-      "Parameters": {
-        "JobName": "${prepare_locations_job_name}",
-        "Arguments": {
-          "--workplace_source": "${dataset_bucket_uri}/domain=ASCWDS/dataset=workplace/",
-          "--cqc_location_source": "${dataset_bucket_uri}/domain=CQC/dataset=locations-api/",
-          "--cqc_provider_source": "${dataset_bucket_uri}/domain=CQC/dataset=providers-api/",
-          "--pir_source": "${dataset_bucket_uri}/domain=CQC/dataset=pir/",
-          "--destination": "${dataset_bucket_uri}/domain=data_engineering/dataset=locations_prepared/version=1.0.0/"
-        }
-      },
-      "ResultPath": null,
-      "Catch": [
-        {
-          "ErrorEquals": [
-            "States.ALL"
-          ],
-          "Next": "Publish failure message to SNS topic",
-          "ResultPath": "$.error"
-        }
-      ],
-      "Next": "Run Data Engineering Crawler 1"
-    },
-    "Run Data Engineering Crawler 1": {
-      "Type": "Task",
-      "Parameters": {
-        "Name": "${data_engineering_crawler_name}"
-      },
-      "Resource": "arn:aws:states:::aws-sdk:glue:startCrawler",
-      "Next": "Parallel"
-    },
-    "Parallel": {
+    "All Transformations": {
       "Type": "Parallel",
       "Branches": [
         {
-          "StartAt": "Run feature engineering job",
+          "StartAt": "Run prepare locations job",
           "States": {
-            "Run feature engineering job": {
+            "Run prepare locations job": {
               "Type": "Task",
               "Resource": "arn:aws:states:::glue:startJobRun.sync",
               "Parameters": {
-                "JobName": "${locations_feature_engineering_job_name}",
+                "JobName": "${prepare_locations_job_name}",
                 "Arguments": {
-                  "--prepared_locations_source": "${dataset_bucket_uri}/domain=data_engineering/dataset=locations_prepared/version=1.0.0/",
-                  "--destination": "${dataset_bucket_uri}/domain=data_engineering/dataset=locations_ml_features/version=1.0.0/"
+                  "--workplace_source": "${dataset_bucket_uri}/domain=ASCWDS/dataset=workplace/",
+                  "--cqc_location_source": "${dataset_bucket_uri}/domain=CQC/dataset=locations-api/",
+                  "--cqc_provider_source": "${dataset_bucket_uri}/domain=CQC/dataset=providers-api/",
+                  "--pir_source": "${dataset_bucket_uri}/domain=CQC/dataset=pir/",
+                  "--ons_source": "${dataset_bucket_uri}/domain=ONS/dataset=postcode-directory-denormalised/",
+                  "--destination": "${dataset_bucket_uri}/domain=data_engineering/dataset=locations_prepared/version=1.0.0/"
                 }
               },
-              "Next": "Run estimate job counts job"
+              "ResultPath": null,
+              "Next": "Run Data Engineering Crawler 1"
             },
-            "Run estimate job counts job": {
+            "Run Data Engineering Crawler 1": {
               "Type": "Task",
-              "Resource": "arn:aws:states:::glue:startJobRun.sync",
               "Parameters": {
-                "JobName": "${estimate_jobs_job_name}",
-                "Arguments": {
-                  "--prepared_locations_source": "${dataset_bucket_uri}/domain=data_engineering/dataset=locations_prepared/version=1.0.0/",
-                  "--prepared_locations_features": "${dataset_bucket_uri}/domain=data_engineering/dataset=locations_ml_features/version=1.0.0/",
-                  "--destination": "${dataset_bucket_uri}/domain=data_engineering/dataset=job_estimates/version=1.0.0/",
-                  "--care_home_model_directory": "${pipeline_resources_bucket_uri}/models/care_home_with_nursing_historical_jobs_prediction/"
-                }
+                "Name": "${data_engineering_crawler_name}"
               },
-              "Next": "Run job role breakdown job"
+              "Resource": "arn:aws:states:::aws-sdk:glue:startCrawler",
+              "Next": "Workers and job breakdown Parallel"
             },
-            "Run job role breakdown job": {
-              "Type": "Task",
-              "Resource": "arn:aws:states:::glue:startJobRun.sync",
-              "Parameters": {
-                "JobName": "${job_role_breakdown_job_name}",
-                "Arguments": {
-                  "--job_estimates_source": "${dataset_bucket_uri}/domain=data_engineering/dataset=job_estimates/version=1.0.0/",
-                  "--worker_source": "${dataset_bucket_uri}/domain=ASCWDS/dataset=worker/",
-                  "--destination": "${dataset_bucket_uri}/domain=data_engineering/dataset=job_role_breakdown/version=1.0.0/"
+            "Workers and job breakdown Parallel": {
+              "Type": "Parallel",
+              "Branches": [
+                {
+                  "StartAt": "Run feature engineering job",
+                  "States": {
+                    "Run feature engineering job": {
+                      "Type": "Task",
+                      "Resource": "arn:aws:states:::glue:startJobRun.sync",
+                      "Parameters": {
+                        "JobName": "${locations_feature_engineering_job_name}",
+                        "Arguments": {
+                          "--prepared_locations_source": "${dataset_bucket_uri}/domain=data_engineering/dataset=locations_prepared/version=1.0.0/",
+                          "--destination": "${dataset_bucket_uri}/domain=data_engineering/dataset=locations_ml_features/version=1.0.0/"
+                        }
+                      },
+                      "Next": "Run estimate job counts job"
+                    },
+                    "Run estimate job counts job": {
+                      "Type": "Task",
+                      "Resource": "arn:aws:states:::glue:startJobRun.sync",
+                      "Parameters": {
+                        "JobName": "${estimate_jobs_job_name}",
+                        "Arguments": {
+                          "--prepared_locations_source": "${dataset_bucket_uri}/domain=data_engineering/dataset=locations_prepared/version=1.0.0/",
+                          "--prepared_locations_features": "${dataset_bucket_uri}/domain=data_engineering/dataset=locations_ml_features/version=1.0.0/",
+                          "--destination": "${dataset_bucket_uri}/domain=data_engineering/dataset=job_estimates/version=1.0.0/",
+                          "--care_home_model_directory": "${pipeline_resources_bucket_uri}/models/care_home_with_nursing_historical_jobs_prediction/"
+                        }
+                      },
+                      "Next": "Run job role breakdown job"
+                    },
+                    "Run job role breakdown job": {
+                      "Type": "Task",
+                      "Resource": "arn:aws:states:::glue:startJobRun.sync",
+                      "Parameters": {
+                        "JobName": "${job_role_breakdown_job_name}",
+                        "Arguments": {
+                          "--job_estimates_source": "${dataset_bucket_uri}/domain=data_engineering/dataset=job_estimates/version=1.0.0/",
+                          "--worker_source": "${dataset_bucket_uri}/domain=ASCWDS/dataset=worker/",
+                          "--destination": "${dataset_bucket_uri}/domain=data_engineering/dataset=job_role_breakdown/version=1.0.0/"
+                        }
+                      },
+                      "End": true
+                    }
+                  }
+                },
+                {
+                  "StartAt": "Run prepare worker jobs",
+                  "States": {
+                    "Run prepare worker jobs": {
+                      "Type": "Task",
+                      "Resource": "arn:aws:states:::glue:startJobRun.sync",
+                      "Parameters": {
+                        "JobName": "${prepare_workers_job_name}",
+                        "Arguments": {
+                          "--source": "${dataset_bucket_uri}/domain=ASCWDS/dataset=worker/",
+                          "--destination": "${dataset_bucket_uri}/domain=data_engineering/dataset=worker_prepared/version=1.0.0/"
+                        }
+                      },
+                      "Next": "Run worker tracking job"
+                    },
+                    "Run worker tracking job": {
+                      "Type": "Task",
+                      "Resource": "arn:aws:states:::glue:startJobRun.sync",
+                      "Parameters": {
+                        "JobName": "${worker_tracking_job_name}",
+                        "Arguments": {
+                          "--source_ascwds_workplace": "${dataset_bucket_uri}/domain=ASCWDS/dataset=workplace/",
+                          "--source_ascwds_worker": "${dataset_bucket_uri}/domain=ASCWDS/dataset=worker/",
+                          "--destination": "${dataset_bucket_uri}/domain=data_engineering/dataset=worker_tracking/version=1.0.0/"
+                        }
+                      },
+                      "End": true
+                    }
+                  }
                 }
-              },
-              "End": true
-            }
-          }
-        },
-        {
-          "StartAt": "Run prepare worker jobs",
-          "States": {
-            "Run prepare worker jobs": {
-              "Type": "Task",
-              "Resource": "arn:aws:states:::glue:startJobRun.sync",
-              "Parameters": {
-                "JobName": "${prepare_workers_job_name}",
-                "Arguments": {
-                  "--source": "${dataset_bucket_uri}/domain=ASCWDS/dataset=worker/",
-                  "--destination": "${dataset_bucket_uri}/domain=data_engineering/dataset=worker_prepared/version=1.0.0/"
-                }
-              },
-              "Next": "Run worker tracking job"
+              ],
+              "Next": "Run Data Engineering Crawler 2"
             },
-            "Run worker tracking job": {
+            "Run Data Engineering Crawler 2": {
               "Type": "Task",
-              "Resource": "arn:aws:states:::glue:startJobRun.sync",
               "Parameters": {
-                "JobName": "${worker_tracking_job_name}",
-                "Arguments": {
-                  "--source_ascwds_workplace": "${dataset_bucket_uri}/domain=ASCWDS/dataset=workplace/",
-                  "--source_ascwds_worker": "${dataset_bucket_uri}/domain=ASCWDS/dataset=worker/",
-                  "--destination": "${dataset_bucket_uri}/domain=data_engineering/dataset=worker_tracking/version=1.0.0/"
-                }
+                "Name": "${data_engineering_crawler_name}"
               },
+              "Resource": "arn:aws:states:::aws-sdk:glue:startCrawler",
               "End": true
             }
           }
         }
       ],
-      "Next": "Run Data Engineering Crawler 2",
       "Catch": [
         {
           "ErrorEquals": [
             "States.ALL"
           ],
-          "Next": "Publish failure message to SNS topic",
-          "ResultPath": "$.response"
+          "Next": "Publish error notification",
+          "ResultPath": "$.error"
         }
-      ]
-    },
-    "Run Data Engineering Crawler 2": {
-      "Type": "Task",
-      "Next": "Success",
-      "Parameters": {
-        "Name": "${data_engineering_crawler_name}"
-      },
-      "Resource": "arn:aws:states:::aws-sdk:glue:startCrawler"
+      ],
+      "Next": "Success"
     },
     "Success": {
       "Type": "Succeed"
     },
-    "Publish failure message to SNS topic": {
+    "Publish error notification": {
       "Type": "Task",
-      "Resource": "arn:aws:states:::sns:publish",
+      "Resource": "arn:aws:states:::lambda:invoke.waitForTaskToken",
       "Parameters": {
-        "Message": {
+        "FunctionName": "${pipeline_failure_lambda_function_arn}:$LATEST",
+        "Payload": {
           "Error.$": "$.error.Cause",
           "ExecutionId.$": "$$.Execution.Id",
           "StateMachineName.$": "$$.StateMachine.Name",
           "StateMachineId.$": "$$.StateMachine.Id",
-          "ExecutionStartTime.$": "$$.ExecutionStartTime"
-        },
-        "TopicArn": "${pipeline_failure_sns_topic}"
+          "ExecutionStartTime.$": "$$.Execution.StartTime",
+          "CallbackToken.$": "$$.Task.Token"
+        }
       },
-      "Next": "Fail",
-      "ResultPath": "$.sns_publish_response"
+      "Next": "Fail"
     },
     "Fail": {
       "Type": "Fail"

--- a/terraform/pipeline/step-functions/DataEngineeringPipeline-StepFunction.json
+++ b/terraform/pipeline/step-functions/DataEngineeringPipeline-StepFunction.json
@@ -1,118 +1,158 @@
 {
-    "Comment": "A description of my state machine",
-    "StartAt": "Run prepare locations job",
-    "States": {
-      "Run prepare locations job": {
-        "Type": "Task",
-        "Resource": "arn:aws:states:::glue:startJobRun.sync",
-        "Parameters": {
-          "JobName": "${prepare_locations_job_name}",
-          "Arguments": {
-            "--workplace_source": "${dataset_bucket_uri}/domain=ASCWDS/dataset=workplace/",
-            "--cqc_location_source": "${dataset_bucket_uri}/domain=CQC/dataset=locations-api/",
-            "--cqc_provider_source": "${dataset_bucket_uri}/domain=CQC/dataset=providers-api/",
-            "--pir_source": "${dataset_bucket_uri}/domain=CQC/dataset=pir/",
-            "--destination": "${dataset_bucket_uri}/domain=data_engineering/dataset=locations_prepared/version=1.0.0/"
-          }
-        },
-        "ResultPath": null,
-        "Next": "Run Data Engineering Crawler 1"
+  "Comment": "A description of my state machine",
+  "StartAt": "Run prepare locations job",
+  "States": {
+    "Run prepare locations job": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::glue:startJobRun.sync",
+      "Parameters": {
+        "JobName": "${prepare_locations_job_name}",
+        "Arguments": {
+          "--workplace_source": "${dataset_bucket_uri}/domain=ASCWDS/dataset=workplace/",
+          "--cqc_location_source": "${dataset_bucket_uri}/domain=CQC/dataset=locations-api/",
+          "--cqc_provider_source": "${dataset_bucket_uri}/domain=CQC/dataset=providers-api/",
+          "--pir_source": "${dataset_bucket_uri}/domain=CQC/dataset=pir/",
+          "--destination": "${dataset_bucket_uri}/domain=data_engineering/dataset=locations_prepared/version=1.0.0/"
+        }
       },
-      "Run Data Engineering Crawler 1": {
-        "Type": "Task",
-        "Parameters": {
-          "Name": "${data_engineering_crawler_name}"
-        },
-        "Resource": "arn:aws:states:::aws-sdk:glue:startCrawler",
-        "Next": "Parallel"
+      "ResultPath": null,
+      "Catch": [
+        {
+          "ErrorEquals": [
+            "States.ALL"
+          ],
+          "Next": "Publish failure message to SNS topic",
+          "ResultPath": "$.error"
+        }
+      ],
+      "Next": "Run Data Engineering Crawler 1"
+    },
+    "Run Data Engineering Crawler 1": {
+      "Type": "Task",
+      "Parameters": {
+        "Name": "${data_engineering_crawler_name}"
       },
-      "Parallel": {
-        "Type": "Parallel",
-        "Branches": [
-          {
-            "StartAt": "Run feature engineering job",
-            "States": {
-              "Run feature engineering job": {
-                "Type": "Task",
-                "Resource": "arn:aws:states:::glue:startJobRun.sync",
-                "Parameters": {
-                  "JobName": "${locations_feature_engineering_job_name}",
-                  "Arguments": {
-                    "--prepared_locations_source": "${dataset_bucket_uri}/domain=data_engineering/dataset=locations_prepared/version=1.0.0/",
-                    "--destination": "${dataset_bucket_uri}/domain=data_engineering/dataset=locations_ml_features/version=1.0.0/"
-                  }
-                },
-                "Next": "Run estimate job counts job"
+      "Resource": "arn:aws:states:::aws-sdk:glue:startCrawler",
+      "Next": "Parallel"
+    },
+    "Parallel": {
+      "Type": "Parallel",
+      "Branches": [
+        {
+          "StartAt": "Run feature engineering job",
+          "States": {
+            "Run feature engineering job": {
+              "Type": "Task",
+              "Resource": "arn:aws:states:::glue:startJobRun.sync",
+              "Parameters": {
+                "JobName": "${locations_feature_engineering_job_name}",
+                "Arguments": {
+                  "--prepared_locations_source": "${dataset_bucket_uri}/domain=data_engineering/dataset=locations_prepared/version=1.0.0/",
+                  "--destination": "${dataset_bucket_uri}/domain=data_engineering/dataset=locations_ml_features/version=1.0.0/"
+                }
               },
-              "Run estimate job counts job": {
-                "Type": "Task",
-                "Resource": "arn:aws:states:::glue:startJobRun.sync",
-                "Parameters": {
-                  "JobName": "${estimate_jobs_job_name}",
-                  "Arguments": {
-                    "--prepared_locations_source": "${dataset_bucket_uri}/domain=data_engineering/dataset=locations_prepared/version=1.0.0/",
-                    "--prepared_locations_features": "${dataset_bucket_uri}/domain=data_engineering/dataset=locations_ml_features/version=1.0.0/",
-                    "--destination": "${dataset_bucket_uri}/domain=data_engineering/dataset=job_estimates/version=1.0.0/",
-                    "--care_home_model_directory": "${pipeline_resources_bucket_uri}/models/care_home_with_nursing_historical_jobs_prediction/"
-                  }
-                },
-                "Next": "Run job role breakdown job"
+              "Next": "Run estimate job counts job"
+            },
+            "Run estimate job counts job": {
+              "Type": "Task",
+              "Resource": "arn:aws:states:::glue:startJobRun.sync",
+              "Parameters": {
+                "JobName": "${estimate_jobs_job_name}",
+                "Arguments": {
+                  "--prepared_locations_source": "${dataset_bucket_uri}/domain=data_engineering/dataset=locations_prepared/version=1.0.0/",
+                  "--prepared_locations_features": "${dataset_bucket_uri}/domain=data_engineering/dataset=locations_ml_features/version=1.0.0/",
+                  "--destination": "${dataset_bucket_uri}/domain=data_engineering/dataset=job_estimates/version=1.0.0/",
+                  "--care_home_model_directory": "${pipeline_resources_bucket_uri}/models/care_home_with_nursing_historical_jobs_prediction/"
+                }
               },
-              "Run job role breakdown job": {
-                "Type": "Task",
-                "Resource": "arn:aws:states:::glue:startJobRun.sync",
-                "Parameters": {
-                  "JobName": "${job_role_breakdown_job_name}",
-                  "Arguments": {
-                    "--job_estimates_source": "${dataset_bucket_uri}/domain=data_engineering/dataset=job_estimates/version=1.0.0/",
-                    "--worker_source": "${dataset_bucket_uri}/domain=ASCWDS/dataset=worker/",
-                    "--destination": "${dataset_bucket_uri}/domain=data_engineering/dataset=job_role_breakdown/version=1.0.0/"
-                  }
-                },
-                "End": true
-              }
-            }
-          },
-          {
-            "StartAt": "Run prepare worker jobs",
-            "States": {
-              "Run prepare worker jobs": {
-                "Type": "Task",
-                "Resource": "arn:aws:states:::glue:startJobRun.sync",
-                "Parameters": {
-                  "JobName": "${prepare_workers_job_name}",
-                  "Arguments": {
-                    "--source": "${dataset_bucket_uri}/domain=ASCWDS/dataset=worker/",
-                    "--destination": "${dataset_bucket_uri}/domain=data_engineering/dataset=worker_prepared/version=1.0.0/"
-                  }
-                },
-                "Next": "Run worker tracking job"
+              "Next": "Run job role breakdown job"
+            },
+            "Run job role breakdown job": {
+              "Type": "Task",
+              "Resource": "arn:aws:states:::glue:startJobRun.sync",
+              "Parameters": {
+                "JobName": "${job_role_breakdown_job_name}",
+                "Arguments": {
+                  "--job_estimates_source": "${dataset_bucket_uri}/domain=data_engineering/dataset=job_estimates/version=1.0.0/",
+                  "--worker_source": "${dataset_bucket_uri}/domain=ASCWDS/dataset=worker/",
+                  "--destination": "${dataset_bucket_uri}/domain=data_engineering/dataset=job_role_breakdown/version=1.0.0/"
+                }
               },
-              "Run worker tracking job": {
-                "Type": "Task",
-                "Resource": "arn:aws:states:::glue:startJobRun.sync",
-                "Parameters": {
-                  "JobName": "${worker_tracking_job_name}",
-                  "Arguments": {
-                    "--source_ascwds_workplace": "${dataset_bucket_uri}/domain=ASCWDS/dataset=workplace/",
-                    "--source_ascwds_worker": "${dataset_bucket_uri}/domain=ASCWDS/dataset=worker/",
-                    "--destination": "${dataset_bucket_uri}/domain=data_engineering/dataset=worker_tracking/version=1.0.0/"
-                  }
-                },
-                "End": true
-              }
+              "End": true
             }
           }
-        ],
-        "Next": "Run Data Engineering Crawler 2"
-      },
-      "Run Data Engineering Crawler 2": {
-        "Type": "Task",
-        "End": true,
-        "Parameters": {
-          "Name": "${data_engineering_crawler_name}"
         },
-        "Resource": "arn:aws:states:::aws-sdk:glue:startCrawler"
-      }
+        {
+          "StartAt": "Run prepare worker jobs",
+          "States": {
+            "Run prepare worker jobs": {
+              "Type": "Task",
+              "Resource": "arn:aws:states:::glue:startJobRun.sync",
+              "Parameters": {
+                "JobName": "${prepare_workers_job_name}",
+                "Arguments": {
+                  "--source": "${dataset_bucket_uri}/domain=ASCWDS/dataset=worker/",
+                  "--destination": "${dataset_bucket_uri}/domain=data_engineering/dataset=worker_prepared/version=1.0.0/"
+                }
+              },
+              "Next": "Run worker tracking job"
+            },
+            "Run worker tracking job": {
+              "Type": "Task",
+              "Resource": "arn:aws:states:::glue:startJobRun.sync",
+              "Parameters": {
+                "JobName": "${worker_tracking_job_name}",
+                "Arguments": {
+                  "--source_ascwds_workplace": "${dataset_bucket_uri}/domain=ASCWDS/dataset=workplace/",
+                  "--source_ascwds_worker": "${dataset_bucket_uri}/domain=ASCWDS/dataset=worker/",
+                  "--destination": "${dataset_bucket_uri}/domain=data_engineering/dataset=worker_tracking/version=1.0.0/"
+                }
+              },
+              "End": true
+            }
+          }
+        }
+      ],
+      "Next": "Run Data Engineering Crawler 2",
+      "Catch": [
+        {
+          "ErrorEquals": [
+            "States.ALL"
+          ],
+          "Next": "Publish failure message to SNS topic",
+          "ResultPath": "$.response"
+        }
+      ]
+    },
+    "Run Data Engineering Crawler 2": {
+      "Type": "Task",
+      "Next": "Success",
+      "Parameters": {
+        "Name": "${data_engineering_crawler_name}"
+      },
+      "Resource": "arn:aws:states:::aws-sdk:glue:startCrawler"
+    },
+    "Success": {
+      "Type": "Succeed"
+    },
+    "Publish failure message to SNS topic": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::sns:publish",
+      "Parameters": {
+        "Message": {
+          "Error.$": "$.error.Cause",
+          "ExecutionId.$": "$$.Execution.Id",
+          "StateMachineName.$": "$$.StateMachine.Name",
+          "StateMachineId.$": "$$.StateMachine.Id",
+          "ExecutionStartTime.$": "$$.ExecutionStartTime"
+        },
+        "TopicArn": "${pipeline_failure_sns_topic}"
+      },
+      "Next": "Fail",
+      "ResultPath": "$.sns_publish_response"
+    },
+    "Fail": {
+      "Type": "Fail"
     }
   }
+}

--- a/tests/unit/test_error_notifications_lambda.py
+++ b/tests/unit/test_error_notifications_lambda.py
@@ -1,0 +1,133 @@
+import boto3
+import json
+import os
+import unittest
+
+from botocore.stub import Stubber, ANY
+
+from lambdas.error_notifications import error_notifications
+
+EXAMPLE_GLUE_FAILURE_PAYLOAD = {
+    "StateMachineId": "arn:aws:states:eu-west-2:1234523454:stateMachine:notifications-on-pipeline-fail-DataEngineeringPipeline",
+    "ExecutionStartTime": "2022-07-25T10:07:59.147Z",
+    "Error": '{"AllocatedCapacity":12,"Arguments":{"--destination":"s3://sfc-notifications-on-pipeline-fail-datasets/domain=data_engineering/dataset=locations_prepared/version=1.0.0/","--cqc_provider_source":"s3://sfc-notifications-on-pipeline-fail-datasets/domain=CQC/dataset=providers-api/","--pir_source":"s3://sfc-notifications-on-pipeline-fail-datasets/domain=CQC/dataset=pir/","--workplace_source":"s3://sfc-notifications-on-pipeline-fail-datasets/domain=ASCWDS/dataset=workplace/","--cqc_location_source":"s3://sfc-notifications-on-pipeline-fail-datasets/domain=CQC/dataset=locations-api/"},"Attempt":0,"CompletedOn":1658743757541,"DPUSeconds":240.0,"ErrorMessage":"AnalysisException: Path does not exist: s3://sfc-notifications-on-pipeline-fail-datasets/domain=ASCWDS/dataset=workplace","ExecutionTime":53,"GlueVersion":"3.0","Id":"jr_21e3085332b17768c24bf9d8c26378c4bf5f9a7c17ae6e6e2a5dbc6ff0fb36e4","JobName":"notifications-on-pipeline-fail-prepare_locations_job","JobRunState":"FAILED","LastModifiedOn":1658743757541,"LogGroupName":"/aws-glue/jobs","MaxCapacity":12.0,"NumberOfWorkers":6,"PredecessorRuns":[],"StartedOn":1658743679354,"Timeout":2880,"WorkerType":"G.2X"}',
+    "StateMachineName": "notifications-on-pipeline-fail-DataEngineeringPipeline",
+    "ExecutionId": "arn:aws:states:eu-west-2:1234523454:execution:notifications-on-pipeline-fail-DataEngineeringPipeline:680d6ef4-66af-eba4-8c4f-6549380eb9a5",
+    "CallbackToken": "jfoieruhggiubergiube",
+}
+
+EXAMPLE_GENERIC_FAILURE_PAYLOAD = {
+    "StateMachineId": "arn:aws:states:eu-west-2:1234523454:stateMachine:notifications-on-pipeline-fail-DataEngineeringPipeline",
+    "ExecutionStartTime": "2022-07-25T10:07:59.147Z",
+    "Error": "Crawler with name notifications-on-pipeline-fail-data_engineering_data_engineering has already started (Service: Glue, Status Code: 400, Request ID: e4f91543-dbca-49c9-8c52-fcd5db89efd9)",
+    "StateMachineName": "notifications-on-pipeline-fail-DataEngineeringPipeline",
+    "ExecutionId": "arn:aws:states:eu-west-2:1234523454:execution:notifications-on-pipeline-fail-DataEngineeringPipeline:680d6ef4-66af-eba4-8c4f-6549380eb9a5",
+    "CallbackToken": "jfoieruhggiubergiube",
+}
+
+
+class ErrorNotifications(unittest.TestCase):
+    def setUp(self) -> None:
+        self.sns_client = boto3.client("sns")
+        self.sns_stubber = Stubber(self.sns_client)
+        self.sf_client = boto3.client("stepfunctions")
+        self.sf_stubber = Stubber(self.sf_client)
+
+    def test_sns_called_with_topic_arn(self):
+        topic_arn = "arn:aws:sns:eu-west-2:1234523454:my-topic"
+        os.environ["SNS_TOPIC_ARN"] = topic_arn
+        self.mock_sns_publish(topic_arn=topic_arn)
+        self.mock_task_success()
+
+        error_notifications.main(
+            EXAMPLE_GLUE_FAILURE_PAYLOAD, {}, self.sns_client, self.sf_client
+        )
+        self.sf_stubber.assert_no_pending_responses()
+
+    def test_sns_correctly_formats_email_text_for_glue_job_errors(self):
+        os.environ["SNS_TOPIC_ARN"] = "arn:aws:sns:eu-west-2:1234523454:my-topic"
+        expected_message = (
+            "Execution of the step function notifications-on-pipeline-fail-DataEngineeringPipeline has failed. "
+            "The failure occured on glue job notifications-on-pipeline-fail-prepare_locations_job with error: \n\n"
+            "AnalysisException: Path does not exist: s3://sfc-notifications-on-pipeline-fail-datasets/domain=ASCWDS/dataset=workplace \n\n"
+            "View the run details of the glue job here: https://eu-west-2.console.aws.amazon.com/gluestudio/home?region=eu-west-2#/job/notifications-on-pipeline-fail-prepare_locations_job/run/jr_21e3085332b17768c24bf9d8c26378c4bf5f9a7c17ae6e6e2a5dbc6ff0fb36e4?from=monitoring \n\n"
+            "View the execution details for the state function here: https://eu-west-2.console.aws.amazon.com/states/home?region=eu-west-2#/v2/executions/details/arn:aws:states:eu-west-2:1234523454:execution:notifications-on-pipeline-fail-DataEngineeringPipeline:680d6ef4-66af-eba4-8c4f-6549380eb9a5 \n"
+        )
+        self.mock_sns_publish(expected_message=expected_message)
+        self.mock_task_success()
+
+        error_notifications.main(
+            EXAMPLE_GLUE_FAILURE_PAYLOAD, {}, self.sns_client, self.sf_client
+        )
+        self.sf_stubber.assert_no_pending_responses()
+
+    def test_sns_correctly_formats_email_text_for_all_other_errors(self):
+        os.environ["SNS_TOPIC_ARN"] = "arn:aws:sns:eu-west-2:1234523454:my-topic"
+        expected_message = (
+            "Execution of the step function notifications-on-pipeline-fail-DataEngineeringPipeline has failed woth error. \n\n"
+            "Crawler with name notifications-on-pipeline-fail-data_engineering_data_engineering has already started (Service: Glue, Status Code: 400, Request ID: e4f91543-dbca-49c9-8c52-fcd5db89efd9) \n\n"
+            "View the execution details for the state function here: https://eu-west-2.console.aws.amazon.com/states/home?region=eu-west-2#/v2/executions/details/arn:aws:states:eu-west-2:1234523454:execution:notifications-on-pipeline-fail-DataEngineeringPipeline:680d6ef4-66af-eba4-8c4f-6549380eb9a5 \n"
+        )
+        self.mock_sns_publish(expected_message=expected_message)
+        self.mock_task_success()
+
+        error_notifications.main(
+            EXAMPLE_GENERIC_FAILURE_PAYLOAD, {}, self.sns_client, self.sf_client
+        )
+        self.sf_stubber.assert_no_pending_responses()
+
+    def test_when_successfully_published_calls_successful_callback(self):
+        self.mock_sns_publish()
+
+        self.mock_task_success(
+            token=EXAMPLE_GLUE_FAILURE_PAYLOAD["CallbackToken"],
+            output=json.dumps({"MessageId": "463rtgygi3"}),
+        )
+
+        error_notifications.main(
+            EXAMPLE_GLUE_FAILURE_PAYLOAD, {}, self.sns_client, self.sf_client
+        )
+
+        self.sf_stubber.assert_no_pending_responses()
+
+    def test_when_it_errors_calls_failure_callback(self):
+        self.sns_stubber.add_client_error(
+            "publish",
+            service_error_code="NotFoundException",
+            service_message="SNS topic could not be found",
+            expected_params={"TopicArn": ANY, "Subject": ANY, "Message": ANY},
+        )
+        self.sns_stubber.activate()
+
+        expected_params = {
+            "taskToken": EXAMPLE_GLUE_FAILURE_PAYLOAD["CallbackToken"],
+            "error": "<class 'botocore.exceptions.ClientError'>",
+            "cause": "An error occurred (NotFoundException) when calling the Publish operation: SNS topic could not be found",
+        }
+        self.sf_stubber.add_response("send_task_failure", {}, expected_params)
+        self.sf_stubber.activate()
+
+        error_notifications.main(
+            EXAMPLE_GLUE_FAILURE_PAYLOAD, {}, self.sns_client, self.sf_client
+        )
+
+        self.sf_stubber.assert_no_pending_responses()
+
+    def mock_task_success(self, token=ANY, output=ANY):
+        self.sf_stubber.add_response(
+            "send_task_success", {}, {"taskToken": token, "output": output}
+        )
+        self.sf_stubber.activate()
+
+    def mock_sns_publish(
+        self, MessageIdResponse="463rtgygi3", topic_arn=ANY, expected_message=ANY
+    ):
+        exepcted_params = {
+            "TopicArn": topic_arn,
+            "Subject": ANY,
+            "Message": expected_message,
+        }
+        self.sns_stubber.add_response(
+            "publish", {"MessageId": MessageIdResponse}, exepcted_params
+        )
+        self.sns_stubber.activate()

--- a/tests/unit/test_error_notifications_lambda.py
+++ b/tests/unit/test_error_notifications_lambda.py
@@ -28,9 +28,9 @@ EXAMPLE_GENERIC_FAILURE_PAYLOAD = {
 
 class ErrorNotifications(unittest.TestCase):
     def setUp(self) -> None:
-        self.sns_client = boto3.client("sns")
+        self.sns_client = boto3.client("sns", region_name="eu-west-2")
         self.sns_stubber = Stubber(self.sns_client)
-        self.sf_client = boto3.client("stepfunctions")
+        self.sf_client = boto3.client("stepfunctions", region_name="eu-west-2")
         self.sf_stubber = Stubber(self.sf_client)
 
     def test_sns_called_with_topic_arn(self):

--- a/tests/unit/test_error_notifications_lambda.py
+++ b/tests/unit/test_error_notifications_lambda.py
@@ -64,7 +64,7 @@ class ErrorNotifications(unittest.TestCase):
     def test_sns_correctly_formats_email_text_for_all_other_errors(self):
         os.environ["SNS_TOPIC_ARN"] = "arn:aws:sns:eu-west-2:1234523454:my-topic"
         expected_message = (
-            "Execution of the step function notifications-on-pipeline-fail-DataEngineeringPipeline has failed woth error. \n\n"
+            "Execution of the step function notifications-on-pipeline-fail-DataEngineeringPipeline has failed with error. \n\n"
             "Crawler with name notifications-on-pipeline-fail-data_engineering_data_engineering has already started (Service: Glue, Status Code: 400, Request ID: e4f91543-dbca-49c9-8c52-fcd5db89efd9) \n\n"
             "View the execution details for the state function here: https://eu-west-2.console.aws.amazon.com/states/home?region=eu-west-2#/v2/executions/details/arn:aws:states:eu-west-2:1234523454:execution:notifications-on-pipeline-fail-DataEngineeringPipeline:680d6ef4-66af-eba4-8c4f-6549380eb9a5 \n"
         )


### PR DESCRIPTION
# Description
A lambda function is invoked when an error is caught in the data engineering pipeline. 
The lambda function will send a message to an SNS topic with details of the failure.

I wrapped the whole pipeline in a parallel execution with one branch so that I could catch any error that occurs in there instead of catching it at each individual step. Here is the graph of an execution where an error is caught midway through: 

<img width="346" alt="Screenshot 2022-07-26 at 17 03 57" src="https://user-images.githubusercontent.com/38878719/181054950-1bab3496-c883-455b-b8c1-c201d1c7fb2a.png">

Emails can be added to the SNS topic in the main workspace in the AWS console to subscribe to these notifications. 

[Trello](https://trello.com/c/lIhtN06J/247-epic4-enable-notifications-if-pipeline-fails-should)

# Developer checklist
- [x] Unit test
- [x] Linked to Trello ticket
