### PR TITLE
PyDeequ package install & example glue job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -139,6 +139,19 @@ jobs:
           command: |
             mkdir dependencies && zip -r dependencies/dependencies.zip utils schemas environment
 
+      - run:
+          name: Download Deequ jar
+          command: |
+            wget https://repo1.maven.org/maven2/com/amazon/deequ/deequ/1.0.3/deequ-1.0.3.jar -O dependencies/deequ-1.0.3.jar
+
+      - run:
+          name: Package PyDeequ
+          command: |
+            pip install -t ./target pydeequ==1.0.1
+            cd target && zip -r pydeequ-1.0.1.zip pydeequ && cd ..
+            mv target/pydeequ-1.0.1.zip dependencies/pydeequ-1.0.1.zip
+            rm -rf target
+
       - aws-s3/sync:
           aws-region: AWS_REGION
           from: dependencies

--- a/jobs/collect_dq_metrics_on_workplaces_job.py
+++ b/jobs/collect_dq_metrics_on_workplaces_job.py
@@ -1,85 +1,111 @@
 import sys
 
-from pydeequ.repository import *
-from pydeequ.anomaly_detection import *
-from pydeequ.analyzers import *
-from pydeequ.verification import *
+from pydeequ.repository import FileSystemMetricsRepository, ResultKey
+from pydeequ.anomaly_detection import RelativeRateOfChangeStrategy
+from pydeequ.analyzers import AnalysisRunner, Size, Mean
+from pydeequ.verification import VerificationSuite, VerificationResult
+from pydeequ.profiles import ColumnProfilerRunner
+from pydeequ.suggestions import ConstraintSuggestionRunner, DEFAULT
+from pydeequ.checks import Check, CheckLevel
 
 from utils import utils
 
 
 def main(source):
     spark = utils.get_spark()
-    metrics_location = f"{source}metrics.json"
-    metricsRepository = FileSystemMetricsRepository(spark, metrics_location)
-
     workplaces = spark.read.parquet(source)
+    try:
 
-    columnns_to_profile = [
-        "totalstaff",
-        "totalstarters",
-        "totalleavers",
-        "totalvacancies",
-        "establishmentid",
-        "providerid",
-        "locationid",
-    ]
+        columnns_to_profile = [
+            "totalstaff",
+            "totalstarters",
+            "totalleavers",
+            "totalvacancies",
+            "establishmentid",
+            "providerid",
+            "locationid",
+        ]
 
-    # ~~~~~~~~~~ Profiling columns ~~~~~~~~~~~~
-    print("GET COLUMNS PROFILES")
+        # ~~~~~~~~~~ Profiling columns ~~~~~~~~~~~~
 
-    result = (
-        ColumnProfilerRunner(spark)
-        .onData(workplaces.select(*columnns_to_profile))
-        .run()
-    )
+        print("COLUMN PROFILES")
 
-    for col, profile in result.profiles.items():
-        print(f"profile for column: {col}")
-        print(profile)
-
-    # ~~~~~~~ Suggestions for constraints to put on columns ~~~~~~~~~~~
-
-    print("GET CONSTRAINT SUGGESTIONS")
-
-    suggestionResult = (
-        ConstraintSuggestionRunner(spark)
-        .onData(workplaces.select(*columnns_to_profile))
-        .addConstraintRule(DEFAULT())
-        .run()
-    )
-
-    print(suggestionResult)
-
-    # ~~~~~~~~~ Defining check to run against the data ~~~~~~~~~~~~~
-    tags = {
-        "dataset": "workplace",
-        "domain": "ASCWDS",
-    }
-
-    result_key = ResultKey(spark_session=spark, tags=tags)
-    verification_suite = (
-        VerificationSuite(spark)
-        .onData(workplaces)
-        .useRepository(metricsRepository)
-        .saveOrAppendResult(result_key)
-        .addCheck(
-            Check(spark, CheckLevel.Error, "Data quality failure")
-            .isComplete("establishmentid")
-            .hasUniqueness(["establishmentid", "import_date"])
+        result = (
+            ColumnProfilerRunner(spark)
+            .onData(workplaces.select(*columnns_to_profile))
+            .run()
         )
-        .addAnomalyCheck(RelativeRateOfChangeStrategy(maxRateIncrease=2.0), Size())
-    )
 
-    # ~~~~~~~~~~~ Getting the results of these checks
-    check_results = VerificationResult.checkResultsAsDataFrame(spark, result.run())
+        for col, profile in result.profiles.items():
+            print(f"profile for column: {col}")
+            print(profile)
 
-    has_error = check_results.where(check_results.constraint_status == "Failure")
-    #  Can fail job here if there are any errors in this dataframe. IE if some of the constraints haven't been met
+        # ~~~~~~~ Suggestions for constraints to put on columns ~~~~~~~~~~~
 
-    # ~~~~~~~~~~~~~ Saving the results of these checks to S3
-    verification_suite.saveOrAppendResult(result_key).run()
+        print("CONSTRAINT SUGGESTIONS")
 
+        suggestionResult = (
+            ConstraintSuggestionRunner(spark)
+            .onData(workplaces.select(*columnns_to_profile))
+            .addConstraintRule(DEFAULT())
+            .run()
+        )
+
+        print(suggestionResult)
+
+        # ~~~~~~~~~~ Setup where to store metric results and any additional tags to save alongside the metrics
+        metrics_location = f"{source}metrics.json"
+        metricsRepository = FileSystemMetricsRepository(spark, metrics_location)
+        tags = {
+            "dataset": "workplace",
+            "domain": "ASCWDS",
+        }
+        result_key = ResultKey(spark_session=spark, tags=tags)
+
+        # ~~~~~~~~ Running analysis on the data
+        workplaces = workplaces.withColumn(
+            "totalstaff", workplaces.totalstaff.cast("int")
+        )
+        analysis_runners = (
+            AnalysisRunner(spark)
+            .onData(workplaces)
+            .useRepository(metricsRepository)
+            .saveOrAppendResult(result_key)
+            .addAnalyzer(Size())
+            .addAnalyzer(Mean("totalstaff"))
+        )
+        analysis_runners.run()
+
+        # ~~~~~~~~~ Defining checks to run against the data
+        verification_suite = (
+            VerificationSuite(spark)
+            .onData(workplaces)
+            .useRepository(metricsRepository)
+            .saveOrAppendResult(result_key)
+            .addCheck(
+                Check(spark, CheckLevel.Error, "Data quality failure")
+                .isComplete("establishmentid")
+                .hasUniqueness(["establishmentid", "import_date"], lambda unq: unq == 1)
+            )
+            # .addAnomalyCheck(RelativeRateOfChangeStrategy(maxRateIncrease=2.0), Size())
+        )
+
+        # ~~~~~~~~~~~ Getting the results of these checks
+        check_results = VerificationResult.checkResultsAsDataFrame(
+            spark, verification_suite.run()
+        )
+        check_results.show()
+        errors = check_results.where(check_results.constraint_status == "Failure")
+        has_error = errors.count() > 0
+        print(has_error)
+
+        #  Can fail job here if any of the constraints haven't been met
+
+        # ~~~~~~~~~~~~~ Saving the results of these checks to S3
+        verification_suite.saveOrAppendResult(result_key).run()
+    finally:
+        spark.sparkContext._gateway.close()
+        spark.stop()
     return
 
 
@@ -89,7 +115,8 @@ if __name__ == "__main__":
     )
     print(f"Job parameters: {sys.argv}")
 
-    source = utils.collect_arguments(
+    (source,) = utils.collect_arguments(
         ("--source", "S3 path to the workplace dataset"),
     )
+
     main(source)

--- a/jobs/collect_dq_metrics_on_workplaces_job.py
+++ b/jobs/collect_dq_metrics_on_workplaces_job.py
@@ -1,0 +1,95 @@
+import sys
+
+from pydeequ.repository import *
+from pydeequ.anomaly_detection import *
+from pydeequ.analyzers import *
+from pydeequ.verification import *
+
+from utils import utils
+
+
+def main(source):
+    spark = utils.get_spark()
+    metrics_location = f"{source}metrics.json"
+    metricsRepository = FileSystemMetricsRepository(spark, metrics_location)
+
+    workplaces = spark.read.parquet(source)
+
+    columnns_to_profile = [
+        "totalstaff",
+        "totalstarters",
+        "totalleavers",
+        "totalvacancies",
+        "establishmentid",
+        "providerid",
+        "locationid",
+    ]
+
+    # ~~~~~~~~~~ Profiling columns ~~~~~~~~~~~~
+    print("GET COLUMNS PROFILES")
+
+    result = (
+        ColumnProfilerRunner(spark)
+        .onData(workplaces.select(*columnns_to_profile))
+        .run()
+    )
+
+    for col, profile in result.profiles.items():
+        print(f"profile for column: {col}")
+        print(profile)
+
+    # ~~~~~~~ Suggestions for constraints to put on columns ~~~~~~~~~~~
+
+    print("GET CONSTRAINT SUGGESTIONS")
+
+    suggestionResult = (
+        ConstraintSuggestionRunner(spark)
+        .onData(workplaces.select(*columnns_to_profile))
+        .addConstraintRule(DEFAULT())
+        .run()
+    )
+
+    print(suggestionResult)
+
+    # ~~~~~~~~~ Defining check to run against the data ~~~~~~~~~~~~~
+    tags = {
+        "dataset": "workplace",
+        "domain": "ASCWDS",
+    }
+
+    result_key = ResultKey(spark_session=spark, tags=tags)
+    verification_suite = (
+        VerificationSuite(spark)
+        .onData(workplaces)
+        .useRepository(metricsRepository)
+        .saveOrAppendResult(result_key)
+        .addCheck(
+            Check(spark, CheckLevel.Error, "Data quality failure")
+            .isComplete("establishmentid")
+            .hasUniqueness(["establishmentid", "import_date"])
+        )
+        .addAnomalyCheck(RelativeRateOfChangeStrategy(maxRateIncrease=2.0), Size())
+    )
+
+    # ~~~~~~~~~~~ Getting the results of these checks
+    check_results = VerificationResult.checkResultsAsDataFrame(spark, result.run())
+
+    has_error = check_results.where(check_results.constraint_status == "Failure")
+    #  Can fail job here if there are any errors in this dataframe. IE if some of the constraints haven't been met
+
+    # ~~~~~~~~~~~~~ Saving the results of these checks to S3
+    verification_suite.saveOrAppendResult(result_key).run()
+
+    return
+
+
+if __name__ == "__main__":
+    print(
+        "Spark job collect data quality metrics on ASC WDS worker dataset starting..."
+    )
+    print(f"Job parameters: {sys.argv}")
+
+    source = utils.collect_arguments(
+        ("--source", "S3 path to the workplace dataset"),
+    )
+    main(source)

--- a/terraform/modules/glue-crawler/glue-crawler.tf
+++ b/terraform/modules/glue-crawler/glue-crawler.tf
@@ -10,7 +10,7 @@ resource "aws_glue_crawler" "crawler" {
 
   s3_target {
     path       = "s3://sfc-${local.workspace_prefix}-datasets/domain=${var.dataset_for_crawler}/"
-    exclusions = var.exclusions
+    exclusions = var.exclusions == null ? ["*.json"] : concat(var.exclusions, ["*.json"])
   }
 
   schema_change_policy {

--- a/terraform/modules/glue-job/glue.tf
+++ b/terraform/modules/glue-job/glue.tf
@@ -15,7 +15,8 @@ resource "aws_glue_job" "glue_job" {
 
   default_arguments = merge(var.job_parameters,
     {
-      "--extra-py-files"                   = "${var.resource_bucket.bucket_uri}/dependencies/dependencies.zip"
+      "--extra-py-files"                   = "${var.resource_bucket.bucket_uri}/dependencies/dependencies.zip,${var.resource_bucket.bucket_uri}/dependencies/pydeequ-1.0.1.zip"
+      "--extra-jars"                       = "${var.resource_bucket.bucket_uri}/dependencies/deequ-1.0.3.jar"
       "--TempDir"                          = "${var.resource_bucket.bucket_uri}/temp/"
       "--enable-continuous-cloudwatch-log" = "true"
       "--enable-auto-scaling"              = var.worker_type == "Standard" ? "false" : "true"

--- a/terraform/pipeline/glue.tf
+++ b/terraform/pipeline/glue.tf
@@ -194,7 +194,7 @@ module "collect_dq_metrics_on_workplaces_job" {
   glue_version    = "2.0"
 
   job_parameters = {
-    "--source" = "s3://sfc-main-datasets/domain=ASCWDS/dataset=workplace/"
+    "--source" = "${module.datasets_bucket.bucket_uri}/domain=ASCWDS/dataset=workplace/"
   }
 }
 

--- a/terraform/pipeline/glue.tf
+++ b/terraform/pipeline/glue.tf
@@ -185,6 +185,20 @@ module "bulk_cqc_locations_download_job" {
   }
 }
 
+module "collect_dq_metrics_on_workplaces_job" {
+  source          = "../modules/glue-job"
+  script_name     = "collect_dq_metrics_on_workplaces_job.py"
+  glue_role       = aws_iam_role.sfc_glue_service_iam_role
+  resource_bucket = module.pipeline_resources
+  datasets_bucket = module.datasets_bucket
+  glue_version    = "2.0"
+
+  job_parameters = {
+    "--source"           = "s3://sfc-main-datasets/domain=ASCWDS/dataset=workplace/"
+    "--metrics_location" = "${module.datasets_bucket.bucket_uri}/domain=ASCWDS/dataset=workplace-dq-metrics/"
+  }
+}
+
 module "ascwds_crawler" {
   source                       = "../modules/glue-crawler"
   dataset_for_crawler          = "ASCWDS"

--- a/terraform/pipeline/glue.tf
+++ b/terraform/pipeline/glue.tf
@@ -194,8 +194,7 @@ module "collect_dq_metrics_on_workplaces_job" {
   glue_version    = "2.0"
 
   job_parameters = {
-    "--source"           = "s3://sfc-main-datasets/domain=ASCWDS/dataset=workplace/"
-    "--metrics_location" = "${module.datasets_bucket.bucket_uri}/domain=ASCWDS/dataset=workplace-dq-metrics/"
+    "--source" = "s3://sfc-main-datasets/domain=ASCWDS/dataset=workplace/"
   }
 }
 


### PR DESCRIPTION
- Add steps to the deployment pipeline to install DeeQu jar & PyDeequ python package.
- Add the Jar and python zip file to glue jobs by default.
- Change the crawlers to exclude .json files, as the metrics will be stored as json files.
- An example glue job that runs some simple analysis & checks on the workplace dataset.