### PR TITLE
Alphabetically sort features list before vectorising

### DIFF
--- a/jobs/locations_feature_engineering.py
+++ b/jobs/locations_feature_engineering.py
@@ -200,6 +200,7 @@ def define_non_res_inc_pir_features_list(regions, local_authorites, cqc_sectors)
 
 
 def vectorize_features(locations_df, feature_list, column_name):
+    feature_list.sort()
     vectorized_df = VectorAssembler(
         inputCols=feature_list, outputCol=column_name, handleInvalid="skip"
     ).transform(locations_df)


### PR DESCRIPTION
This is to ensure the same order of features is used in training and when making all the predictions