### PR TITLE
Additional CQC API download dates

### DIFF
--- a/terraform/pipeline/glue.tf
+++ b/terraform/pipeline/glue.tf
@@ -162,7 +162,7 @@ module "bulk_cqc_providers_download_job" {
   resource_bucket  = module.pipeline_resources
   datasets_bucket  = module.datasets_bucket
   trigger          = true
-  trigger_schedule = "cron(30 01 01 * ? *)"
+  trigger_schedule = "cron(30 01 01,08,15,23 * ? *)"
   glue_version     = "2.0"
 
   job_parameters = {
@@ -177,7 +177,7 @@ module "bulk_cqc_locations_download_job" {
   resource_bucket  = module.pipeline_resources
   datasets_bucket  = module.datasets_bucket
   trigger          = true
-  trigger_schedule = "cron(30 01 01 * ? *)"
+  trigger_schedule = "cron(30 01 01,08,15,23 * ? *)"
   glue_version     = "2.0"
 
   job_parameters = {


### PR DESCRIPTION
Currently we get ASCWDS files on 1st, 8th, 15th and 23rd of every month
We get CQC data on 1st of every month via their API

This change is to increase the frequency of CQC downloads to match ASCWDS data
