### PR TITLE
updating terraform config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,6 +103,29 @@ jobs:
             - terraform/pipeline/.*
             - .
 
+  terraform-plan-dev:
+    working_directory: /tmp/project
+    docker:
+      - image: docker.mirror.hashicorp.services/hashicorp/terraform:1.2.1
+    resource_class: small
+    steps:
+      - checkout
+      - run:
+          name: terraform plan
+          command: |
+            cd terraform/pipeline
+            terraform init -input=false
+            terraform workspace select ${CIRCLE_BRANCH} || terraform workspace new "DEV-${CIRCLE_BRANCH}"
+            terraform plan -out tfapply
+      - store_artifacts:
+          path: terraform/pipeline/tfapply
+      - persist_to_workspace:
+          root: .
+          paths:
+            - terraform/pipeline/tfapply
+            - terraform/pipeline/.*
+            - .
+
   terraform-apply:
     docker:
       - image: docker.mirror.hashicorp.services/hashicorp/terraform:1.2.1
@@ -217,12 +240,12 @@ workflows:
           filters:
             branches:
               ignore: main
-      - terraform-plan:
+      - terraform-plan-dev:
           requires:
             - test
       - terraform-apply:
           requires:
-            - terraform-plan
+            - terraform-plan-dev
       - deploy-dependencies:
           requires:
             - terraform-apply


### PR DESCRIPTION
https://trello.com/c/JjZ16Ctw

# Description
Currently when we deploy branches, a dev version of the pipeline is created in AWS but it is not clear that is what it is due to naming, giving us difficulty in deleting unused resources safely. We should update config so it becomes obvious when a deployment is 'test' versus 'prod'

We propose that when we deploy a branch build, all resources should be prefixed with DEV or QA

# How to test
Acceptance criteria:
- deploy a branch build and confirm pipeline runs end to end without issue, - confirm you can see all expected S3 buckets prefixed with 'dev' or 'sfc-dev'
- check you can see aws crawlers prefixed with dev
- run the crawlers and confirm they complete
- -optionally run data pipelines 

# Developer checklist
- [ ] Unit test
- [ ] Linked to Trello ticket
- [ ] Documentation up to date
