### PR TITLE
moved function two_cols_are_equal_and_not_null

### DIFF
--- a/utils/prepare_locations_utils/job_calculator/calculate_jobcount_estimate_from_beds.py
+++ b/utils/prepare_locations_utils/job_calculator/calculate_jobcount_estimate_from_beds.py
@@ -106,14 +106,6 @@ def total_staff_diff_or_total_staff_pct_diff_within_tolerated_range():
     )
 
 
-def two_cols_are_equal_and_not_null(first_col: str, second_col: str):
-    return (
-        (F.col(first_col) == F.col(second_col))
-        & F.col(second_col).isNotNull()
-        & F.col(first_col).isNotNull()
-    )
-
-
 def calculate_jobcount_estimate_from_beds(input_df):
     input_df = input_df.withColumn(
         "bed_estimate_jobcount",

--- a/utils/prepare_locations_utils/job_calculator/calculate_jobcount_total_staff_equal_worker_records.py
+++ b/utils/prepare_locations_utils/job_calculator/calculate_jobcount_total_staff_equal_worker_records.py
@@ -1,10 +1,15 @@
 from utils.prepare_locations_utils.job_calculator.common_checks import (
     job_count_from_ascwds_is_not_populated,
 )
-from utils.prepare_locations_utils.job_calculator.calculate_jobcount_estimate_from_beds import (
-    two_cols_are_equal_and_not_null,
-)
 import pyspark.sql.functions as F
+
+
+def two_cols_are_equal_and_not_null(first_col: str, second_col: str):
+    return (
+        (F.col(first_col) == F.col(second_col))
+        & F.col(second_col).isNotNull()
+        & F.col(first_col).isNotNull()
+    )
 
 
 def calculate_jobcount_totalstaff_equal_wkrrecs(input_df):


### PR DESCRIPTION
function was in a job which wasn't using it, then called by the other job
Moved into the job it is used in

No change to tests as the same function is being called at the same time, just the location of it has moved

[Trello]https://trello.com/c/PgGzS9jA/62-move-the-function-twocolsareequalandnotnull-into-the-calculatejobcounttotalstaffequalworkerrecords-job
