### PR TITLE
solution to show job source cols that requires less code

### DIFF
--- a/tests/unit/test_calculate_jobs.py
+++ b/tests/unit/test_calculate_jobs.py
@@ -44,7 +44,6 @@ class TestJobCalculator(unittest.TestCase):
         df = self.spark.createDataFrame(rows, columns)
 
         jobcount_df = calculate_jobcount(df)
-        jobcount_df.show()
         jobcount_df_list = jobcount_df.collect()
 
         self.assertEqual(jobcount_df_list[0]["job_count"], 0.0)

--- a/tests/unit/test_calculate_jobs.py
+++ b/tests/unit/test_calculate_jobs.py
@@ -44,17 +44,51 @@ class TestJobCalculator(unittest.TestCase):
         df = self.spark.createDataFrame(rows, columns)
 
         jobcount_df = calculate_jobcount(df)
+        jobcount_df.show()
         jobcount_df_list = jobcount_df.collect()
 
         self.assertEqual(jobcount_df_list[0]["job_count"], 0.0)
+        self.assertEqual(
+            jobcount_df_list[0]["job_count_source"], "coalesce_total_staff_wkrrecs"
+        )
+
         self.assertEqual(jobcount_df_list[1]["job_count"], 500.0)
+        self.assertEqual(
+            jobcount_df_list[1]["job_count_source"], "totalstaff_equal_wkrrecs"
+        )
+
         self.assertEqual(jobcount_df_list[2]["job_count"], 100.0)
+        self.assertEqual(
+            jobcount_df_list[2]["job_count_source"], "coalesce_total_staff_wkrrecs"
+        )
+
         self.assertEqual(jobcount_df_list[3]["job_count"], 10.0)
+        self.assertEqual(
+            jobcount_df_list[3]["job_count_source"], "coalesce_total_staff_wkrrecs"
+        )
+
         self.assertEqual(jobcount_df_list[4]["job_count"], None)
+        self.assertEqual(jobcount_df_list[4]["job_count_source"], None)
+
         self.assertEqual(jobcount_df_list[5]["job_count"], None)
+        self.assertEqual(jobcount_df_list[5]["job_count_source"], None)
+
         self.assertEqual(jobcount_df_list[6]["job_count"], None)
+        self.assertEqual(jobcount_df_list[6]["job_count_source"], None)
+
         self.assertEqual(jobcount_df_list[7]["job_count"], 11.0)
+        self.assertEqual(
+            jobcount_df_list[7]["job_count_source"], "abs_difference_within_range"
+        )
+
         self.assertEqual(jobcount_df_list[8]["job_count"], 23.0)
+        self.assertEqual(jobcount_df_list[8]["job_count_source"], "handle_tiny_values")
+
         self.assertEqual(jobcount_df_list[9]["job_count"], 96.0)
+        self.assertEqual(jobcount_df_list[9]["job_count_source"], "estimate_from_beds")
+
         self.assertEqual(jobcount_df_list[10]["job_count"], 102.0)
+        self.assertEqual(jobcount_df_list[10]["job_count_source"], "estimate_from_beds")
+
         self.assertEqual(jobcount_df_list[11]["job_count"], 90.0)
+        self.assertEqual(jobcount_df_list[11]["job_count_source"], "estimate_from_beds")

--- a/utils/prepare_locations_utils/job_calculator/job_calculator.py
+++ b/utils/prepare_locations_utils/job_calculator/job_calculator.py
@@ -25,9 +25,34 @@ def calculate_jobcount(input_df):
     input_df = input_df.withColumn("job_count_source", F.lit(None).cast(StringType()))
 
     input_df = calculate_jobcount_totalstaff_equal_wkrrecs(input_df)
+    input_df = update_dataframe_with_identifying_rule(
+        input_df, "totalstaff_equal_wkrrecs"
+    )
+
     input_df = calculate_jobcount_coalesce_totalstaff_wkrrecs(input_df)
+    input_df = update_dataframe_with_identifying_rule(
+        input_df, "coalesce_total_staff_wkrrecs"
+    )
+
     input_df = calculate_jobcount_abs_difference_within_range(input_df)
+    input_df = update_dataframe_with_identifying_rule(
+        input_df, "abs_difference_within_range"
+    )
+
     input_df = calculate_jobcount_handle_tiny_values(input_df)
+    input_df = update_dataframe_with_identifying_rule(input_df, "handle_tiny_values")
+
     input_df = calculate_jobcount_estimate_from_beds(input_df)
+    input_df = update_dataframe_with_identifying_rule(input_df, "estimate_from_beds")
 
     return input_df
+
+
+def update_dataframe_with_identifying_rule(input_df, rule_name):
+    return input_df.withColumn(
+        "job_count_source",
+        F.when(
+            (F.col("job_count").isNotNull() & F.col("job_count_source").isNull()),
+            rule_name,
+        ).otherwise(F.col("job_count_source")),
+    )


### PR DESCRIPTION
# Description
Our dependency on Spark's When and Otherwise Logic causes issues if we try and add the job count source logic within our individual rule sets and this is especially true with the bed count estimate logic which is already complex. 

If we elevate this logic to the job calculator we will not have these issues and we write less code and leave our rule sets as they are. We can see it matches the comments in the test cases:
<img width="1468" alt="image" src="https://user-images.githubusercontent.com/122366620/217944616-c66459d0-038e-40ee-a400-fd7653856ee4.png">


# How to test
run prepare locations (you may need to delete a dataset created today or do this on your deploy) and confirm you can see values populated in the job count source
# Developer checklist
- [ ] Unit test
- [ ] Linked to Trello ticket
- [ ] Documentation up to date
