### PR TITLE
locking in glue version for prepare locations

### DIFF
--- a/terraform/pipeline/glue.tf
+++ b/terraform/pipeline/glue.tf
@@ -82,7 +82,7 @@ module "prepare_locations_job" {
   number_of_workers = 6
   resource_bucket   = module.pipeline_resources
   datasets_bucket   = module.datasets_bucket
-
+  glue_version      = "2.0"
   job_parameters = {
     "--workplace_source"    = "${module.datasets_bucket.bucket_uri}/domain=ASCWDS/dataset=workplace/"
     "--cqc_location_source" = "${module.datasets_bucket.bucket_uri}/domain=CQC/dataset=locations-api/"


### PR DESCRIPTION
# Description
Locking in Glue version to prevent the data conversion issue we had as a result of the change to registration dae
# How to test
Confirm pipeline completes its next run successfully (note as part of investigating the issue we manually changed the glue version in the AWS console so this is covered)
Confirm in deployment that the specification of the glue job shows version 2:
<img width="596" alt="image" src="https://user-images.githubusercontent.com/122366620/220411805-4a9dbae1-8976-4103-ae77-08b350b35ed5.png">


# Developer checklist
- [ ] Unit test
- [ ] Linked to Trello ticket
- [ ] Documentation up to date
