### PR TITLE
Alter estimate jobs to show output of models

### DIFF
--- a/tests/unit/test_model_non_res_default.py
+++ b/tests/unit/test_model_non_res_default.py
@@ -33,9 +33,17 @@ class TestModelNonResDefault(unittest.TestCase):
 
         df = df.collect()
         self.assertEqual(df[0]["estimate_job_count"], 54.09)
+        self.assertEqual(df[0]["non_res_default_model"], 54.09)
         self.assertEqual(df[0]["estimate_job_count_source"], "model_non_res_average")
+
         self.assertEqual(df[1]["estimate_job_count"], None)
+        self.assertEqual(df[1]["non_res_default_model"], None)
         self.assertEqual(df[1]["estimate_job_count_source"], None)
+
         self.assertEqual(df[2]["estimate_job_count"], 54.09)
+        self.assertEqual(df[2]["non_res_default_model"], 54.09)
+        self.assertEqual(df[2]["estimate_job_count_source"], "model_non_res_average")
+
         self.assertEqual(df[3]["estimate_job_count"], 10)
+        self.assertEqual(df[3]["non_res_default_model"], 54.09)
         self.assertEqual(df[3]["estimate_job_count_source"], "already_populated")

--- a/tests/unit/test_model_non_res_historical.py
+++ b/tests/unit/test_model_non_res_historical.py
@@ -58,8 +58,13 @@ class EstimateJobCountTests(unittest.TestCase):
         self.assertEqual(
             df[0]["estimate_job_count_source"], "model_non_res_ascwds_projected_forward"
         )
+        self.assertEqual(df[0]["model_non_res_historical"], 10.3)
         self.assertEqual(df[1]["estimate_job_count"], None)
         self.assertEqual(df[1]["estimate_job_count_source"], None)
+        self.assertEqual(df[1]["model_non_res_historical"], None)
         self.assertEqual(df[2]["estimate_job_count"], 20.6)
+        self.assertEqual(df[2]["estimate_job_count_source"], "model_non_res_ascwds_projected_forward")
+        self.assertEqual(df[2]["model_non_res_historical"], 20.6)
         self.assertEqual(df[3]["estimate_job_count"], 10)
         self.assertEqual(df[3]["estimate_job_count_source"], "already_populated")
+        self.assertEqual(df[3]["model_non_res_historical"], 10.3)

--- a/tests/unit/test_model_non_res_historical.py
+++ b/tests/unit/test_model_non_res_historical.py
@@ -63,7 +63,9 @@ class EstimateJobCountTests(unittest.TestCase):
         self.assertEqual(df[1]["estimate_job_count_source"], None)
         self.assertEqual(df[1]["model_non_res_historical"], None)
         self.assertEqual(df[2]["estimate_job_count"], 20.6)
-        self.assertEqual(df[2]["estimate_job_count_source"], "model_non_res_ascwds_projected_forward")
+        self.assertEqual(
+            df[2]["estimate_job_count_source"], "model_non_res_ascwds_projected_forward"
+        )
         self.assertEqual(df[2]["model_non_res_historical"], 20.6)
         self.assertEqual(df[3]["estimate_job_count"], 10)
         self.assertEqual(df[3]["estimate_job_count_source"], "already_populated")

--- a/utils/estimate_job_count/models/care_homes.py
+++ b/utils/estimate_job_count/models/care_homes.py
@@ -26,7 +26,7 @@ def model_care_homes(locations_df, features_df, model_path):
         "data_percentage": (features_df.count() / locations_df.count()) * 100,
     }
     locations_df = insert_predictions_into_locations(
-        locations_df, care_home_predictions
+        locations_df, care_home_predictions, "care_home_model"
     )
 
     locations_df = update_dataframe_with_identifying_rule(

--- a/utils/estimate_job_count/models/non_res_default.py
+++ b/utils/estimate_job_count/models/non_res_default.py
@@ -10,6 +10,8 @@ from utils.prepare_locations_utils.job_calculator.job_calculator import (
 
 import pyspark.sql.functions as F
 
+MEAN_NON_RESIDENTIAL_JOBS = 54.09
+
 
 def model_non_res_default(df: pyspark.sql.DataFrame)-> pyspark.sql.DataFrame:
     """
@@ -24,9 +26,20 @@ def model_non_res_default(df: pyspark.sql.DataFrame)-> pyspark.sql.DataFrame:
                 F.col(ESTIMATE_JOB_COUNT).isNull()
                 & (F.col(PRIMARY_SERVICE_TYPE) == "non-residential")
             ),
-            54.09,
+            MEAN_NON_RESIDENTIAL_JOBS,
         ).otherwise(F.col(ESTIMATE_JOB_COUNT)),
     )
+
+    df = df.withColumn(
+        "non_res_default_model",
+        F.when(
+            (
+                    F.col(PRIMARY_SERVICE_TYPE) == "non-residential"
+            ),
+            MEAN_NON_RESIDENTIAL_JOBS,
+        )
+    )
+
     df = update_dataframe_with_identifying_rule(
         df, "model_non_res_average", ESTIMATE_JOB_COUNT
     )

--- a/utils/estimate_job_count/models/non_res_default.py
+++ b/utils/estimate_job_count/models/non_res_default.py
@@ -1,3 +1,5 @@
+import pyspark.sql
+
 from utils.estimate_job_count.column_names import (
     ESTIMATE_JOB_COUNT,
     PRIMARY_SERVICE_TYPE,
@@ -9,7 +11,7 @@ from utils.prepare_locations_utils.job_calculator.job_calculator import (
 import pyspark.sql.functions as F
 
 
-def model_non_res_default(df):
+def model_non_res_default(df: pyspark.sql.DataFrame)-> pyspark.sql.DataFrame:
     """
     Non-res : Not Historical : Not PIR : 2021 jobs = mean of known 2021 non-res jobs (54.09)
     """

--- a/utils/estimate_job_count/models/non_res_default.py
+++ b/utils/estimate_job_count/models/non_res_default.py
@@ -13,7 +13,7 @@ import pyspark.sql.functions as F
 MEAN_NON_RESIDENTIAL_JOBS = 54.09
 
 
-def model_non_res_default(df: pyspark.sql.DataFrame)-> pyspark.sql.DataFrame:
+def model_non_res_default(df: pyspark.sql.DataFrame) -> pyspark.sql.DataFrame:
     """
     Non-res : Not Historical : Not PIR : 2021 jobs = mean of known 2021 non-res jobs (54.09)
     """
@@ -33,11 +33,9 @@ def model_non_res_default(df: pyspark.sql.DataFrame)-> pyspark.sql.DataFrame:
     df = df.withColumn(
         "non_res_default_model",
         F.when(
-            (
-                    F.col(PRIMARY_SERVICE_TYPE) == "non-residential"
-            ),
+            (F.col(PRIMARY_SERVICE_TYPE) == "non-residential"),
             MEAN_NON_RESIDENTIAL_JOBS,
-        )
+        ),
     )
 
     df = update_dataframe_with_identifying_rule(

--- a/utils/estimate_job_count/models/non_res_historical.py
+++ b/utils/estimate_job_count/models/non_res_historical.py
@@ -8,6 +8,8 @@ from utils.prepare_locations_utils.job_calculator.job_calculator import (
 )
 from pyspark.sql import functions as F
 
+PROJECTION_RATIO = 1.03
+
 
 def model_non_res_historical(df):
     """
@@ -22,9 +24,20 @@ def model_non_res_historical(df):
                 & (F.col(PRIMARY_SERVICE_TYPE) == "non-residential")
                 & F.col(LAST_KNOWN_JOB_COUNT).isNotNull()
             ),
-            F.col(LAST_KNOWN_JOB_COUNT) * 1.03,
+            F.col(LAST_KNOWN_JOB_COUNT) * PROJECTION_RATIO,
         ).otherwise(F.col(ESTIMATE_JOB_COUNT)),
     )
+
+    df = df.withColumn(
+        "model_non_res_historical",
+        F.when(
+            (
+                    (F.col(PRIMARY_SERVICE_TYPE) == "non-residential")
+                    & F.col(LAST_KNOWN_JOB_COUNT).isNotNull()
+            ),
+            F.col(LAST_KNOWN_JOB_COUNT) * PROJECTION_RATIO))
+
+
     df = update_dataframe_with_identifying_rule(
         df,
         "model_non_res_ascwds_projected_forward",

--- a/utils/estimate_job_count/models/non_res_historical.py
+++ b/utils/estimate_job_count/models/non_res_historical.py
@@ -32,11 +32,12 @@ def model_non_res_historical(df):
         "model_non_res_historical",
         F.when(
             (
-                    (F.col(PRIMARY_SERVICE_TYPE) == "non-residential")
-                    & F.col(LAST_KNOWN_JOB_COUNT).isNotNull()
+                (F.col(PRIMARY_SERVICE_TYPE) == "non-residential")
+                & F.col(LAST_KNOWN_JOB_COUNT).isNotNull()
             ),
-            F.col(LAST_KNOWN_JOB_COUNT) * PROJECTION_RATIO))
-
+            F.col(LAST_KNOWN_JOB_COUNT) * PROJECTION_RATIO,
+        ),
+    )
 
     df = update_dataframe_with_identifying_rule(
         df,

--- a/utils/estimate_job_count/models/non_res_with_pir.py
+++ b/utils/estimate_job_count/models/non_res_with_pir.py
@@ -33,7 +33,7 @@ def model_non_residential_with_pir(locations_df, features_df, model_path):
     }
 
     locations_df = insert_predictions_into_locations(
-        locations_df, non_residential_with_pir_predictions
+        locations_df, non_residential_with_pir_predictions, "non_res_with_pir_model"
     )
     locations_df = update_dataframe_with_identifying_rule(
         locations_df,


### PR DESCRIPTION
# Description
Additional columns added to dataset_estimate_jobs for each model, so that the output for each model can be compared.

# How to test
Outputs analysed in tableau. 
Columns compared and estimates are equal for location ids.
# Developer checklist
- [ ] Unit test
- [ ] Linked to Trello ticket
- [ ] Documentation up to date
