### PR TITLE
Fix join in prepare locations

### DIFF
--- a/jobs/prepare_locations.py
+++ b/jobs/prepare_locations.py
@@ -109,7 +109,7 @@ def main(
 
         output_df = cqc_locations_df.join(cqc_providers_df, "providerid", "left")
         output_df = output_df.join(
-            ascwds_workplace_with_coverage_df, "locationid", "full"
+            ascwds_workplace_with_coverage_df, "locationid", "left"
         )
 
         output_df = output_df.join(pir_df, "locationid", "left")

--- a/tests/unit/test_prepare_locations.py
+++ b/tests/unit/test_prepare_locations.py
@@ -4,6 +4,7 @@ from datetime import date
 import warnings
 
 from pyspark.sql import SparkSession
+import pyspark.sql.functions as F
 from pyspark.sql.types import (
     DoubleType,
     IntegerType,
@@ -77,7 +78,7 @@ class PrepareLocationsTests(unittest.TestCase):
         )
 
         self.assertIsNotNone(output_df)
-        self.assertEqual(output_df.count(), 35)
+        self.assertEqual(output_df.count(), 28)
         self.assertEqual(
             output_df.columns,
             [


### PR DESCRIPTION
# Description
Changed joins in prepare_locations.py to make sure they are all left joins
Updated tests to reflect changes.

NB: this fixes about 20,000 of the 73,000 Null values in cqc_sector

# How to test
Unit tests are passing
Run prepare locations in dev branch

# Developer checklist
- [ ] Unit test
- [ ] Linked to Trello ticket
- [ ] Documentation up to date
