### PR TITLE
Move primary service allocation to being allocated during the CQC import process

### DIFF
--- a/jobs/estimate_job_counts.py
+++ b/jobs/estimate_job_counts.py
@@ -37,13 +37,6 @@ from utils.prepare_locations_utils.job_calculator.job_calculator import (
     update_dataframe_with_identifying_rule,
 )
 
-# Constant values
-NURSING_HOME_IDENTIFIER = "Care home with nursing"
-NONE_NURSING_HOME_IDENTIFIER = "Care home without nursing"
-NONE_RESIDENTIAL_IDENTIFIER = "non-residential"
-
-# Column names
-
 
 def main(
     prepared_locations_source,
@@ -64,6 +57,7 @@ def main(
         .select(
             LOCATION_ID,
             SERVICES_OFFERED,
+            PRIMARY_SERVICE_TYPE,
             PEOPLE_DIRECTLY_EMPLOYED,
             NUMBER_OF_BEDS,
             SNAPSHOT_DATE,
@@ -85,8 +79,6 @@ def main(
         ESTIMATE_JOB_COUNT_SOURCE, F.lit(None).cast(StringType())
     )
     latest_snapshot = utils.get_max_snapshot_date(locations_df)
-
-    locations_df = determine_ascwds_primary_service_type(locations_df)
 
     # if job_count is populated, add that figure into estimate_job_count column
     locations_df = populate_estimate_jobs_when_job_count_known(locations_df)
@@ -159,25 +151,6 @@ def main(
         destination,
         append=True,
         partitionKeys=["run_year", "run_month", "run_day"],
-    )
-
-
-def determine_ascwds_primary_service_type(input_df):
-    return input_df.withColumn(
-        PRIMARY_SERVICE_TYPE,
-        F.when(
-            F.array_contains(
-                input_df[SERVICES_OFFERED], "Care home service with nursing"
-            ),
-            NURSING_HOME_IDENTIFIER,
-        )
-        .when(
-            F.array_contains(
-                input_df[SERVICES_OFFERED], "Care home service without nursing"
-            ),
-            NONE_NURSING_HOME_IDENTIFIER,
-        )
-        .otherwise(NONE_RESIDENTIAL_IDENTIFIER),
     )
 
 

--- a/tests/test_file_generator.py
+++ b/tests/test_file_generator.py
@@ -793,6 +793,7 @@ def generate_prepared_locations_file_parquet(
         "ons_region",
         "number_of_beds",
         "services_offered",
+        "primary_service_type",
         "people_directly_employed",
         "job_count",
         "local_authority",
@@ -807,20 +808,20 @@ def generate_prepared_locations_file_parquet(
 
     # fmt: off
     rows = [
-        ("1-1783948", "20220201", "South East", 0, ["Domiciliary care service"], 5, None, "Surrey", partitions[0], partitions[1], partitions[2], "N", "Independent", {"year_2011": "(England/Wales) Rural hamlet and isolated dwellings in a sparse setting"},"rule_1"),
-        ("1-1783948", "20220101", "South East", 0, ["Domiciliary care service"], 5, 67, "Surrey", partitions[0], partitions[1], partitions[2], "N", "Independent", {"year_2011": "(England/Wales) Rural hamlet and isolated dwellings in a sparse setting"},"rule_2"),
-        ("1-348374832", "20220112", "Merseyside", 0, ["Extra Care housing services"], None, 34, "Gloucestershire", partitions[0], partitions[1], partitions[2], "N", "Local authority", {"year_2011": "(England/Wales) Rural hamlet and isolated dwellings"},"rule_3"),
-        ("1-683746776", "20220101", "Merseyside", 0, ["Doctors treatment service", "Long term conditions services", "Shared Lives"], 34, None, "Gloucestershire", partitions[0], partitions[1], partitions[2], "N", "Local authority", {"year_2011": "(England/Wales) Rural hamlet and isolated dwellings"},"rule_1"),
-        ("1-10478686", "20220101", "London Senate", 0, ["Community health care services - Nurses Agency only"], None, None, "Surrey", partitions[0], partitions[1], partitions[2], "N", "", {"year_2011": "(England/Wales) Rural hamlet and isolated dwellings"},"rule_1"),
-        ("1-10235302415", "20220112", "South West", 0, ["Urgent care services", "Supported living service"], 17, None, "Surrey", partitions[0], partitions[1], partitions[2], "N", "Independent", {"year_2011": "(England/Wales) Rural hamlet and isolated dwellings"},"rule_3"),
-        ("1-1060912125", "20220112", "Yorkshire and The Humbler", 0, ["Hospice services at home"], 34, None, "Surrey", partitions[0], partitions[1], partitions[2], "N", "Independent", {"year_2011": "(England/Wales) Rural hamlet and isolated dwellings"},"rule_2"),
-        ("1-107095666", "20220301", "Yorkshire and The Humbler", 0, ["Specialist college service", "Community based services for people who misuse substances", "Urgent care services'"], 34, None, "Lewisham", partitions[0], partitions[1], partitions[2], "N", "Independent", {"year_2011": "(England/Wales) Urban city and town"},"rule_3"),
-        ("1-108369587", "20220308", "South West", 0, ["Specialist college service"], 15, None, "Lewisham", partitions[0], partitions[1], partitions[2], "N", "Independent", {"year_2011": "(England/Wales) Rural town and fringe in a sparse setting"}, "rule_1"),
-        ("1-10758359583", "20220308", None, 0, ["Mobile doctors service"], 17, None, "Lewisham", partitions[0], partitions[1], partitions[2], "N", "Local authority", {"year_2011": "(England/Wales) Urban city and town"}, "rule_2"),
-        ("1-000000001", "20220308", "Yorkshire and The Humbler", 67, ["Care home service with nursing"], None, None, "Lewisham", partitions[0], partitions[1], partitions[2], "Y", "Local authority", {"year_2011": "(England/Wales) Urban city and town"}, "rule_1"),
-        ("1-10894414510", "20220308", "Yorkshire and The Humbler", 10, ["Care home service with nursing"], 0, 25, "Lewisham", partitions[0], partitions[1], partitions[2], "Y", "Independent", {"year_2011": "(England/Wales) Urban city and town"},"rule_3"),
-        ("1-108950835", "20220315", "Merseyside", 20, ["Care home service without nursing"], 23, None, "Lewisham", partitions[0], partitions[1], partitions[2], "Y", "", {"year_2011": "(England/Wales) Urban city and town"}, "rule_1"),
-        ("1-108967195", "20220422", "(pseudo) Wales", 0, ["Supported living service", "Acute services with overnight beds"], 11, None, "Lewisham", partitions[0], partitions[1], partitions[2], "N", "Independent", {"year_2011": "(England/Wales) Urban city and town"},"rule_3"),
+        ("1-1783948", "20220201", "South East", 0, ["Domiciliary care service"], "non-residential", 5, None, "Surrey", partitions[0], partitions[1], partitions[2], "N", "Independent", {"year_2011": "(England/Wales) Rural hamlet and isolated dwellings in a sparse setting"}, "rule_1"),
+        ("1-1783948", "20220101", "South East", 0, ["Domiciliary care service"], "non-residential", 5, 67, "Surrey", partitions[0], partitions[1], partitions[2], "N", "Independent", {"year_2011": "(England/Wales) Rural hamlet and isolated dwellings in a sparse setting"}, "rule_2"),
+        ("1-348374832", "20220112", "Merseyside", 0, ["Extra Care housing services"], "non-residential", None, 34, "Gloucestershire", partitions[0], partitions[1], partitions[2], "N", "Local authority", {"year_2011": "(England/Wales) Rural hamlet and isolated dwellings"}, "rule_3"),
+        ("1-683746776", "20220101", "Merseyside", 0, ["Doctors treatment service", "Long term conditions services", "Shared Lives"], "non-residential", 34, None, "Gloucestershire", partitions[0], partitions[1], partitions[2], "N", "Local authority", {"year_2011": "(England/Wales) Rural hamlet and isolated dwellings"}, "rule_1"),
+        ("1-10478686", "20220101", "London Senate", 0, ["Community health care services - Nurses Agency only"], "non-residential", None, None, "Surrey", partitions[0], partitions[1], partitions[2], "N", "", {"year_2011": "(England/Wales) Rural hamlet and isolated dwellings"}, "rule_1"),
+        ("1-10235302415", "20220112", "South West", 0, ["Urgent care services", "Supported living service"], "non-residential", 17, None, "Surrey", partitions[0], partitions[1], partitions[2], "N", "Independent", {"year_2011": "(England/Wales) Rural hamlet and isolated dwellings"}, "rule_3"),
+        ("1-1060912125", "20220112", "Yorkshire and The Humbler", 0, ["Hospice services at home"], "non-residential", 34, None, "Surrey", partitions[0], partitions[1], partitions[2], "N", "Independent", {"year_2011": "(England/Wales) Rural hamlet and isolated dwellings"}, "rule_2"),
+        ("1-107095666", "20220301", "Yorkshire and The Humbler", 0, ["Specialist college service", "Community based services for people who misuse substances", "Urgent care services'"], "non-residential", 34, None, "Lewisham", partitions[0], partitions[1], partitions[2], "N", "Independent", {"year_2011": "(England/Wales) Urban city and town"}, "rule_3"),
+        ("1-108369587", "20220308", "South West", 0, ["Specialist college service"], "non-residential", 15, None, "Lewisham", partitions[0], partitions[1], partitions[2], "N", "Independent", {"year_2011": "(England/Wales) Rural town and fringe in a sparse setting"}, "rule_1"),
+        ("1-10758359583", "20220308", None, 0, ["Mobile doctors service"], "non-residential", 17, None, "Lewisham", partitions[0], partitions[1], partitions[2], "N", "Local authority", {"year_2011": "(England/Wales) Urban city and town"}, "rule_2"),
+        ("1-000000001", "20220308", "Yorkshire and The Humbler", 67, ["Care home service with nursing"], "Care home with nursing", None, None, "Lewisham", partitions[0], partitions[1], partitions[2], "Y", "Local authority", {"year_2011": "(England/Wales) Urban city and town"}, "rule_1"),
+        ("1-10894414510", "20220308", "Yorkshire and The Humbler", 10, ["Care home service with nursing"], "Care home with nursing", 0, 25, "Lewisham", partitions[0], partitions[1], partitions[2], "Y", "Independent", {"year_2011": "(England/Wales) Urban city and town"}, "rule_3"),
+        ("1-108950835", "20220315", "Merseyside", 20, ["Care home service without nursing"], "Care home without nursing", 23, None, "Lewisham", partitions[0], partitions[1], partitions[2], "Y", "", {"year_2011": "(England/Wales) Urban city and town"}, "rule_1"),
+        ("1-108967195", "20220422", "(pseudo) Wales", 0, ["Supported living service", "Acute services with overnight beds"], "non-residential", 11, None, "Lewisham", partitions[0], partitions[1], partitions[2], "N", "Independent", {"year_2011": "(England/Wales) Urban city and town"}, "rule_3"),
     ]
     # fmt: on
 

--- a/tests/unit/test_estimate_job_counts.py
+++ b/tests/unit/test_estimate_job_counts.py
@@ -89,32 +89,6 @@ class EstimateJobCountTests(unittest.TestCase):
         self.assertIsNotNone(day_partition)
         self.assertEqual(day_partition.groups()[0], "29")
 
-    def test_determine_ascwds_primary_service_type(self):
-        columns = ["locationid", "services_offered"]
-        rows = [
-            (
-                "1-000000001",
-                [
-                    "Care home service with nursing",
-                    "Care home service without nursing",
-                    "Fake service",
-                ],
-            ),
-            ("1-000000002", ["Care home service without nursing", "Fake service"]),
-            ("1-000000003", ["Fake service"]),
-            ("1-000000003", []),
-        ]
-        df = self.spark.createDataFrame(rows, columns)
-
-        df = job.determine_ascwds_primary_service_type(df)
-        self.assertEqual(df.count(), 4)
-
-        df = df.collect()
-        self.assertEqual(df[0]["primary_service_type"], "Care home with nursing")
-        self.assertEqual(df[1]["primary_service_type"], "Care home without nursing")
-        self.assertEqual(df[2]["primary_service_type"], "non-residential")
-        self.assertEqual(df[3]["primary_service_type"], "non-residential")
-
     def test_populate_known_jobs_use_job_count_from_current_snapshot(self):
         columns = [
             "locationid",

--- a/tests/unit/test_prepare_locations.py
+++ b/tests/unit/test_prepare_locations.py
@@ -106,6 +106,7 @@ class PrepareLocationsTests(unittest.TestCase):
                 "dormancy",
                 "number_of_beds",
                 "services_offered",
+                "primary_service_type",
                 "people_directly_employed",
                 "job_count",
                 "job_count_source",
@@ -152,11 +153,32 @@ class PrepareLocationsTests(unittest.TestCase):
         self.assertEqual(cqc_location_df.columns[0], "locationid")
         self.assertEqual(cqc_location_df.columns[1], "providerid")
         self.assertEqual(cqc_location_df.columns[16], "import_date")
+        self.assertEqual(cqc_location_df.columns[17], "primary_service_type")
         self.assertEqual(cqc_location_df.count(), 14)
 
         rows = cqc_location_df.collect()
         self.assertEqual(rows[12]["registration_date"], date(2011, 2, 15))
         self.assertEqual(rows[12]["deregistration_date"], date(2015, 1, 1))
+
+    def test_determine_ascwds_primary_service_type(self):
+        columns = ["locationid", "services_offered"]
+        # fmt: off
+        rows = [
+            ("1-000000001", ["Care home service with nursing", "Care home service without nursing", "Fake service",]),
+            ("1-000000002", ["Care home service without nursing", "Fake service"]),
+            ("1-000000003", ["Fake service"]),
+            ("1-000000004", []),
+        ]
+        df = self.spark.createDataFrame(rows, columns)
+
+        df = prepare_locations.allocate_primary_service_type(df)
+        self.assertEqual(df.count(), 4)
+
+        df = df.collect()
+        self.assertEqual(df[0]["primary_service_type"], "Care home with nursing")
+        self.assertEqual(df[1]["primary_service_type"], "Care home without nursing")
+        self.assertEqual(df[2]["primary_service_type"], "non-residential")
+        self.assertEqual(df[3]["primary_service_type"], "non-residential")
 
     def test_get_cqc_provider_df(self):
         cqc_provider_df = prepare_locations.get_cqc_provider_df(


### PR DESCRIPTION
Primary service is created later in the process in estimate_job_count job but we will need access to it sooner.
Moved it to during the CQC locations import