### PR TITLE
Filter out locations without providerid

### DIFF
--- a/jobs/prepare_locations.py
+++ b/jobs/prepare_locations.py
@@ -40,9 +40,15 @@ def main(
     last_processed_date = utils.get_max_snapshot_partitions(destination)
     if last_processed_date is not None:
         last_processed_date = f"{last_processed_date[LAST_PROCESSED_DATE_INDEX_ZERO]}{last_processed_date[LAST_PROCESSED_DATE_INDEX_ONE]}{last_processed_date[LAST_PROCESSED_DATE_INDEX_TWO]}"
-    complete_ascwds_workplace_df = get_ascwds_workplace_df(workplace_source, since_date=last_processed_date)
-    complete_cqc_location_df = get_cqc_location_df(cqc_location_source, since_date=last_processed_date)
-    complete_cqc_provider_df = get_cqc_provider_df(cqc_provider_source, since_date=last_processed_date)
+    complete_ascwds_workplace_df = get_ascwds_workplace_df(
+        workplace_source, since_date=last_processed_date
+    )
+    complete_cqc_location_df = get_cqc_location_df(
+        cqc_location_source, since_date=last_processed_date
+    )
+    complete_cqc_provider_df = get_cqc_provider_df(
+        cqc_provider_source, since_date=last_processed_date
+    )
     complete_pir_df = get_pir_df(pir_source, since_date=last_processed_date)
 
     latest_ons_data = get_ons_df(ons_source)
@@ -74,36 +80,50 @@ def main(
             ["locationid", "establishmentid", "import_date"],
             "left",
         )
-        ascwds_workplace_with_coverage_df = ascwds_workplace_with_coverage_df.withColumnRenamed(
-            "import_date", "ascwds_workplace_import_date"
+        ascwds_workplace_with_coverage_df = (
+            ascwds_workplace_with_coverage_df.withColumnRenamed(
+                "import_date", "ascwds_workplace_import_date"
+            )
         )
 
         cqc_locations_df = complete_cqc_location_df.filter(
             F.col("import_date") == snapshot_date_row["cqc_location_date"]
         )
         cqc_locations_df = utils.format_import_date(cqc_locations_df)
-        cqc_locations_df = cqc_locations_df.withColumnRenamed("import_date", "cqc_locations_import_date")
+        cqc_locations_df = cqc_locations_df.withColumnRenamed(
+            "import_date", "cqc_locations_import_date"
+        )
 
         cqc_providers_df = complete_cqc_provider_df.filter(
             F.col("import_date") == snapshot_date_row["cqc_provider_date"]
         )
         cqc_providers_df = utils.format_import_date(cqc_providers_df)
-        cqc_providers_df = cqc_providers_df.withColumnRenamed("import_date", "cqc_providers_import_date")
+        cqc_providers_df = cqc_providers_df.withColumnRenamed(
+            "import_date", "cqc_providers_import_date"
+        )
 
-        pir_df = complete_pir_df.filter(F.col("import_date") == snapshot_date_row["pir_date"])
+        pir_df = complete_pir_df.filter(
+            F.col("import_date") == snapshot_date_row["pir_date"]
+        )
         pir_df = utils.format_import_date(pir_df)
         pir_df = pir_df.withColumnRenamed("import_date", "cqc_pir_import_date")
 
         output_df = cqc_locations_df.join(cqc_providers_df, "providerid", "left")
-        output_df = output_df.join(ascwds_workplace_with_coverage_df, "locationid", "left")
+        output_df = output_df.join(
+            ascwds_workplace_with_coverage_df, "locationid", "left"
+        )
 
         output_df = output_df.join(pir_df, "locationid", "left")
         output_df = add_geographical_data(output_df, latest_ons_data)
-        output_df = calculate_jobcount(output_df, "total_staff", "worker_record_count", "job_count")
+        output_df = calculate_jobcount(
+            output_df, "total_staff", "worker_record_count", "job_count"
+        )
 
         output_df = add_column_if_locationid_is_in_ascwds(output_df)
 
-        output_df = output_df.withColumn("snapshot_date", F.lit(snapshot_date_row["snapshot_date"]))
+        output_df = output_df.withColumn(
+            "snapshot_date", F.lit(snapshot_date_row["snapshot_date"])
+        )
 
         output_df = add_three_columns_with_snapshot_date_substrings(output_df)
 
@@ -155,7 +175,11 @@ def main(
         )
 
         if destination:
-            print("Exporting snapshot {} as parquet to {}".format(snapshot_date_row["snapshot_date"], destination))
+            print(
+                "Exporting snapshot {} as parquet to {}".format(
+                    snapshot_date_row["snapshot_date"], destination
+                )
+            )
             utils.write_to_parquet(
                 output_df,
                 destination,
@@ -228,7 +252,11 @@ def get_cqc_location_df(cqc_location_source, since_date=None):
 
     cqc_df = cqc_df.withColumn(
         "region",
-        (F.when(cqc_df.region == "Yorkshire & Humberside", "Yorkshire and The Humber").otherwise(cqc_df.region)),
+        (
+            F.when(
+                cqc_df.region == "Yorkshire & Humberside", "Yorkshire and The Humber"
+            ).otherwise(cqc_df.region)
+        ),
     )
     cqc_df = cqc_df.withColumn("dormancy", cqc_df.dormancy == "Y")
 
@@ -377,8 +405,12 @@ def get_ons_df(ons_source):
 
 
 def get_unique_import_dates(df):
-    distinct_ordered_import_date_df = df.select("import_date").distinct().orderBy("import_date")
-    distinct_ordered_import_date_list = [date.import_date for date in distinct_ordered_import_date_df.collect()]
+    distinct_ordered_import_date_df = (
+        df.select("import_date").distinct().orderBy("import_date")
+    )
+    distinct_ordered_import_date_list = [
+        date.import_date for date in distinct_ordered_import_date_df.collect()
+    ]
     return distinct_ordered_import_date_list
 
 
@@ -392,7 +424,9 @@ def get_date_closest_to_search_date(search_date, date_list):
     return closest_date
 
 
-def generate_closest_date_matrix(dataset_workplace, dataset_locations_api, dataset_providers_api, dataset_pir):
+def generate_closest_date_matrix(
+    dataset_workplace, dataset_locations_api, dataset_providers_api, dataset_pir
+):
     unique_asc_dates = get_unique_import_dates(dataset_workplace)
     unique_cqc_location_dates = get_unique_import_dates(dataset_locations_api)
     unique_cqc_provider_dates = get_unique_import_dates(dataset_providers_api)
@@ -400,8 +434,12 @@ def generate_closest_date_matrix(dataset_workplace, dataset_locations_api, datas
 
     date_matrix = []
     for date in unique_asc_dates:
-        closest_cqc_location_date = get_date_closest_to_search_date(date, unique_cqc_location_dates)
-        closest_cqc_provider_date = get_date_closest_to_search_date(date, unique_cqc_provider_dates)
+        closest_cqc_location_date = get_date_closest_to_search_date(
+            date, unique_cqc_location_dates
+        )
+        closest_cqc_provider_date = get_date_closest_to_search_date(
+            date, unique_cqc_provider_dates
+        )
         closest_pir_date = get_date_closest_to_search_date(date, unique_pir_dates)
         date_matrix.append(
             {
@@ -420,7 +458,9 @@ def add_geographical_data(locations_df, ons_df):
     locations_df = locations_df.withColumn(
         "postal_code_ws_removed", F.regexp_replace(locations_df.postal_code, " ", "")
     )
-    ons_df = ons_df.withColumn("ons_postcode", F.regexp_replace(ons_df.ons_postcode, " ", ""))
+    ons_df = ons_df.withColumn(
+        "ons_postcode", F.regexp_replace(ons_df.ons_postcode, " ", "")
+    )
     locations_df = locations_df.join(
         ons_df,
         F.upper(locations_df.postal_code_ws_removed) == F.upper(ons_df.ons_postcode),
@@ -440,9 +480,13 @@ def clean(input_df):
     input_df = input_df.replace("0", None).replace("-1", None)
 
     # Cast strings to integers
-    input_df = input_df.withColumn("total_staff", input_df["total_staff"].cast(IntegerType()))
+    input_df = input_df.withColumn(
+        "total_staff", input_df["total_staff"].cast(IntegerType())
+    )
 
-    input_df = input_df.withColumn("worker_record_count", input_df["worker_record_count"].cast(IntegerType()))
+    input_df = input_df.withColumn(
+        "worker_record_count", input_df["worker_record_count"].cast(IntegerType())
+    )
 
     return input_df
 
@@ -465,16 +509,22 @@ def create_coverage_df(input_df):
 
     # if the org is a parent, use the max mupddate for all locations at the org
     org_purge_df = (
-        input_df.select("locationid", "orgid", "max_mupddate_and_lastloggedin", "import_date")
+        input_df.select(
+            "locationid", "orgid", "max_mupddate_and_lastloggedin", "import_date"
+        )
         .groupBy("orgid", "import_date")
-        .agg(F.max("max_mupddate_and_lastloggedin").alias("max_mupddate_and_lastloggedin_org"))
+        .agg(
+            F.max("max_mupddate_and_lastloggedin").alias(
+                "max_mupddate_and_lastloggedin_org"
+            )
+        )
     )
     input_df = input_df.join(org_purge_df, ["orgid", "import_date"], "left")
     input_df = input_df.withColumn(
         "date_for_purge",
-        F.when((input_df.isparent == "1"), input_df.max_mupddate_and_lastloggedin_org).otherwise(
-            input_df.max_mupddate_and_lastloggedin
-        ),
+        F.when(
+            (input_df.isparent == "1"), input_df.max_mupddate_and_lastloggedin_org
+        ).otherwise(input_df.max_mupddate_and_lastloggedin),
     )
 
     # Remove ASCWDS accounts which haven't been updated in the 2 years prior to importing
@@ -504,7 +554,9 @@ def purge_workplaces(input_df):
     input_df = input_df.join(org_purge_df, ["orgid", "import_date"], "left")
     input_df = input_df.withColumn(
         "date_for_purge",
-        F.when((input_df.isparent == "1"), input_df.mupddate_org).otherwise(input_df.mupddate),
+        F.when((input_df.isparent == "1"), input_df.mupddate_org).otherwise(
+            input_df.mupddate
+        ),
     )
 
     # Remove ASCWDS accounts which haven't been updated in the 2 years prior to importing
@@ -529,7 +581,9 @@ def add_cqc_sector(input_df):
 
     input_df = input_df.withColumn(
         "cqc_sector",
-        F.when(input_df.cqc_sector == "false", "Independent").otherwise("Local authority"),
+        F.when(input_df.cqc_sector == "false", "Independent").otherwise(
+            "Local authority"
+        ),
     )
 
     return input_df
@@ -538,7 +592,9 @@ def add_cqc_sector(input_df):
 def add_column_if_locationid_is_in_ascwds(df):
     df = df.withColumn(
         "cqc_coverage_in_ascwds",
-        F.when(df.establishmentid.isNull(), LOCATIONID_IS_NOT_IN_ASCWDS).otherwise(LOCATIONID_IS_IN_ASCWDS),
+        F.when(df.establishmentid.isNull(), LOCATIONID_IS_NOT_IN_ASCWDS).otherwise(
+            LOCATIONID_IS_IN_ASCWDS
+        ),
     )
 
     return df

--- a/tests/unit/test_prepare_locations.py
+++ b/tests/unit/test_prepare_locations.py
@@ -511,7 +511,7 @@ class PrepareLocationsTests(unittest.TestCase):
         self,
     ):
         spark = utils.get_spark()
-        ascwds_schema = StructType(
+        cqc_locations_schema = StructType(
             fields=[
                 StructField("locationid", StringType(), True),
                 StructField("providerid", StringType(), True),
@@ -521,7 +521,7 @@ class PrepareLocationsTests(unittest.TestCase):
             ("1", None),
             ("2", "5"),
         ]
-        df = spark.createDataFrame(data=rows, schema=ascwds_schema)
+        df = spark.createDataFrame(data=rows, schema=cqc_locations_schema)
 
         df = prepare_locations.filter_out_locations_with_no_providerid(df)
 

--- a/tests/unit/test_prepare_locations.py
+++ b/tests/unit/test_prepare_locations.py
@@ -45,7 +45,9 @@ class PrepareLocationsTests(unittest.TestCase):
     )
 
     def setUp(self):
-        self.spark = SparkSession.builder.appName("test_prepare_locations").getOrCreate()
+        self.spark = SparkSession.builder.appName(
+            "test_prepare_locations"
+        ).getOrCreate()
         generate_ascwds_workplace_file(self.TEST_ASCWDS_WORKPLACE_FILE)
         self.cqc_loc_df = generate_cqc_locations_file(self.TEST_CQC_LOCATION_FILE)
         generate_cqc_providers_file(self.TEST_CQC_PROVIDERS_FILE)
@@ -130,7 +132,9 @@ class PrepareLocationsTests(unittest.TestCase):
         self.assertEqual(df_collected[0]["cqc_coverage_in_ascwds"], 1)
 
     def test_get_ascwds_workplace_df(self):
-        workplace_df = prepare_locations.get_ascwds_workplace_df(self.TEST_ASCWDS_WORKPLACE_FILE, "20200101")
+        workplace_df = prepare_locations.get_ascwds_workplace_df(
+            self.TEST_ASCWDS_WORKPLACE_FILE, "20200101"
+        )
 
         self.assertEqual(workplace_df.columns[0], "locationid")
         self.assertEqual(workplace_df.columns[1], "establishmentid")
@@ -142,7 +146,9 @@ class PrepareLocationsTests(unittest.TestCase):
         self.assertEqual(workplace_df.count(), 10)
 
     def test_get_cqc_location_df(self):
-        cqc_location_df = prepare_locations.get_cqc_location_df(self.TEST_CQC_LOCATION_FILE, "20200101")
+        cqc_location_df = prepare_locations.get_cqc_location_df(
+            self.TEST_CQC_LOCATION_FILE, "20200101"
+        )
 
         self.assertEqual(cqc_location_df.columns[0], "locationid")
         self.assertEqual(cqc_location_df.columns[1], "providerid")
@@ -154,7 +160,9 @@ class PrepareLocationsTests(unittest.TestCase):
         self.assertEqual(rows[12]["deregistration_date"], date(2015, 1, 1))
 
     def test_get_cqc_provider_df(self):
-        cqc_provider_df = prepare_locations.get_cqc_provider_df(self.TEST_CQC_PROVIDERS_FILE, "20210105")
+        cqc_provider_df = prepare_locations.get_cqc_provider_df(
+            self.TEST_CQC_PROVIDERS_FILE, "20210105"
+        )
 
         self.assertEqual(cqc_provider_df.columns[0], "providerid")
         self.assertEqual(cqc_provider_df.columns[1], "provider_name")
@@ -206,7 +214,9 @@ class PrepareLocationsTests(unittest.TestCase):
         ]
         test_date = date(2022, 3, 12)
 
-        result = prepare_locations.get_date_closest_to_search_date(test_date, date_search_list)
+        result = prepare_locations.get_date_closest_to_search_date(
+            test_date, date_search_list
+        )
         self.assertEqual(result, date(2022, 2, 11))
 
     def test_get_date_closest_to_search_date_returns_None_if_no_historical_dates_available(
@@ -221,18 +231,24 @@ class PrepareLocationsTests(unittest.TestCase):
         ]
         test_date = date(2019, 1, 1)
 
-        result = prepare_locations.get_date_closest_to_search_date(test_date, date_search_list)
+        result = prepare_locations.get_date_closest_to_search_date(
+            test_date, date_search_list
+        )
         self.assertEqual(result, None)
 
     def test_get_date_closest_to_search_date_with_single_valid_date_returns_date(self):
         date_search_list = [date(2020, 3, 31)]
         test_date = date(2022, 5, 1)
 
-        result = prepare_locations.get_date_closest_to_search_date(test_date, date_search_list)
+        result = prepare_locations.get_date_closest_to_search_date(
+            test_date, date_search_list
+        )
         self.assertEqual(result, date(2020, 3, 31))
 
     def test_get_unique_import_dates_from_cqc_location_dataset(self):
-        cqc_location_df = prepare_locations.get_cqc_location_df(self.TEST_CQC_LOCATION_FILE, "20210101")
+        cqc_location_df = prepare_locations.get_cqc_location_df(
+            self.TEST_CQC_LOCATION_FILE, "20210101"
+        )
 
         result = prepare_locations.get_unique_import_dates(cqc_location_df)
         self.assertIsNotNone(result)
@@ -287,7 +303,9 @@ class PrepareLocationsTests(unittest.TestCase):
             #  date(2020, 3, 30)
         )
 
-        result = prepare_locations.generate_closest_date_matrix(workplace_df, cqc_location_df, cqc_provider_df, pir_df)
+        result = prepare_locations.generate_closest_date_matrix(
+            workplace_df, cqc_location_df, cqc_provider_df, pir_df
+        )
 
         self.assertIsNotNone(result)
         # fmt: off
@@ -391,16 +409,24 @@ class PrepareLocationsTests(unittest.TestCase):
         self.assertEqual(df[4]["cqc_sector"], "Independent")
 
     def test_get_cqc_location_df_standardises_yorkshire_and_the_humber_region(self):
-        cqc_locations = prepare_locations.get_cqc_location_df(self.TEST_CQC_LOCATION_FILE)
+        cqc_locations = prepare_locations.get_cqc_location_df(
+            self.TEST_CQC_LOCATION_FILE
+        )
 
-        yorks_and_the_humber_count = cqc_locations.filter(cqc_locations.region == "Yorkshire and The Humber").count()
-        yorks_and_humberside_count = cqc_locations.filter(cqc_locations.region == "Yorkshire & Humberside").count()
+        yorks_and_the_humber_count = cqc_locations.filter(
+            cqc_locations.region == "Yorkshire and The Humber"
+        ).count()
+        yorks_and_humberside_count = cqc_locations.filter(
+            cqc_locations.region == "Yorkshire & Humberside"
+        ).count()
 
         self.assertEqual(yorks_and_humberside_count, 0)
         self.assertEqual(yorks_and_the_humber_count, 5)
 
     def test_get_cqc_location_df_convert_dormancy_to_a_bool(self):
-        cqc_locations = prepare_locations.get_cqc_location_df(self.TEST_CQC_LOCATION_FILE)
+        cqc_locations = prepare_locations.get_cqc_location_df(
+            self.TEST_CQC_LOCATION_FILE
+        )
 
         dormancy_data_type = cqc_locations.schema["dormancy"].dataType
 
@@ -477,9 +503,13 @@ class PrepareLocationsTests(unittest.TestCase):
         self.assertEqual(df_collected[0]["cqc_coverage_in_ascwds"], 0)
         self.assertEqual(df_collected[1]["cqc_coverage_in_ascwds"], 1)
 
-        self.assertEqual(df.columns, ["locationid", "establishmentid", "cqc_coverage_in_ascwds"])
+        self.assertEqual(
+            df.columns, ["locationid", "establishmentid", "cqc_coverage_in_ascwds"]
+        )
 
-    def test_filter_out_locations_with_no_providerid_removes_cases_with_no_provider_id(self):
+    def test_filter_out_locations_with_no_providerid_removes_cases_with_no_provider_id(
+        self,
+    ):
         spark = utils.get_spark()
         ascwds_schema = StructType(
             fields=[

--- a/tests/unit/test_prepare_locations.py
+++ b/tests/unit/test_prepare_locations.py
@@ -45,9 +45,7 @@ class PrepareLocationsTests(unittest.TestCase):
     )
 
     def setUp(self):
-        self.spark = SparkSession.builder.appName(
-            "test_prepare_locations"
-        ).getOrCreate()
+        self.spark = SparkSession.builder.appName("test_prepare_locations").getOrCreate()
         generate_ascwds_workplace_file(self.TEST_ASCWDS_WORKPLACE_FILE)
         self.cqc_loc_df = generate_cqc_locations_file(self.TEST_CQC_LOCATION_FILE)
         generate_cqc_providers_file(self.TEST_CQC_PROVIDERS_FILE)
@@ -132,9 +130,7 @@ class PrepareLocationsTests(unittest.TestCase):
         self.assertEqual(df_collected[0]["cqc_coverage_in_ascwds"], 1)
 
     def test_get_ascwds_workplace_df(self):
-        workplace_df = prepare_locations.get_ascwds_workplace_df(
-            self.TEST_ASCWDS_WORKPLACE_FILE, "20200101"
-        )
+        workplace_df = prepare_locations.get_ascwds_workplace_df(self.TEST_ASCWDS_WORKPLACE_FILE, "20200101")
 
         self.assertEqual(workplace_df.columns[0], "locationid")
         self.assertEqual(workplace_df.columns[1], "establishmentid")
@@ -146,9 +142,7 @@ class PrepareLocationsTests(unittest.TestCase):
         self.assertEqual(workplace_df.count(), 10)
 
     def test_get_cqc_location_df(self):
-        cqc_location_df = prepare_locations.get_cqc_location_df(
-            self.TEST_CQC_LOCATION_FILE, "20200101"
-        )
+        cqc_location_df = prepare_locations.get_cqc_location_df(self.TEST_CQC_LOCATION_FILE, "20200101")
 
         self.assertEqual(cqc_location_df.columns[0], "locationid")
         self.assertEqual(cqc_location_df.columns[1], "providerid")
@@ -160,9 +154,7 @@ class PrepareLocationsTests(unittest.TestCase):
         self.assertEqual(rows[12]["deregistration_date"], date(2015, 1, 1))
 
     def test_get_cqc_provider_df(self):
-        cqc_provider_df = prepare_locations.get_cqc_provider_df(
-            self.TEST_CQC_PROVIDERS_FILE, "20210105"
-        )
+        cqc_provider_df = prepare_locations.get_cqc_provider_df(self.TEST_CQC_PROVIDERS_FILE, "20210105")
 
         self.assertEqual(cqc_provider_df.columns[0], "providerid")
         self.assertEqual(cqc_provider_df.columns[1], "provider_name")
@@ -214,9 +206,7 @@ class PrepareLocationsTests(unittest.TestCase):
         ]
         test_date = date(2022, 3, 12)
 
-        result = prepare_locations.get_date_closest_to_search_date(
-            test_date, date_search_list
-        )
+        result = prepare_locations.get_date_closest_to_search_date(test_date, date_search_list)
         self.assertEqual(result, date(2022, 2, 11))
 
     def test_get_date_closest_to_search_date_returns_None_if_no_historical_dates_available(
@@ -231,24 +221,18 @@ class PrepareLocationsTests(unittest.TestCase):
         ]
         test_date = date(2019, 1, 1)
 
-        result = prepare_locations.get_date_closest_to_search_date(
-            test_date, date_search_list
-        )
+        result = prepare_locations.get_date_closest_to_search_date(test_date, date_search_list)
         self.assertEqual(result, None)
 
     def test_get_date_closest_to_search_date_with_single_valid_date_returns_date(self):
         date_search_list = [date(2020, 3, 31)]
         test_date = date(2022, 5, 1)
 
-        result = prepare_locations.get_date_closest_to_search_date(
-            test_date, date_search_list
-        )
+        result = prepare_locations.get_date_closest_to_search_date(test_date, date_search_list)
         self.assertEqual(result, date(2020, 3, 31))
 
     def test_get_unique_import_dates_from_cqc_location_dataset(self):
-        cqc_location_df = prepare_locations.get_cqc_location_df(
-            self.TEST_CQC_LOCATION_FILE, "20210101"
-        )
+        cqc_location_df = prepare_locations.get_cqc_location_df(self.TEST_CQC_LOCATION_FILE, "20210101")
 
         result = prepare_locations.get_unique_import_dates(cqc_location_df)
         self.assertIsNotNone(result)
@@ -303,9 +287,7 @@ class PrepareLocationsTests(unittest.TestCase):
             #  date(2020, 3, 30)
         )
 
-        result = prepare_locations.generate_closest_date_matrix(
-            workplace_df, cqc_location_df, cqc_provider_df, pir_df
-        )
+        result = prepare_locations.generate_closest_date_matrix(workplace_df, cqc_location_df, cqc_provider_df, pir_df)
 
         self.assertIsNotNone(result)
         # fmt: off
@@ -409,24 +391,16 @@ class PrepareLocationsTests(unittest.TestCase):
         self.assertEqual(df[4]["cqc_sector"], "Independent")
 
     def test_get_cqc_location_df_standardises_yorkshire_and_the_humber_region(self):
-        cqc_locations = prepare_locations.get_cqc_location_df(
-            self.TEST_CQC_LOCATION_FILE
-        )
+        cqc_locations = prepare_locations.get_cqc_location_df(self.TEST_CQC_LOCATION_FILE)
 
-        yorks_and_the_humber_count = cqc_locations.filter(
-            cqc_locations.region == "Yorkshire and The Humber"
-        ).count()
-        yorks_and_humberside_count = cqc_locations.filter(
-            cqc_locations.region == "Yorkshire & Humberside"
-        ).count()
+        yorks_and_the_humber_count = cqc_locations.filter(cqc_locations.region == "Yorkshire and The Humber").count()
+        yorks_and_humberside_count = cqc_locations.filter(cqc_locations.region == "Yorkshire & Humberside").count()
 
         self.assertEqual(yorks_and_humberside_count, 0)
         self.assertEqual(yorks_and_the_humber_count, 5)
 
     def test_get_cqc_location_df_convert_dormancy_to_a_bool(self):
-        cqc_locations = prepare_locations.get_cqc_location_df(
-            self.TEST_CQC_LOCATION_FILE
-        )
+        cqc_locations = prepare_locations.get_cqc_location_df(self.TEST_CQC_LOCATION_FILE)
 
         dormancy_data_type = cqc_locations.schema["dormancy"].dataType
 
@@ -503,9 +477,31 @@ class PrepareLocationsTests(unittest.TestCase):
         self.assertEqual(df_collected[0]["cqc_coverage_in_ascwds"], 0)
         self.assertEqual(df_collected[1]["cqc_coverage_in_ascwds"], 1)
 
-        self.assertEqual(
-            df.columns, ["locationid", "establishmentid", "cqc_coverage_in_ascwds"]
+        self.assertEqual(df.columns, ["locationid", "establishmentid", "cqc_coverage_in_ascwds"])
+
+    def test_filter_out_locations_with_no_providerid_removes_cases_with_no_provider_id(self):
+        spark = utils.get_spark()
+        ascwds_schema = StructType(
+            fields=[
+                StructField("locationid", StringType(), True),
+                StructField("providerid", StringType(), True),
+            ]
         )
+        rows = [
+            ("1", None),
+            ("2", "5"),
+        ]
+        df = spark.createDataFrame(data=rows, schema=ascwds_schema)
+
+        df = prepare_locations.filter_out_locations_with_no_providerid(df)
+
+        self.assertEqual(df.count(), 1)
+
+        df_collected = df.collect()
+
+        self.assertEqual(df_collected[0]["providerid"], "5")
+
+        self.assertEqual(df.columns, ["locationid", "providerid"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Description
Added function to remove rows in cqc locations file that don't have a provider id. The provider id is necessary for joining the data to the cqc providers file.

# How to test

# Developer checklist
- [ ] Unit test
- [ ] Linked to Trello ticket
- [ ] Documentation up to date
