### PR TITLE
Update rolling average model

### DIFF
--- a/terraform/pipeline/step-functions/DataEngineeringPipeline-StepFunction.json
+++ b/terraform/pipeline/step-functions/DataEngineeringPipeline-StepFunction.json
@@ -29,7 +29,7 @@
               "Type": "Task",
               "Resource": "arn:aws:states:::glue:startJobRun.sync",
               "Parameters": {
-                "JobName": "job-count-filtering-prepare_locations_cleaned_job",
+                "JobName": "${prepare_locations_cleaned_job_name}",
                 "Arguments": {
                   "--prepared_locations_source": "${dataset_bucket_uri}/domain=data_engineering/dataset=locations_prepared/version=1.0.0/",
                   "--prepared_locations_cleaned_destination": "${dataset_bucket_uri}/domain=data_engineering/dataset=locations_prepared_cleaned/version=1.0.0/"

--- a/tests/unit/test_calculate_rolling_average.py
+++ b/tests/unit/test_calculate_rolling_average.py
@@ -42,7 +42,9 @@ class TestCalcRollingAvg(unittest.TestCase):
     # fmt: on
 
     def setUp(self):
-        self.spark = SparkSession.builder.appName("test_calculate_rolling_average").getOrCreate()
+        self.spark = SparkSession.builder.appName(
+            "test_calculate_rolling_average"
+        ).getOrCreate()
         df = self.spark.createDataFrame(self.rows, schema=self.column_schema)
 
         self.rolling_avg_df = calculate_rolling_averages(

--- a/tests/unit/test_calculate_rolling_average.py
+++ b/tests/unit/test_calculate_rolling_average.py
@@ -42,9 +42,7 @@ class TestCalcRollingAvg(unittest.TestCase):
     # fmt: on
 
     def setUp(self):
-        self.spark = SparkSession.builder.appName(
-            "test_calculate_rolling_average"
-        ).getOrCreate()
+        self.spark = SparkSession.builder.appName("test_calculate_rolling_average").getOrCreate()
         df = self.spark.createDataFrame(self.rows, schema=self.column_schema)
 
         self.rolling_avg_df = calculate_rolling_averages(

--- a/tests/unit/test_calculate_rolling_average.py
+++ b/tests/unit/test_calculate_rolling_average.py
@@ -1,0 +1,66 @@
+import unittest
+import warnings
+
+from pyspark.sql import SparkSession
+from pyspark.sql.types import (
+    StructType,
+    StructField,
+    StringType,
+    IntegerType,
+    DoubleType,
+)
+from dataclasses import dataclass
+
+from utils.estimate_job_count.calculate_rolling_average import (
+    calculate_rolling_averages,
+)
+
+
+@dataclass
+class TestRollingAverage:
+    MODEL_NAME = "model_name"
+    ROLLING_AVERAGE_TIME_PERIOD = "3 days"
+    ROLLING_AVERAGE_WINDOW_SLIDE = "1 days"
+    DAYS: int = 1
+
+
+class TestCalcRollingAvg(unittest.TestCase):
+    column_schema = StructType(
+        [
+            StructField("snapshot_date", StringType(), False),
+            StructField("job_count", IntegerType(), True),
+        ]
+    )
+    # fmt: off
+    rows = [
+        ("2023-01-04", 15),
+        ("2023-01-03", 5),
+        ("2023-01-02", 10),
+        ("2023-01-01", 15),
+        ("2023-01-25", None),
+    ]
+    # fmt: on
+
+    def setUp(self):
+        self.spark = SparkSession.builder.appName("test_calculate_rolling_average").getOrCreate()
+        df = self.spark.createDataFrame(self.rows, schema=self.column_schema)
+
+        self.rolling_avg_df = calculate_rolling_averages(
+            df,
+            TestRollingAverage.MODEL_NAME,
+            TestRollingAverage.ROLLING_AVERAGE_TIME_PERIOD,
+            TestRollingAverage.ROLLING_AVERAGE_WINDOW_SLIDE,
+            TestRollingAverage.DAYS,
+        )
+
+        warnings.filterwarnings("ignore", category=ResourceWarning)
+        warnings.filterwarnings("ignore", category=DeprecationWarning)
+
+    def test_calc_rolling_average_returns_average(self):
+
+        df = self.rolling_avg_df.orderBy("snapshot_date").collect()
+        self.assertEqual(df[0]["model_name"], 15)
+        self.assertEqual(df[1]["model_name"], 12.5)
+        self.assertEqual(df[2]["model_name"], 10)
+        self.assertEqual(df[3]["model_name"], 10)
+        self.assertEqual(df[4]["model_name"], 10)

--- a/tests/unit/test_model_non_res_rolling_average.py
+++ b/tests/unit/test_model_non_res_rolling_average.py
@@ -12,10 +12,6 @@ from pyspark.sql.types import (
 
 from utils.estimate_job_count.models.non_res_rolling_average import (
     model_non_res_rolling_average,
-    # convert_date_to_unix_timestamp,
-    # convert_days_to_unix_time,
-    # create_non_res_rolling_average_column,
-    ROLLING_AVERAGE_TIME_PERIOD_IN_DAYS,
 )
 
 
@@ -61,7 +57,7 @@ class TestModelNonResDefault(unittest.TestCase):
 
         df = self.non_res_model_df.orderBy("locationid").collect()
         self.assertEqual(df[0]["estimate_job_count"], None)
-        # self.assertEqual(df[0]["model_non_res_rolling_average"], None)
+        self.assertEqual(df[0]["model_non_res_rolling_average"], None)
         self.assertEqual(df[0]["estimate_job_count_source"], None)
 
     def test_model_non_res_rolling_average_returns_average_when_job_count_populated_and_estimate_is_none(
@@ -131,39 +127,3 @@ class TestModelNonResDefault(unittest.TestCase):
         self.assertEqual(df[8]["estimate_job_count"], 30.0)
         self.assertEqual(df[8]["model_non_res_rolling_average"], 15.0)
         self.assertEqual(df[8]["estimate_job_count_source"], "already_populated")
-
-
-"""
-    def test_convert_date_to_unix_timestamp(self):
-        df = self.spark.createDataFrame(self.rows, schema=self.column_schema)
-        df = convert_date_to_unix_timestamp(
-            df, "snapshot_date", "yyyy-MM-dd", "snapshot_date_unix_conv"
-        )
-
-        df = df.orderBy("locationid").collect()
-        self.assertEqual(df[0]["snapshot_date_unix_conv"], 1672531200)
-
-    def test_convert_days_to_unix_time(self):
-        self.assertEqual(convert_days_to_unix_time(1), 86400)
-        self.assertEqual(convert_days_to_unix_time(90), 7776000)
-
-    def test_create_non_res_rolling_average_column_removes_care_home_column(self):
-        df = self.spark.createDataFrame(self.rows, schema=self.column_schema)
-        df = create_non_res_rolling_average_column(
-            df, ROLLING_AVERAGE_TIME_PERIOD_IN_DAYS
-        )
-
-        self.assertEqual(df.count(), 8)
-
-    def test_create_non_res_rolling_average_column_calculates_prediction_column(self):
-        df = self.spark.createDataFrame(self.rows, schema=self.column_schema)
-        df = create_non_res_rolling_average_column(
-            df, ROLLING_AVERAGE_TIME_PERIOD_IN_DAYS
-        )
-
-        df = df.orderBy("locationid").collect()
-        self.assertEqual(df[0]["prediction"], 5.0)
-        self.assertEqual(df[2]["prediction"], 10.0)
-        self.assertEqual(df[4]["prediction"], 30.0)
-        self.assertEqual(df[6]["prediction"], 10.0)
-"""

--- a/tests/unit/test_model_non_res_rolling_average.py
+++ b/tests/unit/test_model_non_res_rolling_average.py
@@ -41,7 +41,9 @@ class TestModelNonResDefault(unittest.TestCase):
     # fmt: on
 
     def setUp(self):
-        self.spark = SparkSession.builder.appName("test_estimate_2021_jobs").getOrCreate()
+        self.spark = SparkSession.builder.appName(
+            "test_estimate_2021_jobs"
+        ).getOrCreate()
         self.non_res_model_df = model_non_res_rolling_average(
             self.spark.createDataFrame(self.rows, schema=self.column_schema)
         )

--- a/tests/unit/test_model_non_res_rolling_average.py
+++ b/tests/unit/test_model_non_res_rolling_average.py
@@ -12,9 +12,9 @@ from pyspark.sql.types import (
 
 from utils.estimate_job_count.models.non_res_rolling_average import (
     model_non_res_rolling_average,
-    convert_date_to_unix_timestamp,
-    convert_days_to_unix_time,
-    create_non_res_rolling_average_column,
+    # convert_date_to_unix_timestamp,
+    # convert_days_to_unix_time,
+    # create_non_res_rolling_average_column,
     ROLLING_AVERAGE_TIME_PERIOD_IN_DAYS,
 )
 
@@ -45,9 +45,7 @@ class TestModelNonResDefault(unittest.TestCase):
     # fmt: on
 
     def setUp(self):
-        self.spark = SparkSession.builder.appName(
-            "test_estimate_2021_jobs"
-        ).getOrCreate()
+        self.spark = SparkSession.builder.appName("test_estimate_2021_jobs").getOrCreate()
         self.non_res_model_df = model_non_res_rolling_average(
             self.spark.createDataFrame(self.rows, schema=self.column_schema)
         )
@@ -134,6 +132,8 @@ class TestModelNonResDefault(unittest.TestCase):
         self.assertEqual(df[8]["model_non_res_rolling_average"], 15.0)
         self.assertEqual(df[8]["estimate_job_count_source"], "already_populated")
 
+
+"""
     def test_convert_date_to_unix_timestamp(self):
         df = self.spark.createDataFrame(self.rows, schema=self.column_schema)
         df = convert_date_to_unix_timestamp(
@@ -166,3 +166,4 @@ class TestModelNonResDefault(unittest.TestCase):
         self.assertEqual(df[2]["prediction"], 10.0)
         self.assertEqual(df[4]["prediction"], 30.0)
         self.assertEqual(df[6]["prediction"], 10.0)
+"""

--- a/tests/unit/test_model_non_res_rolling_average.py
+++ b/tests/unit/test_model_non_res_rolling_average.py
@@ -61,7 +61,7 @@ class TestModelNonResDefault(unittest.TestCase):
 
         df = self.non_res_model_df.orderBy("locationid").collect()
         self.assertEqual(df[0]["estimate_job_count"], None)
-        self.assertEqual(df[0]["model_non_res_rolling_average"], None)
+        # self.assertEqual(df[0]["model_non_res_rolling_average"], None)
         self.assertEqual(df[0]["estimate_job_count_source"], None)
 
     def test_model_non_res_rolling_average_returns_average_when_job_count_populated_and_estimate_is_none(

--- a/tests/unit/test_model_non_res_rolling_average.py
+++ b/tests/unit/test_model_non_res_rolling_average.py
@@ -57,7 +57,7 @@ class TestModelNonResDefault(unittest.TestCase):
 
         df = self.non_res_model_df.orderBy("locationid").collect()
         self.assertEqual(df[0]["estimate_job_count"], None)
-        # self.assertEqual(df[0]["model_non_res_rolling_average"], None)
+        self.assertEqual(df[0]["model_non_res_rolling_average"], None)
         self.assertEqual(df[0]["estimate_job_count_source"], None)
 
     def test_model_non_res_rolling_average_returns_average_when_job_count_populated_and_estimate_is_none(

--- a/tests/unit/test_model_non_res_rolling_average.py
+++ b/tests/unit/test_model_non_res_rolling_average.py
@@ -57,7 +57,7 @@ class TestModelNonResDefault(unittest.TestCase):
 
         df = self.non_res_model_df.orderBy("locationid").collect()
         self.assertEqual(df[0]["estimate_job_count"], None)
-        self.assertEqual(df[0]["model_non_res_rolling_average"], None)
+        # self.assertEqual(df[0]["model_non_res_rolling_average"], None)
         self.assertEqual(df[0]["estimate_job_count_source"], None)
 
     def test_model_non_res_rolling_average_returns_average_when_job_count_populated_and_estimate_is_none(

--- a/tests/unit/test_model_non_res_rolling_average.py
+++ b/tests/unit/test_model_non_res_rolling_average.py
@@ -41,9 +41,7 @@ class TestModelNonResDefault(unittest.TestCase):
     # fmt: on
 
     def setUp(self):
-        self.spark = SparkSession.builder.appName(
-            "test_estimate_2021_jobs"
-        ).getOrCreate()
+        self.spark = SparkSession.builder.appName("test_estimate_2021_jobs").getOrCreate()
         self.non_res_model_df = model_non_res_rolling_average(
             self.spark.createDataFrame(self.rows, schema=self.column_schema)
         )

--- a/utils/estimate_job_count/calculate_rolling_average.py
+++ b/utils/estimate_job_count/calculate_rolling_average.py
@@ -8,9 +8,7 @@ from utils.estimate_job_count.column_names import (
 )
 
 
-def calculate_rolling_averages(
-    df: DataFrame, model_name: str, time_period: str, slide: str, days: int
-) -> DataFrame:
+def calculate_rolling_averages(df: DataFrame, model_name: str, time_period: str, slide: str, days: int) -> DataFrame:
 
     df_all_dates = df.withColumn("snapshot_timestamp", F.to_timestamp(df.snapshot_date))
 

--- a/utils/estimate_job_count/calculate_rolling_average.py
+++ b/utils/estimate_job_count/calculate_rolling_average.py
@@ -8,7 +8,9 @@ from utils.estimate_job_count.column_names import (
 )
 
 
-def calculate_rolling_averages(df: DataFrame, model_name: str, time_period: str, slide: str, days: int) -> DataFrame:
+def calculate_rolling_averages(
+    df: DataFrame, model_name: str, time_period: str, slide: str, days: int
+) -> DataFrame:
 
     df_all_dates = df.withColumn("snapshot_timestamp", F.to_timestamp(df.snapshot_date))
 

--- a/utils/estimate_job_count/calculate_rolling_average.py
+++ b/utils/estimate_job_count/calculate_rolling_average.py
@@ -1,0 +1,32 @@
+from pyspark.sql import DataFrame
+import pyspark.sql.functions as F
+
+
+from utils.estimate_job_count.column_names import (
+    SNAPSHOT_DATE,
+    JOB_COUNT,
+)
+
+
+def calculate_rolling_averages(df: DataFrame, model_name: str, time_period: str, slide: str, days: int) -> DataFrame:
+
+    df_all_dates = df.withColumn("snapshot_timestamp", F.to_timestamp(df.snapshot_date))
+
+    df_all_dates = df_all_dates.orderBy(df_all_dates.snapshot_timestamp)
+    df_all_dates.persist()
+
+    rolling_avg_window = F.window(
+        F.col("snapshot_timestamp"),
+        windowDuration=time_period,
+        slideDuration=slide,
+    ).alias("window")
+
+    rolling_avg = (
+        df_all_dates.groupBy(rolling_avg_window)
+        .agg(F.avg(F.col(JOB_COUNT)).alias(model_name))
+        .withColumn(
+            SNAPSHOT_DATE,
+            F.date_sub(F.col("window.end").cast("date"), days),
+        )
+    ).drop("window")
+    return rolling_avg

--- a/utils/estimate_job_count/models/non_res_rolling_average.py
+++ b/utils/estimate_job_count/models/non_res_rolling_average.py
@@ -1,5 +1,5 @@
 import pyspark.sql
-from pyspark.sql import Window
+from pyspark.sql import DataFrame
 import pyspark.sql.functions as F
 
 from utils.estimate_job_count.column_names import (
@@ -18,8 +18,35 @@ ROLLING_AVERAGE_TIME_PERIOD_IN_DAYS = 90
 
 
 def model_non_res_rolling_average(
-    df: pyspark.sql.DataFrame,
-) -> pyspark.sql.DataFrame:
+    df: DataFrame,
+) -> DataFrame:
+
+    locations_df_single_run = df
+    locations_df_single_run = locations_df_single_run.where(
+        locations_df_single_run.primary_service_type == "non-residential"
+    )
+
+    df_all_dates = locations_df_single_run.withColumn(
+        "snapshot_timestamp", F.to_timestamp(locations_df_single_run.snapshot_date)
+    )
+
+    df_all_dates = df_all_dates.orderBy(df_all_dates.snapshot_timestamp)
+    df_all_dates.persist()
+    df_all_dates.show()
+
+    rolling_avg_window = F.window(
+        F.col("snapshot_timestamp"),
+        windowDuration="91 days",
+        slideDuration="1 days",
+    ).alias("window")
+
+    rolling_avg = (
+        df_all_dates.groupBy(rolling_avg_window)
+        .agg(F.avg(F.col("job_count")).alias("model_non_res_rolling_average"))
+        .withColumn("snapshot_date", F.date_sub(F.col("window.end").cast("date"), 1))
+    )
+
+    df = locations_df_single_run.join(rolling_avg, "snapshot_date", how="left")
 
     df = update_dataframe_with_identifying_rule(df, "model_non_res_rolling_average", ESTIMATE_JOB_COUNT)
 

--- a/utils/estimate_job_count/models/non_res_rolling_average.py
+++ b/utils/estimate_job_count/models/non_res_rolling_average.py
@@ -1,4 +1,4 @@
-import pyspark.sql
+# import pyspark.sql
 from pyspark.sql import DataFrame
 import pyspark.sql.functions as F
 from dataclasses import dataclass

--- a/utils/estimate_job_count/models/non_res_rolling_average.py
+++ b/utils/estimate_job_count/models/non_res_rolling_average.py
@@ -1,7 +1,10 @@
+import pyspark.sql
 from pyspark.sql import DataFrame
 import pyspark.sql.functions as F
+from pyspark.sql.types import DoubleType
 
 from utils.estimate_job_count.column_names import (
+    LOCATION_ID,
     SNAPSHOT_DATE,
     JOB_COUNT,
     ESTIMATE_JOB_COUNT,
@@ -12,58 +15,48 @@ from utils.prepare_locations_utils.job_calculator.job_calculator import (
     update_dataframe_with_identifying_rule,
 )
 
-ROLLING_AVERAGE_TIME_PERIOD = "91 days"
-ROLLING_AVERAGE_WINDOW_SLIDE = "1 days"
-
-NON_RESIDENTIAL = "non-residential"
-SNAPSHOT_TIMESTAMP = "snapshot_timestamp"
-WINDOW = "window"
-WINDOW_END = "window.end"
-MODEL_NAME = "model_non_res_rolling_average"
-
-LEFT_JOIN = "left"
-DATE_TYPE = "date"
-ONE_DAY = 1
+ROLLING_AVERAGE_TIME_PERIOD_IN_DAYS = 90
 
 
 def model_non_res_rolling_average(
     df: DataFrame,
 ) -> DataFrame:
     df.show()
-    non_residential_df = df.where(df.primary_service_type == NON_RESIDENTIAL)
+    non_residential_df = df.where(df.primary_service_type == "non-residential")
     non_residential_df.show()
 
-    df_all_dates = non_residential_df.withColumn(SNAPSHOT_TIMESTAMP, F.to_timestamp(non_residential_df.snapshot_date))
+    df_all_dates = non_residential_df.withColumn("snapshot_timestamp", F.to_timestamp(non_residential_df.snapshot_date))
 
     df_all_dates = df_all_dates.orderBy(df_all_dates.snapshot_timestamp)
     df_all_dates.persist()
 
     rolling_avg_window = F.window(
-        F.col(SNAPSHOT_TIMESTAMP),
-        windowDuration=ROLLING_AVERAGE_TIME_PERIOD,
-        slideDuration=ROLLING_AVERAGE_WINDOW_SLIDE,
-    ).alias(WINDOW)
+        F.col("snapshot_timestamp"),
+        windowDuration="91 days",
+        slideDuration="1 days",
+    ).alias("window")
 
     rolling_avg = (
         df_all_dates.groupBy(rolling_avg_window)
-        .agg(F.avg(F.col(JOB_COUNT)).alias(MODEL_NAME))
-        .withColumn(SNAPSHOT_DATE, F.date_sub(F.col(WINDOW_END).cast(DATE_TYPE), ONE_DAY))
-    ).drop(WINDOW)
-
-    df_with_rolling_average = df.join(rolling_avg, SNAPSHOT_DATE, how=LEFT_JOIN)
+        .agg(F.avg(F.col("job_count")).alias("model_non_res_rolling_average"))
+        .withColumn("snapshot_date", F.date_sub(F.col("window.end").cast("date"), 1))
+    ).drop("window")
+    # it needs to join with the original data frame here and then we want to duplicate into estimate jobs where necessary, then add the column with the source
+    # will need to remove care home df throughout i think
+    df_with_rolling_average = df.join(rolling_avg, "snapshot_date", how="left")
 
     df_with_rolling_average.show()
 
     df_with_rolling_average = df_with_rolling_average.withColumn(
         ESTIMATE_JOB_COUNT,
         F.when(
-            (F.col(ESTIMATE_JOB_COUNT).isNull() & (F.col(PRIMARY_SERVICE_TYPE) == NON_RESIDENTIAL)),
-            F.col(MODEL_NAME),
+            (F.col(ESTIMATE_JOB_COUNT).isNull() & (F.col(PRIMARY_SERVICE_TYPE) == "non-residential")),
+            F.col("model_non_res_rolling_average"),
         ).otherwise(F.col(ESTIMATE_JOB_COUNT)),
     )
 
     df_with_rolling_average = update_dataframe_with_identifying_rule(
-        df_with_rolling_average, MODEL_NAME, ESTIMATE_JOB_COUNT
+        df_with_rolling_average, "model_non_res_rolling_average", ESTIMATE_JOB_COUNT
     )
     df_with_rolling_average.show()
 

--- a/utils/estimate_job_count/models/non_res_rolling_average.py
+++ b/utils/estimate_job_count/models/non_res_rolling_average.py
@@ -21,11 +21,9 @@ ROLLING_AVERAGE_TIME_PERIOD_IN_DAYS = 90
 def model_non_res_rolling_average(
     df: DataFrame,
 ) -> DataFrame:
-
+    df.show()
     non_residential_df = df.where(df.primary_service_type == "non-residential")
-
-    care_home_df = df.where(df.primary_service_type != "non-residential")
-    care_home_df = care_home_df.withColumn("model_non_res_rolling_average", F.lit(None).cast(DoubleType()))
+    non_residential_df.show()
 
     df_all_dates = non_residential_df.withColumn("snapshot_timestamp", F.to_timestamp(non_residential_df.snapshot_date))
 
@@ -43,15 +41,23 @@ def model_non_res_rolling_average(
         .agg(F.avg(F.col("job_count")).alias("model_non_res_rolling_average"))
         .withColumn("snapshot_date", F.date_sub(F.col("window.end").cast("date"), 1))
     ).drop("window")
+    # it needs to join with the original data frame here and then we want to duplicate into estimate jobs where necessary, then add the column with the source
+    # will need to remove care home df throughout i think
+    df_with_rolling_average = df.join(rolling_avg, "snapshot_date", how="left")
 
-    non_residential_df_with_rolling_average = non_residential_df.join(rolling_avg, "snapshot_date", how="left")
-    non_residential_df_with_rolling_average.show()
-    df_with_rolling_average = non_residential_df_with_rolling_average.union(care_home_df)
     df_with_rolling_average.show()
+
+    df_with_rolling_average = df_with_rolling_average.withColumn(
+        ESTIMATE_JOB_COUNT,
+        F.when(
+            (F.col(ESTIMATE_JOB_COUNT).isNull() & (F.col(PRIMARY_SERVICE_TYPE) == "non-residential")),
+            F.col("model_non_res_rolling_average"),
+        ).otherwise(F.col(ESTIMATE_JOB_COUNT)),
+    )
+
     df_with_rolling_average = update_dataframe_with_identifying_rule(
         df_with_rolling_average, "model_non_res_rolling_average", ESTIMATE_JOB_COUNT
     )
     df_with_rolling_average.show()
-    df_with_rolling_average = df_with_rolling_average.drop("snapshot_timestamp")
-    df_with_rolling_average.show()
+
     return df_with_rolling_average

--- a/utils/estimate_job_count/models/non_res_rolling_average.py
+++ b/utils/estimate_job_count/models/non_res_rolling_average.py
@@ -1,10 +1,7 @@
-import pyspark.sql
 from pyspark.sql import DataFrame
 import pyspark.sql.functions as F
-from pyspark.sql.types import DoubleType
 
 from utils.estimate_job_count.column_names import (
-    LOCATION_ID,
     SNAPSHOT_DATE,
     JOB_COUNT,
     ESTIMATE_JOB_COUNT,
@@ -15,48 +12,58 @@ from utils.prepare_locations_utils.job_calculator.job_calculator import (
     update_dataframe_with_identifying_rule,
 )
 
-ROLLING_AVERAGE_TIME_PERIOD_IN_DAYS = 90
+ROLLING_AVERAGE_TIME_PERIOD = "91 days"
+ROLLING_AVERAGE_WINDOW_SLIDE = "1 days"
+
+NON_RESIDENTIAL = "non-residential"
+SNAPSHOT_TIMESTAMP = "snapshot_timestamp"
+WINDOW = "window"
+WINDOW_END = "window.end"
+MODEL_NAME = "model_non_res_rolling_average"
+
+LEFT_JOIN = "left"
+DATE_TYPE = "date"
+ONE_DAY = 1
 
 
 def model_non_res_rolling_average(
     df: DataFrame,
 ) -> DataFrame:
     df.show()
-    non_residential_df = df.where(df.primary_service_type == "non-residential")
+    non_residential_df = df.where(df.primary_service_type == NON_RESIDENTIAL)
     non_residential_df.show()
 
-    df_all_dates = non_residential_df.withColumn("snapshot_timestamp", F.to_timestamp(non_residential_df.snapshot_date))
+    df_all_dates = non_residential_df.withColumn(SNAPSHOT_TIMESTAMP, F.to_timestamp(non_residential_df.snapshot_date))
 
     df_all_dates = df_all_dates.orderBy(df_all_dates.snapshot_timestamp)
     df_all_dates.persist()
 
     rolling_avg_window = F.window(
-        F.col("snapshot_timestamp"),
-        windowDuration="91 days",
-        slideDuration="1 days",
-    ).alias("window")
+        F.col(SNAPSHOT_TIMESTAMP),
+        windowDuration=ROLLING_AVERAGE_TIME_PERIOD,
+        slideDuration=ROLLING_AVERAGE_WINDOW_SLIDE,
+    ).alias(WINDOW)
 
     rolling_avg = (
         df_all_dates.groupBy(rolling_avg_window)
-        .agg(F.avg(F.col("job_count")).alias("model_non_res_rolling_average"))
-        .withColumn("snapshot_date", F.date_sub(F.col("window.end").cast("date"), 1))
-    ).drop("window")
-    # it needs to join with the original data frame here and then we want to duplicate into estimate jobs where necessary, then add the column with the source
-    # will need to remove care home df throughout i think
-    df_with_rolling_average = df.join(rolling_avg, "snapshot_date", how="left")
+        .agg(F.avg(F.col(JOB_COUNT)).alias(MODEL_NAME))
+        .withColumn(SNAPSHOT_DATE, F.date_sub(F.col(WINDOW_END).cast(DATE_TYPE), ONE_DAY))
+    ).drop(WINDOW)
+
+    df_with_rolling_average = df.join(rolling_avg, SNAPSHOT_DATE, how=LEFT_JOIN)
 
     df_with_rolling_average.show()
 
     df_with_rolling_average = df_with_rolling_average.withColumn(
         ESTIMATE_JOB_COUNT,
         F.when(
-            (F.col(ESTIMATE_JOB_COUNT).isNull() & (F.col(PRIMARY_SERVICE_TYPE) == "non-residential")),
-            F.col("model_non_res_rolling_average"),
+            (F.col(ESTIMATE_JOB_COUNT).isNull() & (F.col(PRIMARY_SERVICE_TYPE) == NON_RESIDENTIAL)),
+            F.col(MODEL_NAME),
         ).otherwise(F.col(ESTIMATE_JOB_COUNT)),
     )
 
     df_with_rolling_average = update_dataframe_with_identifying_rule(
-        df_with_rolling_average, "model_non_res_rolling_average", ESTIMATE_JOB_COUNT
+        df_with_rolling_average, MODEL_NAME, ESTIMATE_JOB_COUNT
     )
     df_with_rolling_average.show()
 

--- a/utils/estimate_job_count/models/non_res_rolling_average.py
+++ b/utils/estimate_job_count/models/non_res_rolling_average.py
@@ -9,9 +9,7 @@ from utils.estimate_job_count.column_names import (
     ESTIMATE_JOB_COUNT,
     PRIMARY_SERVICE_TYPE,
 )
-from utils.estimate_job_count.insert_predictions_into_locations import (
-    insert_predictions_into_locations,
-)
+
 from utils.prepare_locations_utils.job_calculator.job_calculator import (
     update_dataframe_with_identifying_rule,
 )
@@ -23,75 +21,6 @@ def model_non_res_rolling_average(
     df: pyspark.sql.DataFrame,
 ) -> pyspark.sql.DataFrame:
 
-    non_res_rolling_average_df = create_non_res_rolling_average_column(
-        df, number_of_days=ROLLING_AVERAGE_TIME_PERIOD_IN_DAYS
-    )
-
-    df = insert_predictions_into_locations(
-        df, non_res_rolling_average_df, "model_non_res_rolling_average"
-    )
-
-    df = df.withColumn(
-        ESTIMATE_JOB_COUNT,
-        F.when(
-            (
-                F.col(ESTIMATE_JOB_COUNT).isNull()
-                & (F.col(PRIMARY_SERVICE_TYPE) == "non-residential")
-            ),
-            F.col("model_non_res_rolling_average"),
-        ).otherwise(F.col(ESTIMATE_JOB_COUNT)),
-    )
-
-    df = update_dataframe_with_identifying_rule(
-        df, "model_non_res_rolling_average", ESTIMATE_JOB_COUNT
-    )
+    df = update_dataframe_with_identifying_rule(df, "model_non_res_rolling_average", ESTIMATE_JOB_COUNT)
 
     return df.drop("snapshot_date_unix_conv")
-
-
-def convert_date_to_unix_timestamp(
-    df: pyspark.sql.DataFrame, date_col: str, date_format: str, new_col_name: str
-) -> pyspark.sql.DataFrame:
-    df = df.withColumn(
-        new_col_name, F.unix_timestamp(F.col(date_col), format=date_format)
-    )
-
-    return df
-
-
-def rolling_average(col_to_average: str, unix_date_col: str, number_of_days: int):
-    return F.avg(col_to_average).over(
-        rolling_average_time_period(unix_date_col, number_of_days)
-    )
-
-
-def rolling_average_time_period(unix_date_col: str, number_of_days: int):
-    return Window.orderBy(F.col(unix_date_col).cast("long")).rangeBetween(
-        -convert_days_to_unix_time(number_of_days), 0
-    )
-
-
-def convert_days_to_unix_time(days: int):
-    return days * 86400
-
-
-def create_non_res_rolling_average_column(
-    df: pyspark.sql.DataFrame, number_of_days: int
-) -> pyspark.sql.DataFrame:
-    non_res_rolling_average_df = df.filter(
-        F.col(PRIMARY_SERVICE_TYPE) == "non-residential"
-    ).select(LOCATION_ID, SNAPSHOT_DATE, JOB_COUNT)
-
-    non_res_rolling_average_df = convert_date_to_unix_timestamp(
-        non_res_rolling_average_df,
-        date_col=SNAPSHOT_DATE,
-        date_format="yyyy-MM-dd",
-        new_col_name="snapshot_date_unix_conv",
-    )
-
-    non_res_rolling_average_df = non_res_rolling_average_df.withColumn(
-        "prediction",
-        rolling_average(JOB_COUNT, "snapshot_date_unix_conv", number_of_days),
-    )
-
-    return non_res_rolling_average_df

--- a/utils/estimate_job_count/models/non_res_rolling_average.py
+++ b/utils/estimate_job_count/models/non_res_rolling_average.py
@@ -1,9 +1,11 @@
+import pyspark.sql
 from pyspark.sql import DataFrame
 import pyspark.sql.functions as F
 from dataclasses import dataclass
 
 
 from utils.estimate_job_count.column_names import (
+    LOCATION_ID,
     SNAPSHOT_DATE,
     ESTIMATE_JOB_COUNT,
     PRIMARY_SERVICE_TYPE,

--- a/utils/estimate_job_count/models/non_res_rolling_average.py
+++ b/utils/estimate_job_count/models/non_res_rolling_average.py
@@ -34,9 +34,7 @@ def model_non_res_rolling_average(
 
     df_with_rolling_average = add_non_residential_rolling_average_column(df)
 
-    df_with_rolling_average = remove_rolling_average_from_care_home_rows(
-        df_with_rolling_average
-    )
+    df_with_rolling_average = remove_rolling_average_from_care_home_rows(df_with_rolling_average)
     df_with_rolling_average = fill_missing_estimate_job_counts(df_with_rolling_average)
 
     df_with_rolling_average = update_dataframe_with_identifying_rule(
@@ -47,9 +45,7 @@ def model_non_res_rolling_average(
 
 
 def add_non_residential_rolling_average_column(df: DataFrame) -> DataFrame:
-    non_residential_df = df.where(
-        df.primary_service_type == NonResRollingAverage.NON_RESIDENTIAL
-    )
+    non_residential_df = df.where(df.primary_service_type == NonResRollingAverage.NON_RESIDENTIAL)
     rolling_averages_df = calculate_rolling_averages(
         non_residential_df,
         NonResRollingAverage.MODEL_NAME,
@@ -63,12 +59,8 @@ def add_non_residential_rolling_average_column(df: DataFrame) -> DataFrame:
 
 
 def remove_rolling_average_from_care_home_rows(df: DataFrame) -> DataFrame:
-    care_home_df = df.where(
-        df.primary_service_type != NonResRollingAverage.NON_RESIDENTIAL
-    )
-    non_residential_df = df.where(
-        df.primary_service_type == NonResRollingAverage.NON_RESIDENTIAL
-    )
+    care_home_df = df.where(df.primary_service_type != NonResRollingAverage.NON_RESIDENTIAL)
+    non_residential_df = df.where(df.primary_service_type == NonResRollingAverage.NON_RESIDENTIAL)
     care_home_df = care_home_df.withColumn(NonResRollingAverage.MODEL_NAME, F.lit(None))
     df = non_residential_df.union(care_home_df)
     return df
@@ -76,15 +68,11 @@ def remove_rolling_average_from_care_home_rows(df: DataFrame) -> DataFrame:
 
 def fill_missing_estimate_job_counts(df: DataFrame) -> DataFrame:
     rows_to_fill_df = df.where(
-        (F.col(ESTIMATE_JOB_COUNT).isNull())
-        & (F.col(PRIMARY_SERVICE_TYPE) == NonResRollingAverage.NON_RESIDENTIAL)
+        (F.col(ESTIMATE_JOB_COUNT).isNull()) & (F.col(PRIMARY_SERVICE_TYPE) == NonResRollingAverage.NON_RESIDENTIAL)
     )
     rows_not_to_fill = df.where(
-        (F.col(ESTIMATE_JOB_COUNT).isNotNull())
-        | (F.col(PRIMARY_SERVICE_TYPE) != NonResRollingAverage.NON_RESIDENTIAL)
+        (F.col(ESTIMATE_JOB_COUNT).isNotNull()) | (F.col(PRIMARY_SERVICE_TYPE) != NonResRollingAverage.NON_RESIDENTIAL)
     )
-    rows_to_fill_df = rows_to_fill_df.withColumn(
-        ESTIMATE_JOB_COUNT, F.col(NonResRollingAverage.MODEL_NAME)
-    )
+    rows_to_fill_df = rows_to_fill_df.withColumn(ESTIMATE_JOB_COUNT, F.col(NonResRollingAverage.MODEL_NAME))
     df = rows_to_fill_df.union(rows_not_to_fill)
     return df

--- a/utils/estimate_job_count/models/non_res_rolling_average.py
+++ b/utils/estimate_job_count/models/non_res_rolling_average.py
@@ -1,7 +1,7 @@
-# import pyspark.sql
 from pyspark.sql import DataFrame
 import pyspark.sql.functions as F
 from dataclasses import dataclass
+from typing import Dict
 
 
 from utils.estimate_job_count.column_names import (

--- a/utils/estimate_job_count/models/non_res_rolling_average.py
+++ b/utils/estimate_job_count/models/non_res_rolling_average.py
@@ -32,7 +32,9 @@ def model_non_res_rolling_average(
 
     df_with_rolling_average = add_non_residential_rolling_average_column(df)
 
-    df_with_rolling_average = remove_rolling_average_from_care_home_rows(df_with_rolling_average)
+    df_with_rolling_average = remove_rolling_average_from_care_home_rows(
+        df_with_rolling_average
+    )
     df_with_rolling_average = fill_missing_estimate_job_counts(df_with_rolling_average)
 
     df_with_rolling_average = update_dataframe_with_identifying_rule(
@@ -43,7 +45,9 @@ def model_non_res_rolling_average(
 
 
 def add_non_residential_rolling_average_column(df: DataFrame) -> DataFrame:
-    non_residential_df = df.where(df.primary_service_type == NonResRollingAverage.NON_RESIDENTIAL)
+    non_residential_df = df.where(
+        df.primary_service_type == NonResRollingAverage.NON_RESIDENTIAL
+    )
     rolling_averages_df = calculate_rolling_averages(
         non_residential_df,
         NonResRollingAverage.MODEL_NAME,
@@ -56,7 +60,9 @@ def add_non_residential_rolling_average_column(df: DataFrame) -> DataFrame:
     return df
 
 
-def calculate_rolling_averages(df: DataFrame, model_name: str, time_period: str, slide: str, days: int) -> DataFrame:
+def calculate_rolling_averages(
+    df: DataFrame, model_name: str, time_period: str, slide: str, days: int
+) -> DataFrame:
 
     df_all_dates = df.withColumn("snapshot_timestamp", F.to_timestamp(df.snapshot_date))
 
@@ -81,8 +87,12 @@ def calculate_rolling_averages(df: DataFrame, model_name: str, time_period: str,
 
 
 def remove_rolling_average_from_care_home_rows(df: DataFrame) -> DataFrame:
-    care_home_df = df.where(df.primary_service_type != NonResRollingAverage.NON_RESIDENTIAL)
-    non_residential_df = df.where(df.primary_service_type == NonResRollingAverage.NON_RESIDENTIAL)
+    care_home_df = df.where(
+        df.primary_service_type != NonResRollingAverage.NON_RESIDENTIAL
+    )
+    non_residential_df = df.where(
+        df.primary_service_type == NonResRollingAverage.NON_RESIDENTIAL
+    )
     care_home_df = care_home_df.withColumn(NonResRollingAverage.MODEL_NAME, F.lit(None))
     df = non_residential_df.union(care_home_df)
     return df
@@ -90,11 +100,15 @@ def remove_rolling_average_from_care_home_rows(df: DataFrame) -> DataFrame:
 
 def fill_missing_estimate_job_counts(df: DataFrame) -> DataFrame:
     rows_to_fill_df = df.where(
-        (F.col(ESTIMATE_JOB_COUNT).isNull()) & (F.col(PRIMARY_SERVICE_TYPE) == NonResRollingAverage.NON_RESIDENTIAL)
+        (F.col(ESTIMATE_JOB_COUNT).isNull())
+        & (F.col(PRIMARY_SERVICE_TYPE) == NonResRollingAverage.NON_RESIDENTIAL)
     )
     rows_not_to_fill = df.where(
-        (F.col(ESTIMATE_JOB_COUNT).isNotNull()) | (F.col(PRIMARY_SERVICE_TYPE) != NonResRollingAverage.NON_RESIDENTIAL)
+        (F.col(ESTIMATE_JOB_COUNT).isNotNull())
+        | (F.col(PRIMARY_SERVICE_TYPE) != NonResRollingAverage.NON_RESIDENTIAL)
     )
-    rows_to_fill_df = rows_to_fill_df.withColumn(ESTIMATE_JOB_COUNT, F.col(NonResRollingAverage.MODEL_NAME))
+    rows_to_fill_df = rows_to_fill_df.withColumn(
+        ESTIMATE_JOB_COUNT, F.col(NonResRollingAverage.MODEL_NAME)
+    )
     df = rows_to_fill_df.union(rows_not_to_fill)
     return df

--- a/utils/estimate_job_count/models/non_res_rolling_average.py
+++ b/utils/estimate_job_count/models/non_res_rolling_average.py
@@ -34,7 +34,9 @@ def model_non_res_rolling_average(
 
     df_with_rolling_average = add_non_residential_rolling_average_column(df)
 
-    df_with_rolling_average = remove_rolling_average_from_care_home_rows(df_with_rolling_average)
+    df_with_rolling_average = remove_rolling_average_from_care_home_rows(
+        df_with_rolling_average
+    )
     df_with_rolling_average = fill_missing_estimate_job_counts(df_with_rolling_average)
 
     df_with_rolling_average = update_dataframe_with_identifying_rule(
@@ -45,7 +47,9 @@ def model_non_res_rolling_average(
 
 
 def add_non_residential_rolling_average_column(df: DataFrame) -> DataFrame:
-    non_residential_df = df.where(df.primary_service_type == NonResRollingAverage.NON_RESIDENTIAL)
+    non_residential_df = df.where(
+        df.primary_service_type == NonResRollingAverage.NON_RESIDENTIAL
+    )
     rolling_averages_df = calculate_rolling_averages(
         non_residential_df,
         NonResRollingAverage.MODEL_NAME,
@@ -59,8 +63,12 @@ def add_non_residential_rolling_average_column(df: DataFrame) -> DataFrame:
 
 
 def remove_rolling_average_from_care_home_rows(df: DataFrame) -> DataFrame:
-    care_home_df = df.where(df.primary_service_type != NonResRollingAverage.NON_RESIDENTIAL)
-    non_residential_df = df.where(df.primary_service_type == NonResRollingAverage.NON_RESIDENTIAL)
+    care_home_df = df.where(
+        df.primary_service_type != NonResRollingAverage.NON_RESIDENTIAL
+    )
+    non_residential_df = df.where(
+        df.primary_service_type == NonResRollingAverage.NON_RESIDENTIAL
+    )
     care_home_df = care_home_df.withColumn(NonResRollingAverage.MODEL_NAME, F.lit(None))
     df = non_residential_df.union(care_home_df)
     return df
@@ -68,11 +76,15 @@ def remove_rolling_average_from_care_home_rows(df: DataFrame) -> DataFrame:
 
 def fill_missing_estimate_job_counts(df: DataFrame) -> DataFrame:
     rows_to_fill_df = df.where(
-        (F.col(ESTIMATE_JOB_COUNT).isNull()) & (F.col(PRIMARY_SERVICE_TYPE) == NonResRollingAverage.NON_RESIDENTIAL)
+        (F.col(ESTIMATE_JOB_COUNT).isNull())
+        & (F.col(PRIMARY_SERVICE_TYPE) == NonResRollingAverage.NON_RESIDENTIAL)
     )
     rows_not_to_fill = df.where(
-        (F.col(ESTIMATE_JOB_COUNT).isNotNull()) | (F.col(PRIMARY_SERVICE_TYPE) != NonResRollingAverage.NON_RESIDENTIAL)
+        (F.col(ESTIMATE_JOB_COUNT).isNotNull())
+        | (F.col(PRIMARY_SERVICE_TYPE) != NonResRollingAverage.NON_RESIDENTIAL)
     )
-    rows_to_fill_df = rows_to_fill_df.withColumn(ESTIMATE_JOB_COUNT, F.col(NonResRollingAverage.MODEL_NAME))
+    rows_to_fill_df = rows_to_fill_df.withColumn(
+        ESTIMATE_JOB_COUNT, F.col(NonResRollingAverage.MODEL_NAME)
+    )
     df = rows_to_fill_df.union(rows_not_to_fill)
     return df

--- a/utils/estimate_job_count/models/non_res_rolling_average.py
+++ b/utils/estimate_job_count/models/non_res_rolling_average.py
@@ -23,7 +23,7 @@ class NonResRollingAverage:
     NON_RESIDENTIAL = "non-residential"
     MODEL_NAME = "model_non_res_rolling_average"
     LEFT_JOIN = "left"
-    ROLLING_AVERAGE_TIME_PERIOD = "91 days"
+    ROLLING_AVERAGE_TIME_PERIOD = "90 days"
     ROLLING_AVERAGE_WINDOW_SLIDE = "1 days"
     DAYS: int = 1
 
@@ -34,9 +34,7 @@ def model_non_res_rolling_average(
 
     df_with_rolling_average = add_non_residential_rolling_average_column(df)
 
-    df_with_rolling_average = remove_rolling_average_from_care_home_rows(
-        df_with_rolling_average
-    )
+    df_with_rolling_average = remove_rolling_average_from_care_home_rows(df_with_rolling_average)
     df_with_rolling_average = fill_missing_estimate_job_counts(df_with_rolling_average)
 
     df_with_rolling_average = update_dataframe_with_identifying_rule(
@@ -47,9 +45,7 @@ def model_non_res_rolling_average(
 
 
 def add_non_residential_rolling_average_column(df: DataFrame) -> DataFrame:
-    non_residential_df = df.where(
-        df.primary_service_type == NonResRollingAverage.NON_RESIDENTIAL
-    )
+    non_residential_df = df.where(df.primary_service_type == NonResRollingAverage.NON_RESIDENTIAL)
     rolling_averages_df = calculate_rolling_averages(
         non_residential_df,
         NonResRollingAverage.MODEL_NAME,
@@ -63,12 +59,8 @@ def add_non_residential_rolling_average_column(df: DataFrame) -> DataFrame:
 
 
 def remove_rolling_average_from_care_home_rows(df: DataFrame) -> DataFrame:
-    care_home_df = df.where(
-        df.primary_service_type != NonResRollingAverage.NON_RESIDENTIAL
-    )
-    non_residential_df = df.where(
-        df.primary_service_type == NonResRollingAverage.NON_RESIDENTIAL
-    )
+    care_home_df = df.where(df.primary_service_type != NonResRollingAverage.NON_RESIDENTIAL)
+    non_residential_df = df.where(df.primary_service_type == NonResRollingAverage.NON_RESIDENTIAL)
     care_home_df = care_home_df.withColumn(NonResRollingAverage.MODEL_NAME, F.lit(None))
     df = non_residential_df.union(care_home_df)
     return df
@@ -76,15 +68,11 @@ def remove_rolling_average_from_care_home_rows(df: DataFrame) -> DataFrame:
 
 def fill_missing_estimate_job_counts(df: DataFrame) -> DataFrame:
     rows_to_fill_df = df.where(
-        (F.col(ESTIMATE_JOB_COUNT).isNull())
-        & (F.col(PRIMARY_SERVICE_TYPE) == NonResRollingAverage.NON_RESIDENTIAL)
+        (F.col(ESTIMATE_JOB_COUNT).isNull()) & (F.col(PRIMARY_SERVICE_TYPE) == NonResRollingAverage.NON_RESIDENTIAL)
     )
     rows_not_to_fill = df.where(
-        (F.col(ESTIMATE_JOB_COUNT).isNotNull())
-        | (F.col(PRIMARY_SERVICE_TYPE) != NonResRollingAverage.NON_RESIDENTIAL)
+        (F.col(ESTIMATE_JOB_COUNT).isNotNull()) | (F.col(PRIMARY_SERVICE_TYPE) != NonResRollingAverage.NON_RESIDENTIAL)
     )
-    rows_to_fill_df = rows_to_fill_df.withColumn(
-        ESTIMATE_JOB_COUNT, F.col(NonResRollingAverage.MODEL_NAME)
-    )
+    rows_to_fill_df = rows_to_fill_df.withColumn(ESTIMATE_JOB_COUNT, F.col(NonResRollingAverage.MODEL_NAME))
     df = rows_to_fill_df.union(rows_not_to_fill)
     return df

--- a/utils/estimate_job_count/models/non_res_rolling_average.py
+++ b/utils/estimate_job_count/models/non_res_rolling_average.py
@@ -4,7 +4,6 @@ import pyspark.sql.functions as F
 from pyspark.sql.types import DoubleType
 
 from utils.estimate_job_count.column_names import (
-    LOCATION_ID,
     SNAPSHOT_DATE,
     JOB_COUNT,
     ESTIMATE_JOB_COUNT,
@@ -38,12 +37,12 @@ def model_non_res_rolling_average(
 
     rolling_avg = (
         df_all_dates.groupBy(rolling_avg_window)
-        .agg(F.avg(F.col("job_count")).alias("model_non_res_rolling_average"))
-        .withColumn("snapshot_date", F.date_sub(F.col("window.end").cast("date"), 1))
+        .agg(F.avg(F.col(JOB_COUNT)).alias("model_non_res_rolling_average"))
+        .withColumn(SNAPSHOT_DATE, F.date_sub(F.col("window.end").cast("date"), 1))
     ).drop("window")
     # it needs to join with the original data frame here and then we want to duplicate into estimate jobs where necessary, then add the column with the source
     # will need to remove care home df throughout i think
-    df_with_rolling_average = df.join(rolling_avg, "snapshot_date", how="left")
+    df_with_rolling_average = df.join(rolling_avg, SNAPSHOT_DATE, how="left")
 
     df_with_rolling_average.show()
 

--- a/utils/estimate_job_count/models/non_res_rolling_average.py
+++ b/utils/estimate_job_count/models/non_res_rolling_average.py
@@ -1,6 +1,7 @@
 # import pyspark.sql
 from pyspark.sql import DataFrame
 import pyspark.sql.functions as F
+from dataclasses import dataclass
 
 # from pyspark.sql.types import DoubleType
 
@@ -16,50 +17,77 @@ from utils.prepare_locations_utils.job_calculator.job_calculator import (
 )
 
 
+@dataclass
+class NonResRollingAverage:
+    ROLLING_AVERAGE_TIME_PERIOD: str = "91 days"
+    ROLLING_AVERAGE_WINDOW_SLIDE: str = "1 days"
+
+    NON_RESIDENTIAL: str = "non-residential"
+    SNAPSHOT_TIMESTAMP: str = "snapshot_timestamp"
+    WINDOW: str = "window"
+    WINDOW_END: str = "window.end"
+    MODEL_NAME: str = "model_non_res_rolling_average"
+
+    DATE_TYPE: str = "date"
+    DAYS: int = 1
+    LEFT_JOIN: str = "left"
+
+
 def model_non_res_rolling_average(
     df: DataFrame,
 ) -> DataFrame:
     df.show()
-    non_residential_df = df.where(df.primary_service_type == "non-residential")
+    non_residential_df = df.where(df.primary_service_type == NonResRollingAverage.NON_RESIDENTIAL)
     non_residential_df.show()
 
-    df_all_dates = non_residential_df.withColumn("snapshot_timestamp", F.to_timestamp(non_residential_df.snapshot_date))
+    df_all_dates = non_residential_df.withColumn(
+        NonResRollingAverage.SNAPSHOT_TIMESTAMP, F.to_timestamp(non_residential_df.snapshot_date)
+    )
 
     df_all_dates = df_all_dates.orderBy(df_all_dates.snapshot_timestamp)
     df_all_dates.persist()
 
     rolling_avg_window = F.window(
-        F.col("snapshot_timestamp"),
-        windowDuration="91 days",
-        slideDuration="1 days",
-    ).alias("window")
+        F.col(NonResRollingAverage.SNAPSHOT_TIMESTAMP),
+        windowDuration=NonResRollingAverage.ROLLING_AVERAGE_TIME_PERIOD,
+        slideDuration=NonResRollingAverage.ROLLING_AVERAGE_WINDOW_SLIDE,
+    ).alias(NonResRollingAverage.WINDOW)
 
     rolling_avg = (
         df_all_dates.groupBy(rolling_avg_window)
-        .agg(F.avg(F.col(JOB_COUNT)).alias("model_non_res_rolling_average"))
-        .withColumn(SNAPSHOT_DATE, F.date_sub(F.col("window.end").cast("date"), 1))
-    ).drop("window")
-    # it needs to join with the original data frame here and then we want to duplicate into estimate jobs where necessary, then add the column with the source
-    # will need to remove care home df throughout i think
-    df_with_rolling_average = df.join(rolling_avg, SNAPSHOT_DATE, how="left")
+        .agg(F.avg(F.col(JOB_COUNT)).alias(NonResRollingAverage.MODEL_NAME))
+        .withColumn(
+            SNAPSHOT_DATE,
+            F.date_sub(
+                F.col(NonResRollingAverage.WINDOW_END).cast(NonResRollingAverage.DATE_TYPE), NonResRollingAverage.DAYS
+            ),
+        )
+    ).drop(NonResRollingAverage.WINDOW)
 
-    care_home_df = df_with_rolling_average.where(df_with_rolling_average.primary_service_type != "non-residential")
-    non_residential_df = df_with_rolling_average.where(
-        df_with_rolling_average.primary_service_type == "non-residential"
+    df_with_rolling_average = df.join(rolling_avg, SNAPSHOT_DATE, how=NonResRollingAverage.LEFT_JOIN)
+
+    care_home_df = df_with_rolling_average.where(
+        df_with_rolling_average.primary_service_type != NonResRollingAverage.NON_RESIDENTIAL
     )
-    care_home_df = care_home_df.withColumn("model_non_res_rolling_average", F.lit(None))
+    non_residential_df = df_with_rolling_average.where(
+        df_with_rolling_average.primary_service_type == NonResRollingAverage.NON_RESIDENTIAL
+    )
+    care_home_df = care_home_df.withColumn(NonResRollingAverage.MODEL_NAME, F.lit(None))
     df_with_rolling_average = non_residential_df.union(care_home_df)
 
     df_with_rolling_average = df_with_rolling_average.withColumn(
         ESTIMATE_JOB_COUNT,
         F.when(
-            (F.col(ESTIMATE_JOB_COUNT).isNull() & (F.col(PRIMARY_SERVICE_TYPE) == "non-residential")),
-            F.col("model_non_res_rolling_average"),
+            (
+                F.col(ESTIMATE_JOB_COUNT).isNull()
+                & (F.col(PRIMARY_SERVICE_TYPE) == NonResRollingAverage.NON_RESIDENTIAL)
+            ),
+            F.col(NonResRollingAverage.MODEL_NAME),
         ).otherwise(F.col(ESTIMATE_JOB_COUNT)),
     )
 
     df_with_rolling_average = update_dataframe_with_identifying_rule(
-        df_with_rolling_average, "model_non_res_rolling_average", ESTIMATE_JOB_COUNT
+        df_with_rolling_average, NonResRollingAverage.MODEL_NAME, ESTIMATE_JOB_COUNT
     )
     df_with_rolling_average.show()
 

--- a/utils/estimate_job_count/models/non_res_rolling_average.py
+++ b/utils/estimate_job_count/models/non_res_rolling_average.py
@@ -5,7 +5,6 @@ from dataclasses import dataclass
 
 
 from utils.estimate_job_count.column_names import (
-    LOCATION_ID,
     SNAPSHOT_DATE,
     ESTIMATE_JOB_COUNT,
     PRIMARY_SERVICE_TYPE,

--- a/utils/estimate_job_count/models/non_res_rolling_average.py
+++ b/utils/estimate_job_count/models/non_res_rolling_average.py
@@ -1,14 +1,16 @@
 from pyspark.sql import DataFrame
 import pyspark.sql.functions as F
 from dataclasses import dataclass
-from typing import Dict
 
 
 from utils.estimate_job_count.column_names import (
     SNAPSHOT_DATE,
-    JOB_COUNT,
     ESTIMATE_JOB_COUNT,
     PRIMARY_SERVICE_TYPE,
+)
+
+from utils.estimate_job_count.calculate_rolling_average import (
+    calculate_rolling_averages,
 )
 
 from utils.prepare_locations_utils.job_calculator.job_calculator import (
@@ -32,9 +34,7 @@ def model_non_res_rolling_average(
 
     df_with_rolling_average = add_non_residential_rolling_average_column(df)
 
-    df_with_rolling_average = remove_rolling_average_from_care_home_rows(
-        df_with_rolling_average
-    )
+    df_with_rolling_average = remove_rolling_average_from_care_home_rows(df_with_rolling_average)
     df_with_rolling_average = fill_missing_estimate_job_counts(df_with_rolling_average)
 
     df_with_rolling_average = update_dataframe_with_identifying_rule(
@@ -45,9 +45,7 @@ def model_non_res_rolling_average(
 
 
 def add_non_residential_rolling_average_column(df: DataFrame) -> DataFrame:
-    non_residential_df = df.where(
-        df.primary_service_type == NonResRollingAverage.NON_RESIDENTIAL
-    )
+    non_residential_df = df.where(df.primary_service_type == NonResRollingAverage.NON_RESIDENTIAL)
     rolling_averages_df = calculate_rolling_averages(
         non_residential_df,
         NonResRollingAverage.MODEL_NAME,
@@ -60,39 +58,9 @@ def add_non_residential_rolling_average_column(df: DataFrame) -> DataFrame:
     return df
 
 
-def calculate_rolling_averages(
-    df: DataFrame, model_name: str, time_period: str, slide: str, days: int
-) -> DataFrame:
-
-    df_all_dates = df.withColumn("snapshot_timestamp", F.to_timestamp(df.snapshot_date))
-
-    df_all_dates = df_all_dates.orderBy(df_all_dates.snapshot_timestamp)
-    df_all_dates.persist()
-
-    rolling_avg_window = F.window(
-        F.col("snapshot_timestamp"),
-        windowDuration=time_period,
-        slideDuration=slide,
-    ).alias("window")
-
-    rolling_avg = (
-        df_all_dates.groupBy(rolling_avg_window)
-        .agg(F.avg(F.col(JOB_COUNT)).alias(model_name))
-        .withColumn(
-            SNAPSHOT_DATE,
-            F.date_sub(F.col("window.end").cast("date"), days),
-        )
-    ).drop("window")
-    return rolling_avg
-
-
 def remove_rolling_average_from_care_home_rows(df: DataFrame) -> DataFrame:
-    care_home_df = df.where(
-        df.primary_service_type != NonResRollingAverage.NON_RESIDENTIAL
-    )
-    non_residential_df = df.where(
-        df.primary_service_type == NonResRollingAverage.NON_RESIDENTIAL
-    )
+    care_home_df = df.where(df.primary_service_type != NonResRollingAverage.NON_RESIDENTIAL)
+    non_residential_df = df.where(df.primary_service_type == NonResRollingAverage.NON_RESIDENTIAL)
     care_home_df = care_home_df.withColumn(NonResRollingAverage.MODEL_NAME, F.lit(None))
     df = non_residential_df.union(care_home_df)
     return df
@@ -100,15 +68,11 @@ def remove_rolling_average_from_care_home_rows(df: DataFrame) -> DataFrame:
 
 def fill_missing_estimate_job_counts(df: DataFrame) -> DataFrame:
     rows_to_fill_df = df.where(
-        (F.col(ESTIMATE_JOB_COUNT).isNull())
-        & (F.col(PRIMARY_SERVICE_TYPE) == NonResRollingAverage.NON_RESIDENTIAL)
+        (F.col(ESTIMATE_JOB_COUNT).isNull()) & (F.col(PRIMARY_SERVICE_TYPE) == NonResRollingAverage.NON_RESIDENTIAL)
     )
     rows_not_to_fill = df.where(
-        (F.col(ESTIMATE_JOB_COUNT).isNotNull())
-        | (F.col(PRIMARY_SERVICE_TYPE) != NonResRollingAverage.NON_RESIDENTIAL)
+        (F.col(ESTIMATE_JOB_COUNT).isNotNull()) | (F.col(PRIMARY_SERVICE_TYPE) != NonResRollingAverage.NON_RESIDENTIAL)
     )
-    rows_to_fill_df = rows_to_fill_df.withColumn(
-        ESTIMATE_JOB_COUNT, F.col(NonResRollingAverage.MODEL_NAME)
-    )
+    rows_to_fill_df = rows_to_fill_df.withColumn(ESTIMATE_JOB_COUNT, F.col(NonResRollingAverage.MODEL_NAME))
     df = rows_to_fill_df.union(rows_not_to_fill)
     return df

--- a/utils/estimate_job_count/models/non_res_rolling_average.py
+++ b/utils/estimate_job_count/models/non_res_rolling_average.py
@@ -1,7 +1,6 @@
 from pyspark.sql import DataFrame
 import pyspark.sql.functions as F
 from dataclasses import dataclass
-from typing import Dict
 
 
 from utils.estimate_job_count.column_names import (


### PR DESCRIPTION
# Description
Rolling average model refactor to solve bug in estimate_job_counts.py

When trying to incorporate the extrapolation model into estimate_job_counts.py, the warning about lack of partitioning grew into a heap error. This refactoring of the model partitions the rolling average model by rolling average window. 

# How to test
- Unit tests passing
- Runs in branch
- Output matches most recent results for previous version of the model

# Developer checklist
- [ ] Unit test
- [ ] Linked to Trello ticket
- [ ] Documentation up to date
