### PR TITLE
Populate zero or null beds values with average of known beds

### DIFF
--- a/tests/test_file_generator.py
+++ b/tests/test_file_generator.py
@@ -847,25 +847,40 @@ def generate_prepared_locations_preclean_file_parquet(
     output_destination=None, partitions=["2022", "03", "08"], append=False
 ):
     spark = utils.get_spark()
-    columns = [
-        "locationid",
-        "snapshot_date",
-        "ons_region",
-        "number_of_beds",
-        "services_offered",
-        "primary_service_type",
-        "people_directly_employed",
-        "job_count_unfiltered",
-        "local_authority",
-        "snapshot_year",
-        "snapshot_month",
-        "snapshot_day",
-        "carehome",
-        "cqc_sector",
-        "rural_urban_indicator",
-        "job_count_unfiltered_source",
-        "registration_status",
-    ]
+    schema = StructType(
+        [
+            StructField("locationId", StringType(), True),
+            StructField("snapshot_date", StringType(), True),
+            StructField("ons_region", StringType(), True),
+            StructField("number_of_beds", IntegerType(), True),
+            StructField(
+                "services_offered",
+                ArrayType(
+                    StringType(),
+                ),
+                True,
+            ),
+            StructField("primary_service_type", StringType(), True),
+            StructField("people_directly_employed", IntegerType(), True),
+            StructField("job_count_unfiltered", DoubleType(), True),
+            StructField("local_authority", StringType(), True),
+            StructField("snapshot_year", StringType(), True),
+            StructField("snapshot_month", StringType(), True),
+            StructField("snapshot_day", StringType(), True),
+            StructField("carehome", StringType(), True),
+            StructField("cqc_sector", StringType(), True),
+            StructField(
+                "rural_urban_indicator",
+                StructType(
+                    [
+                        StructField("year_2011", StringType(), True),
+                    ]
+                ),
+            ),
+            StructField("job_count_unfiltered_source", StringType(), True),
+            StructField("registration_status", StringType(), True),
+        ]
+    )
 
     # fmt: off
     rows = [
@@ -886,7 +901,7 @@ def generate_prepared_locations_preclean_file_parquet(
     ]
     # fmt: on
 
-    df = spark.createDataFrame(rows, columns)
+    df = spark.createDataFrame(rows, schema=schema)
 
     df = df.withColumn("snapshot_date", F.to_date(df.snapshot_date, "yyyyMMdd"))
     if append:

--- a/tests/unit/test_prepare_locations_cleaned.py
+++ b/tests/unit/test_prepare_locations_cleaned.py
@@ -131,11 +131,13 @@ class PrepareLocationsCleanedTests(unittest.TestCase):
             ("1-000000003", "2023-01-01", "Y", 1),
             ("1-000000003", "2023-02-01", "Y", None),
             ("1-000000003", "2023-03-01", "Y", 1),
+            ("1-000000004", "2023-01-01", "Y", 1),
+            ("1-000000004", "2023-02-01", "Y", 3),
         ]
         input_df = self.spark.createDataFrame(input_rows, schema=schema)
 
         df = job.populate_missing_carehome_number_of_beds(input_df)
-        self.assertEqual(df.count(), 5)
+        self.assertEqual(df.count(), 7)
 
         df = df.sort("locationid", "snapshot_date").collect()
         self.assertEqual(df[0]["number_of_beds"], None)
@@ -143,6 +145,8 @@ class PrepareLocationsCleanedTests(unittest.TestCase):
         self.assertEqual(df[2]["number_of_beds"], 1)
         self.assertEqual(df[3]["number_of_beds"], 1)
         self.assertEqual(df[4]["number_of_beds"], 1)
+        self.assertEqual(df[5]["number_of_beds"], 1)
+        self.assertEqual(df[6]["number_of_beds"], 3)
 
     def test_filter_to_carehomes_with_known_beds(self):
         columns = [

--- a/tests/unit/test_prepare_locations_cleaned.py
+++ b/tests/unit/test_prepare_locations_cleaned.py
@@ -6,6 +6,12 @@ import os
 from unittest.mock import patch
 
 from pyspark.sql import SparkSession
+from pyspark.sql.types import (
+    StructField,
+    StructType,
+    StringType,
+    IntegerType,
+)
 
 from tests.test_file_generator import generate_prepared_locations_preclean_file_parquet
 from tests.test_helpers import remove_file_path
@@ -88,6 +94,128 @@ class PrepareLocationsCleanedTests(unittest.TestCase):
 
         df = df.collect()
         self.assertEqual(df[0]["locationid"], "1-000000002")
+
+    def test_replace_zero_beds_with_null(self):
+        columns = [
+            "locationid",
+            "number_of_beds",
+        ]
+        rows = [
+            ("1-000000001", None),
+            ("1-000000002", 0),
+            ("1-000000003", 1),
+        ]
+        df = self.spark.createDataFrame(rows, columns)
+
+        df = job.replace_zero_beds_with_null(df)
+        self.assertEqual(df.count(), 3)
+
+        df = df.collect()
+        self.assertEqual(df[0]["number_of_beds"], None)
+        self.assertEqual(df[1]["number_of_beds"], None)
+        self.assertEqual(df[2]["number_of_beds"], 1)
+
+    def test_populate_missing_carehome_number_of_beds(self):
+        schema = StructType(
+            [
+                StructField("locationId", StringType(), True),
+                StructField("snapshot_date", StringType(), True),
+                StructField("carehome", StringType(), True),
+                StructField("number_of_beds", IntegerType(), True),
+            ]
+        )
+
+        input_rows = [
+            ("1-000000001", "2023-01-01", "Y", None),
+            ("1-000000002", "2023-01-01", "N", None),
+            ("1-000000003", "2023-01-01", "Y", 1),
+            ("1-000000003", "2023-02-01", "Y", None),
+            ("1-000000003", "2023-03-01", "Y", 1),
+        ]
+        input_df = self.spark.createDataFrame(input_rows, schema=schema)
+
+        df = job.populate_missing_carehome_number_of_beds(input_df)
+        self.assertEqual(df.count(), 5)
+
+        df = df.sort("locationid", "snapshot_date").collect()
+        self.assertEqual(df[0]["number_of_beds"], None)
+        self.assertEqual(df[1]["number_of_beds"], None)
+        self.assertEqual(df[2]["number_of_beds"], 1)
+        self.assertEqual(df[3]["number_of_beds"], 1)
+        self.assertEqual(df[4]["number_of_beds"], 1)
+
+    def test_filter_to_carehomes_with_known_beds(self):
+        columns = [
+            "locationid",
+            "carehome",
+            "number_of_beds",
+        ]
+        rows = [
+            ("1-000000001", "Y", None),
+            ("1-000000002", "N", None),
+            ("1-000000003", "Y", 1),
+            ("1-000000004", "N", 1),
+        ]
+        df = self.spark.createDataFrame(rows, columns)
+
+        df = job.filter_to_carehomes_with_known_beds(df)
+        self.assertEqual(df.count(), 1)
+
+        df = df.collect()
+        self.assertEqual(df[0]["locationid"], "1-000000003")
+
+    def test_average_beds_per_location(self):
+        columns = [
+            "locationid",
+            "number_of_beds",
+        ]
+        rows = [
+            ("1-000000001", 1),
+            ("1-000000002", 2),
+            ("1-000000002", 3),
+            ("1-000000003", 2),
+            ("1-000000003", 3),
+            ("1-000000003", 4),
+        ]
+        df = self.spark.createDataFrame(rows, columns)
+
+        df = job.average_beds_per_location(df)
+        self.assertEqual(df.count(), 3)
+
+        df = df.sort("locationid").collect()
+        self.assertEqual(df[0]["avg_beds"], 1)
+        self.assertEqual(df[1]["avg_beds"], 2)
+        self.assertEqual(df[2]["avg_beds"], 3)
+
+    def test_replace_null_beds_with_average(self):
+        columns = ["locationid", "number_of_beds", "avg_beds"]
+        rows = [
+            ("1-000000001", None, None),
+            ("1-000000002", None, 1),
+            ("1-000000003", 2, 2),
+        ]
+        df = self.spark.createDataFrame(rows, columns)
+
+        df = job.replace_null_beds_with_average(df)
+        self.assertEqual(df.count(), 3)
+
+        df = df.collect()
+        self.assertEqual(df[0]["number_of_beds"], None)
+        self.assertEqual(df[1]["number_of_beds"], 1)
+        self.assertEqual(df[2]["number_of_beds"], 2)
+
+    def test_replace_null_beds_with_average_doesnt_change_known_beds(self):
+        columns = ["locationid", "number_of_beds", "avg_beds"]
+        rows = [
+            ("1-000000001", 1, 2),
+        ]
+        df = self.spark.createDataFrame(rows, columns)
+
+        df = job.replace_null_beds_with_average(df)
+        self.assertEqual(df.count(), 1)
+
+        df = df.collect()
+        self.assertEqual(df[0]["number_of_beds"], 1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
CQC appear to have missed the number of beds for some care homes in some time periods. This will input the average number for beds where a number has been provider in other time periods.

The care home model doesn't input a figure when beds is missing (26 cases) so this will also solve that

I've run the job and tested in Athena

[Trello](https://trello.com/c/RcSusSst/86-impute-average-beds-for-that-locationid-when-a-care-home-has-zero-missing-beds)
