### PR TITLE
Redo imports for consistency

### DIFF
--- a/jobs/job_role_breakdown.py
+++ b/jobs/job_role_breakdown.py
@@ -91,7 +91,7 @@ def calculate_job_count_breakdown_by_jobrole(master_df):
 
     master_df = master_df.withColumn(
         "sum_of_estimated_minus_ascwds",
-        sum("estimated_minus_ascwds").over(Window.partitionBy("master_locationid")),
+        F.sum("estimated_minus_ascwds").over(Window.partitionBy("master_locationid")),
     )
 
     master_df = master_df.withColumn(
@@ -124,11 +124,11 @@ def calculate_job_count_breakdown_by_service(master_df):
             "snapshot_date as breakdown_snapshot_date",
         )
         .groupBy("service_type", "job_role", "breakdown_snapshot_date")
-        .agg(sum("ascwds_num_of_jobs").alias("ascwds_num_of_jobs_in_service"))
+        .agg(F.sum("ascwds_num_of_jobs").alias("ascwds_num_of_jobs_in_service"))
     )
     job_role_breakdown_by_service = job_role_breakdown_by_service.withColumn(
         "all_ascwds_jobs_in_service",
-        sum("ascwds_num_of_jobs_in_service").over(
+        F.sum("ascwds_num_of_jobs_in_service").over(
             Window.partitionBy("service_type", "breakdown_snapshot_date")
         ),
     )

--- a/jobs/job_role_breakdown.py
+++ b/jobs/job_role_breakdown.py
@@ -1,7 +1,7 @@
 import argparse
 import sys
 
-from pyspark.sql.functions import col, lit, least, greatest, sum, coalesce, date_format
+import pyspark.sql.functions as F
 from pyspark.sql import Window
 
 from utils import utils
@@ -79,12 +79,14 @@ def calculate_job_count_breakdown_by_jobrole(master_df):
 
     master_df = master_df.withColumn(
         "estimated_jobs_in_role",
-        col("estimate_job_count") * col("estimated_job_role_percentage"),
+        F.col("estimate_job_count") * F.col("estimated_job_role_percentage"),
     ).drop("estimated_job_role_percentage")
 
     master_df = master_df.withColumn(
         "estimated_minus_ascwds",
-        greatest(lit(0), col("estimated_jobs_in_role") - col("ascwds_num_of_jobs")),
+        F.greatest(
+            F.lit(0), F.col("estimated_jobs_in_role") - F.col("ascwds_num_of_jobs")
+        ),
     ).drop("estimated_jobs_in_role")
 
     master_df = master_df.withColumn(
@@ -94,20 +96,20 @@ def calculate_job_count_breakdown_by_jobrole(master_df):
 
     master_df = master_df.withColumn(
         "adjusted_job_role_percentage",
-        coalesce(
-            (col("estimated_minus_ascwds") / col("sum_of_estimated_minus_ascwds")),
-            lit(0.0),
+        F.coalesce(
+            (F.col("estimated_minus_ascwds") / F.col("sum_of_estimated_minus_ascwds")),
+            F.lit(0.0),
         ),
     ).drop("estimated_minus_ascwds", "sum_of_estimated_minus_ascwds")
 
     master_df = master_df.withColumn(
         "estimated_num_of_jobs",
-        col("location_jobs_to_model") * col("adjusted_job_role_percentage"),
+        F.col("location_jobs_to_model") * F.col("adjusted_job_role_percentage"),
     ).drop("location_jobs_to_model", "adjusted_job_role_percentage")
 
     master_df = master_df.withColumn(
         "estimate_job_role_count",
-        col("ascwds_num_of_jobs") + col("estimated_num_of_jobs"),
+        F.col("ascwds_num_of_jobs") + F.col("estimated_num_of_jobs"),
     ).drop("location_worker_records")
 
     return master_df
@@ -132,7 +134,7 @@ def calculate_job_count_breakdown_by_service(master_df):
     )
     job_role_breakdown_by_service = job_role_breakdown_by_service.withColumn(
         "estimated_job_role_percentage",
-        col("ascwds_num_of_jobs_in_service") / col("all_ascwds_jobs_in_service"),
+        F.col("ascwds_num_of_jobs_in_service") / F.col("all_ascwds_jobs_in_service"),
     ).drop("ascwds_num_of_jobs_in_service", "all_ascwds_jobs_in_service")
 
     master_df = master_df.join(
@@ -152,11 +154,15 @@ def calculate_job_count_breakdown_by_service(master_df):
 def determine_worker_record_to_jobs_ratio(master_df):
     master_df = master_df.withColumn(
         "location_jobs_ratio",
-        least(lit(1), col("estimate_job_count") / col("location_worker_records")),
+        F.least(
+            F.lit(1), F.col("estimate_job_count") / F.col("location_worker_records")
+        ),
     )
     master_df = master_df.withColumn(
         "location_jobs_to_model",
-        greatest(lit(0), col("estimate_job_count") - col("location_worker_records")),
+        F.greatest(
+            F.lit(0), F.col("estimate_job_count") - F.col("location_worker_records")
+        ),
     )
 
     return master_df
@@ -192,7 +198,7 @@ def get_worker_dataset(worker_source):
     spark = utils.get_spark()
     print(f"Reading worker source parquet from {worker_source}")
     worker_df = spark.read.parquet(worker_source).select(
-        col("locationid"), col("workerid"), col("mainjrid"), col("import_date")
+        F.col("locationid"), F.col("workerid"), F.col("mainjrid"), F.col("import_date")
     )
 
     worker_df = worker_df.withColumnRenamed("import_date", "snapshot_date")
@@ -204,18 +210,18 @@ def get_job_estimates_dataset(job_estimates_source):
     spark = utils.get_spark()
     print(f"Reading job_estimates_2021 parquet from {job_estimates_source}")
     job_estimates_df = spark.read.parquet(job_estimates_source).select(
-        col("locationid").alias("master_locationid"),
-        col("primary_service_type"),
-        col("estimate_job_count"),
-        col("snapshot_date"),
-        col("run_year"),
-        col("run_month"),
-        col("run_day"),
+        F.col("locationid").alias("master_locationid"),
+        F.col("primary_service_type"),
+        F.col("estimate_job_count"),
+        F.col("snapshot_date"),
+        F.col("run_year"),
+        F.col("run_month"),
+        F.col("run_day"),
     )
 
     job_estimates_df = utils.get_latest_partition(job_estimates_df)
     job_estimates_df = job_estimates_df.withColumn(
-        "snapshot_date", date_format(col("snapshot_date"), "yyyyMMdd")
+        "snapshot_date", F.date_format(F.col("snapshot_date"), "yyyyMMdd")
     )
 
     return job_estimates_df

--- a/jobs/prepare_workers.py
+++ b/jobs/prepare_workers.py
@@ -1,4 +1,3 @@
-import argparse
 import sys
 import json
 import re

--- a/jobs/spss_csv_to_parquet.py
+++ b/jobs/spss_csv_to_parquet.py
@@ -1,6 +1,6 @@
 import sys
 import argparse
-import pyspark.sql.functions as f
+import pyspark.sql.functions as F
 
 from schemas.spss_job_estimates_schema import SPSS_JOBS_ESTIMATES
 from utils import utils
@@ -9,7 +9,7 @@ from utils import utils
 def main(source, destination):
     df = utils.read_csv_with_defined_schema(source, SPSS_JOBS_ESTIMATES)
     df_with_formatted_date = df.withColumn(
-        "snapshot_date_formatted", f.col("Snapshot_date")
+        "snapshot_date_formatted", F.col("Snapshot_date")
     )
     df_with_formatted_date = utils.format_date_fields(
         df_with_formatted_date,

--- a/tests/integration/test_cqc_api_integration.py
+++ b/tests/integration/test_cqc_api_integration.py
@@ -1,8 +1,5 @@
 from utils import cqc_api as cqc
-from pyspark.sql import SparkSession
-import mock
 import unittest
-import requests
 import re
 
 EXAMPLE_LOCATION_ID = "1-10000792582"

--- a/tests/unit/test_calculate_rolling_average.py
+++ b/tests/unit/test_calculate_rolling_average.py
@@ -7,7 +7,6 @@ from pyspark.sql.types import (
     StructField,
     StringType,
     IntegerType,
-    DoubleType,
 )
 from dataclasses import dataclass
 

--- a/tests/unit/test_dataframe_utils.py
+++ b/tests/unit/test_dataframe_utils.py
@@ -4,7 +4,7 @@ import warnings
 from dataclasses import dataclass, asdict
 
 from pyspark.sql import SparkSession
-from pyspark.sql.types import StructType, StringType, IntegerType, StructField
+from pyspark.sql.types import StructType, StringType, StructField
 
 from utils.prepare_locations_utils.dataframe_utils import (
     add_column_with_snaphot_date_substring,

--- a/tests/unit/test_denormalise_ons_data.py
+++ b/tests/unit/test_denormalise_ons_data.py
@@ -4,7 +4,7 @@ import warnings
 
 from pyspark.sql import SparkSession
 
-from jobs import denormalise_ons_data
+import jobs.denormalise_ons_data as job
 
 
 class TestDenormaliseONSDataTests(unittest.TestCase):
@@ -85,100 +85,76 @@ class TestDenormaliseONSDataTests(unittest.TestCase):
         # fmt: on
 
     def test_main_writes_data_to_the_output(self):
-        denormalise_ons_data.main(
-            self.DATA_SOURCE, self.LOOKUPS_SOURCE, self.DESTINATION
-        )
+        job.main(self.DATA_SOURCE, self.LOOKUPS_SOURCE, self.DESTINATION)
 
         ons_data = self.spark.read.parquet(self.DESTINATION)
         self.assertEqual(ons_data.count(), 1)
 
     def test_main_wont_import_data_already_imported(self):
-        denormalise_ons_data.main(
-            self.DATA_SOURCE, self.LOOKUPS_SOURCE, self.DESTINATION
-        )
-        denormalise_ons_data.main(
-            self.DATA_SOURCE, self.LOOKUPS_SOURCE, self.DESTINATION
-        )
+        job.main(self.DATA_SOURCE, self.LOOKUPS_SOURCE, self.DESTINATION)
+        job.main(self.DATA_SOURCE, self.LOOKUPS_SOURCE, self.DESTINATION)
 
         ons_data = self.spark.read.parquet(self.DESTINATION)
         self.assertEqual(ons_data.count(), 1)
 
     def test_replaces_rgn_field_with_lookup_values(self):
-        denormalise_ons_data.main(
-            self.DATA_SOURCE, self.LOOKUPS_SOURCE, self.DESTINATION
-        )
+        job.main(self.DATA_SOURCE, self.LOOKUPS_SOURCE, self.DESTINATION)
 
         ons_data = self.spark.read.parquet(self.DESTINATION)
         ons_data_row = ons_data.collect()[0]
         self.assertEqual(ons_data_row.rgn, "North East")
 
     def test_replaces_nhser_field_with_lookup_values(self):
-        denormalise_ons_data.main(
-            self.DATA_SOURCE, self.LOOKUPS_SOURCE, self.DESTINATION
-        )
+        job.main(self.DATA_SOURCE, self.LOOKUPS_SOURCE, self.DESTINATION)
 
         ons_data = self.spark.read.parquet(self.DESTINATION)
         ons_data_row = ons_data.collect()[0]
         self.assertEqual(ons_data_row.nhser, "London")
 
     def test_replaces_ccg_field_with_lookup_values(self):
-        denormalise_ons_data.main(
-            self.DATA_SOURCE, self.LOOKUPS_SOURCE, self.DESTINATION
-        )
+        job.main(self.DATA_SOURCE, self.LOOKUPS_SOURCE, self.DESTINATION)
 
         ons_data = self.spark.read.parquet(self.DESTINATION)
         ons_data_row = ons_data.collect()[0]
         self.assertEqual(ons_data_row.ccg, "NHS Barnsley CCG")
 
     def test_replaces_ctry_field_with_lookup_values(self):
-        denormalise_ons_data.main(
-            self.DATA_SOURCE, self.LOOKUPS_SOURCE, self.DESTINATION
-        )
+        job.main(self.DATA_SOURCE, self.LOOKUPS_SOURCE, self.DESTINATION)
 
         ons_data = self.spark.read.parquet(self.DESTINATION)
         ons_data_row = ons_data.collect()[0]
         self.assertEqual(ons_data_row.ctry, "England")
 
     def test_replaces_imd_field_with_lookup_values(self):
-        denormalise_ons_data.main(
-            self.DATA_SOURCE, self.LOOKUPS_SOURCE, self.DESTINATION
-        )
+        job.main(self.DATA_SOURCE, self.LOOKUPS_SOURCE, self.DESTINATION)
 
         ons_data = self.spark.read.parquet(self.DESTINATION)
         ons_data_row = ons_data.collect()[0]
         self.assertEqual(ons_data_row.imd, "Tendring 018A")
 
     def test_replaces_lsoa_fields_with_lookup_values(self):
-        denormalise_ons_data.main(
-            self.DATA_SOURCE, self.LOOKUPS_SOURCE, self.DESTINATION
-        )
+        job.main(self.DATA_SOURCE, self.LOOKUPS_SOURCE, self.DESTINATION)
 
         ons_data = self.spark.read.parquet(self.DESTINATION)
         ons_data_row = ons_data.collect()[0]
         self.assertEqual(ons_data_row.lsoa["year_2011"], "Aldergrove 1")
 
     def test_replaces_msoa_fields_with_lookup_values(self):
-        denormalise_ons_data.main(
-            self.DATA_SOURCE, self.LOOKUPS_SOURCE, self.DESTINATION
-        )
+        job.main(self.DATA_SOURCE, self.LOOKUPS_SOURCE, self.DESTINATION)
 
         ons_data = self.spark.read.parquet(self.DESTINATION)
         ons_data_row = ons_data.collect()[0]
         self.assertEqual(ons_data_row.msoa["year_2011"], "City of London 001")
 
     def test_replaces_oslaua_field_with_lookup_values(self):
-        denormalise_ons_data.main(
-            self.DATA_SOURCE, self.LOOKUPS_SOURCE, self.DESTINATION
-        )
+        job.main(self.DATA_SOURCE, self.LOOKUPS_SOURCE, self.DESTINATION)
 
         ons_data = self.spark.read.parquet(self.DESTINATION)
         ons_data_row = ons_data.collect()[0]
         self.assertEqual(ons_data_row.oslaua, "Hartlepool")
 
     def test_replaces_ru_ind_fields_with_lookup_values(self):
-        denormalise_ons_data.main(
-            self.DATA_SOURCE, self.LOOKUPS_SOURCE, self.DESTINATION
-        )
+        job.main(self.DATA_SOURCE, self.LOOKUPS_SOURCE, self.DESTINATION)
 
         ons_data = self.spark.read.parquet(self.DESTINATION)
         ons_data_row = ons_data.collect()[0]
@@ -188,9 +164,7 @@ class TestDenormaliseONSDataTests(unittest.TestCase):
         )
 
     def test_replace_stp_fields_with_lookup_values(self):
-        denormalise_ons_data.main(
-            self.DATA_SOURCE, self.LOOKUPS_SOURCE, self.DESTINATION
-        )
+        job.main(self.DATA_SOURCE, self.LOOKUPS_SOURCE, self.DESTINATION)
 
         ons_data = self.spark.read.parquet(self.DESTINATION)
         ons_data_row = ons_data.collect()[0]

--- a/tests/unit/test_estimate_job_counts.py
+++ b/tests/unit/test_estimate_job_counts.py
@@ -10,7 +10,7 @@ from pyspark.ml.linalg import Vectors
 
 from tests.test_file_generator import generate_prepared_locations_file_parquet
 from tests.test_helpers import remove_file_path
-from jobs import estimate_job_counts as job
+import jobs.estimate_job_counts as job
 
 
 class EstimateJobCountTests(unittest.TestCase):

--- a/tests/unit/test_feature_helper.py
+++ b/tests/unit/test_feature_helper.py
@@ -3,7 +3,6 @@ import unittest
 import warnings
 
 from pyspark.ml.functions import vector_to_array
-from pyspark.ml.linalg import DenseVector
 from pyspark.sql import SparkSession
 from pyspark.sql import functions as F
 

--- a/tests/unit/test_ingest_ascwds_dataset.py
+++ b/tests/unit/test_ingest_ascwds_dataset.py
@@ -2,7 +2,7 @@ import unittest
 
 from pyspark.sql import SparkSession
 
-from jobs import ingest_ascwds_dataset
+import jobs.ingest_ascwds_dataset as job
 
 
 class IngestASCWDSDatasetTests(unittest.TestCase):
@@ -26,7 +26,7 @@ class IngestASCWDSDatasetTests(unittest.TestCase):
 
         df = self.spark.createDataFrame(rows, columns)
 
-        df = ingest_ascwds_dataset.filter_test_accounts(df)
+        df = job.filter_test_accounts(df)
         self.assertEqual(df.count(), 1)
 
         df = df.collect()
@@ -47,7 +47,7 @@ class IngestASCWDSDatasetTests(unittest.TestCase):
 
         df = self.spark.createDataFrame(rows, columns)
 
-        df = ingest_ascwds_dataset.filter_test_accounts(df)
+        df = job.filter_test_accounts(df)
         self.assertEqual(df.count(), 4)
 
 

--- a/tests/unit/test_ingest_cqc_care_directory.py
+++ b/tests/unit/test_ingest_cqc_care_directory.py
@@ -4,7 +4,7 @@ import shutil
 from pyspark.sql import SparkSession, Row
 
 from utils import utils
-from jobs import ingest_cqc_care_directory
+import jobs.ingest_cqc_care_directory as job
 from tests.test_file_generator import (
     generate_raw_cqc_care_directory_csv_file,
     generate_cqc_care_directory_file,
@@ -90,9 +90,7 @@ class CQC_Care_Directory_Tests(unittest.TestCase):
             pass  # Ignore dir does not exist
 
     def test_get_cqc_care_directory(self):
-        df = ingest_cqc_care_directory.get_cqc_care_directory(
-            self.TEST_RAW_CQC_CARE_DIRECTORY_CSV_FILE
-        )
+        df = job.get_cqc_care_directory(self.TEST_RAW_CQC_CARE_DIRECTORY_CSV_FILE)
 
         self.assertEqual(df.count(), 1)
         self.assertEqual(
@@ -107,7 +105,7 @@ class CQC_Care_Directory_Tests(unittest.TestCase):
 
         df = spark.read.parquet(self.TEST_LOCATIONID_AND_PROVIDERID_FILE)
 
-        locations_at_prov_df = ingest_cqc_care_directory.unique_providerids_with_array_of_their_locationids(
+        locations_at_prov_df = job.unique_providerids_with_array_of_their_locationids(
             df
         )
 
@@ -132,7 +130,7 @@ class CQC_Care_Directory_Tests(unittest.TestCase):
 
         df = spark.read.parquet(self.TEST_DUPLICATE_PROVIDER_DATA_FILE)
 
-        distinct_prov_df = ingest_cqc_care_directory.get_distinct_provider_info(df)
+        distinct_prov_df = job.get_distinct_provider_info(df)
 
         self.assertEqual(distinct_prov_df.count(), 4)
         self.assertEqual(
@@ -155,7 +153,7 @@ class CQC_Care_Directory_Tests(unittest.TestCase):
 
         df = spark.read.parquet(self.TEST_CARE_DIRECTORY_LOCATION_DATA_FILE)
 
-        location_df = ingest_cqc_care_directory.get_general_location_info(df)
+        location_df = job.get_general_location_info(df)
 
         self.assertEqual(location_df.count(), 3)
         self.assertEqual(
@@ -186,7 +184,7 @@ class CQC_Care_Directory_Tests(unittest.TestCase):
 
         df = spark.read.csv(self.TEST_MULTIPLE_BOOLEAN_COLUMNS, header=True)
 
-        services_df = ingest_cqc_care_directory.convert_multiple_boolean_columns_into_single_array(
+        services_df = job.convert_multiple_boolean_columns_into_single_array(
             df, self.REFORMAT_DICT, "new_alias"
         )
 
@@ -211,7 +209,7 @@ class CQC_Care_Directory_Tests(unittest.TestCase):
 
         df = spark.read.parquet(self.TEST_CARE_DIRECTORY_REGISTERED_MANAGER_NAME)
 
-        df = ingest_cqc_care_directory.create_contacts_from_registered_manager_name(df)
+        df = job.create_contacts_from_registered_manager_name(df)
 
         self.assertEqual(df.count(), 3)
         self.assertEqual(df.columns, ["locationId", "contacts"])
@@ -256,7 +254,7 @@ class CQC_Care_Directory_Tests(unittest.TestCase):
 
         df = spark.read.parquet(self.TEST_CARE_DIRECTORY_GAC_SERVICE_TYPES)
 
-        df = ingest_cqc_care_directory.convert_gac_service_types_to_struct(df)
+        df = job.convert_gac_service_types_to_struct(df)
 
         self.assertEqual(df.count(), 3)
         self.assertEqual(df.columns, ["locationId", "gacservicetypes"])
@@ -291,7 +289,7 @@ class CQC_Care_Directory_Tests(unittest.TestCase):
 
         df = spark.read.parquet(self.TEST_CARE_DIRECTORY_SPECIALISMS)
 
-        df = ingest_cqc_care_directory.convert_specialisms_to_struct(df)
+        df = job.convert_specialisms_to_struct(df)
 
         self.assertEqual(df.count(), 3)
         self.assertEqual(df.columns, ["locationId", "specialisms"])
@@ -318,7 +316,7 @@ class CQC_Care_Directory_Tests(unittest.TestCase):
 
         df = spark.read.csv(self.TEST_CQC_CARE_DIRECTORY_FILE, header=True)
 
-        provider_df = ingest_cqc_care_directory.convert_to_cqc_provider_api_format(df)
+        provider_df = job.convert_to_cqc_provider_api_format(df)
 
         self.assertEqual(provider_df.count(), 4)
         self.assertEqual(
@@ -354,7 +352,7 @@ class CQC_Care_Directory_Tests(unittest.TestCase):
 
         df = spark.read.csv(self.TEST_CQC_CARE_DIRECTORY_FILE, header=True)
 
-        location_df = ingest_cqc_care_directory.convert_to_cqc_location_api_format(df)
+        location_df = job.convert_to_cqc_location_api_format(df)
 
         self.assertEqual(location_df.count(), 10)
         self.assertEqual(

--- a/tests/unit/test_ingest_ons_data.py
+++ b/tests/unit/test_ingest_ons_data.py
@@ -6,7 +6,7 @@ import warnings
 from pyspark.sql import SparkSession
 from unittest.mock import patch
 
-from jobs import ingest_ons_data
+import jobs.ingest_ons_data as job
 
 
 class IngestIngestONSDataTests(unittest.TestCase):
@@ -94,7 +94,7 @@ class IngestIngestONSDataTests(unittest.TestCase):
             f"{self.DATA_SOURCE}/dataset=postcode-directory/"
         )
 
-        ingest_ons_data.main(self.DATA_SOURCE, self.DESTINATION)
+        job.main(self.DATA_SOURCE, self.DESTINATION)
 
         ons_data = self.spark.read.parquet(
             f"{self.DESTINATION}/dataset=postcode-directory/"
@@ -110,8 +110,8 @@ class IngestIngestONSDataTests(unittest.TestCase):
             f"{self.DATA_SOURCE}/dataset=postcode-directory/"
         )
 
-        ingest_ons_data.main(self.DATA_SOURCE, self.DESTINATION)
-        ingest_ons_data.main(self.DATA_SOURCE, self.DESTINATION)
+        job.main(self.DATA_SOURCE, self.DESTINATION)
+        job.main(self.DATA_SOURCE, self.DESTINATION)
 
         ons_data = self.spark.read.parquet(
             f"{self.DESTINATION}/dataset=postcode-directory/"
@@ -125,11 +125,11 @@ class IngestIngestONSDataTests(unittest.TestCase):
             f"{self.DATA_SOURCE}/dataset=postcode-directory/"
         )
 
-        ingest_ons_data.main(self.DATA_SOURCE, self.DESTINATION)
+        job.main(self.DATA_SOURCE, self.DESTINATION)
         self.generate_ons_test_csv_file(
             f"{self.DATA_SOURCE}/dataset=postcode-directory/", ("2022", "01", "02")
         )
-        ingest_ons_data.main(self.DATA_SOURCE, self.DESTINATION)
+        job.main(self.DATA_SOURCE, self.DESTINATION)
 
         ons_data = self.spark.read.parquet(
             f"{self.DESTINATION}/dataset=postcode-directory/"
@@ -147,7 +147,7 @@ class IngestIngestONSDataTests(unittest.TestCase):
         self.generate_nhs_region_lookup_csv(self.LOOKUPS_SOURCE)
         self.generate_region_lookup_csv(self.LOOKUPS_SOURCE)
 
-        ingest_ons_data.main(self.DATA_SOURCE, self.DESTINATION)
+        job.main(self.DATA_SOURCE, self.DESTINATION)
         rgn_lookup = self.spark.read.parquet(
             f"{self.DESTINATION}/dataset=postcode-directory-field-lookups/field=rgn/"
         )

--- a/tests/unit/test_job_role_breakdown.py
+++ b/tests/unit/test_job_role_breakdown.py
@@ -3,7 +3,7 @@ import shutil
 
 from pyspark.sql import SparkSession
 
-from jobs import job_role_breakdown
+import jobs.job_role_breakdown as job
 from tests.test_file_generator import (
     generate_estimate_jobs_parquet,
     generate_worker_parquet,
@@ -32,9 +32,7 @@ class JobRoleBreakdownTests(unittest.TestCase):
 
     def test_get_job_estimates_dataset(self):
 
-        breakdown_df = job_role_breakdown.get_job_estimates_dataset(
-            self.TEST_JOB_ESTIMATES_FILE
-        )
+        breakdown_df = job.get_job_estimates_dataset(self.TEST_JOB_ESTIMATES_FILE)
 
         self.assertEqual(breakdown_df.count(), 5)
         self.assertEqual(
@@ -51,7 +49,7 @@ class JobRoleBreakdownTests(unittest.TestCase):
         )
 
     def test_get_worker_dataset(self):
-        worker_df = job_role_breakdown.get_worker_dataset(self.TEST_WORKER_FILE)
+        worker_df = job.get_worker_dataset(self.TEST_WORKER_FILE)
 
         self.assertEqual(worker_df.count(), 15)
         self.assertEqual(
@@ -75,9 +73,7 @@ class JobRoleBreakdownTests(unittest.TestCase):
         ]
         df = self.spark.createDataFrame(rows, columns)
 
-        output_df = job_role_breakdown.get_distinct_list(
-            df, column_name="mainjrid", alias="mylist"
-        )
+        output_df = job.get_distinct_list(df, column_name="mainjrid", alias="mylist")
 
         self.assertEqual(output_df.count(), 5)
         self.assertEqual(output_df.columns, ["mylist"])
@@ -104,7 +100,7 @@ class JobRoleBreakdownTests(unittest.TestCase):
         ]
         df = self.spark.createDataFrame(rows, columns)
 
-        output_df = job_role_breakdown.get_distinct_list(df, column_name="mainjrid")
+        output_df = job.get_distinct_list(df, column_name="mainjrid")
 
         self.assertEqual(output_df.count(), 5)
         self.assertEqual(output_df.columns, ["mainjrid"])
@@ -130,9 +126,9 @@ class JobRoleBreakdownTests(unittest.TestCase):
 
         master_df = self.spark.createDataFrame(master_rows, master_columns)
 
-        worker_df = job_role_breakdown.get_worker_dataset(self.TEST_WORKER_FILE)
+        worker_df = job.get_worker_dataset(self.TEST_WORKER_FILE)
 
-        ouput_df = job_role_breakdown.get_comprehensive_list_of_job_roles_to_locations(
+        ouput_df = job.get_comprehensive_list_of_job_roles_to_locations(
             worker_df, master_df
         )
 
@@ -154,7 +150,7 @@ class JobRoleBreakdownTests(unittest.TestCase):
 
         df = self.spark.createDataFrame(rows, columns)
 
-        df = job_role_breakdown.determine_worker_record_to_jobs_ratio(df)
+        df = job.determine_worker_record_to_jobs_ratio(df)
 
         self.assertEqual(df.count(), 4)
         self.assertEqual(
@@ -177,9 +173,7 @@ class JobRoleBreakdownTests(unittest.TestCase):
         self.assertEqual(df_list[3]["location_jobs_to_model"], 0)
 
     def test_main(self):
-        result_df = job_role_breakdown.main(
-            self.TEST_JOB_ESTIMATES_FILE, self.TEST_WORKER_FILE
-        )
+        result_df = job.main(self.TEST_JOB_ESTIMATES_FILE, self.TEST_WORKER_FILE)
 
         self.assertEqual(
             result_df.columns,

--- a/tests/unit/test_locations_care_home_feature_engineering.py
+++ b/tests/unit/test_locations_care_home_feature_engineering.py
@@ -6,10 +6,7 @@ import warnings
 from pyspark.ml.linalg import SparseVector
 from pyspark.sql import SparkSession
 from pyspark.sql import functions as F
-from jobs import locations_care_home_feature_engineering
-from jobs.locations_care_home_feature_engineering import (
-    filter_locations_df_for_independent_care_home_data,
-)
+import jobs.locations_care_home_feature_engineering as job
 
 from tests.test_file_generator import (
     generate_prepared_locations_file_parquet,
@@ -43,9 +40,7 @@ class LocationsFeatureEngineeringTests(unittest.TestCase):
         return super().tearDown()
 
     def test_main_produces_dataframe_with_features(self):
-        result = locations_care_home_feature_engineering.main(
-            self.PREPARED_LOCATIONS_TEST_DATA, self.OUTPUT_DESTINATION
-        )
+        result = job.main(self.PREPARED_LOCATIONS_TEST_DATA, self.OUTPUT_DESTINATION)
 
         expected_features = SparseVector(
             43, [8, 11, 12, 13, 42], [1.0, 10.0, 1.0, 1.0, 1.0]
@@ -57,9 +52,7 @@ class LocationsFeatureEngineeringTests(unittest.TestCase):
         input_df_length = self.test_df.count()
         self.assertTrue(input_df_length, 14)
 
-        result = locations_care_home_feature_engineering.main(
-            self.PREPARED_LOCATIONS_TEST_DATA, self.OUTPUT_DESTINATION
-        )
+        result = job.main(self.PREPARED_LOCATIONS_TEST_DATA, self.OUTPUT_DESTINATION)
 
         self.assertTrue(result.count() == 1)
 
@@ -75,7 +68,7 @@ class LocationsFeatureEngineeringTests(unittest.TestCase):
 
         df = self.spark.createDataFrame(rows, cols)
 
-        result = filter_locations_df_for_independent_care_home_data(
+        result = job.filter_locations_df_for_independent_care_home_data(
             df=df, carehome_col_name="carehome", cqc_col_name="cqc_sector"
         )
         result_row = result.collect()

--- a/tests/unit/test_locations_care_home_feature_engineering.py
+++ b/tests/unit/test_locations_care_home_feature_engineering.py
@@ -1,4 +1,3 @@
-import datetime
 import shutil
 import unittest
 import warnings

--- a/tests/unit/test_locations_non_res_feature_engineering.py
+++ b/tests/unit/test_locations_non_res_feature_engineering.py
@@ -6,10 +6,7 @@ import warnings
 from pyspark.ml.linalg import SparseVector
 from pyspark.sql import SparkSession
 from pyspark.sql import functions as F
-from jobs import locations_non_res_feature_engineering
-from jobs.locations_non_res_feature_engineering import (
-    filter_locations_df_for_independent_non_res_care_home_data,
-)
+import jobs.locations_non_res_feature_engineering as job
 from tests.test_file_generator import (
     generate_prepared_locations_file_parquet,
 )
@@ -70,7 +67,7 @@ class LocationsFeatureEngineeringTests(unittest.TestCase):
         )
 
     def test_main_produces_dataframe_with_features(self):
-        result = locations_non_res_feature_engineering.main(
+        result = job.main(
             self.PREPARED_LOCATIONS_TEST_DATA, self.OUTPUT_DESTINATION
         ).orderBy(F.col("locationid"))
 
@@ -85,9 +82,7 @@ class LocationsFeatureEngineeringTests(unittest.TestCase):
         input_df_length = self.test_df.count()
         self.assertTrue(input_df_length, 14)
 
-        result = locations_non_res_feature_engineering.main(
-            self.PREPARED_LOCATIONS_TEST_DATA, self.OUTPUT_DESTINATION
-        )
+        result = job.main(self.PREPARED_LOCATIONS_TEST_DATA, self.OUTPUT_DESTINATION)
 
         self.assertTrue(result.count() == 7)
 
@@ -103,7 +98,7 @@ class LocationsFeatureEngineeringTests(unittest.TestCase):
 
         df = self.spark.createDataFrame(rows, cols)
 
-        result = filter_locations_df_for_independent_non_res_care_home_data(
+        result = job.filter_locations_df_for_independent_non_res_care_home_data(
             df=df, carehome_col_name="carehome", cqc_col_name="cqc_sector"
         )
         result_row = result.collect()

--- a/tests/unit/test_worker_tracking.py
+++ b/tests/unit/test_worker_tracking.py
@@ -3,7 +3,7 @@ import unittest
 
 from pyspark.sql import SparkSession
 
-from jobs import worker_tracking
+import jobs.worker_tracking as job
 from utils import utils
 from tests.test_file_generator import (
     generate_ascwds_stayer_leaver_workplace_data,
@@ -48,7 +48,7 @@ class Worker_Tracking(unittest.TestCase):
         workplace_dates = spark.read.parquet(self.WORKPLACE_IMPORT_DATES)
         worker_dates = spark.read.parquet(self.WORKER_IMPORT_DATES)
 
-        max_import_date = worker_tracking.max_import_date_in_two_datasets(
+        max_import_date = job.max_import_date_in_two_datasets(
             workplace_dates, worker_dates
         )
 
@@ -60,7 +60,7 @@ class Worker_Tracking(unittest.TestCase):
         workplace_dates = spark.read.parquet(self.WORKPLACE_IMPORT_DATES)
         worker_dates = spark.read.parquet(self.WORKER_IMPORT_DATES)
 
-        start_period_import_date = worker_tracking.get_start_period_import_date(
+        start_period_import_date = job.get_start_period_import_date(
             workplace_dates, worker_dates, "20220101"
         )
 
@@ -72,11 +72,11 @@ class Worker_Tracking(unittest.TestCase):
         workplace_dates = spark.read.parquet(self.WORKPLACE_IMPORT_DATES)
         worker_dates = spark.read.parquet(self.WORKER_IMPORT_DATES)
 
-        end_period_import_date = worker_tracking.max_import_date_in_two_datasets(
+        end_period_import_date = job.max_import_date_in_two_datasets(
             workplace_dates, worker_dates
         )
 
-        start_period_import_date = worker_tracking.get_start_period_import_date(
+        start_period_import_date = job.get_start_period_import_date(
             workplace_dates, worker_dates, end_period_import_date
         )
 
@@ -88,9 +88,7 @@ class Worker_Tracking(unittest.TestCase):
 
         workplaces = spark.read.parquet(self.ASCWDS_WORKPLACE)
 
-        filtered_df = worker_tracking.filter_workplaces(
-            workplaces, "20210101", "20220101"
-        )
+        filtered_df = job.filter_workplaces(workplaces, "20210101", "20220101")
 
         self.assertEqual(filtered_df.columns, ["establishmentid"])
 
@@ -111,7 +109,7 @@ class Worker_Tracking(unittest.TestCase):
         final_column_list = workers.columns
         final_column_list.append("establishment_worker_id")
 
-        df = worker_tracking.get_employees_with_new_identifier(workers)
+        df = job.get_employees_with_new_identifier(workers)
 
         self.assertEqual(df.columns, final_column_list)
         self.assertEqual(df.count(), 36)
@@ -126,7 +124,7 @@ class Worker_Tracking(unittest.TestCase):
         workers = spark.read.parquet(self.ASCWDS_WORKER)
         filtered_workplaces = spark.read.parquet(self.FILTERED_WORKPLACES)
 
-        start_df = worker_tracking.determine_stayer_or_leaver(
+        start_df = job.determine_stayer_or_leaver(
             filtered_workplaces, workers, "20210101", "20220101"
         )
 
@@ -137,7 +135,7 @@ class Worker_Tracking(unittest.TestCase):
         self.assertEqual(collected_start_df[1]["stayer_or_leaver"], "leaver")
 
     def test_main(self):
-        output_df = worker_tracking.main(
+        output_df = job.main(
             self.ASCWDS_WORKPLACE,
             self.ASCWDS_WORKER,
         )

--- a/utils/cqc_api.py
+++ b/utils/cqc_api.py
@@ -1,10 +1,3 @@
-from schemas.cqc_location_schema import LOCATION_SCHEMA
-from pyspark import SparkConf
-from pyspark.context import SparkContext
-from pprint import pprint
-from pyspark.sql.types import *
-from pyspark.sql import SparkSession
-from pyspark.sql import SQLContext
 from ratelimit import limits, sleep_and_retry
 from time import sleep
 


### PR DESCRIPTION
Removed unused imports
Consistency with pyspark.sql.functions
Imported all jobs in test file as 'job' - for some reason it sometimes struggle to recognise jobs when written as 'from jobs import ...'
