### PR TITLE
use legacy parquet date write mode for spark utils session

### DIFF
--- a/utils/utils.py
+++ b/utils/utils.py
@@ -27,7 +27,7 @@ class SetupSpark(object):
     def setupSpark(self):
         spark = SparkSession.builder.appName("sfc_data_engineering").getOrCreate()
         spark.sql("set spark.sql.legacy.timeParserPolicy=LEGACY")
-
+        spark.sql("set spark.sql.legacy.parquet.datetimeRebaseModeInWrite=LEGACY")
         return spark
 
 
@@ -97,10 +97,7 @@ def write_to_parquet(df, output_dir, append=False, partitionKeys=[]):
 
 
 def read_csv(source, delimiter=","):
-    spark = SparkSession.builder.appName(
-        "sfc_data_engineering_csv_to_parquet"
-    ).getOrCreate()
-
+    spark = get_spark()
     df = spark.read.option("delimiter", delimiter).csv(source, header=True)
 
     return df


### PR DESCRIPTION
# Description
Adding in some spark config and using the general spark session in utils

# How to test
Ran the glue job manually to check against a data file that was previously failing to ingest
Will also run this job against all past worker files to check there are no other errors

# Developer checklist
[Trello ticket](https://trello.com/c/lW1CVrNh/117-add-datetimerebasemodeinwritelegacy-config-to-the-ascwds-worker-glue-job)

