### PR TITLE
adds additional parameter to specify cleaned provider source in cqc location script

### DIFF
--- a/jobs/clean_cqc_location_data.py
+++ b/jobs/clean_cqc_location_data.py
@@ -23,8 +23,13 @@ NONE_NURSING_HOME_IDENTIFIER = "Care home without nursing"
 NONE_RESIDENTIAL_IDENTIFIER = "non-residential"
 
 
-def main(cqc_location_source: str, cleaned_cqc_location_destintion: str):
+def main(
+    cqc_location_source: str,
+    cleaned_provider_source: str,
+    cleaned_cqc_location_destintion: str,
+):
     cqc_location_df = utils.read_from_parquet(cqc_location_source)
+    cqc_provider_df = utils.read_from_parquet(cleaned_provider_source)
 
     cqc_location_df = allocate_primary_service_type(cqc_location_df)
 
@@ -61,16 +66,24 @@ if __name__ == "__main__":
     print("Spark job 'clean_cqc_location_data' starting...")
     print(f"Job parameters: {sys.argv}")
 
-    cqc_location_source, cleaned_cqc_location_destination = utils.collect_arguments(
+    (
+        cqc_location_source,
+        cleaned_provider_source,
+        cleaned_cqc_location_destination,
+    ) = utils.collect_arguments(
         (
             "--cqc_location_source",
             "Source s3 directory for parquet CQC locations dataset",
+        ),
+        (
+            "--cqc_provider_cleaned",
+            "Source s3 directory for cleaned parquet CQC provider dataset",
         ),
         (
             "--cleaned_cqc_location_destination",
             "Destination s3 directory for cleaned parquet CQC locations dataset",
         ),
     )
-    main(cqc_location_source, cleaned_cqc_location_destination)
+    main(cqc_location_source, cleaned_provider_source, cleaned_cqc_location_destination)
 
     print("Spark job 'clean_cqc_location_data' complete")

--- a/terraform/pipeline/glue.tf
+++ b/terraform/pipeline/glue.tf
@@ -424,6 +424,7 @@ module "clean_cqc_location_data_job" {
 
   job_parameters = {
     "--cqc_location_source"              = "${module.datasets_bucket.bucket_uri}/domain=CQC/dataset=locations-api/"
+    "--cqc_provider_cleaned"             = "${module.datasets_bucket.bucket_uri}/domain=CQC/dataset=providers-api-cleaned/"
     "--cleaned_cqc_location_destination" = "${module.datasets_bucket.bucket_uri}/domain=CQC/dataset=locations-api-cleaned/"
   }
 }

--- a/tests/unit/test_clean_cqc_location_data.py
+++ b/tests/unit/test_clean_cqc_location_data.py
@@ -1,5 +1,5 @@
 import unittest
-from unittest.mock import ANY, patch
+from unittest.mock import ANY, Mock, patch
 import pyspark.sql.functions as F
 
 import jobs.clean_cqc_location_data as job
@@ -15,7 +15,8 @@ from utils.column_names.ind_cqc_pipeline_columns import (
 
 
 class CleanCQCLocationDatasetTests(unittest.TestCase):
-    TEST_SOURCE = "some/directory"
+    TEST_LOC_SOURCE = "some/directory"
+    TEST_PROV_SOURCE = "some/other/directory"
     TEST_DESTINATION = "some/other/directory"
     partition_keys = [Keys.year, Keys.month, Keys.day, Keys.import_date]
 
@@ -27,9 +28,14 @@ class CleanCQCLocationDatasetTests(unittest.TestCase):
 
     @patch("utils.utils.write_to_parquet")
     @patch("utils.utils.read_from_parquet")
-    def test_main_runs(self, read_from_parquet_patch, write_to_parquet_patch):
+    def test_main_runs(
+        self, read_from_parquet_patch: Mock, write_to_parquet_patch: Mock
+    ):
         read_from_parquet_patch.return_value = self.test_clean_cqc_location_df
-        job.main(self.TEST_SOURCE, self.TEST_DESTINATION)
+
+        job.main(self.TEST_LOC_SOURCE, self.TEST_PROV_SOURCE, self.TEST_DESTINATION)
+
+        self.assertEqual(read_from_parquet_patch.call_count, 2)
         write_to_parquet_patch.assert_called_once_with(
             ANY,
             self.TEST_DESTINATION,


### PR DESCRIPTION
# Description
Add a new parameter to the cqc location cleaning script to pass in the path to the cleaned provider data

# How to test
Run the glue job in main post merge

[Trello ticket](https://trello.com/c/YQWcSer3/128-epic-4-include-cleaned-cqc-provider-data-in-cqc-location-data-must)

# Developer checklist
- [x] Unit test
- [x] Linked to Trello ticket
- [x] Documentation up to date
