### PR TITLE
Split locations file into registered and deregistered

### DIFF
--- a/jobs/clean_cqc_location_data.py
+++ b/jobs/clean_cqc_location_data.py
@@ -1,4 +1,5 @@
 import sys
+import warnings
 
 from utils import utils
 
@@ -98,19 +99,22 @@ def join_cqc_provider_data(locations_df: DataFrame, provider_df: DataFrame):
 def split_dataframe_into_registered_and_deregistered_rows(
     locations_df: DataFrame,
 ) -> DataFrame:
+    invalid_rows = locations_df.where(
+        (locations_df[CQCL.registration_status] != "Registered") & (locations_df[CQCL.registration_status] != "Deregistered")
+    ).count()
+    
+    if invalid_rows != 0:
+        warnings.warn(
+            f"{invalid_rows} row(s) has/have an invalid registration status and have been dropped."
+        )
+
     registered_df = locations_df.where(
         locations_df[CQCL.registration_status] == "Registered"
     )
     deregistered_df = locations_df.where(
         locations_df[CQCL.registration_status] == "Deregistered"
     )
-    rows_without_registration_status = locations_df.where(
-        locations_df[CQCL.registration_status].isNull()
-    ).count()
-    if rows_without_registration_status != 0:
-        print(
-            f"{rows_without_registration_status} rows are missing a registration status and have been dropped."
-        )
+    
     return registered_df, deregistered_df
 
 

--- a/jobs/clean_cqc_location_data.py
+++ b/jobs/clean_cqc_location_data.py
@@ -100,9 +100,10 @@ def split_dataframe_into_registered_and_deregistered_rows(
     locations_df: DataFrame,
 ) -> DataFrame:
     invalid_rows = locations_df.where(
-        (locations_df[CQCL.registration_status] != "Registered") & (locations_df[CQCL.registration_status] != "Deregistered")
+        (locations_df[CQCL.registration_status] != "Registered")
+        & (locations_df[CQCL.registration_status] != "Deregistered")
     ).count()
-    
+
     if invalid_rows != 0:
         warnings.warn(
             f"{invalid_rows} row(s) has/have an invalid registration status and have been dropped."
@@ -114,7 +115,7 @@ def split_dataframe_into_registered_and_deregistered_rows(
     deregistered_df = locations_df.where(
         locations_df[CQCL.registration_status] == "Deregistered"
     )
-    
+
     return registered_df, deregistered_df
 
 

--- a/jobs/clean_cqc_location_data.py
+++ b/jobs/clean_cqc_location_data.py
@@ -41,8 +41,10 @@ def main(
 
     cqc_location_df = allocate_primary_service_type(cqc_location_df)
 
+    registered_locations_df, deregistered_locations_df = split_dataframe_into_registered_and_deregistered_rows(cqc_location_df)
+
     utils.write_to_parquet(
-        cqc_location_df,
+        registered_locations_df,
         cleaned_cqc_location_destintion,
         append=True,
         partitionKeys=cqcPartitionKeys,

--- a/jobs/clean_cqc_location_data.py
+++ b/jobs/clean_cqc_location_data.py
@@ -41,7 +41,10 @@ def main(
 
     cqc_location_df = allocate_primary_service_type(cqc_location_df)
 
-    registered_locations_df, deregistered_locations_df = split_dataframe_into_registered_and_deregistered_rows(cqc_location_df)
+    (
+        registered_locations_df,
+        deregistered_locations_df,
+    ) = split_dataframe_into_registered_and_deregistered_rows(cqc_location_df)
 
     utils.write_to_parquet(
         registered_locations_df,
@@ -91,13 +94,25 @@ def join_cqc_provider_data(locations_df: DataFrame, provider_df: DataFrame):
 
     return joined_df
 
-def split_dataframe_into_registered_and_deregistered_rows(locations_df:DataFrame) -> DataFrame:
-    registered_df = locations_df.where(locations_df[CQCL.registration_status] == "Registered")
-    deregistered_df = locations_df.where(locations_df[CQCL.registration_status] == "Deregistered")
-    rows_without_registration_status = locations_df.where(locations_df[CQCL.registration_status].isNull()).count()
+
+def split_dataframe_into_registered_and_deregistered_rows(
+    locations_df: DataFrame,
+) -> DataFrame:
+    registered_df = locations_df.where(
+        locations_df[CQCL.registration_status] == "Registered"
+    )
+    deregistered_df = locations_df.where(
+        locations_df[CQCL.registration_status] == "Deregistered"
+    )
+    rows_without_registration_status = locations_df.where(
+        locations_df[CQCL.registration_status].isNull()
+    ).count()
     if rows_without_registration_status != 0:
-        print(f"{rows_without_registration_status} rows are missing a registration status and have been dropped.")
+        print(
+            f"{rows_without_registration_status} rows are missing a registration status and have been dropped."
+        )
     return registered_df, deregistered_df
+
 
 if __name__ == "__main__":
     print("Spark job 'clean_cqc_location_data' starting...")

--- a/jobs/clean_cqc_location_data.py
+++ b/jobs/clean_cqc_location_data.py
@@ -89,6 +89,13 @@ def join_cqc_provider_data(locations_df: DataFrame, provider_df: DataFrame):
 
     return joined_df
 
+def split_dataframe_into_registered_and_deregistered_rows(locations_df:DataFrame) -> DataFrame:
+    registered_df = locations_df.where(locations_df[CQCL.registration_status] == "Registered")
+    deregistered_df = locations_df.where(locations_df[CQCL.registration_status] == "Deregistered")
+    rows_without_registration_status = locations_df.where(locations_df[CQCL.registration_status].isNull()).count()
+    if rows_without_registration_status != 0:
+        print(f"{rows_without_registration_status} rows are missing a registration status and have been dropped.")
+    return registered_df, deregistered_df
 
 if __name__ == "__main__":
     print("Spark job 'clean_cqc_location_data' starting...")

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -663,6 +663,19 @@ class CQCLocationsData:
         ),
     ]
 
+    registration_status_rows = [
+        ("loc-1", "Registered",),
+        ("loc-2", "Deregistered",),
+    ]
+
+    expected_deregistered_rows = [
+        ("loc-2", "Deregistered",),
+    ]
+
+    expected_registered_rows = [
+        ("loc-1", "Registered",),
+    ]
+    
 
 @dataclass
 class CleaningUtilsData:

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -666,6 +666,7 @@ class CQCLocationsData:
     registration_status_rows = [
         ("loc-1", "Registered",),
         ("loc-2", "Deregistered",),
+        ("loc-3", None,),
     ]
 
     expected_deregistered_rows = [

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -664,19 +664,34 @@ class CQCLocationsData:
     ]
 
     registration_status_rows = [
-        ("loc-1", "Registered",),
-        ("loc-2", "Deregistered",),
-        ("loc-3", None,),
+        (
+            "loc-1",
+            "Registered",
+        ),
+        (
+            "loc-2",
+            "Deregistered",
+        ),
+        (
+            "loc-3",
+            None,
+        ),
     ]
 
     expected_deregistered_rows = [
-        ("loc-2", "Deregistered",),
+        (
+            "loc-2",
+            "Deregistered",
+        ),
     ]
 
     expected_registered_rows = [
-        ("loc-1", "Registered",),
+        (
+            "loc-1",
+            "Registered",
+        ),
     ]
-    
+
 
 @dataclass
 class CleaningUtilsData:

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -663,7 +663,7 @@ class CQCLocationsData:
         ),
     ]
 
-    registration_status_rows = [
+    registration_status_with_missing_data_rows = [
         (
             "loc-1",
             "Registered",
@@ -674,7 +674,18 @@ class CQCLocationsData:
         ),
         (
             "loc-3",
-            None,
+            "new value",
+        ),
+    ]
+
+    registration_status_rows = [
+        (
+            "loc-1",
+            "Registered",
+        ),
+        (
+            "loc-2",
+            "Deregistered",
         ),
     ]
 

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -284,6 +284,13 @@ class CQCLocationsSchema:
         ]
     )
 
+    registration_status_schema = StructType(
+        [
+            StructField(CQCL.location_id, StringType(), True),
+            StructField(CQCL.registration_status, StringType(), True),
+        ]
+    )
+
 
 @dataclass
 class CleaningUtilsSchemas:

--- a/tests/unit/test_clean_cqc_location_data.py
+++ b/tests/unit/test_clean_cqc_location_data.py
@@ -131,12 +131,13 @@ class CleanCQCLocationDatasetTests(unittest.TestCase):
 
         self.assertEqual(returned_registered_data, expected_registered_data)
         self.assertEqual(returned_deregistered_data, expected_deregistered_data)
-    
+
     def test_split_dataframe_into_registered_and_deregistered_rows_raises_a_warning_if_any_rows_are_invalid(
         self,
     ):
         test_df = self.spark.createDataFrame(
-            Data.registration_status_with_missing_data_rows, Schemas.registration_status_schema
+            Data.registration_status_with_missing_data_rows,
+            Schemas.registration_status_schema,
         )
         (
             returned_registered_df,
@@ -154,7 +155,7 @@ class CleanCQCLocationDatasetTests(unittest.TestCase):
 
         self.assertEqual(returned_registered_data, expected_registered_data)
         self.assertEqual(returned_deregistered_data, expected_deregistered_data)
-   
+
         self.assertWarns(Warning)
 
     def test_split_dataframe_into_registered_and_deregistered_rows_does_not_raise_a_warning_if_all_rows_are_valid(

--- a/tests/unit/test_clean_cqc_location_data.py
+++ b/tests/unit/test_clean_cqc_location_data.py
@@ -110,14 +110,16 @@ class CleanCQCLocationDatasetTests(unittest.TestCase):
     
     def test_split_dataframe_into_registered_and_deregistered_rows_splits_data_correctly(self):
         test_df = self.spark.createDataFrame(Data.registration_status_rows, Schemas.registration_status_schema)
-        
-        returned_registered_df, returned_deregistered_df = job.split_dataframe_into_registered_and_deregistered_rows(test_df)
 
-        expected_registered_df = self.spark.createDataFrame(Data.expected_registered_rows, Schemas.registration_status_schema)
-        expected_deregistered_df = self.spark.createDataFrame(Data.expected_deregistered_rows, Schemas.registration_status_schema)
+        returned_registered_df, returned_deregistered_df = job.split_dataframe_into_registered_and_deregistered_rows(test_df)
+        returned_registered_data = returned_registered_df.collect()
+        returned_deregistered_data = returned_deregistered_df.collect()
         
-        self.assertEqual(returned_registered_df, expected_registered_df)
-        self.assertEqual(returned_deregistered_df, expected_deregistered_df)
+        expected_registered_data = self.spark.createDataFrame(Data.expected_registered_rows, Schemas.registration_status_schema).collect()
+        expected_deregistered_data = self.spark.createDataFrame(Data.expected_deregistered_rows, Schemas.registration_status_schema).collect()
+        
+        self.assertEqual(returned_registered_data, expected_registered_data)
+        self.assertEqual(returned_deregistered_data, expected_deregistered_data)
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_clean_cqc_location_data.py
+++ b/tests/unit/test_clean_cqc_location_data.py
@@ -35,6 +35,7 @@ class CleanCQCLocationDatasetTests(unittest.TestCase):
             Data.join_provider_rows, Schemas.join_provider_schema
         )
 
+
     @patch("utils.utils.write_to_parquet")
     @patch("utils.utils.read_from_parquet")
     def test_main_runs(
@@ -106,6 +107,17 @@ class CleanCQCLocationDatasetTests(unittest.TestCase):
         )
 
         self.assertCountEqual(returned_data, expected_data)
+    
+    def test_split_dataframe_into_registered_and_deregistered_rows_splits_data_correctly(self):
+        test_df = self.spark.createDataFrame(Data.registration_status_rows, Schemas.registration_status_schema)
+        
+        returned_registered_df, returned_deregistered_df = job.split_dataframe_into_registered_and_deregistered_rows(test_df)
+
+        expected_registered_df = self.spark.createDataFrame(Data.expected_registered_rows, Schemas.registration_status_schema)
+        expected_deregistered_df = self.spark.createDataFrame(Data.expected_deregistered_rows, Schemas.registration_status_schema)
+        
+        self.assertEqual(returned_registered_df, expected_registered_df)
+        self.assertEqual(returned_deregistered_df, expected_deregistered_df)
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_clean_cqc_location_data.py
+++ b/tests/unit/test_clean_cqc_location_data.py
@@ -35,7 +35,6 @@ class CleanCQCLocationDatasetTests(unittest.TestCase):
             Data.join_provider_rows, Schemas.join_provider_schema
         )
 
-
     @patch("utils.utils.write_to_parquet")
     @patch("utils.utils.read_from_parquet")
     def test_main_runs(
@@ -107,17 +106,28 @@ class CleanCQCLocationDatasetTests(unittest.TestCase):
         )
 
         self.assertCountEqual(returned_data, expected_data)
-    
-    def test_split_dataframe_into_registered_and_deregistered_rows_splits_data_correctly(self):
-        test_df = self.spark.createDataFrame(Data.registration_status_rows, Schemas.registration_status_schema)
 
-        returned_registered_df, returned_deregistered_df = job.split_dataframe_into_registered_and_deregistered_rows(test_df)
+    def test_split_dataframe_into_registered_and_deregistered_rows_splits_data_correctly(
+        self,
+    ):
+        test_df = self.spark.createDataFrame(
+            Data.registration_status_rows, Schemas.registration_status_schema
+        )
+
+        (
+            returned_registered_df,
+            returned_deregistered_df,
+        ) = job.split_dataframe_into_registered_and_deregistered_rows(test_df)
         returned_registered_data = returned_registered_df.collect()
         returned_deregistered_data = returned_deregistered_df.collect()
-        
-        expected_registered_data = self.spark.createDataFrame(Data.expected_registered_rows, Schemas.registration_status_schema).collect()
-        expected_deregistered_data = self.spark.createDataFrame(Data.expected_deregistered_rows, Schemas.registration_status_schema).collect()
-        
+
+        expected_registered_data = self.spark.createDataFrame(
+            Data.expected_registered_rows, Schemas.registration_status_schema
+        ).collect()
+        expected_deregistered_data = self.spark.createDataFrame(
+            Data.expected_deregistered_rows, Schemas.registration_status_schema
+        ).collect()
+
         self.assertEqual(returned_registered_data, expected_registered_data)
         self.assertEqual(returned_deregistered_data, expected_deregistered_data)
 

--- a/tests/unit/test_clean_cqc_location_data.py
+++ b/tests/unit/test_clean_cqc_location_data.py
@@ -1,4 +1,5 @@
 import unittest
+import warnings
 from unittest.mock import ANY, Mock, patch
 import pyspark.sql.functions as F
 
@@ -130,6 +131,60 @@ class CleanCQCLocationDatasetTests(unittest.TestCase):
 
         self.assertEqual(returned_registered_data, expected_registered_data)
         self.assertEqual(returned_deregistered_data, expected_deregistered_data)
+    
+    def test_split_dataframe_into_registered_and_deregistered_rows_raises_a_warning_if_any_rows_are_invalid(
+        self,
+    ):
+        test_df = self.spark.createDataFrame(
+            Data.registration_status_with_missing_data_rows, Schemas.registration_status_schema
+        )
+        (
+            returned_registered_df,
+            returned_deregistered_df,
+        ) = job.split_dataframe_into_registered_and_deregistered_rows(test_df)
+        returned_registered_data = returned_registered_df.collect()
+        returned_deregistered_data = returned_deregistered_df.collect()
+
+        expected_registered_data = self.spark.createDataFrame(
+            Data.expected_registered_rows, Schemas.registration_status_schema
+        ).collect()
+        expected_deregistered_data = self.spark.createDataFrame(
+            Data.expected_deregistered_rows, Schemas.registration_status_schema
+        ).collect()
+
+        self.assertEqual(returned_registered_data, expected_registered_data)
+        self.assertEqual(returned_deregistered_data, expected_deregistered_data)
+   
+        self.assertWarns(Warning)
+
+    def test_split_dataframe_into_registered_and_deregistered_rows_does_not_raise_a_warning_if_all_rows_are_valid(
+        self,
+    ):
+        test_df = self.spark.createDataFrame(
+            Data.registration_status_rows, Schemas.registration_status_schema
+        )
+        with warnings.catch_warnings(record=True) as warnings_log:
+            (
+                returned_registered_df,
+                returned_deregistered_df,
+            ) = job.split_dataframe_into_registered_and_deregistered_rows(test_df)
+            """
+            returned_registered_data = returned_registered_df.collect()
+            returned_deregistered_data = returned_deregistered_df.collect()
+
+            expected_registered_data = self.spark.createDataFrame(
+                Data.expected_registered_rows, Schemas.registration_status_schema
+            ).collect()
+            expected_deregistered_data = self.spark.createDataFrame(
+                Data.expected_deregistered_rows, Schemas.registration_status_schema
+            ).collect()
+
+            self.assertEqual(returned_registered_data, expected_registered_data)
+            self.assertEqual(returned_deregistered_data, expected_deregistered_data)
+    
+            """
+
+            self.assertEqual(warnings_log, [])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Description
Split the locations file into registered and deregistered locations

https://trello.com/c/A6GwGtyQ/37-epic-4-split-file-based-on-registered-or-de-registered-locations-must

# How to test
Unit tests passing
Ran successfully in branch. No deregistered locations in athena with sample data.

# Developer checklist
- [x] Unit test
- [x] Linked to Trello ticket
- [x] Documentation up to date
