### PR TITLE
Cast total staff and worker records to ints

### DIFF
--- a/jobs/clean_ascwds_workplace_data.py
+++ b/jobs/clean_ascwds_workplace_data.py
@@ -1,5 +1,7 @@
 import sys
 
+from pyspark.sql import DataFrame
+
 from utils import utils
 from utils.column_names.raw_data_files.ascwds_workplace_columns import PartitionKeys
 
@@ -19,6 +21,9 @@ def main(source: str, destination: str):
             PartitionKeys.import_date,
         ],
     )
+
+def cast_to_int(df:DataFrame, column_names:list) -> DataFrame:
+    return df
 
 
 if __name__ == "__main__":

--- a/jobs/clean_ascwds_workplace_data.py
+++ b/jobs/clean_ascwds_workplace_data.py
@@ -13,8 +13,9 @@ from utils.column_names.raw_data_files.ascwds_workplace_columns import (
 def main(source: str, destination: str):
     ascwds_workplace_df = utils.read_from_parquet(source)
 
-
-    ascwds_workplace_df = cast_to_int(ascwds_workplace_df, [AWP.total_staff, AWP.worker_records])
+    ascwds_workplace_df = cast_to_int(
+        ascwds_workplace_df, [AWP.total_staff, AWP.worker_records]
+    )
 
     print(f"Exporting as parquet to {destination}")
     utils.write_to_parquet(
@@ -29,7 +30,8 @@ def main(source: str, destination: str):
         ],
     )
 
-def cast_to_int(df:DataFrame, column_names:list) -> DataFrame:
+
+def cast_to_int(df: DataFrame, column_names: list) -> DataFrame:
     for column in column_names:
         df = df.withColumn(column, df[column].cast(IntegerType()))
     return df

--- a/jobs/clean_ascwds_workplace_data.py
+++ b/jobs/clean_ascwds_workplace_data.py
@@ -1,13 +1,20 @@
 import sys
 
 from pyspark.sql import DataFrame
+from pyspark.sql.types import IntegerType
 
 from utils import utils
-from utils.column_names.raw_data_files.ascwds_workplace_columns import PartitionKeys
+from utils.column_names.raw_data_files.ascwds_workplace_columns import (
+    PartitionKeys,
+    AscwdsWorkplaceColumns as AWP,
+)
 
 
 def main(source: str, destination: str):
     ascwds_workplace_df = utils.read_from_parquet(source)
+
+
+    ascwds_workplace_df = cast_to_int(ascwds_workplace_df, [AWP.total_staff, AWP.worker_records])
 
     print(f"Exporting as parquet to {destination}")
     utils.write_to_parquet(
@@ -23,6 +30,8 @@ def main(source: str, destination: str):
     )
 
 def cast_to_int(df:DataFrame, column_names:list) -> DataFrame:
+    for column in column_names:
+        df = df.withColumn(column, df[column].cast(IntegerType()))
     return df
 
 

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -269,6 +269,17 @@ class ASCWDSWorkplaceData:
         ("loc 4", "ZO", "IB",),
     ]
 
+    cast_to_int_expected_rows = [
+        ("loc 1", 20, 18,),
+    ]
+
+    cast_to_int_errors_expected_rows = [
+        ("loc 1", 20, 18,),
+        ("loc 2", None, 18,),
+        ("loc 3", 20, None,),
+        ("loc 4", None, None,),
+    ]
+
 
 @dataclass
 class CQCProviderData:

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -259,25 +259,65 @@ class ASCWDSWorkplaceData:
     ]
 
     cast_to_int_rows = [
-        ("loc 1", "20", "18",),
+        (
+            "loc 1",
+            "20",
+            "18",
+        ),
     ]
 
     cast_to_int_errors_rows = [
-        ("loc 1", "20", "18",),
-        ("loc 2", "ZO", "18",),
-        ("loc 3", "20", "IB",),
-        ("loc 4", "ZO", "IB",),
+        (
+            "loc 1",
+            "20",
+            "18",
+        ),
+        (
+            "loc 2",
+            "ZO",
+            "18",
+        ),
+        (
+            "loc 3",
+            "20",
+            "IB",
+        ),
+        (
+            "loc 4",
+            "ZO",
+            "IB",
+        ),
     ]
 
     cast_to_int_expected_rows = [
-        ("loc 1", 20, 18,),
+        (
+            "loc 1",
+            20,
+            18,
+        ),
     ]
 
     cast_to_int_errors_expected_rows = [
-        ("loc 1", 20, 18,),
-        ("loc 2", None, 18,),
-        ("loc 3", 20, None,),
-        ("loc 4", None, None,),
+        (
+            "loc 1",
+            20,
+            18,
+        ),
+        (
+            "loc 2",
+            None,
+            18,
+        ),
+        (
+            "loc 3",
+            20,
+            None,
+        ),
+        (
+            "loc 4",
+            None,
+            None,
+        ),
     ]
 
 

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -258,6 +258,17 @@ class ASCWDSWorkplaceData:
         ),
     ]
 
+    cast_to_int_rows = [
+        ("loc 1", "20", "18",),
+    ]
+
+    cast_to_int_errors_rows = [
+        ("loc 1", "20", "18",),
+        ("loc 2", "ZO", "18",),
+        ("loc 3", "20", "IB",),
+        ("loc 4", "ZO", "IB",),
+    ]
+
 
 @dataclass
 class CQCProviderData:

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -229,6 +229,14 @@ class ASCWDSWorkplaceSchemas:
         ]
     )
 
+    cast_to_int_schema = StructType(
+        [
+            StructField(AWP.location_id, StringType(), True),
+            StructField(AWP.total_staff, StringType(), True),
+            StructField(AWP.worker_records, StringType(), True),
+        ]
+    )
+
 
 @dataclass
 class CQCLocationsSchema:

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -237,6 +237,14 @@ class ASCWDSWorkplaceSchemas:
         ]
     )
 
+    cast_to_int_expected_schema = StructType(
+        [
+            StructField(AWP.location_id, StringType(), True),
+            StructField(AWP.total_staff, IntegerType(), True),
+            StructField(AWP.worker_records, IntegerType(), True),
+        ]
+    )
+
 
 @dataclass
 class CQCLocationsSchema:

--- a/tests/unit/test_clean_ascwds_workplace_data.py
+++ b/tests/unit/test_clean_ascwds_workplace_data.py
@@ -1,5 +1,5 @@
 import unittest
-from unittest.mock import patch
+from unittest.mock import patch, ANY
 
 import jobs.clean_ascwds_workplace_data as job
 
@@ -23,22 +23,11 @@ class IngestASCWDSWorkerDatasetTests(unittest.TestCase):
     ]
 
     def setUp(self) -> None:
-        spark = get_spark()
-        self.test_ascwds_worker_df = spark.createDataFrame(
+        self.spark = get_spark()
+        self.test_ascwds_worker_df = self.spark.createDataFrame(
             Data.workplace_rows, Schemas.workplace_schema
         )
-        self.cast_to_int_df = spark.createDataFrame(
-            Data.cast_to_int_rows, Schemas.cast_to_int_schema
-        )
-        self.cast_to_int_with_errors_df = spark.createDataFrame(
-            Data.cast_to_int_errors_rows, Schemas.cast_to_int_schema
-        )
-        self.cast_to_int_expected_df = spark.createDataFrame(
-            Data.cast_to_int_expected_rows, Schemas.cast_to_int_expected_schema
-        )
-        self.cast_to_int_with_errors_expected_df = spark.createDataFrame(
-            Data.cast_to_int_errors_expected_rows, Schemas.cast_to_int_expected_schema
-        )
+        
         self.filled_posts_columns = [AWP.total_staff, AWP.worker_records]
 
     @patch("utils.utils.write_to_parquet")
@@ -50,32 +39,45 @@ class IngestASCWDSWorkerDatasetTests(unittest.TestCase):
 
         read_from_parquet_mock.assert_called_once_with(self.TEST_SOURCE)
         write_to_parquet_mock.assert_called_once_with(
-            self.test_ascwds_worker_df,
+            ANY,
             self.TEST_DESTINATION,
             True,
             self.partition_keys,
         )
 
     def test_cast_to_int_returns_strings_formatted_as_ints_to_ints(self):
-        returned_df = job.cast_to_int(self.cast_to_int_df, self.filled_posts_columns)
+        cast_to_int_df = self.spark.createDataFrame(
+            Data.cast_to_int_rows, Schemas.cast_to_int_schema
+        )
+        cast_to_int_expected_df = self.spark.createDataFrame(
+            Data.cast_to_int_expected_rows, Schemas.cast_to_int_expected_schema
+        )
+
+        returned_df = job.cast_to_int(cast_to_int_df, self.filled_posts_columns)
+
         returned_data = returned_df.sort(AWP.location_id).collect()
-        expected_data = self.cast_to_int_expected_df.sort(AWP.location_id).collect()
-        returned_df.show()
-        returned_df.printSchema()
-        self.cast_to_int_expected_df.show()
-        self.cast_to_int_expected_df.printSchema()
+        expected_data = cast_to_int_expected_df.sort(AWP.location_id).collect()
+
         self.assertEqual(expected_data, returned_data)
 
     def test_cast_to_int_returns_strings_not_formatted_as_ints_as_none(self):
-        returned_df = job.cast_to_int(
-            self.cast_to_int_with_errors_df, self.filled_posts_columns
+        
+        cast_to_int_with_errors_df = self.spark.createDataFrame(
+            Data.cast_to_int_errors_rows, Schemas.cast_to_int_schema
         )
+        cast_to_int_with_errors_expected_df = self.spark.createDataFrame(
+            Data.cast_to_int_errors_expected_rows, Schemas.cast_to_int_expected_schema
+        )
+
+        returned_df = job.cast_to_int(
+            cast_to_int_with_errors_df, self.filled_posts_columns
+        )
+        
         returned_data = returned_df.sort(AWP.location_id).collect()
-        expected_data = self.cast_to_int_with_errors_expected_df.sort(
+        expected_data = cast_to_int_with_errors_expected_df.sort(
             AWP.location_id
         ).collect()
-        returned_df.show()
-        self.cast_to_int_with_errors_expected_df.show()
+
         self.assertEqual(expected_data, returned_data)
 
 

--- a/tests/unit/test_clean_ascwds_workplace_data.py
+++ b/tests/unit/test_clean_ascwds_workplace_data.py
@@ -3,9 +3,12 @@ from unittest.mock import patch
 
 import jobs.clean_ascwds_workplace_data as job
 
-from tests.test_file_data import ASCWDSWorkplaceData
-from tests.test_file_schemas import ASCWDSWorkplaceSchemas
-from utils.column_names.raw_data_files.ascwds_workplace_columns import PartitionKeys
+from tests.test_file_data import ASCWDSWorkplaceData as Data
+from tests.test_file_schemas import ASCWDSWorkplaceSchemas as Schemas
+from utils.column_names.raw_data_files.ascwds_workplace_columns import (
+    PartitionKeys,
+    AscwdsWorkplaceColumns as AWP,
+)
 from utils.utils import get_spark
 
 
@@ -22,8 +25,13 @@ class IngestASCWDSWorkerDatasetTests(unittest.TestCase):
     def setUp(self) -> None:
         spark = get_spark()
         self.test_ascwds_worker_df = spark.createDataFrame(
-            ASCWDSWorkplaceData.workplace_rows, ASCWDSWorkplaceSchemas.workplace_schema
+            Data.workplace_rows, Schemas.workplace_schema
         )
+        self.cast_to_int_df = spark.createDataFrame(Data.cast_to_int_rows, Schemas.cast_to_int_schema)
+        self.cast_to_int_with_errors_df = spark.createDataFrame(Data.cast_to_int_errors_rows, Schemas.cast_to_int_schema)
+        self.cast_to_int_expected_df = spark.createDataFrame(Data.cast_to_int_expected_rows, Schemas.cast_to_int_schema)
+        self.cast_to_int_with_errors_expected_df = spark.createDataFrame(Data.cast_to_int_errors_expected_rows, Schemas.cast_to_int_schema)
+        self.filled_posts_columns = [AWP.total_staff, AWP.worker_records]
 
     @patch("utils.utils.write_to_parquet")
     @patch("utils.utils.read_from_parquet")
@@ -39,6 +47,21 @@ class IngestASCWDSWorkerDatasetTests(unittest.TestCase):
             True,
             self.partition_keys,
         )
+    
+    def test_cast_to_int_returns_strings_formatted_as_ints_to_ints(self):
+        returned_df = job.cast_to_int(self.cast_to_int_df, self.filled_posts_columns)
+        returned_data = returned_df.sort(AWP.location_id).collect()
+        expected_data = self.cast_to_int_expected_df.sort(AWP.location_id).collect()
+
+        self.assertEqual(expected_data, returned_data)
+
+    def test_cast_to_int_returns_strings_not_formatted_as_ints_as_none(self):
+        returned_df = job.cast_to_int(self.cast_to_int_with_errors_df, self.filled_posts_columns)
+        returned_data = returned_df.sort(AWP.location_id).collect()
+        expected_data = self.cast_to_int_with_errors_expected_df.sort(AWP.location_id).collect()
+
+        self.assertEqual(expected_data, returned_data)
+
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_clean_ascwds_workplace_data.py
+++ b/tests/unit/test_clean_ascwds_workplace_data.py
@@ -29,8 +29,8 @@ class IngestASCWDSWorkerDatasetTests(unittest.TestCase):
         )
         self.cast_to_int_df = spark.createDataFrame(Data.cast_to_int_rows, Schemas.cast_to_int_schema)
         self.cast_to_int_with_errors_df = spark.createDataFrame(Data.cast_to_int_errors_rows, Schemas.cast_to_int_schema)
-        self.cast_to_int_expected_df = spark.createDataFrame(Data.cast_to_int_expected_rows, Schemas.cast_to_int_schema)
-        self.cast_to_int_with_errors_expected_df = spark.createDataFrame(Data.cast_to_int_errors_expected_rows, Schemas.cast_to_int_schema)
+        self.cast_to_int_expected_df = spark.createDataFrame(Data.cast_to_int_expected_rows, Schemas.cast_to_int_expected_schema)
+        self.cast_to_int_with_errors_expected_df = spark.createDataFrame(Data.cast_to_int_errors_expected_rows, Schemas.cast_to_int_expected_schema)
         self.filled_posts_columns = [AWP.total_staff, AWP.worker_records]
 
     @patch("utils.utils.write_to_parquet")
@@ -52,14 +52,18 @@ class IngestASCWDSWorkerDatasetTests(unittest.TestCase):
         returned_df = job.cast_to_int(self.cast_to_int_df, self.filled_posts_columns)
         returned_data = returned_df.sort(AWP.location_id).collect()
         expected_data = self.cast_to_int_expected_df.sort(AWP.location_id).collect()
-
+        returned_df.show()
+        returned_df.printSchema()
+        self.cast_to_int_expected_df.show()
+        self.cast_to_int_expected_df.printSchema()
         self.assertEqual(expected_data, returned_data)
 
     def test_cast_to_int_returns_strings_not_formatted_as_ints_as_none(self):
         returned_df = job.cast_to_int(self.cast_to_int_with_errors_df, self.filled_posts_columns)
         returned_data = returned_df.sort(AWP.location_id).collect()
         expected_data = self.cast_to_int_with_errors_expected_df.sort(AWP.location_id).collect()
-
+        returned_df.show()
+        self.cast_to_int_with_errors_expected_df.show()
         self.assertEqual(expected_data, returned_data)
 
 

--- a/tests/unit/test_clean_ascwds_workplace_data.py
+++ b/tests/unit/test_clean_ascwds_workplace_data.py
@@ -27,7 +27,7 @@ class IngestASCWDSWorkerDatasetTests(unittest.TestCase):
         self.test_ascwds_worker_df = self.spark.createDataFrame(
             Data.workplace_rows, Schemas.workplace_schema
         )
-        
+
         self.filled_posts_columns = [AWP.total_staff, AWP.worker_records]
 
     @patch("utils.utils.write_to_parquet")
@@ -61,7 +61,6 @@ class IngestASCWDSWorkerDatasetTests(unittest.TestCase):
         self.assertEqual(expected_data, returned_data)
 
     def test_cast_to_int_returns_strings_not_formatted_as_ints_as_none(self):
-        
         cast_to_int_with_errors_df = self.spark.createDataFrame(
             Data.cast_to_int_errors_rows, Schemas.cast_to_int_schema
         )
@@ -72,7 +71,7 @@ class IngestASCWDSWorkerDatasetTests(unittest.TestCase):
         returned_df = job.cast_to_int(
             cast_to_int_with_errors_df, self.filled_posts_columns
         )
-        
+
         returned_data = returned_df.sort(AWP.location_id).collect()
         expected_data = cast_to_int_with_errors_expected_df.sort(
             AWP.location_id

--- a/tests/unit/test_clean_ascwds_workplace_data.py
+++ b/tests/unit/test_clean_ascwds_workplace_data.py
@@ -27,10 +27,18 @@ class IngestASCWDSWorkerDatasetTests(unittest.TestCase):
         self.test_ascwds_worker_df = spark.createDataFrame(
             Data.workplace_rows, Schemas.workplace_schema
         )
-        self.cast_to_int_df = spark.createDataFrame(Data.cast_to_int_rows, Schemas.cast_to_int_schema)
-        self.cast_to_int_with_errors_df = spark.createDataFrame(Data.cast_to_int_errors_rows, Schemas.cast_to_int_schema)
-        self.cast_to_int_expected_df = spark.createDataFrame(Data.cast_to_int_expected_rows, Schemas.cast_to_int_expected_schema)
-        self.cast_to_int_with_errors_expected_df = spark.createDataFrame(Data.cast_to_int_errors_expected_rows, Schemas.cast_to_int_expected_schema)
+        self.cast_to_int_df = spark.createDataFrame(
+            Data.cast_to_int_rows, Schemas.cast_to_int_schema
+        )
+        self.cast_to_int_with_errors_df = spark.createDataFrame(
+            Data.cast_to_int_errors_rows, Schemas.cast_to_int_schema
+        )
+        self.cast_to_int_expected_df = spark.createDataFrame(
+            Data.cast_to_int_expected_rows, Schemas.cast_to_int_expected_schema
+        )
+        self.cast_to_int_with_errors_expected_df = spark.createDataFrame(
+            Data.cast_to_int_errors_expected_rows, Schemas.cast_to_int_expected_schema
+        )
         self.filled_posts_columns = [AWP.total_staff, AWP.worker_records]
 
     @patch("utils.utils.write_to_parquet")
@@ -47,7 +55,7 @@ class IngestASCWDSWorkerDatasetTests(unittest.TestCase):
             True,
             self.partition_keys,
         )
-    
+
     def test_cast_to_int_returns_strings_formatted_as_ints_to_ints(self):
         returned_df = job.cast_to_int(self.cast_to_int_df, self.filled_posts_columns)
         returned_data = returned_df.sort(AWP.location_id).collect()
@@ -59,13 +67,16 @@ class IngestASCWDSWorkerDatasetTests(unittest.TestCase):
         self.assertEqual(expected_data, returned_data)
 
     def test_cast_to_int_returns_strings_not_formatted_as_ints_as_none(self):
-        returned_df = job.cast_to_int(self.cast_to_int_with_errors_df, self.filled_posts_columns)
+        returned_df = job.cast_to_int(
+            self.cast_to_int_with_errors_df, self.filled_posts_columns
+        )
         returned_data = returned_df.sort(AWP.location_id).collect()
-        expected_data = self.cast_to_int_with_errors_expected_df.sort(AWP.location_id).collect()
+        expected_data = self.cast_to_int_with_errors_expected_df.sort(
+            AWP.location_id
+        ).collect()
         returned_df.show()
         self.cast_to_int_with_errors_expected_df.show()
         self.assertEqual(expected_data, returned_data)
-
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Description
Cast total staff and worker records to integers
https://trello.com/c/EYeGPZXO/133-epic-5-cast-strings-to-ints-for-total-staff-and-worker-records-must 

# How to test
Unit tests passing
Running successfully in branch

# Developer checklist
- [x] Unit test
- [x] Linked to Trello ticket
- [ ] Documentation up to date
