### PR TITLE
Only append new rows cqc pir data

### DIFF
--- a/jobs/clean_cqc_pir_data.py
+++ b/jobs/clean_cqc_pir_data.py
@@ -5,14 +5,17 @@ import utils.cleaning_utils as cUtils
 from utils.column_names.ind_cqc_pipeline_columns import PartitionKeys as Keys
 
 pirPartitionKeys = [Keys.year, Keys.month, Keys.day, Keys.import_date]
+DATE_COLUMN_NAME = "cqc_pir_import_date"
 
 
 def main(cqc_pir_source: str, cleaned_cqc_pir_destination: str):
     cqc_pir_df = utils.read_from_parquet(cqc_pir_source)
 
-    cqc_pir_df = cUtils.column_to_date(
-        cqc_pir_df, Keys.import_date, "cqc_pir_import_date"
+    cqc_pir_df = utils.remove_already_cleaned_data(
+        cqc_pir_df, cleaned_cqc_pir_destination
     )
+
+    cqc_pir_df = cUtils.column_to_date(cqc_pir_df, Keys.import_date, DATE_COLUMN_NAME)
 
     utils.write_to_parquet(
         cqc_pir_df,

--- a/tests/unit/test_clean_cqc_pir_data.py
+++ b/tests/unit/test_clean_cqc_pir_data.py
@@ -1,18 +1,17 @@
 import unittest
-from unittest.mock import ANY, patch
-
-from utils import utils
-
 import jobs.clean_cqc_pir_data as job
 
-from tests.test_file_schemas import CQCPIRSchema as Schemas
+from unittest.mock import patch
+from utils import utils, cleaning_utils
 from utils.column_names.ind_cqc_pipeline_columns import PartitionKeys as Keys
+from tests.test_file_schemas import CQCPIRSchema as Schemas
 from tests.test_file_data import CQCpirData as Data
 
 
 class CleanCQCpirDatasetTests(unittest.TestCase):
     TEST_SOURCE = "some/directory"
     TEST_DESTINATION = "some/other/directory"
+    SCHEMA_LENGTH = len(Schemas.sample_schema)
     partition_keys = [Keys.year, Keys.month, Keys.day, Keys.import_date]
 
     def setUp(self) -> None:
@@ -20,17 +19,75 @@ class CleanCQCpirDatasetTests(unittest.TestCase):
         self.test_cqc_pir_parquet = self.spark.createDataFrame(
             Data.sample_rows_full, schema=Schemas.sample_schema
         )
+        self.test_cqc_pir_parquet_with_import_date = cleaning_utils.column_to_date(
+            self.test_cqc_pir_parquet, Keys.import_date, job.DATE_COLUMN_NAME
+        )
 
+    @patch("utils.cleaning_utils.column_to_date")
+    @patch("utils.utils.remove_already_cleaned_data")
     @patch("utils.utils.write_to_parquet")
     @patch("utils.utils.read_from_parquet")
-    def test_main(self, read_from_parquet_patch, write_to_parquet_patch):
+    def test_main(
+        self,
+        read_from_parquet_patch,
+        write_to_parquet_patch,
+        remove_already_cleaned_data_patch,
+        column_to_date_patch,
+    ):
+        """A test to ensure all functionality is called as expected"""
         read_from_parquet_patch.return_value = self.test_cqc_pir_parquet
+        remove_already_cleaned_data_patch.return_value = self.test_cqc_pir_parquet
+        column_to_date_patch.return_value = self.test_cqc_pir_parquet_with_import_date
+
         job.main(self.TEST_SOURCE, self.TEST_DESTINATION)
+
+        read_from_parquet_patch.assert_called_once_with(self.TEST_SOURCE)
+        remove_already_cleaned_data_patch.assert_called_once_with(
+            self.test_cqc_pir_parquet, self.TEST_DESTINATION
+        )
+        column_to_date_patch.assert_called_once_with(
+            self.test_cqc_pir_parquet, Keys.import_date, job.DATE_COLUMN_NAME
+        )
         write_to_parquet_patch.assert_called_once_with(
-            ANY,
+            self.test_cqc_pir_parquet_with_import_date,
             self.TEST_DESTINATION,
             append=True,
             partitionKeys=self.partition_keys,
+        )
+
+    @patch("utils.cleaning_utils.column_to_date")
+    @patch("utils.utils.remove_already_cleaned_data")
+    @patch("utils.utils.write_to_parquet")
+    @patch("utils.utils.read_from_parquet")
+    def test_correct_number_of_columns_written(
+        self,
+        read_from_parquet_patch,
+        write_to_parquet_patch,
+        remove_already_cleaned_data_patch,
+        column_to_date_patch,
+    ):
+        """A test to ensure the correct number of columns are being written in the correct order"""
+        read_from_parquet_patch.return_value = self.test_cqc_pir_parquet
+        remove_already_cleaned_data_patch.return_value = self.test_cqc_pir_parquet
+        column_to_date_patch.return_value = self.test_cqc_pir_parquet_with_import_date
+
+        job.main(self.TEST_SOURCE, self.TEST_DESTINATION)
+
+        write_to_parquet_patch.assert_called_once_with(
+            self.test_cqc_pir_parquet_with_import_date,
+            self.TEST_DESTINATION,
+            append=True,
+            partitionKeys=self.partition_keys,
+        )
+        self.assertEqual(
+            self.SCHEMA_LENGTH + 1,
+            len(self.test_cqc_pir_parquet_with_import_date.columns),
+        )
+        self.assertTrue(
+            self.test_cqc_pir_parquet_with_import_date.columns.index(
+                job.DATE_COLUMN_NAME
+            )
+            == self.SCHEMA_LENGTH  # The last index of the df
         )
 
 

--- a/tests/unit/test_clean_cqc_pir_data.py
+++ b/tests/unit/test_clean_cqc_pir_data.py
@@ -1,7 +1,7 @@
 import unittest
 import jobs.clean_cqc_pir_data as job
 
-from unittest.mock import patch
+from unittest.mock import patch, ANY
 from utils import utils, cleaning_utils
 from utils.column_names.ind_cqc_pipeline_columns import PartitionKeys as Keys
 from tests.test_file_schemas import CQCPIRSchema as Schemas
@@ -37,19 +37,21 @@ class CleanCQCpirDatasetTests(unittest.TestCase):
         """A test to ensure all functionality is called as expected"""
         read_from_parquet_patch.return_value = self.test_cqc_pir_parquet
         remove_already_cleaned_data_patch.return_value = self.test_cqc_pir_parquet
-        column_to_date_patch.return_value = self.test_cqc_pir_parquet_with_import_date
 
         job.main(self.TEST_SOURCE, self.TEST_DESTINATION)
 
         read_from_parquet_patch.assert_called_once_with(self.TEST_SOURCE)
         remove_already_cleaned_data_patch.assert_called_once_with(
-            self.test_cqc_pir_parquet, self.TEST_DESTINATION
+            self.test_cqc_pir_parquet,
+            self.TEST_DESTINATION,
         )
         column_to_date_patch.assert_called_once_with(
-            self.test_cqc_pir_parquet, Keys.import_date, job.DATE_COLUMN_NAME
+            self.test_cqc_pir_parquet,
+            Keys.import_date,
+            job.DATE_COLUMN_NAME,
         )
         write_to_parquet_patch.assert_called_once_with(
-            self.test_cqc_pir_parquet_with_import_date,
+            ANY,
             self.TEST_DESTINATION,
             append=True,
             partitionKeys=self.partition_keys,
@@ -66,7 +68,7 @@ class CleanCQCpirDatasetTests(unittest.TestCase):
         remove_already_cleaned_data_patch,
         column_to_date_patch,
     ):
-        """A test to ensure the correct number of columns are being written in the correct order"""
+        """A test to ensure the correct number of columns are being written with the added date column being last"""
         read_from_parquet_patch.return_value = self.test_cqc_pir_parquet
         remove_already_cleaned_data_patch.return_value = self.test_cqc_pir_parquet
         column_to_date_patch.return_value = self.test_cqc_pir_parquet_with_import_date

--- a/tests/unit/test_clean_cqc_pir_data.py
+++ b/tests/unit/test_clean_cqc_pir_data.py
@@ -34,7 +34,6 @@ class CleanCQCpirDatasetTests(unittest.TestCase):
         remove_already_cleaned_data_patch,
         column_to_date_patch,
     ):
-        """A test to ensure all functionality is called as expected"""
         read_from_parquet_patch.return_value = self.test_cqc_pir_parquet
         remove_already_cleaned_data_patch.return_value = self.test_cqc_pir_parquet
 
@@ -68,7 +67,6 @@ class CleanCQCpirDatasetTests(unittest.TestCase):
         remove_already_cleaned_data_patch,
         column_to_date_patch,
     ):
-        """A test to ensure the correct number of columns are being written with the added date column being last"""
         read_from_parquet_patch.return_value = self.test_cqc_pir_parquet
         remove_already_cleaned_data_patch.return_value = self.test_cqc_pir_parquet
         column_to_date_patch.return_value = self.test_cqc_pir_parquet_with_import_date

--- a/tests/unit/test_clean_cqc_pir_data.py
+++ b/tests/unit/test_clean_cqc_pir_data.py
@@ -4,6 +4,9 @@ import jobs.clean_cqc_pir_data as job
 from unittest.mock import patch, ANY
 from utils import utils, cleaning_utils
 from utils.column_names.ind_cqc_pipeline_columns import PartitionKeys as Keys
+from utils.column_names.cleaned_data_files.cqc_pir_cleaned_values import (
+    CqcLPIRCleanedColumns as PIRClean,
+)
 from tests.test_file_schemas import CQCPIRSchema as Schemas
 from tests.test_file_data import CQCpirData as Data
 
@@ -20,7 +23,7 @@ class CleanCQCpirDatasetTests(unittest.TestCase):
             Data.sample_rows_full, schema=Schemas.sample_schema
         )
         self.test_cqc_pir_parquet_with_import_date = cleaning_utils.column_to_date(
-            self.test_cqc_pir_parquet, Keys.import_date, job.DATE_COLUMN_NAME
+            self.test_cqc_pir_parquet, Keys.import_date, PIRClean.cqc_pir_import_date
         )
 
     @patch("utils.cleaning_utils.column_to_date")
@@ -47,7 +50,7 @@ class CleanCQCpirDatasetTests(unittest.TestCase):
         column_to_date_patch.assert_called_once_with(
             self.test_cqc_pir_parquet,
             Keys.import_date,
-            job.DATE_COLUMN_NAME,
+            PIRClean.cqc_pir_import_date,
         )
         write_to_parquet_patch.assert_called_once_with(
             ANY,
@@ -85,7 +88,7 @@ class CleanCQCpirDatasetTests(unittest.TestCase):
         )
         self.assertTrue(
             self.test_cqc_pir_parquet_with_import_date.columns.index(
-                job.DATE_COLUMN_NAME
+                PIRClean.cqc_pir_import_date
             )
             == self.SCHEMA_LENGTH  # The last index of the df
         )

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -6,7 +6,7 @@ from io import BytesIO
 from enum import Enum
 from unittest.mock import Mock, patch
 from pyspark.sql.dataframe import DataFrame
-
+from pyspark.sql.utils import AnalysisException
 from pyspark.shell import spark
 from pyspark.sql import SparkSession
 from pyspark.sql.types import (
@@ -698,7 +698,7 @@ class UtilsTests(unittest.TestCase):
         )
 
         test_df = test_df.drop("import_date")
-        with self.assertRaises(Exception) as context:
+        with self.assertRaises(AnalysisException) as context:
             utils.remove_already_cleaned_data(test_df, "some destination")
 
         self.assertTrue(

--- a/utils/cleaning_utils.py
+++ b/utils/cleaning_utils.py
@@ -11,6 +11,7 @@ import pyspark.sql.functions as F
 
 key: str = "key"
 value: str = "value"
+import_date_s3_uri_format = "yyyyMMdd"
 
 
 def apply_categorical_labels(
@@ -111,7 +112,7 @@ def column_to_date(
     df: DataFrame,
     column_to_format: str,
     new_column: str = None,
-    string_format: str = "yyyyMMdd",
+    string_format: str = import_date_s3_uri_format,
 ) -> DataFrame:
     if new_column is None:
         new_column = column_to_format

--- a/utils/cleaning_utils.py
+++ b/utils/cleaning_utils.py
@@ -12,8 +12,6 @@ import pyspark.sql.functions as F
 key: str = "key"
 value: str = "value"
 
-YYYYMMDD_FORMAT = "yyyyMMdd"
-
 
 def apply_categorical_labels(
     df: DataFrame,
@@ -113,7 +111,7 @@ def column_to_date(
     df: DataFrame,
     column_to_format: str,
     new_column: str = None,
-    string_format: str = YYYYMMDD_FORMAT,
+    string_format: str = "yyyyMMdd",
 ) -> DataFrame:
     if new_column is None:
         new_column = column_to_format

--- a/utils/cleaning_utils.py
+++ b/utils/cleaning_utils.py
@@ -12,6 +12,8 @@ import pyspark.sql.functions as F
 key: str = "key"
 value: str = "value"
 
+YYYYMMDD_FORMAT = "yyyyMMdd"
+
 
 def apply_categorical_labels(
     df: DataFrame,
@@ -111,7 +113,7 @@ def column_to_date(
     df: DataFrame,
     column_to_format: str,
     new_column: str = None,
-    string_format: str = "yyyyMMdd",
+    string_format: str = YYYYMMDD_FORMAT,
 ) -> DataFrame:
     if new_column is None:
         new_column = column_to_format

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -217,7 +217,10 @@ def get_latest_partition(df, partition_keys=("run_year", "run_month", "run_day")
 def remove_already_cleaned_data(
     df: pyspark.sql.DataFrame,
     destination: str,
-):
+) -> pyspark.sql.DataFrame:
+    """Return a filtered dataframe with the latest data,
+    and if there is no new data, returns input dataframe"""
+
     if "import_date" not in df.columns:
         raise Exception("Input dataframe must have import_date column")
 

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -219,7 +219,9 @@ def remove_already_cleaned_data(
     destination: str,
 ) -> pyspark.sql.DataFrame:
     """Return a filtered dataframe with the latest data,
-    and if there is no new data, returns input dataframe"""
+    and if there is no new data then an empty dataframe is returned.
+    If a file read is not possible, or the latest cleaned data import data is None,
+    then the original dataframe supplied is returned."""
 
     if "import_date" not in df.columns:
         raise AnalysisException("Input dataframe must have import_date column")

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -222,7 +222,7 @@ def remove_already_cleaned_data(
     and if there is no new data, returns input dataframe"""
 
     if "import_date" not in df.columns:
-        raise Exception("Input dataframe must have import_date column")
+        raise AnalysisException("Input dataframe must have import_date column")
 
     try:
         cleaned_df = read_from_parquet(destination)


### PR DESCRIPTION
# Description
https://trello.com/c/ubpptuZg/142-epic-2-set-up-cleaning-script-so-it-does-not-process-rows-already-cleaned-and-only-append-new-rows-must

## Changes summary

- Refactored existing function to abstract hard constants
- Added logic as ticket describes
- Updated and upgraded tests
- Specified the exception being thrown by new method should import_date not be present

# How to test

# Developer checklist
- [x] Unit test
- [x] Linked to Trello ticket
- [x] Documentation up to date