### PR TITLE
Format ascwds workplace date fields

### DIFF
--- a/jobs/clean_ascwds_workplace_data.py
+++ b/jobs/clean_ascwds_workplace_data.py
@@ -16,6 +16,8 @@ from utils.column_names.cleaned_data_files.ascwds_workplace_cleaned_values impor
     AscwdsWorkplaceCleanedValues as AWPValues,
 )
 
+DATE_COLUMN_IDENTIFIER = "date"
+
 
 def main(source: str, destination: str):
     ascwds_workplace_df = utils.read_from_parquet(source)
@@ -24,6 +26,18 @@ def main(source: str, destination: str):
         ascwds_workplace_df,
         PartitionKeys.import_date,
         AWPClean.ascwds_workplace_import_date,
+    )
+
+    ascwds_workplace_df = utils.format_date_fields(
+        ascwds_workplace_df,
+        date_column_identifier=DATE_COLUMN_IDENTIFIER,
+        raw_date_format="dd/MM/yyyy",
+    )
+
+    ascwds_workplace_df = utils.format_date_fields(
+        ascwds_workplace_df,
+        date_column_identifier=AWP.last_logged_in,
+        raw_date_format="dd/MM/yyyy",
     )
 
     ascwds_workplace_df = cast_to_int(

--- a/jobs/clean_ascwds_workplace_data.py
+++ b/jobs/clean_ascwds_workplace_data.py
@@ -28,15 +28,13 @@ def main(source: str, destination: str):
         AWPClean.ascwds_workplace_import_date,
     )
 
-    ascwds_workplace_df = utils.format_date_fields(
-        ascwds_workplace_df,
-        date_column_identifier=DATE_COLUMN_IDENTIFIER,
-        raw_date_format="dd/MM/yyyy",
+    ascwds_workplace_df = ascwds_workplace_df.withColumnRenamed(
+        AWP.last_logged_in, AWPClean.last_logged_in_date
     )
 
     ascwds_workplace_df = utils.format_date_fields(
         ascwds_workplace_df,
-        date_column_identifier=AWP.last_logged_in,
+        date_column_identifier=DATE_COLUMN_IDENTIFIER,
         raw_date_format="dd/MM/yyyy",
     )
 

--- a/jobs/ingest_ascwds_dataset.py
+++ b/jobs/ingest_ascwds_dataset.py
@@ -40,7 +40,7 @@ def ingest_dataset(source: str, destination: str, delimiter: str):
     df = utils.read_csv(source, delimiter)
     df = filter_test_accounts(df)
     df = remove_white_space_from_nmdsid(df)
-    df = utils.format_date_fields(df, raw_date_format="dd/MM/yyyy")
+
 
     print(f"Exporting as parquet to {destination}")
     utils.write_to_parquet(df, destination)

--- a/jobs/ingest_ascwds_dataset.py
+++ b/jobs/ingest_ascwds_dataset.py
@@ -41,7 +41,6 @@ def ingest_dataset(source: str, destination: str, delimiter: str):
     df = filter_test_accounts(df)
     df = remove_white_space_from_nmdsid(df)
 
-
     print(f"Exporting as parquet to {destination}")
     utils.write_to_parquet(df, destination)
 

--- a/tests/unit/test_clean_ascwds_workplace_data.py
+++ b/tests/unit/test_clean_ascwds_workplace_data.py
@@ -1,6 +1,6 @@
 from datetime import date
 import unittest
-from unittest.mock import patch, ANY , Mock
+from unittest.mock import patch, ANY, Mock
 
 import jobs.clean_ascwds_workplace_data as job
 
@@ -43,13 +43,18 @@ class MainTests(IngestASCWDSWorkerDatasetTests):
     @patch("utils.utils.format_date_fields", wraps=format_date_fields)
     @patch("utils.utils.write_to_parquet")
     @patch("utils.utils.read_from_parquet")
-    def test_main(self, read_from_parquet_mock: Mock, write_to_parquet_mock: Mock, format_date_fields_mock: Mock):
+    def test_main(
+        self,
+        read_from_parquet_mock: Mock,
+        write_to_parquet_mock: Mock,
+        format_date_fields_mock: Mock,
+    ):
         read_from_parquet_mock.return_value = self.test_ascwds_worker_df
 
         job.main(self.TEST_SOURCE, self.TEST_DESTINATION)
 
         self.assertEqual(format_date_fields_mock.call_count, 2)
-        
+
         read_from_parquet_mock.assert_called_once_with(self.TEST_SOURCE)
         write_to_parquet_mock.assert_called_once_with(
             ANY,

--- a/tests/unit/test_clean_ascwds_workplace_data.py
+++ b/tests/unit/test_clean_ascwds_workplace_data.py
@@ -53,7 +53,7 @@ class MainTests(IngestASCWDSWorkerDatasetTests):
 
         job.main(self.TEST_SOURCE, self.TEST_DESTINATION)
 
-        self.assertEqual(format_date_fields_mock.call_count, 2)
+        self.assertEqual(format_date_fields_mock.call_count, 1)
 
         read_from_parquet_mock.assert_called_once_with(self.TEST_SOURCE)
         write_to_parquet_mock.assert_called_once_with(

--- a/tests/unit/test_clean_ascwds_workplace_data.py
+++ b/tests/unit/test_clean_ascwds_workplace_data.py
@@ -1,6 +1,6 @@
 from datetime import date
 import unittest
-from unittest.mock import patch, ANY
+from unittest.mock import patch, ANY , Mock
 
 import jobs.clean_ascwds_workplace_data as job
 
@@ -10,7 +10,10 @@ from utils.column_names.raw_data_files.ascwds_workplace_columns import (
     PartitionKeys,
     AscwdsWorkplaceColumns as AWP,
 )
-from utils.utils import get_spark
+from utils.utils import (
+    get_spark,
+    format_date_fields,
+)
 import utils.cleaning_utils as cUtils
 
 
@@ -37,13 +40,16 @@ class MainTests(IngestASCWDSWorkerDatasetTests):
     def setUp(self) -> None:
         super().setUp()
 
+    @patch("utils.utils.format_date_fields", wraps=format_date_fields)
     @patch("utils.utils.write_to_parquet")
     @patch("utils.utils.read_from_parquet")
-    def test_main(self, read_from_parquet_mock, write_to_parquet_mock):
+    def test_main(self, read_from_parquet_mock: Mock, write_to_parquet_mock: Mock, format_date_fields_mock: Mock):
         read_from_parquet_mock.return_value = self.test_ascwds_worker_df
 
         job.main(self.TEST_SOURCE, self.TEST_DESTINATION)
 
+        self.assertEqual(format_date_fields_mock.call_count, 2)
+        
         read_from_parquet_mock.assert_called_once_with(self.TEST_SOURCE)
         write_to_parquet_mock.assert_called_once_with(
             ANY,

--- a/utils/column_names/cleaned_data_files/ascwds_workplace_cleaned_values.py
+++ b/utils/column_names/cleaned_data_files/ascwds_workplace_cleaned_values.py
@@ -9,6 +9,7 @@ from utils.column_names.raw_data_files.ascwds_workplace_columns import (
 class AscwdsWorkplaceCleanedColumns(AscwdsWorkplaceColumns):
     ascwds_workplace_import_date: str = "ascwds_workplace_import_date"
     purge_data: str = "purge_data"
+    last_logged_in_date: str = "last_logged_in_date"
 
 
 @dataclass


### PR DESCRIPTION
# Description
https://trello.com/c/nVRBSpNd/139-epic-5-format-date-fields-must

## Changes
* Removed format date fields step from ingest ascwds data.py
* Added two calls to format date fields in clean ascwds workplace data.py
* Updated test main in test clean ascwds workplace data.py to check for two calls to function


# How to test
Unit tests passing
Ran successfully in branch
**Both scripts will need running after merge into main**


# Developer checklist
- [x] Unit test
- [x] Linked to Trello ticket
- [ ] Documentation up to date
