### PR TITLE
remove calcuation min secondary date function

### DIFF
--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -949,9 +949,6 @@ class CleaningUtilsData:
     ]
 
     align_dates_secondary_rows = [
-        (date(2015, 1, 1), "loc 1"),
-        (date(2016, 1, 1), "loc 1"),
-        (date(2017, 1, 1), "loc 1"),
         (date(2018, 1, 1), "loc 1"),
         (date(2019, 1, 1), "loc 1"),
         (date(2020, 1, 1), "loc 1"),
@@ -1037,27 +1034,19 @@ class CleaningUtilsData:
             date(2021, 1, 1),
             date(2021, 1, 8),
         ),
+        (
+            date(2020, 1, 1),
+            date(2018, 1, 1),
+        ),
+        (
+            date(2020, 1, 8),
+            date(2018, 1, 1),
+        ),
+        (
+            date(2021, 1, 1),
+            date(2018, 1, 1),
+        ),
     ]
-    """
-    primary_dates_rows = [
-        (date(2020, 1, 1),),
-        (date(2020, 1, 8),),
-        (date(2021, 1, 1),),
-        (date(2021, 1, 1),),
-    ]
-
-    secondary_dates_rows = [
-        (date(2015, 1, 1),),
-        (date(2016, 1, 1),),
-        (date(2017, 1, 1),),
-        (date(2018, 1, 1),),
-        (date(2019, 1, 1),),
-        (date(2020, 1, 1),),
-        (date(2020, 2, 1),),
-        (date(2021, 1, 8),),
-        (date(2020, 2, 1),),
-    ]
-    """
 
     expected_merged_rows = [
         (date(2020, 1, 1), date(2020, 1, 1), date(2020, 1, 1), "loc 1"),

--- a/tests/unit/test_cleaning_utils.py
+++ b/tests/unit/test_cleaning_utils.py
@@ -531,16 +531,6 @@ class TestCleaningUtilsAlignDates(unittest.TestCase):
         ).collect()
         self.assertEqual(returned_data, expected_data)
 
-    def test_calculate_min_secondary_date(self):
-        returned_min_secondary_date = job.calculate_min_secondary_date(
-            self.primary_dates,
-            self.secondary_dates,
-            self.primary_column,
-            self.secondary_column,
-        )
-        expected_min_secondary_date = date(2019, 1, 1)
-        self.assertEqual(returned_min_secondary_date, expected_min_secondary_date)
-
     def test_join_on_misaligned_import_dates_completes(self):
         returned_df = job.join_on_misaligned_import_dates(
             self.primary_df,
@@ -628,7 +618,6 @@ class TestCleaningUtilsAlignDates(unittest.TestCase):
             self.single_join_column,
         )
         returned_columns = len(returned_df.columns)
-        returned_df.show()
 
         expected_columns = len(self.later_merged_dates_df.columns)
 

--- a/utils/cleaning_utils.py
+++ b/utils/cleaning_utils.py
@@ -148,13 +148,7 @@ def cross_join_unique_dates(
 ) -> DataFrame:
     primary_dates = primary_df.select(primary_column).dropDuplicates()
     secondary_dates = secondary_df.select(secondary_column).dropDuplicates()
-    min_secondary_date = calculate_min_secondary_date(
-        primary_dates, secondary_dates, primary_column, secondary_column
-    )
-    if min_secondary_date != None:
-        secondary_dates = secondary_dates.where(
-            secondary_dates[secondary_column] >= F.lit(min_secondary_date)
-        )
+
     possible_matches = primary_dates.crossJoin(secondary_dates).repartition(
         primary_column
     )
@@ -182,27 +176,6 @@ def determine_best_date_matches(
     )
 
     return aligned_dates.select(primary_column, secondary_column)
-
-
-def calculate_min_secondary_date(
-    primary_dates: DataFrame,
-    secondary_dates: DataFrame,
-    primary_column: str,
-    secondary_column: str,
-) -> str:
-    min_primary_date = primary_dates.select(
-        F.min(primary_dates[primary_column])
-    ).collect()[0][0]
-
-    earlier_secondary_dates = secondary_dates.where(
-        secondary_dates[secondary_column] < min_primary_date
-    )
-
-    min_secondary_date = earlier_secondary_dates.select(
-        F.max(secondary_dates[secondary_column])
-    ).collect()[0][0]
-
-    return min_secondary_date
 
 
 def join_on_misaligned_import_dates(


### PR DESCRIPTION
# Description
Remove functionality that will not be used

# How to test
Whole feature should be tested once this function is being used

https://trello.com/c/d80xsoBD/202-refactor-align-dates-functionality-remove-function-calculateminsecondarydate

# Developer checklist
- [ ] Unit test
- [ ] Linked to Trello ticket
- [ ] Documentation up to date
