### PR TITLE
Refactor align dates join functionality

### DIFF
--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -1049,17 +1049,17 @@ class CleaningUtilsData:
     ]
 
     expected_merged_rows = [
-        (date(2020, 1, 1), date(2020, 1, 1), date(2020, 1, 1), "loc 1"),
-        (date(2020, 1, 8), date(2020, 1, 8), date(2020, 1, 1), "loc 1"),
-        (date(2021, 1, 1), date(2021, 1, 1), date(2020, 2, 1), "loc 1"),
-        (date(2021, 1, 1), date(2021, 1, 1), date(2020, 2, 1), "loc 2"),
+        (date(2020, 1, 1), date(2020, 1, 1), "loc 1"),
+        (date(2020, 1, 8), date(2020, 1, 1), "loc 1"),
+        (date(2021, 1, 1), date(2020, 2, 1), "loc 1"),
+        (date(2021, 1, 1), date(2020, 2, 1), "loc 2"),
     ]
 
     expected_later_merged_rows = [
-        (date(2020, 1, 1), date(2020, 1, 1), None, "loc 1"),
-        (date(2020, 1, 8), date(2020, 1, 8), None, "loc 1"),
-        (date(2021, 1, 1), date(2021, 1, 1), date(2020, 2, 1), "loc 1"),
-        (date(2021, 1, 1), date(2021, 1, 1), date(2020, 2, 1), "loc 2"),
+        (date(2020, 1, 1), None, "loc 1"),
+        (date(2020, 1, 8), None, "loc 1"),
+        (date(2021, 1, 1), date(2020, 2, 1), "loc 1"),
+        (date(2021, 1, 1), date(2020, 2, 1), "loc 2"),
     ]
 
     column_to_date_data = [

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -441,7 +441,6 @@ class CleaningUtilsSchemas:
 
     expected_merged_dates_schema = StructType(
         [
-            StructField("snapshot_date", DateType(), True),
             StructField(AWPClean.ascwds_workplace_import_date, DateType(), True),
             StructField(CQCLClean.cqc_location_import_date, DateType(), True),
             StructField(CQCL.location_id, StringType(), True),

--- a/tests/unit/test_cleaning_utils.py
+++ b/tests/unit/test_cleaning_utils.py
@@ -457,8 +457,6 @@ class TestCleaningUtilsAlignDates(unittest.TestCase):
             Data.expected_later_merged_rows, Schemas.expected_merged_dates_schema
         )
         self.column_order_for_assertion = [
-            self.snapshot_date,
-            self.single_join_column,
             self.primary_column,
             self.secondary_column,
         ]
@@ -531,74 +529,62 @@ class TestCleaningUtilsAlignDates(unittest.TestCase):
         ).collect()
         self.assertEqual(returned_data, expected_data)
 
-    def test_join_on_misaligned_import_dates_completes(self):
-        returned_df = job.join_on_misaligned_import_dates(
+    def test_add_aligned_date_column_columns_completes(self):
+        returned_df = job.add_aligned_date_column(
             self.primary_df,
             self.secondary_df,
-            self.expected_aligned_dates,
             self.primary_column,
             self.secondary_column,
-            self.single_join_column,
         )
 
         self.assertTrue(returned_df)
 
-    def test_join_on_misaligned_dates_joins_correctly_when_secondary_data_starts_before_primary(
+    def test_add_aligned_date_column_joins_secondary_date_correctly(
         self,
     ):
-        returned_df = job.join_on_misaligned_import_dates(
+        returned_df = job.add_aligned_date_column(
             self.primary_df,
             self.secondary_df,
-            self.expected_aligned_dates,
             self.primary_column,
             self.secondary_column,
-            self.single_join_column,
         )
-        returned_data = (
-            returned_df.select(self.column_order_for_assertion)
-            .sort(self.snapshot_date, self.single_join_column)
-            .collect()
-        )
+        returned_data = returned_df.sort(self.primary_column).collect()
         expected_data = (
-            self.merged_dates_df.select(self.column_order_for_assertion)
-            .sort(self.snapshot_date, self.single_join_column)
+            self.merged_dates_df.select(returned_df.columns)
+            .sort(self.primary_column)
             .collect()
         )
         self.assertEqual(returned_data, expected_data)
 
-    def test_join_on_misaligned_dates_joins_correctly_when_secondary_data_start_later_than_primary(
+    def test_add_aligned_date_column_joins_correctly_when_secondary_data_start_later_than_primary(
         self,
     ):
-        returned_df = job.join_on_misaligned_import_dates(
+        returned_df = job.add_aligned_date_column(
             self.primary_df,
             self.later_secondary_df,
-            self.expected_later_aligned_dates,
             self.primary_column,
             self.secondary_column,
-            self.single_join_column,
         )
         returned_data = (
             returned_df.select(self.column_order_for_assertion)
-            .sort(self.snapshot_date, self.single_join_column)
+            .sort(self.primary_column)
             .collect()
         )
         expected_data = (
             self.later_merged_dates_df.select(self.column_order_for_assertion)
-            .sort(self.snapshot_date, self.single_join_column)
+            .sort(self.primary_column)
             .collect()
         )
         self.assertEqual(returned_data, expected_data)
 
-    def test_join_on_misaligned_dates_returns_the_correct_number_of_rows(
+    def test_add_aligned_date_column_returns_the_correct_number_of_rows(
         self,
     ):
-        returned_df = job.join_on_misaligned_import_dates(
+        returned_df = job.add_aligned_date_column(
             self.primary_df,
             self.later_secondary_df,
-            self.expected_later_aligned_dates,
             self.primary_column,
             self.secondary_column,
-            self.single_join_column,
         )
         returned_rows = returned_df.count()
 
@@ -606,16 +592,14 @@ class TestCleaningUtilsAlignDates(unittest.TestCase):
 
         self.assertEqual(returned_rows, expected_rows)
 
-    def test_join_on_misaligned_dates_returns_the_correct_number_of_columns(
+    def test_add_aligned_date_column_returns_the_correct_number_of_columns(
         self,
     ):
-        returned_df = job.join_on_misaligned_import_dates(
+        returned_df = job.add_aligned_date_column(
             self.primary_df,
             self.later_secondary_df,
-            self.expected_later_aligned_dates,
             self.primary_column,
             self.secondary_column,
-            self.single_join_column,
         )
         returned_columns = len(returned_df.columns)
 

--- a/tests/unit/test_cleaning_utils.py
+++ b/tests/unit/test_cleaning_utils.py
@@ -424,8 +424,6 @@ class TestCleaningUtilsAlignDates(unittest.TestCase):
         self.spark = utils.get_spark()
         self.primary_column = AWPClean.ascwds_workplace_import_date
         self.secondary_column = CQCLClean.cqc_location_import_date
-        self.single_join_column = AWPClean.location_id
-        self.snapshot_date = "snapshot_date"
         self.primary_df = self.spark.createDataFrame(
             Data.align_dates_primary_rows, Schemas.align_dates_primary_schema
         )
@@ -448,8 +446,6 @@ class TestCleaningUtilsAlignDates(unittest.TestCase):
             Data.expected_later_aligned_dates_rows,
             Schemas.expected_aligned_dates_schema,
         )
-        self.primary_dates = self.primary_df.select(self.primary_column)
-        self.secondary_dates = self.secondary_df.select(self.secondary_column)
         self.merged_dates_df = self.spark.createDataFrame(
             Data.expected_merged_rows, Schemas.expected_merged_dates_schema
         )

--- a/utils/cleaning_utils.py
+++ b/utils/cleaning_utils.py
@@ -178,20 +178,18 @@ def determine_best_date_matches(
     return aligned_dates.select(primary_column, secondary_column)
 
 
-def join_on_misaligned_import_dates(
+def add_aligned_date_column(
     primary_df: DataFrame,
     secondary_df: DataFrame,
-    aligned_dates: DataFrame,
     primary_column: str,
     secondary_column: str,
-    other_join_column: str,
 ) -> DataFrame:
+    aligned_dates = align_import_dates(
+        primary_df, secondary_df, primary_column, secondary_column
+    )
+
     primary_df_with_aligned_dates = primary_df.join(
         aligned_dates, primary_column, "left"
     )
-    secondary_join_criteria = [secondary_column] + [other_join_column]
-    joined_df = primary_df_with_aligned_dates.join(
-        secondary_df, secondary_join_criteria, "left"
-    )
-    joined_df = joined_df.withColumn("snapshot_date", F.col(primary_column))
-    return joined_df
+
+    return primary_df_with_aligned_dates


### PR DESCRIPTION
# Description
refactor the join function for align dates so that now it adds a new column to the first dataframe with the aligned dates from the second

# How to test
Test full slice when the following tickets for this feature are implemented

[Trello ticket](https://trello.com/c/UfNHxbqO/198-refactor-align-dates-functionality-prepare-dfs-for-join)

# Developer checklist
- [x] Unit test
- [x] Linked to Trello ticket
- [x] Documentation up to date
