### PR TITLE
Add care home column to pir data

### DIFF
--- a/jobs/clean_cqc_pir_data.py
+++ b/jobs/clean_cqc_pir_data.py
@@ -1,5 +1,7 @@
 import sys
 
+from pyspark.sql import DataFrame
+
 from utils import utils
 import utils.cleaning_utils as cUtils
 from utils.column_names.ind_cqc_pipeline_columns import PartitionKeys as Keys
@@ -22,12 +24,17 @@ def main(cqc_pir_source: str, cleaned_cqc_pir_destination: str):
         cqc_pir_df, Keys.import_date, PIRClean.cqc_pir_import_date
     )
 
+
+
     utils.write_to_parquet(
         cqc_pir_df,
         cleaned_cqc_pir_destination,
         mode="append",
         partitionKeys=pirPartitionKeys,
     )
+
+def add_care_home_column(df:DataFrame) -> DataFrame:
+    return df
 
 
 if __name__ == "__main__":

--- a/jobs/clean_cqc_pir_data.py
+++ b/jobs/clean_cqc_pir_data.py
@@ -35,6 +35,7 @@ def main(cqc_pir_source: str, cleaned_cqc_pir_destination: str):
         partitionKeys=pirPartitionKeys,
     )
 
+
 def add_care_home_column(df:DataFrame) -> DataFrame:
     df = df.withColumn(
         PIRCleanCols.care_home,

--- a/jobs/clean_cqc_pir_data.py
+++ b/jobs/clean_cqc_pir_data.py
@@ -26,8 +26,6 @@ def main(cqc_pir_source: str, cleaned_cqc_pir_destination: str):
         cqc_pir_df, Keys.import_date, PIRCleanCols.cqc_pir_import_date
     )
 
-
-
     utils.write_to_parquet(
         cqc_pir_df,
         cleaned_cqc_pir_destination,
@@ -36,13 +34,14 @@ def main(cqc_pir_source: str, cleaned_cqc_pir_destination: str):
     )
 
 
-def add_care_home_column(df:DataFrame) -> DataFrame:
+def add_care_home_column(df: DataFrame) -> DataFrame:
     df = df.withColumn(
         PIRCleanCols.care_home,
         F.when(
             F.col(PIRCleanCols.pir_type) == PIRCleanValues.residential,
             PIRCleanValues.yes,
-        ).otherwise(F.lit(PIRCleanValues.no)))
+        ).otherwise(F.lit(PIRCleanValues.no)),
+    )
     return df
 
 

--- a/jobs/clean_cqc_pir_data.py
+++ b/jobs/clean_cqc_pir_data.py
@@ -7,7 +7,7 @@ import utils.cleaning_utils as cUtils
 from utils.column_names.ind_cqc_pipeline_columns import PartitionKeys as Keys
 
 from utils.column_names.cleaned_data_files.cqc_pir_cleaned_values import (
-    CqcLPIRCleanedColumns as PIRClean,
+    CqcPIRCleanedColumns as PIRClean,
 )
 
 pirPartitionKeys = [Keys.year, Keys.month, Keys.day, Keys.import_date]

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -526,8 +526,17 @@ class CQCpirData:
         ),
     ]
 
-    add_care_home_column_rows = []
-    expected_care_home_column_rows = []
+    add_care_home_column_rows = [
+        ("loc 1", "Residential"),
+        ("loc 2", None), 
+        ("loc 3", "Other value"),
+
+    ]
+    expected_care_home_column_rows = [
+        ("loc 1", "Residential", "Y"),
+        ("loc 2", None, "N"), 
+        ("loc 3", "Other value", "N"),
+    ]
 
 
 @dataclass

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -528,13 +528,12 @@ class CQCpirData:
 
     add_care_home_column_rows = [
         ("loc 1", "Residential"),
-        ("loc 2", None), 
+        ("loc 2", None),
         ("loc 3", "Other value"),
-
     ]
     expected_care_home_column_rows = [
         ("loc 1", "Residential", "Y"),
-        ("loc 2", None, "N"), 
+        ("loc 2", None, "N"),
         ("loc 3", "Other value", "N"),
     ]
 

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -526,6 +526,9 @@ class CQCpirData:
         ),
     ]
 
+    add_care_home_column_rows = []
+    expected_care_home_column_rows = []
+
 
 @dataclass
 class CQCLocationsData:

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -531,7 +531,7 @@ class CQCPIRSchema:
 
     add_care_home_column_schema = StructType(
         [
-            StructField(CQCPIR.location_id , StringType(), True),
+            StructField(CQCPIR.location_id, StringType(), True),
             StructField(CQCPIR.pir_type, StringType(), True),
         ]
     )
@@ -542,6 +542,7 @@ class CQCPIRSchema:
             StructField(CQCPIRClean.care_home, StringType(), True),
         ]
     )
+
 
 @dataclass
 class IngestONSData:

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -51,7 +51,9 @@ from utils.column_names.raw_data_files.cqc_pir_columns import (
 from utils.column_names.raw_data_files.ascwds_workplace_columns import (
     AscwdsWorkplaceColumns as AWP,
 )
-
+from utils.column_names.cleaned_data_files.cqc_pir_cleaned_values import (
+    CqcPIRCleanedColumns as CQCPIRClean,
+)
 from utils.column_names.cleaned_data_files.cqc_provider_cleaned_values import (
     CqcProviderCleanedColumns as CQCPClean,
 )
@@ -527,6 +529,19 @@ class CQCPIRSchema:
         ]
     )
 
+    add_care_home_column_schema = StructType(
+        [
+            StructField(CQCPIR.location_id , StringType(), True),
+            StructField(CQCPIR.pir_type, StringType(), True),
+        ]
+    )
+
+    expected_care_home_column_schema = StructType(
+        [
+            *add_care_home_column_schema,
+            StructField(CQCPIRClean.care_home, StringType(), True),
+        ]
+    )
 
 @dataclass
 class IngestONSData:

--- a/tests/unit/test_clean_cqc_pir_data.py
+++ b/tests/unit/test_clean_cqc_pir_data.py
@@ -25,8 +25,11 @@ class CleanCQCpirDatasetTests(unittest.TestCase):
         self.test_cqc_pir_parquet_with_import_date = cleaning_utils.column_to_date(
             self.test_cqc_pir_parquet, Keys.import_date, PIRClean.cqc_pir_import_date
         )
+        self.test_add_care_home_column_df = self.spark.createDataFrame(
+            Data.add_care_home_column_rows, Schemas.add_care_home_column_schema
+        )
         self.test_expected_care_home_column_df = self.spark.createDataFrame(
-            Data.expected_care_home_column_rows, Schemas.expected_care_home_columns_schema
+            Data.expected_care_home_column_rows, Schemas.expected_care_home_column_schema
         )
 
     @patch("utils.cleaning_utils.column_to_date")

--- a/tests/unit/test_clean_cqc_pir_data.py
+++ b/tests/unit/test_clean_cqc_pir_data.py
@@ -110,7 +110,7 @@ class CleanCQCpirDatasetTests(unittest.TestCase):
         
         self.assertCountEqual(expected_df.columns, returned_df.columns)
 
-    @unittest.skip("to do")
+
     def test_add_care_home_column_categorises_care_homes_correctly(self):
         returned_df = job.add_care_home_column(
             self.test_add_care_home_column_df

--- a/tests/unit/test_clean_cqc_pir_data.py
+++ b/tests/unit/test_clean_cqc_pir_data.py
@@ -29,7 +29,8 @@ class CleanCQCpirDatasetTests(unittest.TestCase):
             Data.add_care_home_column_rows, Schemas.add_care_home_column_schema
         )
         self.test_expected_care_home_column_df = self.spark.createDataFrame(
-            Data.expected_care_home_column_rows, Schemas.expected_care_home_column_schema
+            Data.expected_care_home_column_rows,
+            Schemas.expected_care_home_column_schema,
         )
 
     @patch("utils.cleaning_utils.column_to_date")
@@ -99,27 +100,19 @@ class CleanCQCpirDatasetTests(unittest.TestCase):
             == self.SCHEMA_LENGTH  # The last index of the df
         )
 
-
     def test_add_care_home_column_adds_a_column(self):
-        returned_df = job.add_care_home_column(
-            self.test_add_care_home_column_df
-        )
+        returned_df = job.add_care_home_column(self.test_add_care_home_column_df)
 
         expected_df = self.test_expected_care_home_column_df
 
-        
         self.assertCountEqual(expected_df.columns, returned_df.columns)
 
-
     def test_add_care_home_column_categorises_care_homes_correctly(self):
-        returned_df = job.add_care_home_column(
-            self.test_add_care_home_column_df
-        )
+        returned_df = job.add_care_home_column(self.test_add_care_home_column_df)
         returned_data = returned_df.sort(PIRClean.location_id).collect()
         expected_df = self.test_expected_care_home_column_df
         expected_data = expected_df.sort(PIRClean.location_id).collect()
 
-        
         self.assertCountEqual(expected_data, returned_data)
 
 

--- a/tests/unit/test_clean_cqc_pir_data.py
+++ b/tests/unit/test_clean_cqc_pir_data.py
@@ -25,6 +25,9 @@ class CleanCQCpirDatasetTests(unittest.TestCase):
         self.test_cqc_pir_parquet_with_import_date = cleaning_utils.column_to_date(
             self.test_cqc_pir_parquet, Keys.import_date, PIRClean.cqc_pir_import_date
         )
+        self.test_expected_care_home_column_df = self.spark.createDataFrame(
+            Data.expected_care_home_column_rows, Schemas.expected_care_home_columns_schema
+        )
 
     @patch("utils.cleaning_utils.column_to_date")
     @patch("utils.utils.remove_already_cleaned_data")
@@ -92,6 +95,29 @@ class CleanCQCpirDatasetTests(unittest.TestCase):
             )
             == self.SCHEMA_LENGTH  # The last index of the df
         )
+
+
+    def test_add_care_home_column_adds_a_column(self):
+        returned_df = job.add_care_home_column(
+            self.test_add_care_home_column_df
+        )
+
+        expected_df = self.test_expected_care_home_column_df
+
+        
+        self.assertCountEqual(expected_df.columns, returned_df.columns)
+
+    @unittest.skip("to do")
+    def test_add_care_home_column_categorises_care_homes_correctly(self):
+        returned_df = job.add_care_home_column(
+            self.test_add_care_home_column_df
+        )
+        returned_data = returned_df.sort(PIRClean.location_id).collect()
+        expected_df = self.test_expected_care_home_column_df
+        expected_data = expected_df.sort(PIRClean.location_id).collect()
+
+        
+        self.assertCountEqual(expected_data, returned_data)
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_clean_cqc_pir_data.py
+++ b/tests/unit/test_clean_cqc_pir_data.py
@@ -5,7 +5,7 @@ from unittest.mock import patch, ANY
 from utils import utils, cleaning_utils
 from utils.column_names.ind_cqc_pipeline_columns import PartitionKeys as Keys
 from utils.column_names.cleaned_data_files.cqc_pir_cleaned_values import (
-    CqcLPIRCleanedColumns as PIRClean,
+    CqcPIRCleanedColumns as PIRClean,
 )
 from tests.test_file_schemas import CQCPIRSchema as Schemas
 from tests.test_file_data import CQCpirData as Data

--- a/utils/column_names/cleaned_data_files/cqc_pir_cleaned_values.py
+++ b/utils/column_names/cleaned_data_files/cqc_pir_cleaned_values.py
@@ -7,3 +7,9 @@ from utils.column_names.raw_data_files.cqc_pir_columns import CqcPirColumns
 class CqcPIRCleanedColumns(CqcPirColumns):
     cqc_pir_import_date: str = "cqc_pir_import_date"
     care_home: str = "careHome"
+
+@dataclass
+class CqcPIRCleanedValues:
+    yes:str = "Y"
+    no: str = "N"
+    residential: str = "Residential"

--- a/utils/column_names/cleaned_data_files/cqc_pir_cleaned_values.py
+++ b/utils/column_names/cleaned_data_files/cqc_pir_cleaned_values.py
@@ -2,7 +2,9 @@ from dataclasses import dataclass
 
 from utils.column_names.raw_data_files.cqc_pir_columns import CqcPirColumns
 
-from utils.column_names.raw_data_files.cqc_location_api_columns import CqcLocationApiColumns
+from utils.column_names.raw_data_files.cqc_location_api_columns import (
+    CqcLocationApiColumns,
+)
 
 
 @dataclass
@@ -10,8 +12,9 @@ class CqcPIRCleanedColumns(CqcPirColumns):
     cqc_pir_import_date: str = "cqc_pir_import_date"
     care_home: str = CqcLocationApiColumns.care_home
 
+
 @dataclass
 class CqcPIRCleanedValues:
-    yes:str = "Y"
+    yes: str = "Y"
     no: str = "N"
     residential: str = "Residential"

--- a/utils/column_names/cleaned_data_files/cqc_pir_cleaned_values.py
+++ b/utils/column_names/cleaned_data_files/cqc_pir_cleaned_values.py
@@ -6,3 +6,4 @@ from utils.column_names.raw_data_files.cqc_pir_columns import CqcPirColumns
 @dataclass
 class CqcLPIRCleanedColumns(CqcPirColumns):
     cqc_pir_import_date: str = "cqc_pir_import_date"
+    carehome: str = "careHome"

--- a/utils/column_names/cleaned_data_files/cqc_pir_cleaned_values.py
+++ b/utils/column_names/cleaned_data_files/cqc_pir_cleaned_values.py
@@ -4,6 +4,6 @@ from utils.column_names.raw_data_files.cqc_pir_columns import CqcPirColumns
 
 
 @dataclass
-class CqcLPIRCleanedColumns(CqcPirColumns):
+class CqcPIRCleanedColumns(CqcPirColumns):
     cqc_pir_import_date: str = "cqc_pir_import_date"
-    carehome: str = "careHome"
+    care_home: str = "careHome"

--- a/utils/column_names/cleaned_data_files/cqc_pir_cleaned_values.py
+++ b/utils/column_names/cleaned_data_files/cqc_pir_cleaned_values.py
@@ -2,11 +2,13 @@ from dataclasses import dataclass
 
 from utils.column_names.raw_data_files.cqc_pir_columns import CqcPirColumns
 
+from utils.column_names.raw_data_files.cqc_location_api_columns import CqcLocationApiColumns
+
 
 @dataclass
 class CqcPIRCleanedColumns(CqcPirColumns):
     cqc_pir_import_date: str = "cqc_pir_import_date"
-    care_home: str = "careHome"
+    care_home: str = CqcLocationApiColumns.care_home
 
 @dataclass
 class CqcPIRCleanedValues:


### PR DESCRIPTION
# Description
https://trello.com/c/MyZTr9W2/190-epic-2-create-a-carehome-column-into-pir-data-must

Add a column that flags when a row is a care home (type = residential) or otherwise.

# How to test
Unit tests passing
Ran successfully in branch

# Developer checklist
- [x] Unit test
- [x] Linked to Trello ticket

