### PR TITLE
Amend pir carehome rules

### DIFF
--- a/jobs/clean_cqc_pir_data.py
+++ b/jobs/clean_cqc_pir_data.py
@@ -26,6 +26,8 @@ def main(cqc_pir_source: str, cleaned_cqc_pir_destination: str):
         cqc_pir_df, Keys.import_date, PIRCleanCols.cqc_pir_import_date
     )
 
+    cqc_pir_df = add_care_home_column(cqc_pir_df)
+
     utils.write_to_parquet(
         cqc_pir_df,
         cleaned_cqc_pir_destination,

--- a/jobs/clean_cqc_pir_data.py
+++ b/jobs/clean_cqc_pir_data.py
@@ -40,7 +40,12 @@ def add_care_home_column(df: DataFrame) -> DataFrame:
         F.when(
             F.col(PIRCleanCols.pir_type) == PIRCleanValues.residential,
             PIRCleanValues.yes,
-        ).otherwise(PIRCleanValues.no),
+        )
+        .when(
+            F.col(PIRCleanCols.pir_type) == PIRCleanValues.community,
+            PIRCleanValues.no,
+        )
+        .otherwise(None),
     )
     return df
 

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -528,13 +528,15 @@ class CQCpirData:
 
     add_care_home_column_rows = [
         ("loc 1", "Residential"),
-        ("loc 2", None),
-        ("loc 3", "Other value"),
+        ("loc 2", "Shared Lives"),
+        ("loc 3", None),
+        ("loc 4", "Community"),
     ]
     expected_care_home_column_rows = [
         ("loc 1", "Residential", "Y"),
-        ("loc 2", None, "N"),
-        ("loc 3", "Other value", "N"),
+        ("loc 2", "Shared Lives", None),
+        ("loc 3", None, None),
+        ("loc 4", "Community", "N"),
     ]
 
 

--- a/tests/unit/test_clean_cqc_pir_data.py
+++ b/tests/unit/test_clean_cqc_pir_data.py
@@ -33,6 +33,7 @@ class CleanCQCpirDatasetTests(unittest.TestCase):
             Schemas.expected_care_home_column_schema,
         )
 
+    @patch("add_care_home_column")
     @patch("utils.cleaning_utils.column_to_date")
     @patch("utils.utils.remove_already_cleaned_data")
     @patch("utils.utils.write_to_parquet")
@@ -43,9 +44,11 @@ class CleanCQCpirDatasetTests(unittest.TestCase):
         write_to_parquet_patch,
         remove_already_cleaned_data_patch,
         column_to_date_patch,
+        add_care_home_column,
     ):
         read_from_parquet_patch.return_value = self.test_cqc_pir_parquet
         remove_already_cleaned_data_patch.return_value = self.test_cqc_pir_parquet
+        column_to_date_patch.return_value = self.test_cqc_pir_parquet_with_import_date
 
         job.main(self.TEST_SOURCE, self.TEST_DESTINATION)
 
@@ -59,45 +62,14 @@ class CleanCQCpirDatasetTests(unittest.TestCase):
             Keys.import_date,
             PIRClean.cqc_pir_import_date,
         )
+        add_care_home_column.assert_called_once_with(
+            self.test_cqc_pir_parquet_with_import_date
+        )
         write_to_parquet_patch.assert_called_once_with(
             ANY,
             self.TEST_DESTINATION,
             mode="overwrite",
             partitionKeys=self.partition_keys,
-        )
-
-    @patch("utils.cleaning_utils.column_to_date")
-    @patch("utils.utils.remove_already_cleaned_data")
-    @patch("utils.utils.write_to_parquet")
-    @patch("utils.utils.read_from_parquet")
-    def test_correct_number_of_columns_written(
-        self,
-        read_from_parquet_patch,
-        write_to_parquet_patch,
-        remove_already_cleaned_data_patch,
-        column_to_date_patch,
-    ):
-        read_from_parquet_patch.return_value = self.test_cqc_pir_parquet
-        remove_already_cleaned_data_patch.return_value = self.test_cqc_pir_parquet
-        column_to_date_patch.return_value = self.test_cqc_pir_parquet_with_import_date
-
-        job.main(self.TEST_SOURCE, self.TEST_DESTINATION)
-
-        write_to_parquet_patch.assert_called_once_with(
-            self.test_cqc_pir_parquet_with_import_date,
-            self.TEST_DESTINATION,
-            mode="overwrite",
-            partitionKeys=self.partition_keys,
-        )
-        self.assertEqual(
-            self.SCHEMA_LENGTH + 1,
-            len(self.test_cqc_pir_parquet_with_import_date.columns),
-        )
-        self.assertTrue(
-            self.test_cqc_pir_parquet_with_import_date.columns.index(
-                PIRClean.cqc_pir_import_date
-            )
-            == self.SCHEMA_LENGTH  # The last index of the df
         )
 
     def test_add_care_home_column_adds_a_column(self):

--- a/tests/unit/test_clean_cqc_pir_data.py
+++ b/tests/unit/test_clean_cqc_pir_data.py
@@ -33,7 +33,7 @@ class CleanCQCpirDatasetTests(unittest.TestCase):
             Schemas.expected_care_home_column_schema,
         )
 
-    @patch("add_care_home_column")
+    @patch("jobs.clean_cqc_pir_data.add_care_home_column")
     @patch("utils.cleaning_utils.column_to_date")
     @patch("utils.utils.remove_already_cleaned_data")
     @patch("utils.utils.write_to_parquet")

--- a/tests/unit/test_clean_cqc_pir_data.py
+++ b/tests/unit/test_clean_cqc_pir_data.py
@@ -85,7 +85,10 @@ class CleanCQCpirDatasetTests(unittest.TestCase):
         expected_df = self.test_expected_care_home_column_df
         expected_data = expected_df.sort(PIRClean.location_id).collect()
 
-        self.assertCountEqual(expected_data, returned_data)
+        self.assertCountEqual(expected_data[0], returned_data[0])
+        self.assertCountEqual(expected_data[1], returned_data[1])
+        self.assertCountEqual(expected_data[2], returned_data[2])
+        self.assertCountEqual(expected_data[3], returned_data[3])
 
 
 if __name__ == "__main__":

--- a/utils/column_names/cleaned_data_files/cqc_pir_cleaned_values.py
+++ b/utils/column_names/cleaned_data_files/cqc_pir_cleaned_values.py
@@ -18,3 +18,4 @@ class CqcPIRCleanedValues:
     yes: str = "Y"
     no: str = "N"
     residential: str = "Residential"
+    community: str = "Community"


### PR DESCRIPTION
# Description
This ticket does two things:
- Amends the code previously written so only 'Community' gets a 'N' value ('Shared Lives' or anything else returns None). This is so that the services in this match link up with CQC careHome data)
- I noticed that this function wasn't actually added to main previously so it wasn't doing anything. Added it in and updated tests to account for that.

[Trello](https://trello.com/c/TOLlbnIV/273-epic-2-amend-addcarehomecolumn-function-must)

# Developer checklist
- [X] Unit test
- [X] Linked to Trello ticket
- [X] Documentation up to date
