### PR TITLE
Remove rows where loc id is duplicated

### DIFF
--- a/jobs/clean_cqc_location_data.py
+++ b/jobs/clean_cqc_location_data.py
@@ -62,6 +62,8 @@ def main(
 
     cqc_location_df = remove_invalid_postcodes(cqc_location_df)
 
+    cqc_location_df = remove_locations_with_duplicates(cqc_location_df)
+
     cqc_location_df = join_cqc_provider_data(cqc_location_df, cqc_provider_df)
 
     cqc_location_df = allocate_primary_service_type(cqc_location_df)

--- a/jobs/clean_cqc_location_data.py
+++ b/jobs/clean_cqc_location_data.py
@@ -7,7 +7,6 @@ import utils.cleaning_utils as cUtils
 from pyspark.sql.dataframe import DataFrame
 
 import pyspark.sql.functions as F
-from pyspark.sql.window import Window
 
 from utils.column_names.ind_cqc_pipeline_columns import (
     PartitionKeys as Keys,
@@ -62,8 +61,6 @@ def main(
 
     cqc_location_df = remove_invalid_postcodes(cqc_location_df)
 
-    cqc_location_df = remove_locations_with_duplicates(cqc_location_df)
-
     cqc_location_df = join_cqc_provider_data(cqc_location_df, cqc_provider_df)
 
     cqc_location_df = allocate_primary_service_type(cqc_location_df)
@@ -90,18 +87,6 @@ def remove_invalid_postcodes(df: DataFrame):
 
     map_func = F.udf(lambda row: post_codes_mapping.get(row, row))
     return df.withColumn(CQCL.postcode, map_func(F.col(CQCL.postcode)))
-
-
-def remove_locations_with_duplicates(df: DataFrame):
-    loc_id_import_date_window = Window.partitionBy(CQCL.location_id, Keys.import_date)
-
-    df_with_count = df.withColumn(
-        "location_id_count", F.count(CQCL.location_id).over(loc_id_import_date_window)
-    )
-
-    df_without_duplicates = df_with_count.filter(F.col("location_id_count") == 1)
-
-    return df_without_duplicates.drop("location_id_count")
 
 
 def allocate_primary_service_type(df: DataFrame):

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -756,6 +756,20 @@ class CQCLocationsData:
         ),
     ]
 
+    location_rows_with_duplicates = [
+        *small_location_rows,
+        (
+            "loc-3",
+            "prov-10",
+            "2020-01-01",
+        ),
+        (
+            "loc-4",
+            "prov-10",
+            "2021-01-01",
+        ),
+    ]
+
     join_provider_rows = [
         (
             "prov-1",

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -770,6 +770,33 @@ class CQCLocationsData:
         ),
     ]
 
+    location_rows_with_different_import_dates = [
+        *small_location_rows,
+        (
+            "loc-3",
+            "prov-10",
+            "2021-01-01",
+        ),
+        (
+            "loc-4",
+            "prov-10",
+            "2022-01-01",
+        ),
+    ]
+
+    expected_filtered_location_rows = [
+        (
+            "loc-1",
+            "prov-1",
+            "2020-01-01",
+        ),
+        (
+            "loc-2",
+            "prov-1",
+            "2020-01-01",
+        ),
+    ]
+
     join_provider_rows = [
         (
             "prov-1",

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -327,6 +327,70 @@ class ASCWDSWorkplaceData:
         ),
     ]
 
+    small_location_rows = [
+        (
+            "loc-1",
+            "2020-01-01",
+            "1",
+        ),
+        (
+            "loc-2",
+            "2020-01-01",
+            "1",
+        ),
+        (
+            "loc-3",
+            "2020-01-01",
+            "2",
+        ),
+        (
+            "loc-4",
+            "2021-01-01",
+            "2",
+        ),
+    ]
+
+    location_rows_with_duplicates = [
+        *small_location_rows,
+        (
+            "loc-3",
+            "2020-01-01",
+            "10",
+        ),
+        (
+            "loc-4",
+            "2021-01-01",
+            "10",
+        ),
+    ]
+
+    location_rows_with_different_import_dates = [
+        *small_location_rows,
+        (
+            "loc-3",
+            "2021-01-01",
+            "10",
+        ),
+        (
+            "loc-4",
+            "2022-01-01",
+            "10",
+        ),
+    ]
+
+    expected_filtered_location_rows = [
+        (
+            "loc-1",
+            "2020-01-01",
+            "1",
+        ),
+        (
+            "loc-2",
+            "2020-01-01",
+            "1",
+        ),
+    ]
+
     purge_outdated_data = [
         (
             "1-000000001",
@@ -753,47 +817,6 @@ class CQCLocationsData:
             "loc-4",
             "prov-2",
             "2021-01-01",
-        ),
-    ]
-
-    location_rows_with_duplicates = [
-        *small_location_rows,
-        (
-            "loc-3",
-            "prov-10",
-            "2020-01-01",
-        ),
-        (
-            "loc-4",
-            "prov-10",
-            "2021-01-01",
-        ),
-    ]
-
-    location_rows_with_different_import_dates = [
-        *small_location_rows,
-        (
-            "loc-3",
-            "prov-10",
-            "2021-01-01",
-        ),
-        (
-            "loc-4",
-            "prov-10",
-            "2022-01-01",
-        ),
-    ]
-
-    expected_filtered_location_rows = [
-        (
-            "loc-1",
-            "prov-1",
-            "2020-01-01",
-        ),
-        (
-            "loc-2",
-            "prov-1",
-            "2020-01-01",
         ),
     ]
 

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -257,6 +257,14 @@ class ASCWDSWorkplaceSchemas:
         ]
     )
 
+    location_schema = StructType(
+        [
+            StructField(AWP.location_id, StringType(), True),
+            StructField(AWP.import_date, StringType(), True),
+            StructField(AWP.organisation_id, StringType(), True),
+        ]
+    )
+
     purge_outdated_schema = StructType(
         [
             StructField(AWP.location_id, StringType(), True),

--- a/tests/unit/test_clean_cqc_location_data.py
+++ b/tests/unit/test_clean_cqc_location_data.py
@@ -261,48 +261,5 @@ class SplitDataframeIntoRegAndDeRegTests(CleanCQCLocationDatasetTests):
             self.assertEqual(warnings_log, [])
 
 
-class RemoveLocationsWithDuplicatesTests(CleanCQCLocationDatasetTests):
-    def setUp(self) -> None:
-        super().setUp()
-        self.returned_df = job.remove_locations_with_duplicates(self.test_location_df)
-
-        self.test_duplicate_loc_df = self.spark.createDataFrame(
-            Data.location_rows_with_duplicates, Schemas.small_location_schema
-        )
-
-    def test_returns_a_dataframe(self):
-        self.assertEqual(type(self.returned_df), DataFrame)
-
-    def test_returns_the_correct_columns(self):
-        self.assertCountEqual(
-            self.returned_df.columns, ["locationId", "providerId", "import_date"]
-        )
-
-    def test_does_not_remove_rows_if_no_duplicates(self):
-        self.assertEqual(self.returned_df.count(), self.test_location_df.count())
-        self.assertEqual(self.returned_df.collect(), self.test_location_df.collect())
-
-    def test_removes_duplicate_location_id_with_same_import_date(self):
-        filtered_df = job.remove_locations_with_duplicates(self.test_duplicate_loc_df)
-        expected_df = self.spark.createDataFrame(
-            Data.expected_filtered_location_rows, Schemas.small_location_schema
-        )
-        self.assertEqual(filtered_df.collect(), expected_df.collect())
-
-    def test_does_not_remove_duplicate_location_id_with_different_import_dates(self):
-        locations_with_different_import_dates_df = self.spark.createDataFrame(
-            Data.location_rows_with_different_import_dates,
-            Schemas.small_location_schema,
-        ).orderBy(CQCL.location_id)
-
-        filtered_df = job.remove_locations_with_duplicates(
-            locations_with_different_import_dates_df
-        ).orderBy(CQCL.location_id)
-
-        self.assertEqual(
-            filtered_df.collect(), locations_with_different_import_dates_df.collect()
-        )
-
-
 if __name__ == "__main__":
     unittest.main(warnings="ignore")


### PR DESCRIPTION
# Description
remove locations where location id is duplicated for the same import date

# How to test
Currently testing in branch - will update

https://trello.com/c/9to9YH3t/183-epic-5-remove-all-rows-where-the-locationid-is-duplicated-in-ascwds-workplace-file-must

# Developer checklist
- [ ] Unit test
- [ ] Linked to Trello ticket
- [ ] Documentation up to date
