### PR TITLE
Update read from parquet to only select some columns

### DIFF
--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -478,6 +478,11 @@ class UtilsTests(unittest.TestCase):
         self.assertEqual(df.columns, ["col_a", "col_b", "col_c"])
         self.assertEqual(df.count(), 3)
 
+    def test_read_from_parquet_imports_all_rows(self):
+        df = utils.read_from_parquet(self.example_parquet_path)
+
+        self.assertEqual(df.count(), 2270)
+
     def test_read_from_parquet_imports_all_columns_when_column_list_is_None(self):
         df = utils.read_from_parquet(self.example_parquet_path)
 
@@ -508,7 +513,6 @@ class UtilsTests(unittest.TestCase):
                 CQCColNames.uprn,
             ],
         )
-        self.assertEqual(df.count(), 2270)
 
     def test_read_from_parquet_only_imports_selected_columns(self):
         column_list = [
@@ -529,7 +533,6 @@ class UtilsTests(unittest.TestCase):
                 CQCColNames.registration_status,
             ],
         )
-        self.assertEqual(df.count(), 2270)
 
     def test_write(self):
         df = utils.read_csv(self.test_csv_path)

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -478,7 +478,7 @@ class UtilsTests(unittest.TestCase):
         self.assertEqual(df.columns, ["col_a", "col_b", "col_c"])
         self.assertEqual(df.count(), 3)
 
-    def test_read_from_parquet(self):
+    def test_read_from_parquet_imports_all_columns_when_column_list_is_None(self):
         df = utils.read_from_parquet(self.example_parquet_path)
 
         self.assertCountEqual(
@@ -506,6 +506,27 @@ class UtilsTests(unittest.TestCase):
                 CQCColNames.town_or_city,
                 CQCColNames.type,
                 CQCColNames.uprn,
+            ],
+        )
+        self.assertEqual(df.count(), 2270)
+
+    def test_read_from_parquet_only_imports_selected_columns(self):
+        column_list = [
+            CQCColNames.provider_id,
+            CQCColNames.name,
+            CQCColNames.registration_status,
+        ]
+
+        df = utils.read_from_parquet(
+            self.example_parquet_path, selected_columns=column_list
+        )
+
+        self.assertCountEqual(
+            df.columns,
+            [
+                CQCColNames.provider_id,
+                CQCColNames.name,
+                CQCColNames.registration_status,
             ],
         )
         self.assertEqual(df.count(), 2270)

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -91,16 +91,24 @@ def generate_s3_datasets_dir_date_path(destination_prefix, domain, dataset, date
 
 
 def read_from_parquet(
-    data_source, optional_columns_to_import=None
+    data_source: str, selected_columns: list[str] = None
 ) -> pyspark.sql.DataFrame:
     """
-    Reads a parquet file from a provided source into a DataFrame.
-    Optional to include a specified list of columns (None will import all columns).
+    Reads data from a parquet file and returns a DataFrame with all/selected columns.
+
+    Args:
+        data_source: Path to the Parquet file.
+        (optional) selected_columns: List of column names to select. Defaults to None (all columns).
     """
     spark_session = get_spark()
     print(f"Reading data from {data_source}")
 
-    return spark_session.read.parquet(data_source, columns=optional_columns_to_import)
+    df = spark_session.read.parquet(data_source)
+
+    if selected_columns:
+        df = df.select(selected_columns)
+
+    return df
 
 
 def write_to_parquet(

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -90,14 +90,17 @@ def generate_s3_datasets_dir_date_path(destination_prefix, domain, dataset, date
     return output_dir
 
 
-def read_from_parquet(data_source) -> pyspark.sql.DataFrame:
+def read_from_parquet(
+    data_source, optional_columns_to_import=None
+) -> pyspark.sql.DataFrame:
     """
-    Reads a parquet file from a provided source into a DataFrame
+    Reads a parquet file from a provided source into a DataFrame.
+    Optional to include a specified list of columns (None will import all columns).
     """
     spark_session = get_spark()
     print(f"Reading data from {data_source}")
 
-    return spark_session.read.parquet(data_source)
+    return spark_session.read.parquet(data_source, columns=optional_columns_to_import)
 
 
 def write_to_parquet(


### PR DESCRIPTION
# Description
Some of our datasets are huge and we're now getting to the point where we're merging data.
This function will allow us to slim data frames down ready for merging without affecting any current functionality

Not entering an option means that the original functionality will occur, so this won't affect any existing data/jobs

[Trello](https://trello.com/c/boX0ryEA/284-general-change-readfromparquet-function-to-have-optional-column-list-must)
