### PR TITLE
Changed from list[str] to List[str]

### DIFF
--- a/jobs/locations_care_home_feature_engineering.py
+++ b/jobs/locations_care_home_feature_engineering.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 
 import pyspark
 import pyspark.sql.functions as F
+from typing import List
 
 from utils import utils
 from utils.feature_engineering_dictionaries import (
@@ -100,7 +101,7 @@ def main(prepared_locations_source, destination=None):
         snapshot_date_col=features_from_prepare_locations.snapshot_date,
     )
 
-    list_for_vectorisation: list[str] = sorted(
+    list_for_vectorisation: List[str] = sorted(
         [
             new_cols_for_features.service_count,
             features_from_prepare_locations.number_of_beds,

--- a/jobs/locations_non_res_feature_engineering.py
+++ b/jobs/locations_non_res_feature_engineering.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 
 import pyspark
 import pyspark.sql.functions as F
+from typing import List
 
 from utils import utils
 from utils.feature_engineering_dictionaries import (
@@ -105,7 +106,7 @@ def main(prepared_locations_source, destination=None):
         snapshot_date_col=features_from_prepare_locations.snapshot_date,
     )
 
-    list_for_vectorisation: list[str] = sorted(
+    list_for_vectorisation: List[str] = sorted(
         [
             new_cols_for_features.service_count,
             features_from_prepare_locations.people_directly_employed,

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -1,5 +1,4 @@
 import os
-import sys
 import re
 import csv
 import argparse
@@ -8,6 +7,7 @@ from pyspark.sql import SparkSession, DataFrame, Column, Window
 import pyspark.sql.functions as F
 from pyspark.sql.utils import AnalysisException
 import pyspark.sql
+from typing import List
 
 import boto3
 
@@ -91,7 +91,7 @@ def generate_s3_datasets_dir_date_path(destination_prefix, domain, dataset, date
 
 
 def read_from_parquet(
-    data_source: str, selected_columns: list[str] = None
+    data_source: str, selected_columns: List[str] = None
 ) -> pyspark.sql.DataFrame:
     """
     Reads data from a parquet file and returns a DataFrame with all/selected columns.


### PR DESCRIPTION
# Description
list[str] is available from python 3.9 (we're on python 3.9.6) but glue 3.0 uses python 3.7, so change to List[str]