### PR TITLE
Apply universal scale function

### DIFF
--- a/jobs/clean_ascwds_workplace_data.py
+++ b/jobs/clean_ascwds_workplace_data.py
@@ -17,8 +17,10 @@ from utils.column_names.cleaned_data_files.ascwds_workplace_cleaned_values impor
     AscwdsWorkplaceCleanedColumns as AWPClean,
     AscwdsWorkplaceCleanedValues as AWPValues,
 )
+from utils.scale_variable_limits import AscwdsScaleVariableLimits
 
 DATE_COLUMN_IDENTIFIER = "date"
+COLUMNS_TO_BOUND = [AWP.total_staff, AWP.worker_records]
 
 
 def main(source: str, destination: str):
@@ -46,8 +48,20 @@ def main(source: str, destination: str):
 
     ascwds_workplace_df = remove_locations_with_duplicates(ascwds_workplace_df)
 
-    ascwds_workplace_df = cast_to_int(
-        ascwds_workplace_df, [AWP.total_staff, AWP.worker_records]
+    ascwds_workplace_df = cast_to_int(ascwds_workplace_df, COLUMNS_TO_BOUND)
+
+    ascwds_workplace_df = cUtils.set_column_bounds(
+        ascwds_workplace_df,
+        AWP.total_staff,
+        AWPClean.total_staff_bounded,
+        AscwdsScaleVariableLimits.total_staff_lower_limit,
+    )
+
+    ascwds_workplace_df = cUtils.set_column_bounds(
+        ascwds_workplace_df,
+        AWP.worker_records,
+        AWPClean.worker_records_bounded,
+        AscwdsScaleVariableLimits.worker_records_lower_limit,
     )
 
     ascwds_workplace_df = create_column_with_repeated_values_removed(

--- a/tests/unit/test_clean_ascwds_workplace_data.py
+++ b/tests/unit/test_clean_ascwds_workplace_data.py
@@ -48,6 +48,7 @@ class MainTests(IngestASCWDSWorkerDatasetTests):
     @patch(
         "jobs.clean_ascwds_workplace_data.create_column_with_repeated_values_removed"
     )
+    @patch("utils.cleaning_utils.set_column_bounds")
     @patch("utils.utils.format_date_fields", wraps=format_date_fields)
     @patch("utils.utils.write_to_parquet")
     @patch("utils.utils.read_from_parquet")
@@ -56,6 +57,7 @@ class MainTests(IngestASCWDSWorkerDatasetTests):
         read_from_parquet_mock: Mock,
         write_to_parquet_mock: Mock,
         format_date_fields_mock: Mock,
+        set_column_bounds_mock: Mock,
         create_column_with_repeated_values_removed_mock: Mock,
     ):
         read_from_parquet_mock.return_value = self.test_ascwds_workplace_df
@@ -64,6 +66,7 @@ class MainTests(IngestASCWDSWorkerDatasetTests):
 
         self.assertEqual(format_date_fields_mock.call_count, 1)
         self.assertEqual(create_column_with_repeated_values_removed_mock.call_count, 2)
+        self.assertEqual(set_column_bounds_mock.call_count, 2)
 
         read_from_parquet_mock.assert_called_once_with(self.TEST_SOURCE)
         write_to_parquet_mock.assert_called_once_with(

--- a/utils/cleaning_utils.py
+++ b/utils/cleaning_utils.py
@@ -79,6 +79,22 @@ def convert_labels_to_dataframe(labels: list, spark: SparkSession) -> DataFrame:
 def set_column_bounds(
     df: DataFrame, col_name: str, new_col_name: str, lower_limit=None, upper_limit=None
 ) -> DataFrame:
+    """
+    Creates a new column based on a previous column, dropping values that exist outside of the lower and upper limits, where provided.
+
+        Args:
+            df: The DataFrame containing the column to bound
+            col_name: The name of the column to be bounded, as a string
+            new_col_name: What the newly created column will be called, as a string
+            lower_limit: The value of the lower limit. Must be an integer or float value if provided, and is otherwise defaulted to None
+            upper_limit: The value of the upper limit. Must be an integer or float value if provided, and is otherwise defaulted to None
+
+        Returns:
+            df: The DataFrame with the new column only containing numerical values that fell within the bounds.
+
+        Raises:
+            ValueError: If both limits are comparable numerical types, and the upper limit is lower than the lower limit.
+    """
     if lower_limit is None and upper_limit is None:
         return df
 

--- a/utils/column_names/cleaned_data_files/ascwds_workplace_cleaned_values.py
+++ b/utils/column_names/cleaned_data_files/ascwds_workplace_cleaned_values.py
@@ -10,6 +10,8 @@ class AscwdsWorkplaceCleanedColumns(AscwdsWorkplaceColumns):
     ascwds_workplace_import_date: str = "ascwds_workplace_import_date"
     purge_data: str = "purge_data"
     last_logged_in_date: str = "last_logged_in_date"
+    total_staff_bounded: str = AscwdsWorkplaceColumns.total_staff + "_bounded"
+    worker_records_bounded: str = AscwdsWorkplaceColumns.worker_records + "_bounded"
 
 
 @dataclass

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -91,7 +91,7 @@ def generate_s3_datasets_dir_date_path(destination_prefix, domain, dataset, date
 
 
 def read_from_parquet(
-    data_source: str, selected_columns: list[str] = None
+    data_source: str, selected_columns: list = None
 ) -> pyspark.sql.DataFrame:
     """
     Reads data from a parquet file and returns a DataFrame with all/selected columns.


### PR DESCRIPTION
# Description
Applied function to create a new column in ascwds workplace file where total staff and worker records are recoded to remove values below lower limit. Lower limit was set to 1 for both.

# How to test
Ran the login separelty and also checked output in Athena for correct result. Saw totalstaff/worker records orginal values change from 0 to null.

# Developer checklist
- [x ] Unit test
- [x] Linked to Trello ticket
- [x ] Documentation up to date
