### PR TITLE
Use alligned dates when joining cqc data

### DIFF
--- a/jobs/clean_cqc_location_data.py
+++ b/jobs/clean_cqc_location_data.py
@@ -1,5 +1,6 @@
 import sys
 import warnings
+from typing import Tuple
 
 from utils import utils
 import utils.cleaning_utils as cUtils
@@ -189,7 +190,7 @@ def join_cqc_provider_data(locations_df: DataFrame, provider_df: DataFrame):
 
 def split_dataframe_into_registered_and_deregistered_rows(
     locations_df: DataFrame,
-) -> tuple[DataFrame, DataFrame]:
+) -> Tuple[DataFrame, DataFrame]:
     invalid_rows = locations_df.where(
         (locations_df[CQCL.registration_status] != CQCLValues.registered)
         & (locations_df[CQCL.registration_status] != CQCLValues.deregistered)

--- a/jobs/clean_cqc_location_data.py
+++ b/jobs/clean_cqc_location_data.py
@@ -57,6 +57,12 @@ ons_cols_to_import = [
     *contemporary_geography_columns,
     *current_geography_columns,
 ]
+cqc_provider_cols_to_import = [
+    CQCPClean.provider_id,
+    CQCPClean.name,
+    CQCPClean.cqc_sector,
+    CQCPClean.cqc_provider_import_date,
+]
 
 
 def main(
@@ -68,7 +74,9 @@ def main(
     cqc_location_df = utils.read_from_parquet(
         cqc_location_source, selected_columns=cqc_location_api_cols_to_import
     )
-    cqc_provider_df = utils.read_from_parquet(cleaned_cqc_provider_source)
+    cqc_provider_df = utils.read_from_parquet(
+        cleaned_cqc_provider_source, selected_columns=cqc_provider_cols_to_import
+    )
     ons_postcode_directory_df = utils.read_from_parquet(
         cleaned_ons_postcode_directory_source, selected_columns=ons_cols_to_import
     )
@@ -173,11 +181,11 @@ def join_cqc_provider_data(locations_df: DataFrame, provider_df: DataFrame):
         CQCPClean.cqc_provider_import_date,
     )
 
-    provider_data_to_join_df = provider_df.select(
-        provider_df[CQCPClean.provider_id].alias(CQCLClean.provider_id),
-        provider_df[CQCPClean.name].alias(CQCLClean.provider_name),
-        provider_df[CQCPClean.cqc_sector],
-        provider_df[CQCPClean.cqc_provider_import_date],
+    provider_data_to_join_df = provider_df.withColumnsRenamed(
+        {
+            CQCPClean.provider_id: CQCLClean.provider_id,
+            CQCPClean.name: CQCLClean.provider_name,
+        }
     )
 
     joined_df = locations_df.join(

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -881,21 +881,18 @@ class CQCLocationsData:
             "prov-1",
             "Apple Tree Care Homes",
             "Local authority",
-            "North East",
             date(2020, 1, 1),
         ),
         (
             "prov-2",
             "Sunshine Domestic Care",
             "Independent",
-            "North West",
             date(2020, 1, 1),
         ),
         (
             "prov-3",
             "Sunny Days Domestic Care",
             "Independent",
-            "North East",
             date(2020, 1, 1),
         ),
     ]

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -854,22 +854,22 @@ class CQCLocationsData:
         (
             "loc-1",
             "prov-1",
-            "2020-01-01",
+            "20200101",
         ),
         (
             "loc-2",
             "prov-1",
-            "2020-01-01",
+            "20200101",
         ),
         (
             "loc-3",
             "prov-2",
-            "2020-01-01",
+            "20200101",
         ),
         (
             "loc-4",
             "prov-2",
-            "2021-01-01",
+            "20210101",
         ),
     ]
 
@@ -879,21 +879,21 @@ class CQCLocationsData:
             "Apple Tree Care Homes",
             "Local authority",
             "North East",
-            "2020-01-01",
+            date(2020, 1, 1),
         ),
         (
             "prov-2",
             "Sunshine Domestic Care",
             "Independent",
             "North West",
-            "2020-01-01",
+            date(2020, 1, 1),
         ),
         (
-            "prov-2",
+            "prov-3",
             "Sunny Days Domestic Care",
             "Independent",
             "North East",
-            "2021-01-01",
+            date(2020, 1, 1),
         ),
     ]
 
@@ -903,28 +903,32 @@ class CQCLocationsData:
             "prov-1",
             "Apple Tree Care Homes",
             "Local authority",
-            "2020-01-01",
+            date(2020, 1, 1),
+            date(2020, 1, 1),
         ),
         (
             "loc-2",
             "prov-1",
             "Apple Tree Care Homes",
             "Local authority",
-            "2020-01-01",
+            date(2020, 1, 1),
+            date(2020, 1, 1),
         ),
         (
             "loc-3",
             "prov-2",
             "Sunshine Domestic Care",
             "Independent",
-            "2020-01-01",
+            date(2020, 1, 1),
+            date(2020, 1, 1),
         ),
         (
             "loc-4",
             "prov-2",
-            "Sunny Days Domestic Care",
+            "Sunshine Domestic Care",
             "Independent",
-            "2021-01-01",
+            date(2021, 1, 1),
+            date(2020, 1, 1),
         ),
     ]
 

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -433,7 +433,6 @@ class CQCLocationsSchema:
             StructField(CQCPClean.provider_id, StringType(), True),
             StructField(CQCPClean.name, StringType(), True),
             StructField(CQCPClean.cqc_sector, StringType(), True),
-            StructField(CQCPClean.region, StringType(), True),
             StructField(CQCPClean.cqc_provider_import_date, DateType(), True),
         ]
     )

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -417,7 +417,7 @@ class CQCLocationsSchema:
             StructField(CQCPClean.name, StringType(), True),
             StructField(CQCPClean.cqc_sector, StringType(), True),
             StructField(CQCPClean.region, StringType(), True),
-            StructField(Keys.import_date, StringType(), True),
+            StructField(CQCPClean.cqc_provider_import_date, DateType(), True),
         ]
     )
 
@@ -427,7 +427,8 @@ class CQCLocationsSchema:
             StructField(CQCL.provider_id, StringType(), True),
             StructField(CQCLClean.provider_name, StringType(), True),
             StructField(CQCPClean.cqc_sector, StringType(), True),
-            StructField(Keys.import_date, StringType(), True),
+            StructField(CQCLClean.cqc_location_import_date, DateType(), True),
+            StructField(CQCPClean.cqc_provider_import_date, DateType(), True),
         ]
     )
 

--- a/tests/unit/test_clean_cqc_location_data.py
+++ b/tests/unit/test_clean_cqc_location_data.py
@@ -206,12 +206,17 @@ class AllocatePrimaryServiceTests(CleanCQCLocationDatasetTests):
 class JoinCqcProviderDataTests(CleanCQCLocationDatasetTests):
     def setUp(self) -> None:
         super().setUp()
+        self.test_location_df = cUtils.column_to_date(
+            self.test_location_df,
+            Keys.import_date,
+            CQCLCleaned.cqc_location_import_date,
+        ).drop(CQCLCleaned.import_date)
 
     def test_join_cqc_provider_data_adds_two_columns(self):
         returned_df = job.join_cqc_provider_data(
             self.test_location_df, self.test_provider_df
         )
-        new_columns = 2
+        new_columns = 3
         expected_columns = len(self.test_location_df.columns) + new_columns
 
         self.assertEqual(len(returned_df.columns), expected_columns)

--- a/tests/unit/test_clean_cqc_location_data.py
+++ b/tests/unit/test_clean_cqc_location_data.py
@@ -212,7 +212,7 @@ class JoinCqcProviderDataTests(CleanCQCLocationDatasetTests):
             CQCLCleaned.cqc_location_import_date,
         ).drop(CQCLCleaned.import_date)
 
-    def test_join_cqc_provider_data_adds_two_columns(self):
+    def test_join_cqc_provider_data_adds_three_columns(self):
         returned_df = job.join_cqc_provider_data(
             self.test_location_df, self.test_provider_df
         )

--- a/utils/column_names/cleaned_data_files/cqc_location_cleaned_values.py
+++ b/utils/column_names/cleaned_data_files/cqc_location_cleaned_values.py
@@ -20,6 +20,7 @@ class CqcLocationCleanedColumns(CqcLocationApiColumns):
     cqc_sector: str = CQCPClean.cqc_sector
     provider_name: str = "provider_name"
     cqc_location_import_date: str = "cqc_location_import_date"
+    cqc_provider_import_date: str = CQCPClean.cqc_provider_import_date
     ons_contemporary_import_date: str = ONSClean.contemporary_ons_import_date
     ons_contemporary_geographies: str = ONSClean.contemporary
     ons_current_import_date: str = ONSClean.current_ons_import_date


### PR DESCRIPTION
# Description
align dates when joining provider data into cqc location data

# How to test
tested on personal stack here: https://eu-west-2.console.aws.amazon.com/gluestudio/home?region=eu-west-2#/job/jf-clean_cqc_location_data_job/run/jr_55c609127d34b8598e4801fc514b77cf68dc58d4e18fd3100615649e1eecfdd5

ticket: https://trello.com/c/fwFckHQw/241-epic-4-amend-joincqcproviderdata-so-it-uses-the-align-date-function-must

# Developer checklist
- [ ] Unit test
- [ ] Linked to Trello ticket
- [ ] Documentation up to date
