### PR TITLE
Bug fix prepare locations mh

### DIFF
--- a/jobs/clean_cqc_location_data.py
+++ b/jobs/clean_cqc_location_data.py
@@ -30,8 +30,6 @@ from utils.cqc_location_dictionaries import InvalidPostcodes
 
 cqcPartitionKeys = [Keys.year, Keys.month, Keys.day, Keys.import_date]
 
-DATE_COLUMN_IDENTIFIER = "registration_date"
-
 cqc_location_api_cols_to_import = [
     CQCL.care_home,
     CQCL.dormancy,
@@ -77,7 +75,7 @@ def main(
     cqc_location_df = allocate_primary_service_type(cqc_location_df)
     cqc_location_df = utils.format_date_fields(
         cqc_location_df,
-        date_column_identifier=DATE_COLUMN_IDENTIFIER,
+        date_column_identifier=CQCLClean.registration_date, # This will format both registration date and deregistration date
         raw_date_format="yyyy-MM-dd",
     )
     cqc_location_df = cUtils.column_to_date(

--- a/jobs/clean_cqc_location_data.py
+++ b/jobs/clean_cqc_location_data.py
@@ -75,7 +75,7 @@ def main(
     cqc_location_df = allocate_primary_service_type(cqc_location_df)
     cqc_location_df = utils.format_date_fields(
         cqc_location_df,
-        date_column_identifier=CQCLClean.registration_date, # This will format both registration date and deregistration date
+        date_column_identifier=CQCLClean.registration_date,  # This will format both registration date and deregistration date
         raw_date_format="yyyy-MM-dd",
     )
     cqc_location_df = cUtils.column_to_date(

--- a/jobs/prepare_locations.py
+++ b/jobs/prepare_locations.py
@@ -215,7 +215,9 @@ def get_ascwds_workplace_df(workplace_source, since_date=None):
         )
     )
 
-    workplace_df = utils.format_date_fields(workplace_df, "mupddate", raw_date_format="dd/MM/yyyy")
+    workplace_df = utils.format_date_fields(
+        workplace_df, "mupddate", raw_date_format="dd/MM/yyyy"
+    )
     workplace_df = workplace_df.drop_duplicates(subset=["locationid", "import_date"])
     workplace_df = clean(workplace_df)
 

--- a/jobs/prepare_locations.py
+++ b/jobs/prepare_locations.py
@@ -215,6 +215,7 @@ def get_ascwds_workplace_df(workplace_source, since_date=None):
         )
     )
 
+    workplace_df = utils.format_date_fields(workplace_df, "mupddate", raw_date_format="dd/MM/yyyy")
     workplace_df = workplace_df.drop_duplicates(subset=["locationid", "import_date"])
     workplace_df = clean(workplace_df)
 

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -104,9 +104,7 @@ class UtilsTests(unittest.TestCase):
     smaller_string_boost = 35
 
     def setUp(self):
-        self.spark = SparkSession.builder.appName(
-            "sfc_data_engineering_csv_to_parquet"
-        ).getOrCreate()
+        self.spark = utils.get_spark()
         self.df = self.spark.read.csv(self.test_csv_path, header=True)
         self.test_workplace_df = generate_ascwds_workplace_file(
             self.TEST_ASCWDS_WORKPLACE_FILE
@@ -546,6 +544,30 @@ class UtilsTests(unittest.TestCase):
         formatted_df = utils.format_date_fields(self.df, raw_date_format="dd/MM/yyyy")
         self.assertEqual(type(formatted_df.select("date_col").first()[0]), date)
         self.assertEqual(formatted_df.select("date_col").first()[0], date(1993, 11, 28))
+
+    def test_format_date_fields_can_handle_timestamps_as_strings(self):
+        test_rows = [
+            ("loc 1", "2011-01-19 00:00:00"), 
+            ("loc 2", "2011-01-19"),
+        ]
+        test_schema = StructType(
+            [
+                StructField("id", StringType(), True),
+                StructField("date_column", StringType(), True),
+            ]
+        )   
+        test_df = self.spark.createDataFrame(test_rows, test_schema)
+        returned_df = utils.format_date_fields(test_df, raw_date_format="yyyy-MM-dd")
+        expected_rows = [("loc 1", date(2011, 1, 19),), ("loc 2", date(2011, 1,19))]
+        expected_schema = StructType(
+            [
+                StructField("id", StringType(), True),
+                StructField("date_column", DateType(), True),
+            ]
+        )  
+        expected_data = self.spark.createDataFrame(expected_rows, expected_schema).collect()
+        returned_data = returned_df.collect()
+        self.assertEqual(expected_data, returned_data)
 
     def test_format_date_string(self):
         formatted_df = utils.format_date_string(

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -547,7 +547,7 @@ class UtilsTests(unittest.TestCase):
 
     def test_format_date_fields_can_handle_timestamps_as_strings(self):
         test_rows = [
-            ("loc 1", "2011-01-19 00:00:00"), 
+            ("loc 1", "2011-01-19 00:00:00"),
             ("loc 2", "2011-01-19"),
         ]
         test_schema = StructType(
@@ -555,17 +555,25 @@ class UtilsTests(unittest.TestCase):
                 StructField("id", StringType(), True),
                 StructField("date_column", StringType(), True),
             ]
-        )   
+        )
         test_df = self.spark.createDataFrame(test_rows, test_schema)
         returned_df = utils.format_date_fields(test_df, raw_date_format="yyyy-MM-dd")
-        expected_rows = [("loc 1", date(2011, 1, 19),), ("loc 2", date(2011, 1,19))]
+        expected_rows = [
+            (
+                "loc 1",
+                date(2011, 1, 19),
+            ),
+            ("loc 2", date(2011, 1, 19)),
+        ]
         expected_schema = StructType(
             [
                 StructField("id", StringType(), True),
                 StructField("date_column", DateType(), True),
             ]
-        )  
-        expected_data = self.spark.createDataFrame(expected_rows, expected_schema).collect()
+        )
+        expected_data = self.spark.createDataFrame(
+            expected_rows, expected_schema
+        ).collect()
         returned_data = returned_df.collect()
         self.assertEqual(expected_data, returned_data)
 

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -29,6 +29,7 @@ class SetupSpark(object):
         spark = SparkSession.builder.appName("sfc_data_engineering").getOrCreate()
         spark.sql("set spark.sql.legacy.parquet.datetimeRebaseModeInWrite=LEGACY")
         spark.sql("set spark.sql.legacy.parquet.datetimeRebaseModeInRead=LEGACY")
+        spark.sql("set spark.sql.legacy.timeParserPolicy=LEGACY")
         return spark
 
 


### PR DESCRIPTION
# Description
Fixing bugs with how dates are parsed in spark. Some of our date columns contain timestamps as strings and adding the legacy setting allows spark to handle this.
Also fixed related bug in clean cqc locations where it was not reading in the registration date columns properly
Added a test to utils to check these timestamps-as-strings can be converted 
Will add a ticket to trello to add a cleaning step to convert timestamps-as-strings into dates-as-strings. 

# How to test
Unit tests passing
running successfully in branch

# Developer checklist
- [x] Unit test
No trello ticket - part of BAU work