### PR TITLE
move job count to cleaned job

### DIFF
--- a/jobs/prepare_locations.py
+++ b/jobs/prepare_locations.py
@@ -6,9 +6,6 @@ from pyspark.sql import DataFrame
 from pyspark.sql.types import IntegerType
 
 from utils import utils
-from utils.prepare_locations_utils.job_calculator.job_calculator import (
-    calculate_jobcount,
-)
 from utils.prepare_locations_utils.ons_postcode_aliases import OnsPostcodeDataAliases
 from utils.prepare_locations_utils.dataframe_utils import (
     add_three_columns_with_snapshot_date_substrings,
@@ -118,9 +115,6 @@ def main(
 
         output_df = output_df.join(pir_df, "locationid", "left")
         output_df = add_geographical_data(output_df, latest_ons_data)
-        output_df = calculate_jobcount(
-            output_df, "total_staff", "worker_record_count", "job_count_unfiltered"
-        )
 
         output_df = add_column_if_locationid_is_in_ascwds(output_df)
 
@@ -160,8 +154,8 @@ def main(
             "services_offered",
             "primary_service_type",
             "people_directly_employed",
-            "job_count_unfiltered",
-            "job_count_unfiltered_source",
+            "total_staff",
+            "worker_record_count",
             "region",
             "postal_code",
             "constituency",

--- a/jobs/prepare_locations_cleaned.py
+++ b/jobs/prepare_locations_cleaned.py
@@ -9,6 +9,9 @@ from utils import utils
 from utils.prepare_locations_utils.filter_job_count.filter_job_count import (
     null_job_count_outliers,
 )
+from utils.prepare_locations_utils.job_calculator.job_calculator import (
+    calculate_jobcount,
+)
 
 
 COLUMNS_TO_IMPORT = [
@@ -27,8 +30,8 @@ COLUMNS_TO_IMPORT = [
     "registration_status",
     "number_of_beds",
     "people_directly_employed",
-    "job_count_unfiltered_source",
-    "job_count_unfiltered",
+    "total_staff",
+    "worker_record_count",
 ]
 
 
@@ -51,6 +54,10 @@ def main(
 
     locations_df = replace_zero_beds_with_null(locations_df)
     locations_df = populate_missing_carehome_number_of_beds(locations_df)
+
+    locations_df = calculate_jobcount(
+        locations_df, "total_staff", "worker_record_count", "job_count_unfiltered"
+    )
 
     locations_df = null_job_count_outliers(locations_df)
 

--- a/tests/test_file_generator.py
+++ b/tests/test_file_generator.py
@@ -873,7 +873,7 @@ def generate_prepared_locations_preclean_file_parquet(
             ),
             StructField("primary_service_type", StringType(), True),
             StructField("people_directly_employed", IntegerType(), True),
-            StructField("job_count_unfiltered", DoubleType(), True),
+            StructField("total_staff", IntegerType(), True),
             StructField("local_authority", StringType(), True),
             StructField("snapshot_year", StringType(), True),
             StructField("snapshot_month", StringType(), True),
@@ -881,27 +881,27 @@ def generate_prepared_locations_preclean_file_parquet(
             StructField("carehome", StringType(), True),
             StructField("cqc_sector", StringType(), True),
             StructField("rural_urban_indicator", StringType(), True),
-            StructField("job_count_unfiltered_source", StringType(), True),
+            StructField("worker_record_count", IntegerType(), True),
             StructField("registration_status", StringType(), True),
         ]
     )
 
     # fmt: off
     rows = [
-        ("1-1783948", "20220201", "South East", 0, ["Domiciliary care service"], "non-residential", 5, None, "Surrey", partitions[0], partitions[1], partitions[2], "N", "Independent", "Rural hamlet and isolated dwellings in a sparse setting", "rule_1", "Registered"),
-        ("1-1783948", "20220101", "South East", 0, ["Domiciliary care service"], "non-residential", 5, 67.0, "Surrey", partitions[0], partitions[1], partitions[2], "N", "Independent", "Rural hamlet and isolated dwellings in a sparse setting", "rule_2", "Registered"),
-        ("1-348374832", "20220112", "Merseyside", 0, ["Extra Care housing services"], "non-residential", None, 34.0, "Gloucestershire", partitions[0], partitions[1], partitions[2], "N", "Local authority", "Rural hamlet and isolated dwellings", "rule_3", "Registered"),
-        ("1-683746776", "20220101", "Merseyside", 0, ["Doctors treatment service", "Long term conditions services", "Shared Lives"], "non-residential", 34, None, "Gloucestershire", partitions[0], partitions[1], partitions[2], "N", "Local authority", "Rural hamlet and isolated dwellings", "rule_1", "Registered"),
-        ("1-10478686", "20220101", "London Senate", 0, ["Community health care services - Nurses Agency only"], "non-residential", None, None, "Surrey", partitions[0], partitions[1], partitions[2], "N", "", "Rural hamlet and isolated dwellings", "rule_1", "Registered"),
-        ("1-10235302415", "20220112", "South West", 0, ["Urgent care services", "Supported living service"], "non-residential", 17, None, "Surrey", partitions[0], partitions[1], partitions[2], "N", "Independent", "Rural hamlet and isolated dwellings", "rule_3", "Registered"),
-        ("1-1060912125", "20220112", "Yorkshire and The Humbler", 0, ["Hospice services at home"], "non-residential", 34, None, "Surrey", partitions[0], partitions[1], partitions[2], "N", "Independent", "Rural hamlet and isolated dwellings", "rule_2", "Registered"),
-        ("1-107095666", "20220301", "Yorkshire and The Humbler", 0, ["Specialist college service", "Community based services for people who misuse substances", "Urgent care services'"], "non-residential", 34, None, "Lewisham", partitions[0], partitions[1], partitions[2], "N", "Independent", "Urban city and town", "rule_3", "Registered"),
-        ("1-108369587", "20220308", "South West", 0, ["Specialist college service"], "non-residential", 15, None, "Lewisham", partitions[0], partitions[1], partitions[2], "N", "Independent", "Rural town and fringe in a sparse setting", "rule_1", "Registered"),
-        ("1-10758359583", "20220308", None, 0, ["Mobile doctors service"], "non-residential", 17, None, "Lewisham", partitions[0], partitions[1], partitions[2], "N", "Local authority", "Urban city and town", "rule_2", "Registered"),
-        ("1-000000001", "20220308", "Yorkshire and The Humbler", 67, ["Care home service with nursing"], "Care home with nursing", None, None, "Lewisham", partitions[0], partitions[1], partitions[2], "Y", "Local authority", "Urban city and town", "rule_1", "Registered"),
-        ("1-10894414510", "20220308", "Yorkshire and The Humbler", 10, ["Care home service with nursing"], "Care home with nursing", 0, 25.0, "Lewisham", partitions[0], partitions[1], partitions[2], "Y", "Independent", "Urban city and town", "rule_3", "Registered"),
-        ("1-108950835", "20220315", "Merseyside", 20, ["Care home service without nursing"], "Care home without nursing", 23, None, "Lewisham", partitions[0], partitions[1], partitions[2], "Y", "", "Urban city and town", "rule_1", "Registered"),
-        ("1-108967195", "20220422", "(pseudo) Wales", 0, ["Supported living service", "Acute services with overnight beds"], "non-residential", 11, None, "Lewisham", partitions[0], partitions[1], partitions[2], "N", "Independent", "Urban city and town", "rule_3", "Deregistered"),
+        ("1-1783948", "20220201", "South East", 0, ["Domiciliary care service"], "non-residential", 5, None, "Surrey", partitions[0], partitions[1], partitions[2], "N", "Independent", "Rural hamlet and isolated dwellings in a sparse setting", 1, "Registered"),
+        ("1-1783948", "20220101", "South East", 0, ["Domiciliary care service"], "non-residential", 5, 67, "Surrey", partitions[0], partitions[1], partitions[2], "N", "Independent", "Rural hamlet and isolated dwellings in a sparse setting", 1, "Registered"),
+        ("1-348374832", "20220112", "Merseyside", 0, ["Extra Care housing services"], "non-residential", None, 34, "Gloucestershire", partitions[0], partitions[1], partitions[2], "N", "Local authority", "Rural hamlet and isolated dwellings", 1, "Registered"),
+        ("1-683746776", "20220101", "Merseyside", 0, ["Doctors treatment service", "Long term conditions services", "Shared Lives"], "non-residential", 34, None, "Gloucestershire", partitions[0], partitions[1], partitions[2], "N", "Local authority", "Rural hamlet and isolated dwellings", 1, "Registered"),
+        ("1-10478686", "20220101", "London Senate", 0, ["Community health care services - Nurses Agency only"], "non-residential", None, None, "Surrey", partitions[0], partitions[1], partitions[2], "N", "", "Rural hamlet and isolated dwellings", 1, "Registered"),
+        ("1-10235302415", "20220112", "South West", 0, ["Urgent care services", "Supported living service"], "non-residential", 17, None, "Surrey", partitions[0], partitions[1], partitions[2], "N", "Independent", "Rural hamlet and isolated dwellings", 1, "Registered"),
+        ("1-1060912125", "20220112", "Yorkshire and The Humbler", 0, ["Hospice services at home"], "non-residential", 34, None, "Surrey", partitions[0], partitions[1], partitions[2], "N", "Independent", "Rural hamlet and isolated dwellings", 1, "Registered"),
+        ("1-107095666", "20220301", "Yorkshire and The Humbler", 0, ["Specialist college service", "Community based services for people who misuse substances", "Urgent care services'"], "non-residential", 34, None, "Lewisham", partitions[0], partitions[1], partitions[2], "N", "Independent", "Urban city and town", 1, "Registered"),
+        ("1-108369587", "20220308", "South West", 0, ["Specialist college service"], "non-residential", 15, None, "Lewisham", partitions[0], partitions[1], partitions[2], "N", "Independent", "Rural town and fringe in a sparse setting", 1, "Registered"),
+        ("1-10758359583", "20220308", None, 0, ["Mobile doctors service"], "non-residential", 17, None, "Lewisham", partitions[0], partitions[1], partitions[2], "N", "Local authority", "Urban city and town", 1, "Registered"),
+        ("1-000000001", "20220308", "Yorkshire and The Humbler", 67, ["Care home service with nursing"], "Care home with nursing", None, None, "Lewisham", partitions[0], partitions[1], partitions[2], "Y", "Local authority", "Urban city and town", 1, "Registered"),
+        ("1-10894414510", "20220308", "Yorkshire and The Humbler", 10, ["Care home service with nursing"], "Care home with nursing", 0, 25, "Lewisham", partitions[0], partitions[1], partitions[2], "Y", "Independent", "Urban city and town", 1, "Registered"),
+        ("1-108950835", "20220315", "Merseyside", 20, ["Care home service without nursing"], "Care home without nursing", 23, None, "Lewisham", partitions[0], partitions[1], partitions[2], "Y", "", "Urban city and town", 1, "Registered"),
+        ("1-108967195", "20220422", "(pseudo) Wales", 0, ["Supported living service", "Acute services with overnight beds"], "non-residential", 11, None, "Lewisham", partitions[0], partitions[1], partitions[2], "N", "Independent", "Urban city and town", 1, "Deregistered"),
     ]
     # fmt: on
 

--- a/tests/unit/test_prepare_locations.py
+++ b/tests/unit/test_prepare_locations.py
@@ -4,10 +4,7 @@ from datetime import date
 import warnings
 
 from pyspark.sql import SparkSession
-import pyspark.sql.functions as F
 from pyspark.sql.types import (
-    DoubleType,
-    IntegerType,
     StringType,
     StructField,
     StructType,
@@ -32,16 +29,6 @@ class PrepareLocationsTests(unittest.TestCase):
     TEST_PIR_FILE = "tests/test_data/domain=cqc/dataset=pir"
     TEST_ONS_FILE = "tests/test_data/domain=ons/dataset=postcodes"
     DESTINATION = "tests/test_data/domain=data_engineering/dataset=locations_prepared/version=1.0.0"
-
-    calculate_jobs_schema = StructType(
-        [
-            StructField("locationid", StringType(), False),
-            StructField("total_staff", IntegerType(), True),
-            StructField("worker_record_count", IntegerType(), True),
-            StructField("number_of_beds", IntegerType(), True),
-            StructField("job_count_unfiltered", DoubleType(), True),
-        ]
-    )
 
     def setUp(self):
         self.spark = SparkSession.builder.appName(
@@ -108,8 +95,8 @@ class PrepareLocationsTests(unittest.TestCase):
                 "services_offered",
                 "primary_service_type",
                 "people_directly_employed",
-                "job_count_unfiltered",
-                "job_count_unfiltered_source",
+                "total_staff",
+                "worker_record_count",
                 "region",
                 "postal_code",
                 "constituency",


### PR DESCRIPTION
# Description
In order to not break locations prepared, I've moved the calculate_jobcount function out of it and into locations prepared clean job - which we no longer need/use

# Developer checklist
- [X] Unit test
- [X] Linked to Trello ticket
- [X] Documentation up to date
