### PR TITLE
alter cron from running everyday per branch to only be the days where data might have changed

### DIFF
--- a/terraform/pipeline/glue.tf
+++ b/terraform/pipeline/glue.tf
@@ -513,7 +513,7 @@ module "cqc_crawler" {
   source                       = "../modules/glue-crawler"
   dataset_for_crawler          = "CQC"
   glue_role                    = aws_iam_role.sfc_glue_service_iam_role
-  schedule                     = "cron(00 07 * * ? *)"
+  schedule                     = "cron(00 07 01,08,15,23 * ? *)"
   workspace_glue_database_name = "${local.workspace_prefix}-${var.glue_database_name}"
 }
 


### PR DESCRIPTION
# Description
Full description and reasoning here: https://trello.com/c/zdqvzLEQ/307-change-the-number-of-job-executions-for-the-cqc-crawler-to-reduce-costs
Estimated cost savings are around $6-10 a month based there being ~155 crawler runs in February, and this would reduce that number down to more like 20-30 (or 1/7 of the number of runs, and thus the cost).

# How to test
Ensure it runs at the new designated times.

# Possible issues:
Currently the job runt times are quite long, so it could exceed 7 hours and the crawler might not capture the latest data. If this is the case, it would just need re-running, it's still a cost saving.

# Developer checklist
- [x] Linked to Trello ticket

