### PR TITLE
upgrade workers to 5, shown to work in AWS

### DIFF
--- a/terraform/pipeline/glue.tf
+++ b/terraform/pipeline/glue.tf
@@ -461,11 +461,14 @@ module "clean_cqc_location_data_job" {
 }
 
 module "merge_ind_cqc_data_job" {
-  source          = "../modules/glue-job"
-  script_name     = "merge_ind_cqc_data.py"
-  glue_role       = aws_iam_role.sfc_glue_service_iam_role
-  resource_bucket = module.pipeline_resources
-  datasets_bucket = module.datasets_bucket
+  source            = "../modules/glue-job"
+  script_name       = "merge_ind_cqc_data.py"
+  glue_role         = aws_iam_role.sfc_glue_service_iam_role
+  resource_bucket   = module.pipeline_resources
+  datasets_bucket   = module.datasets_bucket
+  glue_version      = "3.0"
+  worker_type       = "G.2X"
+  number_of_workers = 5
 
   job_parameters = {
     "--cleaned_cqc_location_source"     = "${module.datasets_bucket.bucket_uri}/domain=CQC/dataset=locations_api_cleaned/"


### PR DESCRIPTION
# Description
Noticed the merge ind cqc job was failing with a broadcast error, but increase the number of workers seemed to mitigate this. It's not a fix, as the underlying problem is not known, but does allow us to get past the step function issues.

# How to test

# Developer checklist
- [ ] Unit test
- [ ] Linked to Trello ticket
- [ ] Documentation up to date
