### PR TITLE
Add cleaned ascwds worker as source

### DIFF
--- a/jobs/estimate_ind_cqc_filled_posts_by_job_role.py
+++ b/jobs/estimate_ind_cqc_filled_posts_by_job_role.py
@@ -8,6 +8,7 @@ PartitionKeys = [Keys.year, Keys.month, Keys.day, Keys.import_date]
 
 def main(
     estimated_ind_cqc_filled_posts_source: str,
+    cleaned_ascwds_worker_source: str,
     estimated_ind_cqc_filled_posts_by_job_role_destination: str,
 ):
     """creates job role estimates
@@ -18,6 +19,9 @@ def main(
     """
     df_estimated_ind_cqc_filled_posts_data = utils.read_from_parquet(
         estimated_ind_cqc_filled_posts_source
+    )
+    df_cleaned_ascwds_worker_data = utils.read_from_parquet(
+        cleaned_ascwds_worker_source
     )
 
     utils.write_to_parquet(
@@ -34,11 +38,16 @@ if __name__ == "__main__":
 
     (
         estimated_ind_cqc_filled_posts_source,
+        cleaned_ascwds_worker_source,
         estimated_ind_cqc_filled_posts_by_job_role_destination,
     ) = utils.collect_arguments(
         (
             "--estimated_ind_cqc_filled_posts_source",
             "Source s3 directory for estimated ind cqc filled posts data",
+        ),
+        (
+            "--cleaned_ascwds_worker_source",
+            "Source s3 directory for parquet ASCWDS worker cleaned dataset",
         ),
         (
             "--estimated_ind_cqc_filled_posts_by_job_role_destination",
@@ -48,5 +57,6 @@ if __name__ == "__main__":
 
     main(
         estimated_ind_cqc_filled_posts_source,
+        cleaned_ascwds_worker_source,
         estimated_ind_cqc_filled_posts_by_job_role_destination,
     )

--- a/terraform/pipeline/glue.tf
+++ b/terraform/pipeline/glue.tf
@@ -410,7 +410,7 @@ module "estimate_ind_cqc_filled_posts_by_job_role_job" {
 
   job_parameters = {
     "--estimated_ind_cqc_filled_posts_source"                  = "${module.datasets_bucket.bucket_uri}/domain=ind_cqc_filled_posts/dataset=estimated_ind_cqc_filled_posts/"
-    "--cleaned_ascwds_worker_source"                        = "${module.datasets_bucket.bucket_uri}/domain=ASCWDS/dataset=worker_cleaned/"
+    "--cleaned_ascwds_worker_source"                           = "${module.datasets_bucket.bucket_uri}/domain=ASCWDS/dataset=worker_cleaned/"
     "--estimated_ind_cqc_filled_posts_by_job_role_destination" = "${module.datasets_bucket.bucket_uri}/domain=ind_cqc_filled_posts/dataset=estimated_ind_cqc_filled_posts_by_job_role/"
   }
 }

--- a/terraform/pipeline/glue.tf
+++ b/terraform/pipeline/glue.tf
@@ -410,6 +410,7 @@ module "estimate_ind_cqc_filled_posts_by_job_role_job" {
 
   job_parameters = {
     "--estimated_ind_cqc_filled_posts_source"                  = "${module.datasets_bucket.bucket_uri}/domain=ind_cqc_filled_posts/dataset=estimated_ind_cqc_filled_posts/"
+    "--cleaned_ascwds_worker_source"                        = "${module.datasets_bucket.bucket_uri}/domain=ASCWDS/dataset=worker_cleaned/"
     "--estimated_ind_cqc_filled_posts_by_job_role_destination" = "${module.datasets_bucket.bucket_uri}/domain=ind_cqc_filled_posts/dataset=estimated_ind_cqc_filled_posts_by_job_role/"
   }
 }

--- a/tests/unit/test_estimate_ind_cqc_filled_posts_by_job_role.py
+++ b/tests/unit/test_estimate_ind_cqc_filled_posts_by_job_role.py
@@ -1,5 +1,5 @@
 import unittest
-from unittest.mock import ANY, patch, Mock
+from unittest.mock import ANY, call, patch, Mock
 import jobs.estimate_ind_cqc_filled_posts_by_job_role as job
 from utils.column_names.ind_cqc_pipeline_columns import (
     PartitionKeys as Keys,
@@ -19,12 +19,15 @@ class MainTests(BaseSetup):
     def test_main_function(
         self, read_from_parquet_mock: Mock, write_to_parquet_mock: Mock
     ):
-        SOURCE = "some/source"
+        ESTIMATE_SOURCE = "some/source"
+        ASCWDS_WORKER_SOURCE = "some/other/source"
         OUTPUT_DIR = "some/destination"
 
-        job.main(SOURCE, OUTPUT_DIR)
+        job.main(ESTIMATE_SOURCE, ASCWDS_WORKER_SOURCE, OUTPUT_DIR)
 
-        read_from_parquet_mock.assert_called_once_with(SOURCE)
+        read_from_parquet_mock.assert_has_calls(
+            [call(ESTIMATE_SOURCE), call(ASCWDS_WORKER_SOURCE)]
+        )
         write_to_parquet_mock.assert_called_once_with(
             ANY, OUTPUT_DIR, "overwrite", PartitionKeys
         )


### PR DESCRIPTION
# Description
Pull in cleaned worker data into estimate by job role job

# How to test
[Testing in branch currently](https://eu-west-2.console.aws.amazon.com/gluestudio/home?region=eu-west-2#/job/jf-estimate_ind_cqc_filled_posts_by_job_role_job/run/jr_94a587e32500b324d794027d15e9fb2db04773caf088ac92e60cc870faf78fe0)

Trello ticket: https://trello.com/c/JgNxylHX/322-epic-10-add-cleaned-ascwds-workers-as-a-2nd-source-must

# Developer checklist
- [ ] Unit test
- [ ] Linked to Trello ticket
- [ ] Documentation up to date
