### PR TITLE
Set spark session broadcast timeout to about 30 mins

### DIFF
--- a/jobs/merge_ind_cqc_data.py
+++ b/jobs/merge_ind_cqc_data.py
@@ -77,6 +77,9 @@ def main(
     cleaned_ascwds_workplace_source: str,
     destination: str,
 ):
+    spark = utils.get_spark()
+    spark.sql("set spark.sql.broadcastTimeout = 2000")
+
     cqc_location_df = utils.read_from_parquet(
         cleaned_cqc_location_source,
         selected_columns=cleaned_cqc_locations_columns_to_import,


### PR DESCRIPTION
# Description
This fix adjusts the spark session to allow a longer period for the broadcast join before assuming it has failed.
https://trello.com/c/HNWFZHec/321-tech-debt-get-merge-ind-cqc-data-job-to-complete

# How to test
Unit tests passing
Run successfully in branch - returns correct number of rows

# Developer checklist
- [x] Unit test
- [x] Linked to Trello ticket

