### PR TITLE
implement fix for single parameter variant of collect_arguments function

### DIFF
--- a/jobs/bulk_download_cqc_locations.py
+++ b/jobs/bulk_download_cqc_locations.py
@@ -37,7 +37,7 @@ def main(destination):
 
 
 if __name__ == "__main__":
-    destination_prefix = utils.collect_arguments(
+    destination_prefix, *_ = utils.collect_arguments(
         (
             "--destination_prefix",
             "Source s3 directory for parquet CQC locations dataset",

--- a/jobs/bulk_download_cqc_locations_new.py
+++ b/jobs/bulk_download_cqc_locations_new.py
@@ -37,7 +37,7 @@ def main(destination):
 
 
 if __name__ == "__main__":
-    destination_prefix = utils.collect_arguments(
+    destination_prefix, *_ = utils.collect_arguments(
         (
             "--destination_prefix",
             "Source s3 directory for parquet CQC locations dataset",

--- a/jobs/bulk_download_cqc_providers.py
+++ b/jobs/bulk_download_cqc_providers.py
@@ -37,7 +37,7 @@ def main(destination):
 
 
 if __name__ == "__main__":
-    destination_prefix = utils.collect_arguments(
+    destination_prefix, *_ = utils.collect_arguments(
         (
             "--destination_prefix",
             "Source s3 directory for parquet CQC providers dataset",

--- a/jobs/bulk_download_cqc_providers_new.py
+++ b/jobs/bulk_download_cqc_providers_new.py
@@ -37,7 +37,7 @@ def main(destination):
 
 
 if __name__ == "__main__":
-    destination_prefix = utils.collect_arguments(
+    destination_prefix, *_ = utils.collect_arguments(
         (
             "--destination_prefix",
             "Source s3 directory for parquet CQC providers dataset",

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -251,12 +251,12 @@ def collect_arguments(*args):
     Args:
         *args: This is intended to be used to contain parsed arguments when run at command line, and is generally to contain keys and values as a tuple.
 
-    Yields:
+    Returns:
         Generator[Any, None, None]: A generator used for parsing parsed parameters.
 
     Examples:
     >>> single_parameter, *_ = collect_arguments(("--single_parameter","This is how you read a single parameter"))
-    >>> (parameter_1, parameter_2 = collect_arguments(("--parameter_1","parameter_1 help text"),("--parameter_2","parameter_2 help text for non-required parameter", False))
+    >>> (parameter_1, parameter_2) = collect_arguments(("--parameter_1","parameter_1 help text"),("--parameter_2","parameter_2 help text for non-required parameter", False))
     """
     parser = argparse.ArgumentParser()
     for arg in args:

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -244,6 +244,20 @@ def get_latest_partition(df, partition_keys=("run_year", "run_month", "run_day")
 
 
 def collect_arguments(*args):
+    """
+    Creates a new parser, and for each arg in the provided args parameter returns a Namespace object, and uses vars() function to convert the namespace to a dictionary,
+    where the keys are constructed from the symbolic names, and the values from the information about the object that each name references.
+
+    Args:
+        *args: This is intended to be used to contain parsed arguments when run at command line, and is generally to contain keys and values as a tuple.
+
+    Yields:
+        Generator[Any, None, None]: A generator used for parsing parsed parameters.
+
+    Examples:
+    >>> single_parameter, *_ = collect_arguments(("--single_parameter","This is how you read a single parameter"))
+    >>> (parameter_1, parameter_2 = collect_arguments(("--parameter_1","parameter_1 help text"),("--parameter_2","parameter_2 help text for non-required parameter", False))
+    """
     parser = argparse.ArgumentParser()
     for arg in args:
         parser.add_argument(


### PR DESCRIPTION
# Description
https://skillsforcare.atlassian.net/wiki/spaces/DE/pages/1044938754/Collecting+single+arguments+variant+bug+fix - Decision log captures the problem cause and fix for 1 argument.

Old job run examples on 10 pages:
https://eu-west-2.console.aws.amazon.com/gluestudio/home?region=eu-west-2#/editor/job/fix-collect-argument-bulk-jobs-bulk_download_cqc_providers_job/runs
https://eu-west-2.console.aws.amazon.com/gluestudio/home?region=eu-west-2#/editor/job/fix-collect-argument-bulk-jobs-bulk_download_cqc_locations_job/runs

# How to test
I abstracted the functionality in question into a script called `arg_parser_example.py` which contained the following:
`import argparse

def collect_arguments(*args):
    parser = argparse.ArgumentParser()
    for arg in args:
        parser.add_argument(
            arg[0],
            help=arg[1],
            required=True,
        )

    parsed_args, _ = parser.parse_known_args()

    return (vars(parsed_args)[arg[0][2:]] for arg in args)


destination_prefix, *_ = collect_arguments(
    (
        "--destination_prefix",
        "Source s3 directory for parquet CQC providers dataset",
        False,
    ),
)

print(destination_prefix)
`

And then ran it with:
`python3 arg_parser_example.py --destination_prefix "s3://sfc-create-new-cqc-api-location-sc-datasets"`

You should see the correct destination_prefix is now printed

# Developer checklist
- [x] Unit test
- [x] Linked to Trello ticket
- [x] Documentation up to date
