### PR TITLE
Update new bulk downloads to save as v2

### DIFF
--- a/jobs/bulk_download_cqc_locations_new.py
+++ b/jobs/bulk_download_cqc_locations_new.py
@@ -50,6 +50,7 @@ if __name__ == "__main__":
         domain="CQC",
         dataset="locations_api_new",
         date=todays_date,
+        version="2.0.0",
     )
 
     print(destination)

--- a/jobs/bulk_download_cqc_providers_new.py
+++ b/jobs/bulk_download_cqc_providers_new.py
@@ -50,6 +50,7 @@ if __name__ == "__main__":
         domain="CQC",
         dataset="providers_api_new",
         date=todays_date,
+        version="2.0.0",
     )
 
     main(destination)

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -368,8 +368,8 @@ class UtilsTests(unittest.TestCase):
             "s3://sfc-main-datasets",
             "test_domain",
             "test_dateset",
-            version_number,
             dec_first_21,
+            version_number,
         )
         self.assertEqual(
             dir_path,

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -359,7 +359,26 @@ class UtilsTests(unittest.TestCase):
 
         self.assertEqual(delimiter, "|")
 
-    def test_generate_s3_datasets_dir_date_path(self):
+    def test_generate_s3_datasets_dir_date_path_changes_version_when_version_number_is_passed(
+        self,
+    ):
+        dec_first_21 = datetime(2021, 12, 1)
+        version_number = "2.0.0"
+        dir_path = utils.generate_s3_datasets_dir_date_path(
+            "s3://sfc-main-datasets",
+            "test_domain",
+            "test_dateset",
+            version_number,
+            dec_first_21,
+        )
+        self.assertEqual(
+            dir_path,
+            "s3://sfc-main-datasets/domain=test_domain/dataset=test_dateset/version=2.0.0/year=2021/month=12/day=01/import_date=20211201/",
+        )
+
+    def test_generate_s3_datasets_dir_date_path_uses_version_one_when_no_version_number_is_passed(
+        self,
+    ):
         dec_first_21 = datetime(2021, 12, 1)
         dir_path = utils.generate_s3_datasets_dir_date_path(
             "s3://sfc-main-datasets", "test_domain", "test_dateset", dec_first_21

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -81,12 +81,18 @@ def identify_csv_delimiter(sample_csv):
     return dialect.delimiter
 
 
-def generate_s3_datasets_dir_date_path(destination_prefix, domain, dataset, date):
+def generate_s3_datasets_dir_date_path(
+    destination_prefix,
+    domain,
+    dataset,
+    date,
+    version="1.0.0",
+):
     year = f"{date.year}"
     month = f"{date.month:02d}"
     day = f"{date.day:02d}"
     import_date = year + month + day
-    output_dir = f"{destination_prefix}/domain={domain}/dataset={dataset}/version=1.0.0/year={year}/month={month}/day={day}/import_date={import_date}/"
+    output_dir = f"{destination_prefix}/domain={domain}/dataset={dataset}/version={version}/year={year}/month={month}/day={day}/import_date={import_date}/"
     print(f"Generated output s3 dir: {output_dir}")
     return output_dir
 


### PR DESCRIPTION
# Description
Updated function to accept a version parameter which currently defaults to "1.0.0"
Added version 2 parameter to new bulk download jobs.
Updated unit tests to cover behaviour
https://trello.com/c/c0Dwa932/342-cqc-api-update-new-bulk-download-jobs-to-save-to-v2-folder-must

# How to test
Unit test passing
Currently running provider job in branch to test

# Developer checklist
- [x] Unit test
- [x] Linked to Trello ticket
