### PR TITLE
added prefix OLD_ to cqc location schema where missing

### DIFF
--- a/jobs/ingest_cqc_care_directory.py
+++ b/jobs/ingest_cqc_care_directory.py
@@ -139,7 +139,7 @@ def convert_to_cqc_location_api_format(df):
     location_df = location_df.join(specialisms_df, LocationApiCols.location_id)
 
     output_location_df = spark.createDataFrame(
-        data=[], schema=cqc_location_schema.LOCATION_SCHEMA
+        data=[], schema=cqc_location_schema.OLD_LOCATION_SCHEMA
     )
     output_location_df = output_location_df.unionByName(
         location_df, allowMissingColumns=True

--- a/schemas/cqc_location_schema.py
+++ b/schemas/cqc_location_schema.py
@@ -532,7 +532,7 @@ LOCATION_SCHEMA_NEW = StructType(
     ]
 )
 
-LOCATION_SCHEMA = StructType(
+OLD_LOCATION_SCHEMA = StructType(
     fields=[
         StructField(OldColNames.location_id, StringType(), True),
         StructField(OldColNames.provider_id, StringType(), True),

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -71,7 +71,7 @@ from utils.column_names.ind_cqc_pipeline_columns import (
     IndCqcColumns as IndCQC,
 )
 
-from schemas.cqc_location_schema import LOCATION_SCHEMA
+from schemas.cqc_location_schema import OLD_LOCATION_SCHEMA
 
 
 from utils.column_names.ind_cqc_pipeline_columns import (
@@ -458,7 +458,7 @@ class CapacityTrackerDomCareSchema:
 class CQCLocationsSchema:
     full_schema = StructType(
         [
-            *LOCATION_SCHEMA,
+            *OLD_LOCATION_SCHEMA,
             StructField(Keys.import_date, StringType(), True),
         ]
     )


### PR DESCRIPTION
# Description
Ran the main-bulk_download_cqc_locations_job but received the error below
ImportError: cannot import name 'OLD_LOCATION_SCHEMA' from 'schemas.cqc_location_schema'
[Glue run](https://eu-west-2.console.aws.amazon.com/gluestudio/home?region=eu-west-2#/editor/job/main-bulk_download_cqc_locations_job/runs)

some references had been changed to 'OLD_LOCATION_SCHEMA' whilst others were still 'LOCATION_SCHEMA'
