### PR TITLE
Amended duplication removal function to only look at workplaces with a locationid

### DIFF
--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -354,17 +354,27 @@ class ASCWDSWorkplaceData:
         (
             "loc-2",
             "2020-01-01",
-            "1",
+            "2",
         ),
         (
             "loc-3",
             "2020-01-01",
-            "2",
+            "3",
         ),
         (
             "loc-4",
             "2021-01-01",
-            "2",
+            "4",
+        ),
+        (
+            None,
+            "2021-01-01",
+            "5",
+        ),
+        (
+            None,
+            "2021-01-01",
+            "6",
         ),
     ]
 
@@ -373,12 +383,12 @@ class ASCWDSWorkplaceData:
         (
             "loc-3",
             "2020-01-01",
-            "10",
+            "7",
         ),
         (
             "loc-4",
             "2021-01-01",
-            "10",
+            "8",
         ),
     ]
 
@@ -387,12 +397,12 @@ class ASCWDSWorkplaceData:
         (
             "loc-3",
             "2021-01-01",
-            "10",
+            "3",
         ),
         (
             "loc-4",
             "2022-01-01",
-            "10",
+            "4",
         ),
     ]
 
@@ -405,7 +415,17 @@ class ASCWDSWorkplaceData:
         (
             "loc-2",
             "2020-01-01",
-            "1",
+            "2",
+        ),
+        (
+            None,
+            "2021-01-01",
+            "5",
+        ),
+        (
+            None,
+            "2021-01-01",
+            "6",
         ),
     ]
 
@@ -2590,7 +2610,7 @@ class ModelInterpolation:
 @dataclass
 class ValidateMergedIndCqcData:
     # fmt: off
-    cqc_locations_rows =  [
+    cqc_locations_rows = [
         (date(2024, 1, 1), "1-000000001", "Independent", "Y", 10,),
         (date(2024, 1, 1), "1-000000002", "Independent", "N", None,),
         (date(2024, 1, 1), "1-000000003", "Independent", "N", None,),
@@ -2601,8 +2621,8 @@ class ValidateMergedIndCqcData:
         (date(2024, 3, 1), "1-000000002", "Independent", "N", None,),
         (date(2024, 3, 1), "1-000000003", "Independent", "N", None,),
     ]
-   
-    merged_ind_cqc_rows =[
+
+    merged_ind_cqc_rows = [
         ("1-000000001", date(2024, 1, 1), date(2024, 1, 1), "Independent", "Y", 10, "1", 1, 10, date(2024, 1, 1)),
         ("1-000000002", date(2024, 1, 1), date(2024, 1, 1), "Independent", "N", None, None, None, 20, date(2024, 1, 1)),
         ("1-000000003", date(2024, 1, 1), date(2024, 1, 1), "Independent", "N", None, "3", 2, None, date(2024, 1, 1)),
@@ -2614,7 +2634,7 @@ class ValidateMergedIndCqcData:
         ("1-000000003", date(2024, 3, 1), date(2024, 3, 1), "Independent", "N", None, "4", 6, None, date(2024, 2, 1)),
     ]
 
-    merged_ind_cqc_extra_row_rows =[
+    merged_ind_cqc_extra_row_rows = [
         ("1-000000001", date(2024, 1, 1), date(2024, 1, 1), "Independent", "Y", 10, "1", 1, 10, date(2024, 1, 1)),
         ("1-000000002", date(2024, 1, 1), date(2024, 1, 1), "Independent", "N", None, None, None, 20, date(2024, 1, 1)),
         ("1-000000003", date(2024, 1, 1), date(2024, 1, 1), "Independent", "N", None, "3", 2, None, date(2024, 1, 1)),
@@ -2627,7 +2647,7 @@ class ValidateMergedIndCqcData:
         ("1-000000004", date(2024, 3, 1), date(2024, 3, 1), "Independent", "N", None, "4", 6, None, date(2024, 2, 1)),
     ]
 
-    merged_ind_cqc_missing_row_rows =[
+    merged_ind_cqc_missing_row_rows = [
         ("1-000000001", date(2024, 1, 1), date(2024, 1, 1), "Independent", "Y", 10, "1", 1, 10, date(2024, 1, 1)),
         ("1-000000002", date(2024, 1, 1), date(2024, 1, 1), "Independent", "N", None, None, None, 20, date(2024, 1, 1)),
         ("1-000000003", date(2024, 1, 1), date(2024, 1, 1), "Independent", "N", None, "3", 2, None, date(2024, 1, 1)),
@@ -2638,7 +2658,7 @@ class ValidateMergedIndCqcData:
         ("1-000000002", date(2024, 3, 1), date(2024, 3, 1), "Independent", "N", None, None, None, 4, date(2024, 2, 1)),
     ]
 
-    merged_ind_cqc_with_cqc_sector_null_rows =[
+    merged_ind_cqc_with_cqc_sector_null_rows = [
         ("1-000000001", date(2024, 1, 1), date(2024, 1, 1), "Independent", "Y", 10, "1", 1, 10, date(2024, 1, 1)),
         ("1-000000002", date(2024, 1, 1), date(2024, 1, 1), "Independent", "N", None, None, None, 20, date(2024, 1, 1)),
         ("1-000000003", date(2024, 1, 1), date(2024, 1, 1), "Independent", "N", None, "3", 2, None, date(2024, 1, 1)),
@@ -2650,7 +2670,7 @@ class ValidateMergedIndCqcData:
         ("1-000000003", date(2024, 3, 1), date(2024, 3, 1), None, "N", None, "4", 6, None, date(2024, 2, 1)),
     ]
 
-    merged_ind_cqc_with_duplicate_data_rows =[
+    merged_ind_cqc_with_duplicate_data_rows = [
         ("1-000000001", date(2024, 1, 1), date(2024, 1, 1), "Independent", "Y", 10, "1", 1, 10, date(2024, 1, 1)),
         ("1-000000002", date(2024, 1, 1), date(2024, 1, 1), "Independent", "N", None, None, None, 20, date(2024, 1, 1)),
         ("1-000000003", date(2024, 1, 1), date(2024, 1, 1), "Independent", "N", None, "3", 2, None, date(2024, 1, 1)),

--- a/tests/unit/test_clean_ascwds_workplace_data.py
+++ b/tests/unit/test_clean_ascwds_workplace_data.py
@@ -261,7 +261,10 @@ class RemoveLocationsWithDuplicatesTests(IngestASCWDSWorkerDatasetTests):
         )
 
     def test_does_not_remove_rows_if_no_duplicates(self):
-        self.assertEqual(self.returned_df.collect(), self.test_location_df.collect())
+        self.assertEqual(
+            self.returned_df.sort(AWP.organisation_id).collect(),
+            self.test_location_df.sort(AWP.organisation_id).collect(),
+        )
 
     def test_removes_duplicate_location_id_with_same_import_date(self):
         filtered_df = job.remove_workplaces_with_duplicate_location_ids(
@@ -270,20 +273,26 @@ class RemoveLocationsWithDuplicatesTests(IngestASCWDSWorkerDatasetTests):
         expected_df = self.spark.createDataFrame(
             Data.expected_filtered_location_rows, Schemas.location_schema
         )
-        self.assertEqual(filtered_df.collect(), expected_df.collect())
+        self.assertEqual(
+            filtered_df.sort(AWP.organisation_id).collect(),
+            expected_df.sort(AWP.organisation_id).collect(),
+        )
 
     def test_does_not_remove_duplicate_location_id_with_different_import_dates(self):
         locations_with_different_import_dates_df = self.spark.createDataFrame(
             Data.location_rows_with_different_import_dates,
             Schemas.location_schema,
-        ).orderBy(AWP.location_id)
+        )
 
         filtered_df = job.remove_workplaces_with_duplicate_location_ids(
             locations_with_different_import_dates_df
-        ).orderBy(AWP.location_id)
+        )
 
         self.assertEqual(
-            filtered_df.collect(), locations_with_different_import_dates_df.collect()
+            filtered_df.sort(AWP.organisation_id).collect(),
+            locations_with_different_import_dates_df.sort(
+                AWP.organisation_id
+            ).collect(),
         )
 
 

--- a/tests/unit/test_clean_ascwds_workplace_data.py
+++ b/tests/unit/test_clean_ascwds_workplace_data.py
@@ -231,7 +231,7 @@ class PurgeOutdatedWorkplacesColumn(AddPurgeOutdatedWorkplacesColumnTests):
         self.assertEqual(purge_data_list, expected_list)
 
 
-class RemoveLocationsWithDuplicatesTests(IngestASCWDSWorkerDatasetTests):
+class RemoveWorkplacesWithDuplicateLocationIdsTests(IngestASCWDSWorkerDatasetTests):
     def setUp(self) -> None:
         super().setUp()
 

--- a/tests/unit/test_clean_ascwds_workplace_data.py
+++ b/tests/unit/test_clean_ascwds_workplace_data.py
@@ -235,12 +235,12 @@ class RemoveLocationsWithDuplicatesTests(IngestASCWDSWorkerDatasetTests):
     def setUp(self) -> None:
         super().setUp()
 
-        self.input_df = self.spark.createDataFrame(
+        self.test_location_df = self.spark.createDataFrame(
             Data.small_location_rows, Schemas.location_schema
         )
 
-        self.workplaces_with_duplicate_location_ids_removed_df = (
-            job.remove_workplaces_with_duplicate_location_ids(self.input_df)
+        self.returned_df = job.remove_workplaces_with_duplicate_location_ids(
+            self.input_df
         )
 
         self.test_duplicate_loc_df = self.spark.createDataFrame(
@@ -248,13 +248,11 @@ class RemoveLocationsWithDuplicatesTests(IngestASCWDSWorkerDatasetTests):
         )
 
     def test_returns_a_dataframe(self):
-        self.assertEqual(
-            type(self.workplaces_with_duplicate_location_ids_removed_df), DataFrame
-        )
+        self.assertEqual(type(self.returned_df), DataFrame)
 
     def test_returns_the_correct_columns(self):
         self.assertCountEqual(
-            self.workplaces_with_duplicate_location_ids_removed_df.columns,
+            self.returned_df.columns,
             [
                 AWP.location_id,
                 AWP.import_date,
@@ -263,35 +261,39 @@ class RemoveLocationsWithDuplicatesTests(IngestASCWDSWorkerDatasetTests):
         )
 
     def test_does_not_remove_rows_if_no_duplicates(self):
+        expected_df = self.test_location_df
         self.assertEqual(
-            self.workplaces_with_duplicate_location_ids_removed_df.sort(
-                AWP.organisation_id
-            ).collect(),
-            self.input_df.sort(AWP.organisation_id).collect(),
+            self.returned_df.sort(AWP.organisation_id).collect(),
+            expected_df.sort(AWP.organisation_id).collect(),
         )
 
     def test_removes_duplicate_location_id_with_same_import_date(self):
-        output_df = job.remove_workplaces_with_duplicate_location_ids(
+        returned_df = job.remove_workplaces_with_duplicate_location_ids(
             self.test_duplicate_loc_df
         )
         expected_df = self.spark.createDataFrame(
             Data.expected_filtered_location_rows, Schemas.location_schema
         )
         self.assertEqual(
-            output_df.sort(AWP.organisation_id).collect(),
+            returned_df.sort(AWP.organisation_id).collect(),
             expected_df.sort(AWP.organisation_id).collect(),
         )
 
     def test_does_not_remove_duplicate_location_id_with_different_import_dates(self):
-        input_df = self.spark.createDataFrame(
-            Data.location_rows_with_different_import_dates,
-            Schemas.location_schema,
+        duplicate_location_id_with_different_import_dates_df = (
+            self.spark.createDataFrame(
+                Data.location_rows_with_different_import_dates,
+                Schemas.location_schema,
+            )
         )
-        output_df = job.remove_workplaces_with_duplicate_location_ids(input_df)
+        returned_df = job.remove_workplaces_with_duplicate_location_ids(
+            duplicate_location_id_with_different_import_dates_df
+        )
+        expected_df = duplicate_location_id_with_different_import_dates_df
 
         self.assertEqual(
-            output_df.sort(AWP.organisation_id).collect(),
-            input_df.sort(AWP.organisation_id).collect(),
+            returned_df.sort(AWP.organisation_id).collect(),
+            expected_df.sort(AWP.organisation_id).collect(),
         )
 
 

--- a/tests/unit/test_clean_ascwds_workplace_data.py
+++ b/tests/unit/test_clean_ascwds_workplace_data.py
@@ -240,7 +240,7 @@ class RemoveLocationsWithDuplicatesTests(IngestASCWDSWorkerDatasetTests):
         )
 
         self.returned_df = job.remove_workplaces_with_duplicate_location_ids(
-            self.input_df
+            self.test_location_df
         )
 
         self.test_duplicate_loc_df = self.spark.createDataFrame(


### PR DESCRIPTION
# Description
The function remove_locations_with_duplicates simply removes all workplaces in ASCWDS who have a duplicate ID.
That works fine for the CQC pipeline, but it doesn't work for other work as it removes every workplace in ASCWDS which doesn't have an ID (treats all None values as duplicates).

The amendment
- separates the data into 2 dfs - those with and those without a location id
- duplication step only applied to those with a location id
- appends that data back with those without a location id

Amended tests accordingly (added two blank location id workplaces and checked they were unaffected)

[successful branch run](https://eu-west-2.console.aws.amazon.com/states/home?region=eu-west-2#/v2/executions/details/arn:aws:states:eu-west-2:344210435447:execution:non-cqc-ascwds-fix-Ind-CQC-Filled-Post-Estimates-Pipeline:1440e732-8c3c-466e-b4e6-b5ec8fcd6a19)

# Developer checklist
- [X] Unit test
