### PR TITLE
Reconciliation prepare cqc data

### DIFF
--- a/jobs/clean_ons_data.py
+++ b/jobs/clean_ons_data.py
@@ -41,11 +41,9 @@ def main(ons_source: str, cleaned_ons_destination: str):
 
 
 def prepare_current_ons_data(df: DataFrame) -> DataFrame:
-    max_import_date = df.agg(F.max(ONSClean.contemporary_ons_import_date)).collect()[0][
-        0
-    ]
-    df = df.filter(F.col(ONSClean.contemporary_ons_import_date) == max_import_date)
-
+    df = utils.filter_df_to_maximum_value_in_column(
+        df, ONSClean.contemporary_ons_import_date
+    )
     current_ons_df = df.select(
         df[ONSClean.postcode],
         df[ONSClean.contemporary_ons_import_date].alias(

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -1422,6 +1422,22 @@ class CQCLocationsData:
 
 
 @dataclass
+class UtilsData:
+    filter_to_max_value_rows = [
+        ("1", date(2024, 1, 1), "20220101"),
+        ("2", date(2024, 1, 1), "20230101"),
+        ("3", date(2023, 1, 1), "20240101"),
+    ]
+    expected_filter_to_max_date_rows = [
+        ("1", date(2024, 1, 1), "20220101"),
+        ("2", date(2024, 1, 1), "20230101"),
+    ]
+    expected_filter_to_max_string_rows = [
+        ("3", date(2023, 1, 1), "20240101"),
+    ]
+
+
+@dataclass
 class CleaningUtilsData:
     worker_rows = [
         ("1", "1", "100"),

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -1812,15 +1812,35 @@ class ReconciliationData:
         ("20240401", "1-003", "Registered", None),
         ("20240401", "1-004", "Registered", None),
         ("20240401", "1-902", "Deregistered", "2024-01-01"),
-        ("20240401", "1-912", "Deregistered", "2024-01-01"),
-        ("20240401", "1-922", "Deregistered", "2024-01-01"),
         ("20240401", "1-903", "Deregistered", "2024-03-01"),
         ("20240401", "1-904", "Deregistered", "2024-03-01"),
+        ("20240401", "1-912", "Deregistered", "2024-01-01"),
         ("20240401", "1-913", "Deregistered", "2024-03-01"),
+        ("20240401", "1-922", "Deregistered", "2024-01-01"),
         ("20240401", "1-923", "Deregistered", "2024-03-01"),
         ("20240401", "1-995", "Deregistered", "2024-04-01"),
     ]
     # fmt: on
+
+    expected_prepared_most_recent_cqc_location_rows = [
+        ("1-001", "Registered", None, date(2024, 4, 1)),
+        ("1-002", "Registered", None, date(2024, 4, 1)),
+        ("1-003", "Registered", None, date(2024, 4, 1)),
+        ("1-004", "Registered", None, date(2024, 4, 1)),
+        ("1-902", "Deregistered", date(2024, 1, 1), date(2024, 4, 1)),
+        ("1-903", "Deregistered", date(2024, 3, 1), date(2024, 4, 1)),
+        ("1-904", "Deregistered", date(2024, 3, 1), date(2024, 4, 1)),
+        ("1-912", "Deregistered", date(2024, 1, 1), date(2024, 4, 1)),
+        ("1-913", "Deregistered", date(2024, 3, 1), date(2024, 4, 1)),
+        ("1-922", "Deregistered", date(2024, 1, 1), date(2024, 4, 1)),
+        ("1-923", "Deregistered", date(2024, 3, 1), date(2024, 4, 1)),
+        ("1-995", "Deregistered", date(2024, 4, 1), date(2024, 4, 1)),
+    ]
+
+    dates_to_use_rows = [
+        ("1-001", date(2024, 3, 28)),
+        ("1-002", date(2023, 1, 1)),
+    ]
 
 
 @dataclass

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -926,10 +926,26 @@ class ReconciliationSchema:
     )
     input_cqc_location_api_schema = StructType(
         [
-            StructField(CQCLClean.import_date, StringType(), True),
-            StructField(CQCLClean.location_id, StringType(), True),
-            StructField(CQCLClean.registration_status, StringType(), True),
-            StructField(CQCLClean.deregistration_date, StringType(), True),
+            StructField(Keys.import_date, StringType(), True),
+            StructField(CQCL.location_id, StringType(), True),
+            StructField(CQCL.registration_status, StringType(), True),
+            StructField(CQCL.deregistration_date, StringType(), True),
+        ]
+    )
+
+    expected_prepared_most_recent_cqc_location_schema = StructType(
+        [
+            StructField(CQCL.location_id, StringType(), True),
+            StructField(CQCL.registration_status, StringType(), True),
+            StructField(CQCL.deregistration_date, DateType(), True),
+            StructField(CQCLClean.cqc_location_import_date, DateType(), True),
+        ]
+    )
+
+    dates_to_use_schema = StructType(
+        [
+            StructField(CQCL.location_id, StringType(), True),
+            StructField(CQCLClean.cqc_location_import_date, DateType(), True),
         ]
     )
 

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -587,6 +587,17 @@ class CQCLocationsSchema:
 
 
 @dataclass
+class UtilsSchema:
+    filter_to_max_value_schema = StructType(
+        [
+            StructField("id", StringType(), True),
+            StructField("date_type_column", DateType(), True),
+            StructField("import_date_style_col", StringType(), True),
+        ]
+    )
+
+
+@dataclass
 class CleaningUtilsSchemas:
     worker_schema = StructType(
         [

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -3,10 +3,8 @@ import re
 import csv
 import argparse
 
-from pyspark.sql import DataFrame, Column, Window, SparkSession
-import pyspark.sql.functions as F
+from pyspark.sql import DataFrame, Column, Window, SparkSession, functions as F
 from pyspark.sql.utils import AnalysisException
-import pyspark.sql
 from typing import List
 
 import boto3
@@ -103,7 +101,7 @@ def generate_s3_datasets_dir_date_path(
 
 def read_from_parquet(
     data_source: str, selected_columns: List[str] = None
-) -> pyspark.sql.DataFrame:
+) -> DataFrame:
     """
     Reads data from a parquet file and returns a DataFrame with all/selected columns.
 
@@ -205,8 +203,8 @@ def format_import_date(df, fieldname="import_date"):
 
 
 def create_unix_timestamp_variable_from_date_column(
-    df: pyspark.sql.DataFrame, date_col: str, date_format: str, new_col_name: str
-) -> pyspark.sql.DataFrame:
+    df: DataFrame, date_col: str, date_format: str, new_col_name: str
+) -> DataFrame:
     return df.withColumn(
         new_col_name, F.unix_timestamp(F.col(date_col), format=date_format)
     )
@@ -318,3 +316,11 @@ def latest_datefield_for_grouping(
 
 def normalise_column_values(df: DataFrame, col_name: str):
     return df.withColumn(col_name, F.upper(F.regexp_replace(F.col(col_name), " ", "")))
+
+
+def filter_df_to_maximum_value_in_column(
+    df: DataFrame, column_to_filter_on: str
+) -> DataFrame:
+    max_value = df.agg(F.max(column_to_filter_on)).collect()[0][0]
+
+    return df.filter(F.col(column_to_filter_on) == max_value)


### PR DESCRIPTION
# Description
Reconciliation - preparing the CQC data ready for merging with ASCWDS

We need the most recent file and needs registered and deregistered locations so we can't use the 'cleaned' version (registered only)

We also need to auto define dates so that and data in the 'current' month is excluded and any data older than the previous month is also excluded from single/sub accounts

Also created a utils function to filter to the max value in a column - added to ONS script and also removed a test file generator which created an actual file

# Developer checklist
- [X] Unit test
- [X] Linked to Trello ticket
- [X] Documentation up to date
