### PR TITLE
ONS moved standard join into main script

### DIFF
--- a/jobs/clean_ons_data.py
+++ b/jobs/clean_ons_data.py
@@ -1,7 +1,5 @@
 import sys
-
 from pyspark.sql import DataFrame
-import pyspark.sql.functions as F
 
 from utils import utils
 import utils.cleaning_utils as cUtils
@@ -28,8 +26,8 @@ def main(ons_source: str, cleaned_ons_destination: str):
 
     refactored_current_ons_df = prepare_current_ons_data(contemporary_ons_df)
 
-    contemporary_with_current_ons_df = join_current_ons_df_into_contemporary_df(
-        refactored_contemporary_ons_df, refactored_current_ons_df
+    contemporary_with_current_ons_df = refactored_contemporary_ons_df.join(
+        refactored_current_ons_df, ONSClean.postcode, "left"
     )
 
     utils.write_to_parquet(
@@ -102,12 +100,6 @@ def prepare_contemporary_ons_data(df: DataFrame) -> DataFrame:
         df[Keys.import_date],
     )
     return df
-
-
-def join_current_ons_df_into_contemporary_df(
-    contemporary_ons_df: DataFrame, current_ons_df: DataFrame
-) -> DataFrame:
-    return contemporary_ons_df.join(current_ons_df, ONSClean.postcode, "left")
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_clean_ons_data.py
+++ b/tests/unit/test_clean_ons_data.py
@@ -1,5 +1,5 @@
 import unittest
-from unittest.mock import ANY, patch
+from unittest.mock import ANY, Mock, patch
 from pyspark.sql.dataframe import DataFrame
 from datetime import date
 
@@ -41,7 +41,7 @@ class MainTests(CleanONSDatasetTests):
 
     @patch("utils.utils.write_to_parquet")
     @patch("utils.utils.read_from_parquet")
-    def test_main(self, read_from_parquet_patch, write_to_parquet_patch):
+    def test_main(self, read_from_parquet_patch: Mock, write_to_parquet_patch: Mock):
         read_from_parquet_patch.return_value = self.test_ons_parquet
         job.main(self.TEST_SOURCE, self.TEST_DESTINATION)
         write_to_parquet_patch.assert_called_once_with(


### PR DESCRIPTION
# Description
The left join was in a function of it's own and untested - as it's just a left join I've moved it into the main script and deleted the function

[successful branch run](https://eu-west-2.console.aws.amazon.com/states/home?region=eu-west-2#/v2/executions/details/arn:aws:states:eu-west-2:344210435447:execution:add-test-for-join-current-ons-Ind-CQC-Filled-Post-Estimates-Pipeline:17ca633c-8ce2-4fc2-ae28-75795679af10) - ONS data looks correct in Athena