### PR TITLE
Set up job to flatten cqc ratings

### DIFF
--- a/jobs/flatten_cqc_ratings.py
+++ b/jobs/flatten_cqc_ratings.py
@@ -2,17 +2,15 @@ import sys
 
 from utils import utils
 
+
 def main(cqc_location_source: str, cqc_ratings_destination: str):
     cqc_location_df = utils.read_from_parquet(cqc_location_source)
-
-
 
     utils.write_to_parquet(
         cqc_location_df,
         cqc_ratings_destination,
         mode="overwrite",
     )
-
 
 
 if __name__ == "__main__":

--- a/jobs/flatten_cqc_ratings.py
+++ b/jobs/flatten_cqc_ratings.py
@@ -1,0 +1,34 @@
+import sys
+
+from utils import utils
+
+def main(cqc_location_source: str, cqc_ratings_destination: str):
+    cqc_location_df = utils.read_from_parquet(cqc_location_source)
+
+
+
+    utils.write_to_parquet(
+        cqc_location_df,
+        cqc_ratings_destination,
+        mode="overwrite",
+    )
+
+
+
+if __name__ == "__main__":
+    print("Spark job 'flatten_cqc_ratings' starting...")
+    print(f"Job parameters: {sys.argv}")
+
+    source, destination = utils.collect_arguments(
+        (
+            "--cqc_location_source",
+            "Source s3 directory for parquet CQC locations dataset",
+        ),
+        (
+            "--cqc_ratings_destination",
+            "Destination s3 directory for cleaned parquet CQC ratings dataset",
+        ),
+    )
+    main(source, destination)
+
+    print("Spark job 'flatten_cqc_ratings' complete")

--- a/jobs/flatten_cqc_ratings.py
+++ b/jobs/flatten_cqc_ratings.py
@@ -3,8 +3,16 @@ import sys
 from utils import utils
 
 
-def main(cqc_location_source: str, cqc_ratings_destination: str):
+def main(
+    cqc_location_source: str,
+    cqc_provider_source: str,
+    ascwds_workplace_source: str,
+    cqc_ratings_destination: str,
+    benchmark_ratings_destination: str,
+):
     cqc_location_df = utils.read_from_parquet(cqc_location_source)
+    cqc_provider_df = utils.read_from_parquet(cqc_provider_source)
+    ascwds_workplace_df = utils.read_from_parquet(ascwds_workplace_source)
 
     utils.write_to_parquet(
         cqc_location_df,
@@ -17,16 +25,40 @@ if __name__ == "__main__":
     print("Spark job 'flatten_cqc_ratings' starting...")
     print(f"Job parameters: {sys.argv}")
 
-    source, destination = utils.collect_arguments(
+    (
+        cqc_location_source,
+        cqc_provider_source,
+        ascwds_workplace_source,
+        cqc_ratings_destination,
+        benchmark_ratings_destination,
+    ) = utils.collect_arguments(
         (
             "--cqc_location_source",
             "Source s3 directory for parquet CQC locations dataset",
         ),
         (
+            "--cqc_provider_source",
+            "Source s3 directory for parquet CQC providers dataset",
+        ),
+        (
+            "--ascwds_workplace_source",
+            "Source s3 directory for parquet ASCWDS workplace dataset",
+        ),
+        (
             "--cqc_ratings_destination",
             "Destination s3 directory for cleaned parquet CQC ratings dataset",
         ),
+        (
+            "--benchmark_ratings_destination",
+            "Destination s3 directory for cleaned parquet benchmark ratings dataset",
+        ),
     )
-    main(source, destination)
+    main(
+        cqc_location_source,
+        cqc_provider_source,
+        ascwds_workplace_source,
+        cqc_ratings_destination,
+        benchmark_ratings_destination,
+    )
 
     print("Spark job 'flatten_cqc_ratings' complete")

--- a/jobs/flatten_cqc_ratings.py
+++ b/jobs/flatten_cqc_ratings.py
@@ -5,13 +5,11 @@ from utils import utils
 
 def main(
     cqc_location_source: str,
-    cqc_provider_source: str,
     ascwds_workplace_source: str,
     cqc_ratings_destination: str,
     benchmark_ratings_destination: str,
 ):
     cqc_location_df = utils.read_from_parquet(cqc_location_source)
-    cqc_provider_df = utils.read_from_parquet(cqc_provider_source)
     ascwds_workplace_df = utils.read_from_parquet(ascwds_workplace_source)
 
     utils.write_to_parquet(
@@ -27,7 +25,6 @@ if __name__ == "__main__":
 
     (
         cqc_location_source,
-        cqc_provider_source,
         ascwds_workplace_source,
         cqc_ratings_destination,
         benchmark_ratings_destination,
@@ -35,10 +32,6 @@ if __name__ == "__main__":
         (
             "--cqc_location_source",
             "Source s3 directory for parquet CQC locations dataset",
-        ),
-        (
-            "--cqc_provider_source",
-            "Source s3 directory for parquet CQC providers dataset",
         ),
         (
             "--ascwds_workplace_source",
@@ -55,7 +48,6 @@ if __name__ == "__main__":
     )
     main(
         cqc_location_source,
-        cqc_provider_source,
         ascwds_workplace_source,
         cqc_ratings_destination,
         benchmark_ratings_destination,

--- a/terraform/pipeline/glue.tf
+++ b/terraform/pipeline/glue.tf
@@ -314,8 +314,11 @@ module "flatten_cqc_ratings_job" {
   datasets_bucket = module.datasets_bucket
 
   job_parameters = {
-    "--cqc_location_source"     = "${module.datasets_bucket.bucket_uri}/domain=CQC/dataset=locations_api/version=2.0.0/"
-    "--cqc_ratings_destination" = "${module.datasets_bucket.bucket_uri}/domain=SfC/dataset=cqc_ratings/"
+    "--cqc_location_source"           = "${module.datasets_bucket.bucket_uri}/domain=CQC/dataset=locations_api/version=2.0.0/"
+    "--cqc_provider_source"           = "${module.datasets_bucket.bucket_uri}/domain=CQC/dataset=providers_api/version=2.0.0/"
+    "--ascwds_workplace_source"       = "${module.datasets_bucket.bucket_uri}/domain=ASCWDS/dataset=workplace/"
+    "--cqc_ratings_destination"       = "${module.datasets_bucket.bucket_uri}/domain=SfC/dataset=cqc_ratings/"
+    "--benchmark_ratings_destination" = "${module.datasets_bucket.bucket_uri}/domain=SfC/dataset=benchmark_ratings/"
   }
 }
 

--- a/terraform/pipeline/glue.tf
+++ b/terraform/pipeline/glue.tf
@@ -315,7 +315,6 @@ module "flatten_cqc_ratings_job" {
 
   job_parameters = {
     "--cqc_location_source"           = "${module.datasets_bucket.bucket_uri}/domain=CQC/dataset=locations_api/version=2.0.0/"
-    "--cqc_provider_source"           = "${module.datasets_bucket.bucket_uri}/domain=CQC/dataset=providers_api/version=2.0.0/"
     "--ascwds_workplace_source"       = "${module.datasets_bucket.bucket_uri}/domain=ASCWDS/dataset=workplace/"
     "--cqc_ratings_destination"       = "${module.datasets_bucket.bucket_uri}/domain=SfC/dataset=cqc_ratings/"
     "--benchmark_ratings_destination" = "${module.datasets_bucket.bucket_uri}/domain=SfC/dataset=benchmark_ratings/"

--- a/terraform/pipeline/glue.tf
+++ b/terraform/pipeline/glue.tf
@@ -314,7 +314,7 @@ module "flatten_cqc_ratings_job" {
   datasets_bucket = module.datasets_bucket
 
   job_parameters = {
-    "--cqc_location_source"  = "${module.datasets_bucket.bucket_uri}/domain=CQC/dataset=locations_api/version=2.0.0/"
+    "--cqc_location_source"     = "${module.datasets_bucket.bucket_uri}/domain=CQC/dataset=locations_api/version=2.0.0/"
     "--cqc_ratings_destination" = "${module.datasets_bucket.bucket_uri}/domain=SfC/dataset=cqc_ratings/"
   }
 }

--- a/terraform/pipeline/glue.tf
+++ b/terraform/pipeline/glue.tf
@@ -306,6 +306,19 @@ module "estimate_direct_payments_job" {
   }
 }
 
+module "flatten_cqc_ratings_job" {
+  source          = "../modules/glue-job"
+  script_name     = "flatten_cqc_ratings.py"
+  glue_role       = aws_iam_role.sfc_glue_service_iam_role
+  resource_bucket = module.pipeline_resources
+  datasets_bucket = module.datasets_bucket
+
+  job_parameters = {
+    "--cqc_location_source"  = "${module.datasets_bucket.bucket_uri}/domain=CQC/dataset=locations_api/version=2.0.0/"
+    "--cqc_ratings_destination" = "${module.datasets_bucket.bucket_uri}/domain=SfC/dataset=cqc_ratings/"
+  }
+}
+
 module "clean_cqc_provider_data_job" {
   source          = "../modules/glue-job"
   script_name     = "clean_cqc_provider_data.py"

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -2925,5 +2925,4 @@ class ValidateMergedIndCqcData:
 @dataclass
 class FlattenCQCRatings:
     test_cqc_locations_rows = CQCLocationsData.sample_rows_full
-    test_cqc_providers_rows = CQCProviderData.sample_rows_full
     test_ascwds_workplace_rows = ASCWDSWorkplaceData.workplace_rows

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -2920,3 +2920,9 @@ class ValidateMergedIndCqcData:
         ("1-000000003", date(2024, 3, 1), date(2024, 3, 1), "Independent", "N", None, "4", 6, None, date(2024, 2, 1)),
     ]
     # fmt: on
+
+@dataclass
+class FlattenCQCRatings:
+    test_cqc_locations_rows = CQCLocationsData.sample_rows_full
+    test_cqc_providers_rows = CQCProviderData.sample_rows_full
+    test_ascwds_workplace_rows = ASCWDSWorkplaceData.workplace_rows

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -2921,6 +2921,7 @@ class ValidateMergedIndCqcData:
     ]
     # fmt: on
 
+
 @dataclass
 class FlattenCQCRatings:
     test_cqc_locations_rows = CQCLocationsData.sample_rows_full

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -1593,6 +1593,7 @@ class ValidateMergedIndCqcData:
         ]
     )
 
+
 @dataclass
 class FlattenCQCRatings:
     test_cqc_locations_schema = CQCLocationsSchema.full_schema

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -1597,5 +1597,4 @@ class ValidateMergedIndCqcData:
 @dataclass
 class FlattenCQCRatings:
     test_cqc_locations_schema = CQCLocationsSchema.full_schema
-    test_cqc_providers_schema = CQCProviderSchema.full_schema
     test_ascwds_workplace_schema = ASCWDSWorkplaceSchemas.workplace_schema

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -1592,3 +1592,9 @@ class ValidateMergedIndCqcData:
             StructField(CQCPIRClean.cqc_pir_import_date, DateType(), True),
         ]
     )
+
+@dataclass
+class FlattenCQCRatings:
+    test_cqc_locations_schema = CQCLocationsSchema.full_schema
+    test_cqc_providers_schema = CQCProviderSchema.full_schema
+    test_ascwds_workplace_schema = ASCWDSWorkplaceSchemas.workplace_schema

--- a/tests/unit/test_flatten_cqc_ratings.py
+++ b/tests/unit/test_flatten_cqc_ratings.py
@@ -10,11 +10,10 @@ from tests.test_file_data import CQCLocationsData as Data
 from tests.test_file_schemas import CQCLocationsSchema as Schema
 
 
-
 class CleanCQCProviderDatasetTests(unittest.TestCase):
     TEST_SOURCE = "some/directory"
     TEST_DESTINATION = "some/other/directory"
-    
+
     def setUp(self) -> None:
         self.spark = utils.get_spark()
         self.test_cqc_locations_df = self.spark.createDataFrame(
@@ -36,7 +35,6 @@ class MainTests(CleanCQCProviderDatasetTests):
             self.TEST_DESTINATION,
             mode="overwrite",
         )
-
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_flatten_cqc_ratings.py
+++ b/tests/unit/test_flatten_cqc_ratings.py
@@ -6,18 +6,27 @@ from utils import utils
 
 import jobs.flatten_cqc_ratings as job
 
-from tests.test_file_data import CQCLocationsData as Data
-from tests.test_file_schemas import CQCLocationsSchema as Schema
+from tests.test_file_data import FlattenCQCRatings as Data
+from tests.test_file_schemas import FlattenCQCRatings as Schema
 
 
 class CleanCQCProviderDatasetTests(unittest.TestCase):
-    TEST_SOURCE = "some/directory"
-    TEST_DESTINATION = "some/other/directory"
+    TEST_LOCATIONS_SOURCE = "some/directory"
+    TEST_PROVIDERS_SOURCE = "some/directory"
+    TEST_WORKPLACE_SOURCE = "some/directory"
+    TEST_CQC_RATINGS_DESTINATION = "some/other/directory"
+    TEST_BENCHMARK_RATINGS_DESTINATION = "some/other/directory"
 
     def setUp(self) -> None:
         self.spark = utils.get_spark()
         self.test_cqc_locations_df = self.spark.createDataFrame(
-            Data.sample_rows_full, schema=Schema.full_schema
+            Data.test_cqc_locations_rows, schema=Schema.test_cqc_locations_schema
+        )
+        self.test_cqc_providers_df = self.spark.createDataFrame(
+            Data.test_cqc_providers_rows, schema=Schema.test_cqc_providers_schema
+        )
+        self.test_ascwds_df = self.spark.createDataFrame(
+            Data.test_ascwds_workplace_rows, schema=Schema.test_ascwds_workplace_schema
         )
 
 
@@ -28,11 +37,15 @@ class MainTests(CleanCQCProviderDatasetTests):
     @patch("utils.utils.write_to_parquet")
     @patch("utils.utils.read_from_parquet")
     def test_main(self, read_from_parquet_patch: Mock, write_to_parquet_patch: Mock):
-        read_from_parquet_patch.return_value = self.test_cqc_locations_df
-        job.main(self.TEST_SOURCE, self.TEST_DESTINATION)
+        read_from_parquet_patch.side_effect = [
+            self.test_cqc_locations_df,
+            self.test_cqc_providers_df,
+            self.test_ascwds_df,
+        ]
+        job.main(self.TEST_LOCATIONS_SOURCE, self.TEST_PROVIDERS_SOURCE, self.TEST_WORKPLACE_SOURCE, self.TEST_CQC_RATINGS_DESTINATION, self.TEST_BENCHMARK_RATINGS_DESTINATION)
         write_to_parquet_patch.assert_called_once_with(
             ANY,
-            self.TEST_DESTINATION,
+            self.TEST_CQC_RATINGS_DESTINATION,
             mode="overwrite",
         )
 

--- a/tests/unit/test_flatten_cqc_ratings.py
+++ b/tests/unit/test_flatten_cqc_ratings.py
@@ -1,0 +1,43 @@
+import unittest
+from unittest.mock import ANY, Mock, patch
+import pyspark.sql.functions as F
+
+from utils import utils
+
+import jobs.flatten_cqc_ratings as job
+
+from tests.test_file_data import CQCLocationsData as Data
+from tests.test_file_schemas import CQCLocationsSchema as Schema
+
+
+
+class CleanCQCProviderDatasetTests(unittest.TestCase):
+    TEST_SOURCE = "some/directory"
+    TEST_DESTINATION = "some/other/directory"
+    
+    def setUp(self) -> None:
+        self.spark = utils.get_spark()
+        self.test_cqc_locations_df = self.spark.createDataFrame(
+            Data.sample_rows_full, schema=Schema.full_schema
+        )
+
+
+class MainTests(CleanCQCProviderDatasetTests):
+    def setUp(self) -> None:
+        super().setUp()
+
+    @patch("utils.utils.write_to_parquet")
+    @patch("utils.utils.read_from_parquet")
+    def test_main(self, read_from_parquet_patch: Mock, write_to_parquet_patch: Mock):
+        read_from_parquet_patch.return_value = self.test_cqc_locations_df
+        job.main(self.TEST_SOURCE, self.TEST_DESTINATION)
+        write_to_parquet_patch.assert_called_once_with(
+            ANY,
+            self.TEST_DESTINATION,
+            mode="overwrite",
+        )
+
+
+
+if __name__ == "__main__":
+    unittest.main(warnings="ignore")

--- a/tests/unit/test_flatten_cqc_ratings.py
+++ b/tests/unit/test_flatten_cqc_ratings.py
@@ -43,6 +43,7 @@ class MainTests(CleanCQCProviderDatasetTests):
             self.TEST_CQC_RATINGS_DESTINATION,
             self.TEST_BENCHMARK_RATINGS_DESTINATION,
         )
+        self.assertEqual(read_from_parquet_patch.call_count, 2)
         write_to_parquet_patch.assert_called_once_with(
             ANY,
             self.TEST_CQC_RATINGS_DESTINATION,

--- a/tests/unit/test_flatten_cqc_ratings.py
+++ b/tests/unit/test_flatten_cqc_ratings.py
@@ -12,7 +12,6 @@ from tests.test_file_schemas import FlattenCQCRatings as Schema
 
 class CleanCQCProviderDatasetTests(unittest.TestCase):
     TEST_LOCATIONS_SOURCE = "some/directory"
-    TEST_PROVIDERS_SOURCE = "some/directory"
     TEST_WORKPLACE_SOURCE = "some/directory"
     TEST_CQC_RATINGS_DESTINATION = "some/other/directory"
     TEST_BENCHMARK_RATINGS_DESTINATION = "some/other/directory"
@@ -21,9 +20,6 @@ class CleanCQCProviderDatasetTests(unittest.TestCase):
         self.spark = utils.get_spark()
         self.test_cqc_locations_df = self.spark.createDataFrame(
             Data.test_cqc_locations_rows, schema=Schema.test_cqc_locations_schema
-        )
-        self.test_cqc_providers_df = self.spark.createDataFrame(
-            Data.test_cqc_providers_rows, schema=Schema.test_cqc_providers_schema
         )
         self.test_ascwds_df = self.spark.createDataFrame(
             Data.test_ascwds_workplace_rows, schema=Schema.test_ascwds_workplace_schema
@@ -39,12 +35,10 @@ class MainTests(CleanCQCProviderDatasetTests):
     def test_main(self, read_from_parquet_patch: Mock, write_to_parquet_patch: Mock):
         read_from_parquet_patch.side_effect = [
             self.test_cqc_locations_df,
-            self.test_cqc_providers_df,
             self.test_ascwds_df,
         ]
         job.main(
             self.TEST_LOCATIONS_SOURCE,
-            self.TEST_PROVIDERS_SOURCE,
             self.TEST_WORKPLACE_SOURCE,
             self.TEST_CQC_RATINGS_DESTINATION,
             self.TEST_BENCHMARK_RATINGS_DESTINATION,

--- a/tests/unit/test_flatten_cqc_ratings.py
+++ b/tests/unit/test_flatten_cqc_ratings.py
@@ -42,7 +42,13 @@ class MainTests(CleanCQCProviderDatasetTests):
             self.test_cqc_providers_df,
             self.test_ascwds_df,
         ]
-        job.main(self.TEST_LOCATIONS_SOURCE, self.TEST_PROVIDERS_SOURCE, self.TEST_WORKPLACE_SOURCE, self.TEST_CQC_RATINGS_DESTINATION, self.TEST_BENCHMARK_RATINGS_DESTINATION)
+        job.main(
+            self.TEST_LOCATIONS_SOURCE,
+            self.TEST_PROVIDERS_SOURCE,
+            self.TEST_WORKPLACE_SOURCE,
+            self.TEST_CQC_RATINGS_DESTINATION,
+            self.TEST_BENCHMARK_RATINGS_DESTINATION,
+        )
         write_to_parquet_patch.assert_called_once_with(
             ANY,
             self.TEST_CQC_RATINGS_DESTINATION,


### PR DESCRIPTION
# Description
Setting up the script, test file and terraform to create a new glue job for flattening the CQC ratings.

# How to test
Unit tests passing
Run successfully in branch: https://eu-west-2.console.aws.amazon.com/gluestudio/home?region=eu-west-2#/editor/job/flatten-cqc-ratings-flatten_cqc_ratings_job/runs 

