### PR TITLE
Flatten cqc ratings refactor date selection

### DIFF
--- a/jobs/flatten_cqc_ratings.py
+++ b/jobs/flatten_cqc_ratings.py
@@ -63,7 +63,9 @@ def main(
     )
 
     cqc_location_df = filter_to_first_import_of_most_recent_month(cqc_location_df)
-    ascwds_workplace_df = filter_to_first_import_of_most_recent_month(ascwds_workplace_df)
+    ascwds_workplace_df = filter_to_first_import_of_most_recent_month(
+        ascwds_workplace_df
+    )
 
     cqc_location_df = utils.select_rows_with_value(
         cqc_location_df, CQCL.type, CQCLValues.social_care_identifier

--- a/jobs/flatten_cqc_ratings.py
+++ b/jobs/flatten_cqc_ratings.py
@@ -99,11 +99,12 @@ def main(
 
 
 def filter_to_first_import_of_most_recent_month(df: DataFrame) -> DataFrame:
-    import_dates_df = df.select(Keys.year, Keys.month, Keys.day)
-    max_year = import_dates_df.agg(F.max(import_dates_df[Keys.year])).collect()[0][0]
-    max_month = import_dates_df.agg(F.max(import_dates_df[Keys.month])).collect()[0][0]
-    min_day = import_dates_df.agg(F.min(import_dates_df[Keys.day])).collect()[0][0]
-    df = df.where((df[Keys.year] == max_year) & (df[Keys.month] == max_month) & (df[Keys.day] == min_day))
+    max_year = df.agg(F.max(df[Keys.year])).collect()[0][0]
+    df = df.where(df[Keys.year] == max_year)
+    max_month = df.agg(F.max(df[Keys.month])).collect()[0][0]
+    df = df.where(df[Keys.month] == max_month)
+    min_day = df.agg(F.min(df[Keys.day])).collect()[0][0]
+    df = df.where(df[Keys.day] == min_day)
     return df
 
 

--- a/jobs/flatten_cqc_ratings.py
+++ b/jobs/flatten_cqc_ratings.py
@@ -92,7 +92,7 @@ def main(
     )
 
 
-def filter_to_start_of_most_recent_month(df: DataFrame) -> DataFrame:
+def filter_to_first_import_of_most_recent_month(df: DataFrame) -> DataFrame:
     max_import_date = df.agg(F.max(df[Keys.import_date])).collect()[0][0]
     first_day_of_the_month = "01"
     month_and_year_of_import_date = max_import_date[0:6]

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -2939,8 +2939,131 @@ class PAFilledPostsSampleData:
 
 @dataclass
 class FlattenCQCRatings:
-    test_cqc_locations_rows = CQCLocationsData.sample_rows_full
-    test_ascwds_workplace_rows = ASCWDSWorkplaceData.workplace_rows
+    test_cqc_locations_rows = [
+        (
+            "loc_1",
+            CQCLValues.registered,
+            CQCLValues.social_care_identifier,
+            "20240101",
+            "2024",
+            "01",
+            "01",
+            {
+                CQCL.overall: {
+                    CQCL.organisation_id: None,
+                    CQCL.rating: "Overall rating Excellent",
+                    CQCL.report_date: "report_date",
+                    CQCL.report_link_id: None,
+                    CQCLNew.use_of_resources: {
+                        CQCL.organisation_id: None,
+                        CQCLNew.summary: None,
+                        CQCLNew.use_of_resources_rating: None,
+                        CQCLNew.combined_quality_summary: None,
+                        CQCLNew.combined_quality_rating: None,
+                        CQCL.report_date: None,
+                        CQCL.report_link_id: None,
+                    },
+                    CQCL.key_question_ratings: [
+                        {
+                            CQCL.name: "Safe",
+                            CQCL.rating: "Safe rating Good",
+                            CQCL.report_date: None,
+                            CQCL.organisation_id: None,
+                            CQCL.report_link_id: None,
+                        },
+                        {
+                            CQCL.name: "Well-led",
+                            CQCL.rating: "Well-led rating Good",
+                            CQCL.report_date: None,
+                            CQCL.organisation_id: None,
+                            CQCL.report_link_id: None,
+                        },
+                        {
+                            CQCL.name: "Caring",
+                            CQCL.rating: "Caring rating Good",
+                            CQCL.report_date: None,
+                            CQCL.organisation_id: None,
+                            CQCL.report_link_id: None,
+                        },
+                        {
+                            CQCL.name: "Responsive",
+                            CQCL.rating: "Responsive rating Good",
+                            CQCL.report_date: None,
+                            CQCL.organisation_id: None,
+                            CQCL.report_link_id: None,
+                        },
+                        {
+                            CQCL.name: "Effective",
+                            CQCL.rating: "Effective rating Good",
+                            CQCL.report_date: None,
+                            CQCL.organisation_id: None,
+                            CQCL.report_link_id: None,
+                        },
+                    ],
+                },
+                CQCLNew.service_ratings: [
+                    {
+                        CQCL.name: None,
+                        CQCL.rating: None,
+                        CQCL.report_date: None,
+                        CQCL.organisation_id: None,
+                        CQCL.report_link_id: None,
+                        CQCL.key_question_ratings: [
+                            {
+                                CQCL.name: None,
+                                CQCL.rating: None,
+                            },
+                        ],
+                    },
+                ],
+            },
+            [
+                {
+                    CQCL.report_date: "report_date",
+                    CQCL.report_link_id: None,
+                    CQCL.organisation_id: None,
+                    CQCLNew.service_ratings: [
+                        {
+                            CQCL.name: None,
+                            CQCL.rating: None,
+                            CQCL.key_question_ratings: [
+                                {
+                                    CQCL.name: None,
+                                    CQCL.rating: None,
+                                },
+                            ],
+                        },
+                    ],
+                    CQCL.overall: {
+                        CQCL.rating: "Overall rating Excellent",
+                        CQCLNew.use_of_resources: {
+                            CQCLNew.combined_quality_rating: None,
+                            CQCLNew.combined_quality_summary: None,
+                            CQCLNew.use_of_resources_rating: None,
+                            CQCLNew.use_of_resources_summary: None,
+                        },
+                        CQCL.key_question_ratings: [
+                            {CQCL.name: "Safe", CQCL.rating: "Safe rating Good"},
+                            {
+                                CQCL.name: "Well-led",
+                                CQCL.rating: "Well-led rating Good",
+                            },
+                            {CQCL.name: "Caring", CQCL.rating: "Caring rating Good"},
+                            {
+                                CQCL.name: "Responsive",
+                                CQCL.rating: "Responsive rating Good",
+                            },
+                            {
+                                CQCL.name: "Effective",
+                                CQCL.rating: "Effective rating Good",
+                            },
+                        ],
+                    },
+                },
+            ],
+        ),
+    ]
+    test_ascwds_workplace_rows = [("loc_1", "estab_1", "20240101", "2021", "01", "01")]
     filter_to_first_import_of_most_recent_month_rows = [
         ("loc_1", "20240101", "2024", "01", "01"),
         ("loc_2", "20231201", "2023", "12", "01"),

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -2959,7 +2959,7 @@ class FlattenCQCRatings:
         ("loc_1", "20240101", "2024", "01", "01"),
     ]
     expected_filter_to_first_import_of_most_recent_month_when_earliest_date_is_not_first_of_month_rows = [
-        ("loc_1", "20240101", "2024", "01", "02"),
+        ("loc_1", "20240102", "2024", "01", "02"),
     ]
 
     flatten_current_ratings_rows = [

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -2942,21 +2942,24 @@ class FlattenCQCRatings:
     test_cqc_locations_rows = CQCLocationsData.sample_rows_full
     test_ascwds_workplace_rows = ASCWDSWorkplaceData.workplace_rows
     filter_to_first_import_of_most_recent_month_rows = [
-        ("loc_1", "20240101"),
-        ("loc_2", "20231201"),
+        ("loc_1", "20240101", "2024", "01", "01"),
+        ("loc_2", "20231201", "2023", "12", "01"),
     ]
     filter_to_first_import_of_most_recent_month_when_two_imports_in_most_recent_month_rows = [
-        ("loc_1", "20240101"),
-        ("loc_2", "20231201"),
-        ("loc_3", "20240104"),
+        ("loc_1", "20240101", "2024", "01", "01"),
+        ("loc_2", "20231201", "2023", "12", "01"),
+        ("loc_3", "20240104", "2024", "01", "04"),
     ]
     filter_to_first_import_of_most_recent_month_when_earliest_date_is_not_first_of_month_rows = [
-        ("loc_1", "20240102"),
-        ("loc_2", "20231201"),
-        ("loc_3", "20240104"),
+        ("loc_1", "20240102", "2024", "01", "02"),
+        ("loc_2", "20231201", "2023", "12", "01"),
+        ("loc_3", "20240104", "2024", "01", "04"),
     ]
     expected_filter_to_first_import_of_most_recent_month_rows = [
-        ("loc_1", "20240101"),
+        ("loc_1", "20240101", "2024", "01", "01"),
+    ]
+    expected_filter_to_first_import_of_most_recent_month_when_earliest_date_is_not_first_of_month_rows = [
+        ("loc_1", "20240101", "2024", "01", "02"),
     ]
 
     flatten_current_ratings_rows = [

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -2941,16 +2941,21 @@ class PAFilledPostsSampleData:
 class FlattenCQCRatings:
     test_cqc_locations_rows = CQCLocationsData.sample_rows_full
     test_ascwds_workplace_rows = ASCWDSWorkplaceData.workplace_rows
-    filter_to_monthly_import_date_rows = [
+    filter_to_first_import_of_most_recent_month_rows = [
         ("loc_1", "20240101"),
         ("loc_2", "20231201"),
     ]
-    filter_to_start_of_most_recent_month_when_not_first_of_month_rows = [
+    filter_to_first_import_of_most_recent_month_when_two_imports_in_most_recent_month_rows = [
         ("loc_1", "20240101"),
         ("loc_2", "20231201"),
         ("loc_3", "20240104"),
     ]
-    expected_filter_to_start_of_most_recent_month_rows = [
+    filter_to_first_import_of_most_recent_month_when_earliest_date_is_not_first_of_month_rows = [
+        ("loc_1", "20240102"),
+        ("loc_2", "20231201"),
+        ("loc_3", "20240104"),
+    ]
+    expected_filter_to_first_import_of_most_recent_month_rows = [
         ("loc_1", "20240101"),
     ]
 

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -1619,6 +1619,9 @@ class FlattenCQCRatings:
         [
             StructField(CQCL.location_id, StringType(), True),
             StructField(Keys.import_date, StringType(), False),
+            StructField(Keys.year, StringType(), False),
+            StructField(Keys.month, StringType(), False),
+            StructField(Keys.day, StringType(), False),
         ]
     )
     flatten_current_ratings_schema = StructType(

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -1615,7 +1615,7 @@ class PAFilledPostsSampleData:
 class FlattenCQCRatings:
     test_cqc_locations_schema = CQCLocationsSchema.full_schema
     test_ascwds_workplace_schema = ASCWDSWorkplaceSchemas.workplace_schema
-    filter_to_start_of_most_recent_month_schema = StructType(
+    filter_to_first_import_of_most_recent_month_schema = StructType(
         [
             StructField(CQCL.location_id, StringType(), True),
             StructField(Keys.import_date, StringType(), False),

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -1613,8 +1613,277 @@ class PAFilledPostsSampleData:
 
 @dataclass
 class FlattenCQCRatings:
-    test_cqc_locations_schema = CQCLocationsSchema.full_schema
-    test_ascwds_workplace_schema = ASCWDSWorkplaceSchemas.workplace_schema
+    test_cqc_locations_schema = StructType(
+        [
+            StructField(CQCL.location_id, StringType(), True),
+            StructField(CQCL.registration_status, StringType(), True),
+            StructField(CQCL.type, StringType(), True),
+            StructField(Keys.import_date, StringType(), False),
+            StructField(Keys.year, StringType(), False),
+            StructField(Keys.month, StringType(), False),
+            StructField(Keys.day, StringType(), False),
+            StructField(
+                CQCL.current_ratings,
+                StructType(
+                    [
+                        StructField(
+                            CQCL.overall,
+                            StructType(
+                                [
+                                    StructField(
+                                        CQCL.organisation_id, StringType(), True
+                                    ),
+                                    StructField(CQCL.rating, StringType(), True),
+                                    StructField(CQCL.report_date, StringType(), True),
+                                    StructField(
+                                        CQCL.report_link_id, StringType(), True
+                                    ),
+                                    StructField(
+                                        CQCLNew.use_of_resources,
+                                        StructType(
+                                            [
+                                                StructField(
+                                                    CQCL.organisation_id,
+                                                    StringType(),
+                                                    True,
+                                                ),
+                                                StructField(
+                                                    CQCLNew.summary, StringType(), True
+                                                ),
+                                                StructField(
+                                                    CQCLNew.use_of_resources_rating,
+                                                    StringType(),
+                                                    True,
+                                                ),
+                                                StructField(
+                                                    CQCLNew.combined_quality_summary,
+                                                    StringType(),
+                                                    True,
+                                                ),
+                                                StructField(
+                                                    CQCLNew.combined_quality_rating,
+                                                    StringType(),
+                                                    True,
+                                                ),
+                                                StructField(
+                                                    CQCL.report_date,
+                                                    StringType(),
+                                                    True,
+                                                ),
+                                                StructField(
+                                                    CQCL.report_link_id,
+                                                    StringType(),
+                                                    True,
+                                                ),
+                                            ]
+                                        ),
+                                        True,
+                                    ),
+                                    StructField(
+                                        CQCL.key_question_ratings,
+                                        ArrayType(
+                                            StructType(
+                                                [
+                                                    StructField(
+                                                        CQCL.name, StringType(), True
+                                                    ),
+                                                    StructField(
+                                                        CQCL.rating,
+                                                        StringType(),
+                                                        True,
+                                                    ),
+                                                    StructField(
+                                                        CQCL.report_date,
+                                                        StringType(),
+                                                        True,
+                                                    ),
+                                                    StructField(
+                                                        CQCL.organisation_id,
+                                                        StringType(),
+                                                        True,
+                                                    ),
+                                                    StructField(
+                                                        CQCL.report_link_id,
+                                                        StringType(),
+                                                        True,
+                                                    ),
+                                                ]
+                                            ),
+                                            True,
+                                        ),
+                                        True,
+                                    ),
+                                ]
+                            ),
+                            True,
+                        ),
+                        StructField(
+                            CQCLNew.service_ratings,
+                            ArrayType(
+                                StructType(
+                                    [
+                                        StructField(CQCL.name, StringType(), True),
+                                        StructField(CQCL.rating, StringType(), True),
+                                        StructField(
+                                            CQCL.report_date, StringType(), True
+                                        ),
+                                        StructField(
+                                            CQCL.organisation_id, StringType(), True
+                                        ),
+                                        StructField(
+                                            CQCL.report_link_id, StringType(), True
+                                        ),
+                                        StructField(
+                                            CQCL.key_question_ratings,
+                                            ArrayType(
+                                                StructType(
+                                                    [
+                                                        StructField(
+                                                            CQCL.name,
+                                                            StringType(),
+                                                            True,
+                                                        ),
+                                                        StructField(
+                                                            CQCL.rating,
+                                                            StringType(),
+                                                            True,
+                                                        ),
+                                                    ]
+                                                ),
+                                                True,
+                                            ),
+                                            True,
+                                        ),
+                                    ]
+                                ),
+                                True,
+                            ),
+                            True,
+                        ),
+                    ]
+                ),
+                True,
+            ),
+            StructField(
+                CQCL.historic_ratings,
+                ArrayType(
+                    StructType(
+                        [
+                            StructField(CQCL.report_date, StringType(), True),
+                            StructField(CQCL.report_link_id, StringType(), True),
+                            StructField(CQCL.organisation_id, StringType(), True),
+                            StructField(
+                                CQCLNew.service_ratings,
+                                ArrayType(
+                                    StructType(
+                                        [
+                                            StructField(CQCL.name, StringType(), True),
+                                            StructField(
+                                                CQCL.rating, StringType(), True
+                                            ),
+                                            StructField(
+                                                CQCL.key_question_ratings,
+                                                ArrayType(
+                                                    StructType(
+                                                        [
+                                                            StructField(
+                                                                CQCL.name,
+                                                                StringType(),
+                                                                True,
+                                                            ),
+                                                            StructField(
+                                                                CQCL.rating,
+                                                                StringType(),
+                                                                True,
+                                                            ),
+                                                        ]
+                                                    ),
+                                                    True,
+                                                ),
+                                                True,
+                                            ),
+                                        ]
+                                    ),
+                                    True,
+                                ),
+                                True,
+                            ),
+                            StructField(
+                                CQCL.overall,
+                                StructType(
+                                    [
+                                        StructField(CQCL.rating, StringType(), True),
+                                        StructField(
+                                            CQCLNew.use_of_resources,
+                                            StructType(
+                                                [
+                                                    StructField(
+                                                        CQCLNew.combined_quality_rating,
+                                                        StringType(),
+                                                        True,
+                                                    ),
+                                                    StructField(
+                                                        CQCLNew.combined_quality_summary,
+                                                        StringType(),
+                                                        True,
+                                                    ),
+                                                    StructField(
+                                                        CQCLNew.use_of_resources_rating,
+                                                        StringType(),
+                                                        True,
+                                                    ),
+                                                    StructField(
+                                                        CQCLNew.use_of_resources_summary,
+                                                        StringType(),
+                                                        True,
+                                                    ),
+                                                ]
+                                            ),
+                                            True,
+                                        ),
+                                        StructField(
+                                            CQCL.key_question_ratings,
+                                            ArrayType(
+                                                StructType(
+                                                    [
+                                                        StructField(
+                                                            CQCL.name,
+                                                            StringType(),
+                                                            True,
+                                                        ),
+                                                        StructField(
+                                                            CQCL.rating,
+                                                            StringType(),
+                                                            True,
+                                                        ),
+                                                    ]
+                                                ),
+                                                True,
+                                            ),
+                                            True,
+                                        ),
+                                    ]
+                                ),
+                                True,
+                            ),
+                        ]
+                    ),
+                    True,
+                ),
+                True,
+            ),
+        ]
+    )
+    test_ascwds_workplace_schema = StructType(
+        [
+            StructField(AWP.location_id, StringType(), True),
+            StructField(AWP.establishment_id, StringType(), True),
+            StructField(Keys.import_date, StringType(), False),
+            StructField(Keys.year, StringType(), False),
+            StructField(Keys.month, StringType(), False),
+            StructField(Keys.day, StringType(), False),
+        ]
+    )
     filter_to_first_import_of_most_recent_month_schema = StructType(
         [
             StructField(CQCL.location_id, StringType(), True),

--- a/tests/unit/test_flatten_cqc_ratings.py
+++ b/tests/unit/test_flatten_cqc_ratings.py
@@ -110,7 +110,7 @@ class FilterToFirstImportOfMostRecentMonth(FlattenCQCRatingsTests):
             self.test_cqc_when_two_imports_in_most_recent_month_df
         ).collect()
         self.assertEqual(returned_data, self.expected_data)
-    
+
     def test_filter_to_first_import_of_most_recent_month_returns_correct_rows_when_earliest_date_in_month_is_not_the_first_of_the_month(
         self,
     ):

--- a/tests/unit/test_flatten_cqc_ratings.py
+++ b/tests/unit/test_flatten_cqc_ratings.py
@@ -71,23 +71,27 @@ class MainTests(FlattenCQCRatingsTests):
         )
 
 
-class FilterToStartOfMostRecentMonth(FlattenCQCRatingsTests):
+class FilterToFirstImportOfMostRecentMonth(FlattenCQCRatingsTests):
     def setUp(self) -> None:
         super().setUp()
         self.test_cqc_df = self.spark.createDataFrame(
-            Data.filter_to_monthly_import_date_rows,
-            Schema.filter_to_start_of_most_recent_month_schema,
+            Data.filter_to_first_import_of_most_recent_month_rows,
+            Schema.filter_to_first_import_of_most_recent_month_schema,
         )
-        self.test_cqc_when_not_first_of_month_df = self.spark.createDataFrame(
-            Data.filter_to_start_of_most_recent_month_when_not_first_of_month_rows,
-            Schema.filter_to_start_of_most_recent_month_schema,
+        self.test_cqc_when_two_imports_in_most_recent_month_df = self.spark.createDataFrame(
+            Data.filter_to_first_import_of_most_recent_month_when_two_imports_in_most_recent_month_rows,
+            Schema.filter_to_first_import_of_most_recent_month_schema,
+        )
+        self.test_cqc_when_earliest_date_is_not_first_of_month_df = self.spark.createDataFrame(
+            Data.filter_to_first_import_of_most_recent_month_when_earliest_date_is_not_first_of_month_rows,
+            Schema.filter_to_first_import_of_most_recent_month_schema,
         )
         self.expected_data = self.spark.createDataFrame(
-            Data.expected_filter_to_start_of_most_recent_month_rows,
-            Schema.filter_to_start_of_most_recent_month_schema,
+            Data.expected_filter_to_first_import_of_most_recent_month_rows,
+            Schema.filter_to_first_import_of_most_recent_month_schema,
         ).collect()
 
-    def test_filter_to_monthly_import_date_returns_correct_rows_when_most_recent_data_is_the_first_of_the_month(
+    def test_filter_to_first_import_of_most_recent_month_returns_correct_rows_when_most_recent_data_is_the_first_of_the_month(
         self,
     ):
         returned_data = job.filter_to_start_of_most_recent_month(
@@ -95,11 +99,19 @@ class FilterToStartOfMostRecentMonth(FlattenCQCRatingsTests):
         ).collect()
         self.assertEqual(returned_data, self.expected_data)
 
-    def test_filter_to_monthly_import_date_returns_correct_rows_when_most_recent_data_is_not_the_first_of_the_month(
+    def test_filter_to_first_import_of_most_recent_month_returns_correct_rows_when_most_recent_data_is_not_the_first_of_the_month(
         self,
     ):
         returned_data = job.filter_to_start_of_most_recent_month(
-            self.test_cqc_when_not_first_of_month_df
+            self.test_cqc_when_two_imports_in_most_recent_month_df
+        ).collect()
+        self.assertEqual(returned_data, self.expected_data)
+    
+    def test_filter_to_first_import_of_most_recent_month_returns_correct_rows_when_earliest_date_in_month_is_not_the_first_of_the_month(
+        self,
+    ):
+        returned_data = job.filter_to_start_of_most_recent_month(
+            self.test_cqc_when_earliest_date_is_not_first_of_month_df
         ).collect()
         self.assertEqual(returned_data, self.expected_data)
 

--- a/tests/unit/test_flatten_cqc_ratings.py
+++ b/tests/unit/test_flatten_cqc_ratings.py
@@ -90,6 +90,10 @@ class FilterToFirstImportOfMostRecentMonth(FlattenCQCRatingsTests):
             Data.expected_filter_to_first_import_of_most_recent_month_rows,
             Schema.filter_to_first_import_of_most_recent_month_schema,
         ).collect()
+        self.expected_data_when_not_first_of_month = self.spark.createDataFrame(
+            Data.expected_filter_to_first_import_of_most_recent_month_when_earliest_date_is_not_first_of_month_rows,
+            Schema.filter_to_first_import_of_most_recent_month_schema,
+        ).collect()
 
     def test_filter_to_first_import_of_most_recent_month_returns_correct_rows_when_most_recent_data_is_the_first_of_the_month(
         self,
@@ -113,7 +117,7 @@ class FilterToFirstImportOfMostRecentMonth(FlattenCQCRatingsTests):
         returned_data = job.filter_to_first_import_of_most_recent_month(
             self.test_cqc_when_earliest_date_is_not_first_of_month_df
         ).collect()
-        self.assertEqual(returned_data, self.expected_data)
+        self.assertEqual(returned_data, self.expected_data_when_not_first_of_month)
 
 
 class FlattenCurrentRatings(FlattenCQCRatingsTests):

--- a/tests/unit/test_flatten_cqc_ratings.py
+++ b/tests/unit/test_flatten_cqc_ratings.py
@@ -94,7 +94,7 @@ class FilterToFirstImportOfMostRecentMonth(FlattenCQCRatingsTests):
     def test_filter_to_first_import_of_most_recent_month_returns_correct_rows_when_most_recent_data_is_the_first_of_the_month(
         self,
     ):
-        returned_data = job.filter_to_start_of_most_recent_month(
+        returned_data = job.filter_to_first_import_of_most_recent_month(
             self.test_cqc_df
         ).collect()
         self.assertEqual(returned_data, self.expected_data)
@@ -102,7 +102,7 @@ class FilterToFirstImportOfMostRecentMonth(FlattenCQCRatingsTests):
     def test_filter_to_first_import_of_most_recent_month_returns_correct_rows_when_most_recent_data_is_not_the_first_of_the_month(
         self,
     ):
-        returned_data = job.filter_to_start_of_most_recent_month(
+        returned_data = job.filter_to_first_import_of_most_recent_month(
             self.test_cqc_when_two_imports_in_most_recent_month_df
         ).collect()
         self.assertEqual(returned_data, self.expected_data)
@@ -110,7 +110,7 @@ class FilterToFirstImportOfMostRecentMonth(FlattenCQCRatingsTests):
     def test_filter_to_first_import_of_most_recent_month_returns_correct_rows_when_earliest_date_in_month_is_not_the_first_of_the_month(
         self,
     ):
-        returned_data = job.filter_to_start_of_most_recent_month(
+        returned_data = job.filter_to_first_import_of_most_recent_month(
             self.test_cqc_when_earliest_date_is_not_first_of_month_df
         ).collect()
         self.assertEqual(returned_data, self.expected_data)


### PR DESCRIPTION
# Description
Refactoring of the import date selection function to cover cases where we haven't imported on the first of the month for some reason.

# How to test
Unit tests passing
https://eu-west-2.console.aws.amazon.com/gluestudio/home?region=eu-west-2#/editor/job/flatten-cqc-ratings-refactor-d-flatten_cqc_ratings_job/runs

