### PR TITLE
Add timezone to cron

### DIFF
--- a/terraform/pipeline/eventbridge.tf
+++ b/terraform/pipeline/eventbridge.tf
@@ -124,8 +124,8 @@ resource "aws_scheduler_schedule" "bulk_download_cqc_api_schedule" {
     mode = "OFF"
   }
 
-  schedule_expression          = "cron(00,15,30,45 15,16 01,03,08,15,23 * ? *)"
-  schedule_expression_timezone = "GMT"
+  schedule_expression          = "cron(00,15,30,45 15,16 01,02,08,15,23 * ? *)"
+  schedule_expression_timezone = "Europe/London"
 
   target {
     arn      = aws_sfn_state_machine.bulk-download-cqc-api-state-machine.arn

--- a/terraform/pipeline/eventbridge.tf
+++ b/terraform/pipeline/eventbridge.tf
@@ -117,14 +117,14 @@ resource "aws_iam_policy" "scheduler" {
 
 resource "aws_scheduler_schedule" "bulk_download_cqc_api_schedule" {
   name        = "${local.workspace_prefix}-CqcApiSchedule"
-  state       = terraform.workspace == "main" ? "ENABLED" : "DISABLED"
+  state       = terraform.workspace == "add-timezone-to-cron" ? "ENABLED" : "DISABLED"
   description = "Regular scheduling of the CQC API bulk download pipeline on the first, eighth, fifteenth and twenty third of each month."
 
   flexible_time_window {
     mode = "OFF"
   }
 
-  schedule_expression = "cron(30 01 01,08,15,23 * ? *)"
+  schedule_expression = "cron(00,15,30,45 15,16 01,03,08,15,23 * ? *)"
   schedule_expression_timezone = "GMT"
 
   target {

--- a/terraform/pipeline/eventbridge.tf
+++ b/terraform/pipeline/eventbridge.tf
@@ -125,6 +125,7 @@ resource "aws_scheduler_schedule" "bulk_download_cqc_api_schedule" {
   }
 
   schedule_expression = "cron(30 01 01,08,15,23 * ? *)"
+  schedule_expression_timezone = "GMT"
 
   target {
     arn      = aws_sfn_state_machine.bulk-download-cqc-api-state-machine.arn

--- a/terraform/pipeline/eventbridge.tf
+++ b/terraform/pipeline/eventbridge.tf
@@ -117,14 +117,14 @@ resource "aws_iam_policy" "scheduler" {
 
 resource "aws_scheduler_schedule" "bulk_download_cqc_api_schedule" {
   name        = "${local.workspace_prefix}-CqcApiSchedule"
-  state       = terraform.workspace == "add-timezone-to-cron" ? "ENABLED" : "DISABLED"
+  state       = terraform.workspace == "main" ? "ENABLED" : "DISABLED"
   description = "Regular scheduling of the CQC API bulk download pipeline on the first, eighth, fifteenth and twenty third of each month."
 
   flexible_time_window {
     mode = "OFF"
   }
 
-  schedule_expression          = "cron(00,15,30,45 15,16 01,02,08,15,23 * ? *)"
+  schedule_expression          = "cron(30 01 01,08,15,23 * ? *)"
   schedule_expression_timezone = "Europe/London"
 
   target {

--- a/terraform/pipeline/eventbridge.tf
+++ b/terraform/pipeline/eventbridge.tf
@@ -124,7 +124,7 @@ resource "aws_scheduler_schedule" "bulk_download_cqc_api_schedule" {
     mode = "OFF"
   }
 
-  schedule_expression = "cron(00,15,30,45 15,16 01,03,08,15,23 * ? *)"
+  schedule_expression          = "cron(00,15,30,45 15,16 01,03,08,15,23 * ? *)"
   schedule_expression_timezone = "GMT"
 
   target {

--- a/terraform/pipeline/glue.tf
+++ b/terraform/pipeline/glue.tf
@@ -469,7 +469,6 @@ module "cqc_crawler" {
   source                       = "../modules/glue-crawler"
   dataset_for_crawler          = "CQC"
   glue_role                    = aws_iam_role.sfc_glue_service_iam_role
-  schedule                     = "cron(00 07 01,08,15,23 * ? *)"
   workspace_glue_database_name = "${local.workspace_prefix}-${var.glue_database_name}"
 }
 


### PR DESCRIPTION
# Description
Added the timezone variable to aws scheduler schedule

# How to test
Event triggered here: https://eu-west-2.console.aws.amazon.com/states/home?region=eu-west-2#/v2/executions/details/arn:aws:states:eu-west-2:344210435447:execution:add-timezone-to-cron-Bulk-Download-CQC-API-Pipeline:866633a3-68e6-42cf-83ae-eddd2ba80ec6
Timezone update visible here in upcoming schedule: https://eu-west-2.console.aws.amazon.com/scheduler/home?region=eu-west-2#schedules/default/add-timezone-to-cron-CqcApiSchedule
