### PR TITLE
Refactor validation for merged ind cqc

### DIFF
--- a/jobs/validate_merged_ind_cqc_data.py
+++ b/jobs/validate_merged_ind_cqc_data.py
@@ -45,7 +45,6 @@ def main(
     rules[RuleName.size_of_dataset] = cqc_location_df.count()
 
     check_result_df = validate_dataset(merged_ind_cqc_df, rules)
-    check_result_df.show()
 
     utils.write_to_parquet(check_result_df, report_destination, mode="overwrite")
 

--- a/jobs/validate_merged_ind_cqc_data.py
+++ b/jobs/validate_merged_ind_cqc_data.py
@@ -34,10 +34,10 @@ def main(
         selected_columns=cleaned_cqc_locations_columns_to_import,
     )
     merged_ind_cqc_df = utils.read_from_parquet(
-            merged_ind_cqc_source,
-        )
-    
-    cqc_location_df_size = cqc_location_df.count()    
+        merged_ind_cqc_source,
+    )
+
+    cqc_location_df_size = cqc_location_df.count()
 
     complete_columns = [
         IndCqcColumns.location_id,
@@ -72,19 +72,21 @@ def main(
         VerificationSuite(spark)
         .onData(merged_ind_cqc_df)
         .addCheck(
-            check.areComplete(complete_columns)
+            check.areComplete(complete_columns, "Completeness should be 1.")
             .hasUniqueness(
                 [IndCqcColumns.location_id, IndCqcColumns.cqc_location_import_date],
                 lambda x: x == 1,
+                "Uniqueness should be 1.",
             )
             .hasSize(
                 lambda x: x == cqc_location_df_size,
-                f"DataFrame row count should be {cqc_location_df_size}",
+                f"DataFrame row count should be {cqc_location_df_size}.",
             )
         )
         .run()
     )
     check_result_df = VerificationResult.checkResultsAsDataFrame(spark, check_result)
+    check_result_df.show()
 
     utils.write_to_parquet(check_result_df, report_destination, mode="overwrite")
 

--- a/jobs/validate_merged_ind_cqc_data.py
+++ b/jobs/validate_merged_ind_cqc_data.py
@@ -3,8 +3,6 @@ import sys
 
 os.environ["SPARK_VERSION"] = "3.3"
 
-from pydeequ.checks import Check, CheckLevel
-from pydeequ.verification import VerificationResult, VerificationSuite
 from pyspark.sql.dataframe import DataFrame
 
 from utils import utils
@@ -12,7 +10,6 @@ from utils.column_names.cleaned_data_files.cqc_location_cleaned_values import (
     CqcLocationCleanedColumns as CQCLClean,
 )
 from utils.column_names.ind_cqc_pipeline_columns import (
-    IndCqcColumns,
     PartitionKeys as Keys,
 )
 from utils.validation.validation_rules.merged_ind_cqc_validation_rules import (

--- a/jobs/validate_merged_ind_cqc_data.py
+++ b/jobs/validate_merged_ind_cqc_data.py
@@ -18,7 +18,7 @@ from utils.column_names.ind_cqc_pipeline_columns import (
 from utils.validation.validation_rules.merged_ind_cqc_validation_rules import (
     MergedIndCqcValidationRules as Rules,
 )
-import utils.validation.validation_utils as Vutils
+from utils.validation.validation_utils import validate_dataset
 from utils.validation.validation_rule_names import RuleNames as RuleName
 
 PartitionKeys = [Keys.year, Keys.month, Keys.day, Keys.import_date]
@@ -47,20 +47,7 @@ def main(
 
     rules[RuleName.size_of_dataset] = cqc_location_df.count()
 
-    verification_run = VerificationSuite(spark).onData(merged_ind_cqc_df)
-    verification_run = Vutils.add_checks_to_run(verification_run, rules)
-    check_result = verification_run.run()
-    """
-    check_result = (
-        VerificationSuite(spark)
-        .onData(merged_ind_cqc_df)
-        .addCheck(check_dataset_size)
-        .addCheck(check_index_columns_are_unique)
-        .addCheck(check_column_completeness)
-        .run()
-    )
-    """
-    check_result_df = VerificationResult.checkResultsAsDataFrame(spark, check_result)
+    check_result_df = validate_dataset(merged_ind_cqc_df, rules)
     check_result_df.show()
 
     utils.write_to_parquet(check_result_df, report_destination, mode="overwrite")

--- a/jobs/validate_merged_ind_cqc_data.py
+++ b/jobs/validate_merged_ind_cqc_data.py
@@ -33,12 +33,37 @@ def main(
         cleaned_cqc_location_source,
         selected_columns=cleaned_cqc_locations_columns_to_import,
     )
-
-    cqc_location_df_size = cqc_location_df.count()
-
     merged_ind_cqc_df = utils.read_from_parquet(
-        merged_ind_cqc_source,
-    )
+            merged_ind_cqc_source,
+        )
+    
+    cqc_location_df_size = cqc_location_df.count()    
+
+    complete_columns = [
+        IndCqcColumns.location_id,
+        IndCqcColumns.ascwds_workplace_import_date,
+        IndCqcColumns.cqc_location_import_date,
+        IndCqcColumns.cqc_pir_import_date,
+        IndCqcColumns.care_home,
+        IndCqcColumns.provider_id,
+        IndCqcColumns.cqc_sector,
+        IndCqcColumns.registration_status,
+        IndCqcColumns.registration_date,
+        IndCqcColumns.dormancy,
+        IndCqcColumns.number_of_beds,
+        IndCqcColumns.services_offered,
+        IndCqcColumns.primary_service_type,
+        IndCqcColumns.contemporary_ons_import_date,
+        IndCqcColumns.contemporary_cssr,
+        IndCqcColumns.contemporary_region,
+        IndCqcColumns.current_ons_import_date,
+        IndCqcColumns.current_cssr,
+        IndCqcColumns.current_region,
+        IndCqcColumns.current_rural_urban_indicator_2011,
+        IndCqcColumns.people_directly_employed,
+        IndCqcColumns.establishment_id,
+        IndCqcColumns.organisation_id,
+    ]
 
     spark = utils.get_spark()
 
@@ -47,7 +72,7 @@ def main(
         VerificationSuite(spark)
         .onData(merged_ind_cqc_df)
         .addCheck(
-            check.isComplete(IndCqcColumns.cqc_sector)
+            check.areComplete(complete_columns)
             .hasUniqueness(
                 [IndCqcColumns.location_id, IndCqcColumns.cqc_location_import_date],
                 lambda x: x == 1,

--- a/jobs/validate_merged_ind_cqc_data.py
+++ b/jobs/validate_merged_ind_cqc_data.py
@@ -15,6 +15,10 @@ from utils.column_names.ind_cqc_pipeline_columns import (
     IndCqcColumns,
     PartitionKeys as Keys,
 )
+from utils.validation.validation_rules.merged_ind_cqc_validation_rules import (
+    MergedIndCqcValidationRules as Rules,
+)
+import utils.validation.validation_utils as Vutils
 
 PartitionKeys = [Keys.year, Keys.month, Keys.day, Keys.import_date]
 
@@ -36,53 +40,24 @@ def main(
     merged_ind_cqc_df = utils.read_from_parquet(
         merged_ind_cqc_source,
     )
-
-    cqc_location_df_size = cqc_location_df.count()
-
-    complete_columns = [
-        IndCqcColumns.location_id,
-        IndCqcColumns.ascwds_workplace_import_date,
-        IndCqcColumns.cqc_location_import_date,
-        IndCqcColumns.cqc_pir_import_date,
-        IndCqcColumns.care_home,
-        IndCqcColumns.provider_id,
-        IndCqcColumns.cqc_sector,
-        IndCqcColumns.registration_status,
-        IndCqcColumns.registration_date,
-        IndCqcColumns.dormancy,
-        IndCqcColumns.number_of_beds,
-        IndCqcColumns.services_offered,
-        IndCqcColumns.primary_service_type,
-        IndCqcColumns.contemporary_ons_import_date,
-        IndCqcColumns.contemporary_cssr,
-        IndCqcColumns.contemporary_region,
-        IndCqcColumns.current_ons_import_date,
-        IndCqcColumns.current_cssr,
-        IndCqcColumns.current_region,
-        IndCqcColumns.current_rural_urban_indicator_2011,
-        IndCqcColumns.people_directly_employed,
-        IndCqcColumns.establishment_id,
-        IndCqcColumns.organisation_id,
-    ]
-
     spark = utils.get_spark()
 
-    check = Check(spark, CheckLevel.Warning, "Review Check")
+    expected_size = cqc_location_df.count()
+
+    check_dataset_size = Vutils.create_check_of_size_of_dataset(expected_size)
+    check_index_columns_are_unique = (
+        Vutils.create_check_of_uniqueness_of_two_index_columns(Rules.index_columns)
+    )
+    check_column_completeness = Vutils.create_check_for_column_completeness(
+        Rules.complete_columns
+    )
+
     check_result = (
         VerificationSuite(spark)
         .onData(merged_ind_cqc_df)
-        .addCheck(
-            check.areComplete(complete_columns, "Completeness should be 1.")
-            .hasUniqueness(
-                [IndCqcColumns.location_id, IndCqcColumns.cqc_location_import_date],
-                lambda x: x == 1,
-                "Uniqueness should be 1.",
-            )
-            .hasSize(
-                lambda x: x == cqc_location_df_size,
-                f"DataFrame row count should be {cqc_location_df_size}.",
-            )
-        )
+        .addCheck(check_dataset_size)
+        .addCheck(check_index_columns_are_unique)
+        .addCheck(check_column_completeness)
         .run()
     )
     check_result_df = VerificationResult.checkResultsAsDataFrame(spark, check_result)

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -3043,25 +3043,15 @@ class ValidateMergedIndCqcData:
     cqc_locations_rows = [
         (date(2024, 1, 1), "1-000000001", "Independent", "Y", 10,),
         (date(2024, 1, 1), "1-000000002", "Independent", "N", None,),
-        (date(2024, 1, 1), "1-000000003", "Independent", "N", None,),
         (date(2024, 2, 1), "1-000000001", "Independent", "Y", 10,),
         (date(2024, 2, 1), "1-000000002", "Independent", "N", None,),
-        (date(2024, 2, 1), "1-000000003", "Independent", "N", None,),
-        (date(2024, 3, 1), "1-000000001", "Independent", "Y", 10,),
-        (date(2024, 3, 1), "1-000000002", "Independent", "N", None,),
-        (date(2024, 3, 1), "1-000000003", "Independent", "N", None,),
     ]
 
     merged_ind_cqc_rows = [
-        ("1-000000001", date(2024, 1, 1), date(2024, 1, 1), "Independent", "Y", 10, "1", 1, 10, date(2024, 1, 1)),
-        ("1-000000002", date(2024, 1, 1), date(2024, 1, 1), "Independent", "N", None, None, None, 20, date(2024, 1, 1)),
-        ("1-000000003", date(2024, 1, 1), date(2024, 1, 1), "Independent", "N", None, "3", 2, None, date(2024, 1, 1)),
-        ("1-000000001", date(2024, 1, 9), date(2024, 2, 1), "Independent", "Y", 10, "1", 4, 1, date(2024, 2, 1)),
-        ("1-000000002", date(2024, 1, 9), date(2024, 2, 1), "Independent", "N", None, None, None, 4, date(2024, 2, 1)),
-        ("1-000000003", date(2024, 1, 9), date(2024, 2, 1), "Independent", "N", None, "3", 5, None, date(2024, 2, 1)),
-        ("1-000000001", date(2024, 3, 1), date(2024, 3, 1), "Independent", "Y", 10, None, None, 1, date(2024, 2, 1)),
-        ("1-000000002", date(2024, 3, 1), date(2024, 3, 1), "Independent", "N", None, None, None, 4, date(2024, 2, 1)),
-        ("1-000000003", date(2024, 3, 1), date(2024, 3, 1), "Independent", "N", None, "4", 6, None, date(2024, 2, 1)),
+        ("1-000000001", date(2024, 1, 1), date(2024, 1, 1), date(2024, 1, 1), "Y", "name", "prov_1", "prov_name", CQCPValues.independent, CQCLValues.registered, date(2024, 1, 1), "Y", 5, ["service"], CQCLValues.care_home_only, date(2024, 1, 1), "cssr", "region", date(2024, 1, 1), "cssr", "region", "RUI", 5, "estab_1", "org_1", 5, 5),
+        ("1-000000002", date(2024, 1, 1), date(2024, 1, 1), date(2024, 1, 1), "Y", "name", "prov_1", "prov_name", CQCPValues.independent, CQCLValues.registered, date(2024, 1, 1), "Y", 5, ["service"], CQCLValues.care_home_only, date(2024, 1, 1), "cssr", "region", date(2024, 1, 1), "cssr", "region", "RUI", 5, "estab_1", "org_1", 5, 5),
+        ("1-000000001", date(2024, 1, 9), date(2024, 1, 1), date(2024, 1, 1), "Y", "name", "prov_1", "prov_name", CQCPValues.independent, CQCLValues.registered, date(2024, 1, 1), "Y", 5, ["service"], CQCLValues.care_home_only, date(2024, 1, 1), "cssr", "region", date(2024, 1, 1), "cssr", "region", "RUI", 5, "estab_1", "org_1", 5, 5),
+        ("1-000000002", date(2024, 1, 9), date(2024, 1, 1), date(2024, 1, 1), "Y", "name", "prov_1", "prov_name", CQCPValues.independent, CQCLValues.registered, date(2024, 1, 1), "Y", 5, ["service"], CQCLValues.care_home_only, date(2024, 1, 1), "cssr", "region", date(2024, 1, 1), "cssr", "region", "RUI", 5, "estab_1", "org_1", 5, 5),
     ]
 
     merged_ind_cqc_extra_row_rows = [

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -3055,51 +3055,31 @@ class ValidateMergedIndCqcData:
     ]
 
     merged_ind_cqc_extra_row_rows = [
-        ("1-000000001", date(2024, 1, 1), date(2024, 1, 1), "Independent", "Y", 10, "1", 1, 10, date(2024, 1, 1)),
-        ("1-000000002", date(2024, 1, 1), date(2024, 1, 1), "Independent", "N", None, None, None, 20, date(2024, 1, 1)),
-        ("1-000000003", date(2024, 1, 1), date(2024, 1, 1), "Independent", "N", None, "3", 2, None, date(2024, 1, 1)),
-        ("1-000000001", date(2024, 1, 9), date(2024, 2, 1), "Independent", "Y", 10, "1", 4, 1, date(2024, 2, 1)),
-        ("1-000000002", date(2024, 1, 9), date(2024, 2, 1), "Independent", "N", None, None, None, 4, date(2024, 2, 1)),
-        ("1-000000003", date(2024, 1, 9), date(2024, 2, 1), "Independent", "N", None, "3", 5, None, date(2024, 2, 1)),
-        ("1-000000001", date(2024, 3, 1), date(2024, 3, 1), "Independent", "Y", 10, None, None, 1, date(2024, 2, 1)),
-        ("1-000000002", date(2024, 3, 1), date(2024, 3, 1), "Independent", "N", None, None, None, 4, date(2024, 2, 1)),
-        ("1-000000003", date(2024, 3, 1), date(2024, 3, 1), "Independent", "N", None, "4", 6, None, date(2024, 2, 1)),
-        ("1-000000004", date(2024, 3, 1), date(2024, 3, 1), "Independent", "N", None, "4", 6, None, date(2024, 2, 1)),
+        ("1-000000001", date(2024, 1, 1), date(2024, 1, 1), date(2024, 1, 1), "Y", "name", "prov_1", "prov_name", CQCPValues.independent, CQCLValues.registered, date(2024, 1, 1), "Y", 5, ["service"], CQCLValues.care_home_only, date(2024, 1, 1), "cssr", "region", date(2024, 1, 1), "cssr", "region", "RUI", 5, "estab_1", "org_1", 5, 5),
+        ("1-000000002", date(2024, 1, 1), date(2024, 1, 1), date(2024, 1, 1), "Y", "name", "prov_1", "prov_name", CQCPValues.independent, CQCLValues.registered, date(2024, 1, 1), "Y", 5, ["service"], CQCLValues.care_home_only, date(2024, 1, 1), "cssr", "region", date(2024, 1, 1), "cssr", "region", "RUI", 5, "estab_1", "org_1", 5, 5),
+        ("1-000000001", date(2024, 1, 9), date(2024, 1, 1), date(2024, 1, 1), "Y", "name", "prov_1", "prov_name", CQCPValues.independent, CQCLValues.registered, date(2024, 1, 1), "Y", 5, ["service"], CQCLValues.care_home_only, date(2024, 1, 1), "cssr", "region", date(2024, 1, 1), "cssr", "region", "RUI", 5, "estab_1", "org_1", 5, 5),
+        ("1-000000002", date(2024, 1, 9), date(2024, 1, 1), date(2024, 1, 1), "Y", "name", "prov_1", "prov_name", CQCPValues.independent, CQCLValues.registered, date(2024, 1, 1), "Y", 5, ["service"], CQCLValues.care_home_only, date(2024, 1, 1), "cssr", "region", date(2024, 1, 1), "cssr", "region", "RUI", 5, "estab_1", "org_1", 5, 5),
+        ("1-000000003", date(2024, 1, 9), date(2024, 1, 1), date(2024, 1, 1), "Y", "name", "prov_1", "prov_name", CQCPValues.independent, CQCLValues.registered, date(2024, 1, 1), "Y", 5, ["service"], CQCLValues.care_home_only, date(2024, 1, 1), "cssr", "region", date(2024, 1, 1), "cssr", "region", "RUI", 5, "estab_1", "org_1", 5, 5),
     ]
 
     merged_ind_cqc_missing_row_rows = [
-        ("1-000000001", date(2024, 1, 1), date(2024, 1, 1), "Independent", "Y", 10, "1", 1, 10, date(2024, 1, 1)),
-        ("1-000000002", date(2024, 1, 1), date(2024, 1, 1), "Independent", "N", None, None, None, 20, date(2024, 1, 1)),
-        ("1-000000003", date(2024, 1, 1), date(2024, 1, 1), "Independent", "N", None, "3", 2, None, date(2024, 1, 1)),
-        ("1-000000001", date(2024, 1, 9), date(2024, 2, 1), "Independent", "Y", 10, "1", 4, 1, date(2024, 2, 1)),
-        ("1-000000002", date(2024, 1, 9), date(2024, 2, 1), "Independent", "N", None, None, None, 4, date(2024, 2, 1)),
-        ("1-000000003", date(2024, 1, 9), date(2024, 2, 1), "Independent", "N", None, "3", 5, None, date(2024, 2, 1)),
-        ("1-000000001", date(2024, 3, 1), date(2024, 3, 1), "Independent", "Y", 10, None, None, 1, date(2024, 2, 1)),
-        ("1-000000002", date(2024, 3, 1), date(2024, 3, 1), "Independent", "N", None, None, None, 4, date(2024, 2, 1)),
+        ("1-000000001", date(2024, 1, 1), date(2024, 1, 1), date(2024, 1, 1), "Y", "name", "prov_1", "prov_name", CQCPValues.independent, CQCLValues.registered, date(2024, 1, 1), "Y", 5, ["service"], CQCLValues.care_home_only, date(2024, 1, 1), "cssr", "region", date(2024, 1, 1), "cssr", "region", "RUI", 5, "estab_1", "org_1", 5, 5),
+        ("1-000000002", date(2024, 1, 1), date(2024, 1, 1), date(2024, 1, 1), "Y", "name", "prov_1", "prov_name", CQCPValues.independent, CQCLValues.registered, date(2024, 1, 1), "Y", 5, ["service"], CQCLValues.care_home_only, date(2024, 1, 1), "cssr", "region", date(2024, 1, 1), "cssr", "region", "RUI", 5, "estab_1", "org_1", 5, 5),
+        ("1-000000001", date(2024, 1, 9), date(2024, 1, 1), date(2024, 1, 1), "Y", "name", "prov_1", "prov_name", CQCPValues.independent, CQCLValues.registered, date(2024, 1, 1), "Y", 5, ["service"], CQCLValues.care_home_only, date(2024, 1, 1), "cssr", "region", date(2024, 1, 1), "cssr", "region", "RUI", 5, "estab_1", "org_1", 5, 5),
     ]
 
     merged_ind_cqc_with_cqc_sector_null_rows = [
-        ("1-000000001", date(2024, 1, 1), date(2024, 1, 1), "Independent", "Y", 10, "1", 1, 10, date(2024, 1, 1)),
-        ("1-000000002", date(2024, 1, 1), date(2024, 1, 1), "Independent", "N", None, None, None, 20, date(2024, 1, 1)),
-        ("1-000000003", date(2024, 1, 1), date(2024, 1, 1), "Independent", "N", None, "3", 2, None, date(2024, 1, 1)),
-        ("1-000000001", date(2024, 1, 9), date(2024, 2, 1), "Independent", "Y", 10, "1", 4, 1, date(2024, 2, 1)),
-        ("1-000000002", date(2024, 1, 9), date(2024, 2, 1), "Independent", "N", None, None, None, 4, date(2024, 2, 1)),
-        ("1-000000003", date(2024, 1, 9), date(2024, 2, 1), "Independent", "N", None, "3", 5, None, date(2024, 2, 1)),
-        ("1-000000001", date(2024, 3, 1), date(2024, 3, 1), "Independent", "Y", 10, None, None, 1, date(2024, 2, 1)),
-        ("1-000000002", date(2024, 3, 1), date(2024, 3, 1), "Independent", "N", None, None, None, 4, date(2024, 2, 1)),
-        ("1-000000003", date(2024, 3, 1), date(2024, 3, 1), None, "N", None, "4", 6, None, date(2024, 2, 1)),
+        ("1-000000001", date(2024, 1, 1), date(2024, 1, 1), date(2024, 1, 1), "Y", "name", "prov_1", "prov_name", CQCPValues.independent, CQCLValues.registered, date(2024, 1, 1), "Y", 5, ["service"], CQCLValues.care_home_only, date(2024, 1, 1), "cssr", "region", date(2024, 1, 1), "cssr", "region", "RUI", 5, "estab_1", "org_1", 5, 5),
+        ("1-000000002", date(2024, 1, 1), date(2024, 1, 1), date(2024, 1, 1), "Y", "name", "prov_1", "prov_name", CQCPValues.independent, CQCLValues.registered, date(2024, 1, 1), "Y", 5, ["service"], CQCLValues.care_home_only, date(2024, 1, 1), "cssr", "region", date(2024, 1, 1), "cssr", "region", "RUI", 5, "estab_1", "org_1", 5, 5),
+        ("1-000000001", date(2024, 1, 9), date(2024, 1, 1), date(2024, 1, 1), "Y", "name", "prov_1", "prov_name", CQCPValues.independent, CQCLValues.registered, date(2024, 1, 1), "Y", 5, ["service"], CQCLValues.care_home_only, date(2024, 1, 1), "cssr", "region", date(2024, 1, 1), "cssr", "region", "RUI", 5, "estab_1", "org_1", 5, 5),
+        ("1-000000002", date(2024, 1, 9), date(2024, 1, 1), date(2024, 1, 1), "Y", "name", "prov_1", "prov_name", None, CQCLValues.registered, date(2024, 1, 1), "Y", 5, ["service"], CQCLValues.care_home_only, date(2024, 1, 1), "cssr", "region", date(2024, 1, 1), "cssr", "region", "RUI", 5, "estab_1", "org_1", 5, 5),
     ]
 
     merged_ind_cqc_with_duplicate_data_rows = [
-        ("1-000000001", date(2024, 1, 1), date(2024, 1, 1), "Independent", "Y", 10, "1", 1, 10, date(2024, 1, 1)),
-        ("1-000000002", date(2024, 1, 1), date(2024, 1, 1), "Independent", "N", None, None, None, 20, date(2024, 1, 1)),
-        ("1-000000003", date(2024, 1, 1), date(2024, 1, 1), "Independent", "N", None, "3", 2, None, date(2024, 1, 1)),
-        ("1-000000001", date(2024, 1, 9), date(2024, 1, 1), "Independent", "Y", 10, "1", 4, 1, date(2024, 2, 1)),
-        ("1-000000002", date(2024, 1, 9), date(2024, 2, 1), "Independent", "N", None, None, None, 4, date(2024, 2, 1)),
-        ("1-000000003", date(2024, 1, 9), date(2024, 2, 1), "Independent", "N", None, "3", 5, None, date(2024, 2, 1)),
-        ("1-000000001", date(2024, 3, 1), date(2024, 3, 1), "Independent", "Y", 10, None, None, 1, date(2024, 2, 1)),
-        ("1-000000002", date(2024, 3, 1), date(2024, 3, 1), "Independent", "N", None, None, None, 4, date(2024, 2, 1)),
-        ("1-000000003", date(2024, 3, 1), date(2024, 3, 1), "Independent", "N", None, "4", 6, None, date(2024, 2, 1)),
+        ("1-000000001", date(2024, 1, 1), date(2024, 1, 1), date(2024, 1, 1), "Y", "name", "prov_1", "prov_name", CQCPValues.independent, CQCLValues.registered, date(2024, 1, 1), "Y", 5, ["service"], CQCLValues.care_home_only, date(2024, 1, 1), "cssr", "region", date(2024, 1, 1), "cssr", "region", "RUI", 5, "estab_1", "org_1", 5, 5),
+        ("1-000000002", date(2024, 1, 1), date(2024, 1, 1), date(2024, 1, 1), "Y", "name", "prov_1", "prov_name", CQCPValues.independent, CQCLValues.registered, date(2024, 1, 1), "Y", 5, ["service"], CQCLValues.care_home_only, date(2024, 1, 1), "cssr", "region", date(2024, 1, 1), "cssr", "region", "RUI", 5, "estab_1", "org_1", 5, 5),
+        ("1-000000002", date(2024, 1, 9), date(2024, 1, 1), date(2024, 1, 1), "Y", "name", "prov_1", "prov_name", CQCPValues.independent, CQCLValues.registered, date(2024, 1, 1), "Y", 5, ["service"], CQCLValues.care_home_only, date(2024, 1, 1), "cssr", "region", date(2024, 1, 1), "cssr", "region", "RUI", 5, "estab_1", "org_1", 5, 5),
+        ("1-000000002", date(2024, 1, 9), date(2024, 1, 1), date(2024, 1, 1), "Y", "name", "prov_1", "prov_name", CQCPValues.independent, CQCLValues.registered, date(2024, 1, 1), "Y", 5, ["service"], CQCLValues.care_home_only, date(2024, 1, 1), "cssr", "region", date(2024, 1, 1), "cssr", "region", "RUI", 5, "estab_1", "org_1", 5, 5),
     ]
     # fmt: on
 

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -2051,9 +2051,33 @@ class ValidateMergedIndCqcData:
     cqc_locations_schema = MergeIndCQCData.clean_cqc_location_for_merge_schema
     merged_ind_cqc_schema = StructType(
         [
-            *MergeIndCQCData.expected_cqc_and_ascwds_merged_schema,
-            StructField(CQCPIRClean.people_directly_employed, IntegerType(), True),
-            StructField(CQCPIRClean.cqc_pir_import_date, DateType(), True),
+            StructField(IndCQC.location_id, StringType(), True),
+            StructField(IndCQC.cqc_location_import_date, DateType(), True),
+            StructField(IndCQC.ascwds_workplace_import_date, DateType(), True),
+            StructField(IndCQC.cqc_pir_import_date, DateType(), True),
+            StructField(IndCQC.care_home, StringType(), True),
+            StructField(IndCQC.name, StringType(), True),
+            StructField(IndCQC.provider_id, StringType(), True),
+            StructField(IndCQC.provider_name, StringType(), True),
+            StructField(IndCQC.cqc_sector, StringType(), True),
+            StructField(IndCQC.registration_status, StringType(), True),
+            StructField(IndCQC.registration_date, DateType(), True),
+            StructField(IndCQC.dormancy, StringType(), True),
+            StructField(IndCQC.number_of_beds, IntegerType(), True),
+            StructField(IndCQC.services_offered, ArrayType(StructField(StringType())), True),
+            StructField(IndCQC.primary_service_type, StringType(), True),
+            StructField(IndCQC.contemporary_ons_import_date, DateType(), True),
+            StructField(IndCQC.contemporary_cssr, StringType(), True),
+            StructField(IndCQC.contemporary_region, StringType(), True),
+            StructField(IndCQC.current_ons_import_date, DateType(), True),
+            StructField(IndCQC.current_cssr, StringType(), True),
+            StructField(IndCQC.current_region, StringType(), True),
+            StructField(IndCQC.current_rural_urban_indicator_2011, StringType(), True),
+            StructField(IndCQC.people_directly_employed, IntegerType(), True),
+            StructField(IndCQC.establishment_id, StringType(), True),
+            StructField(IndCQC.organisation_id, StringType(), True),
+            StructField(IndCQC.total_staff_bounded, IntegerType(), True),
+            StructField(IndCQC.worker_records_bounded, IntegerType(), True),
         ]
     )
 

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -2064,7 +2064,13 @@ class ValidateMergedIndCqcData:
             StructField(IndCQC.registration_date, DateType(), True),
             StructField(IndCQC.dormancy, StringType(), True),
             StructField(IndCQC.number_of_beds, IntegerType(), True),
-            StructField(IndCQC.services_offered, ArrayType(StructField(StringType())), True),
+            StructField(
+                IndCQC.services_offered,
+                ArrayType(
+                    StringType(),
+                ),
+                True,
+            ),
             StructField(IndCQC.primary_service_type, StringType(), True),
             StructField(IndCQC.contemporary_ons_import_date, DateType(), True),
             StructField(IndCQC.contemporary_cssr, StringType(), True),

--- a/tests/unit/test_validate_merged_ind_cqc_data.py
+++ b/tests/unit/test_validate_merged_ind_cqc_data.py
@@ -194,7 +194,7 @@ class ValidateMergedIndCQCDatasetTests(unittest.TestCase):
             .select(self.constraint_message)
             .collect()[0][0]
         )
-        expected_failure_message = "Value: 0.75 does not meet the constraint requirement! Completeness should be 1."
+        expected_failure_message = "Value: 0.75 does not meet the constraint requirement! Completeness of cqc_sector should be 1."
 
         self.assertEqual(failure_count, expected_failure_count)
         self.assertEqual(failure_message, expected_failure_message)

--- a/tests/unit/test_validate_merged_ind_cqc_data.py
+++ b/tests/unit/test_validate_merged_ind_cqc_data.py
@@ -126,7 +126,7 @@ class ValidateMergedIndCQCDatasetTests(unittest.TestCase):
             .select(self.constraint_message)
             .collect()[0][0]
         )
-        expected_failure_message = "Value: 10 does not meet the constraint requirement! DataFrame row count should be 9"
+        expected_failure_message = "Value: 5 does not meet the constraint requirement! DataFrame row count should be 4."
 
         self.assertEqual(failure_count, expected_failure_count)
         self.assertEqual(failure_message, expected_failure_message)
@@ -160,7 +160,7 @@ class ValidateMergedIndCQCDatasetTests(unittest.TestCase):
             .select(self.constraint_message)
             .collect()[0][0]
         )
-        expected_failure_message = "Value: 8 does not meet the constraint requirement! DataFrame row count should be 9"
+        expected_failure_message = "Value: 3 does not meet the constraint requirement! DataFrame row count should be 4."
 
         self.assertEqual(failure_count, expected_failure_count)
         self.assertEqual(failure_message, expected_failure_message)
@@ -194,9 +194,7 @@ class ValidateMergedIndCQCDatasetTests(unittest.TestCase):
             .select(self.constraint_message)
             .collect()[0][0]
         )
-        expected_failure_message = (
-            "Value: 0.8888888888888888 does not meet the constraint requirement!"
-        )
+        expected_failure_message = "Value: 0.75 does not meet the constraint requirement! Completeness should be 1."
 
         self.assertEqual(failure_count, expected_failure_count)
         self.assertEqual(failure_message, expected_failure_message)
@@ -231,9 +229,7 @@ class ValidateMergedIndCQCDatasetTests(unittest.TestCase):
             .select(self.constraint_message)
             .collect()[0][0]
         )
-        expected_failure_message = (
-            "Value: 0.7777777777777778 does not meet the constraint requirement!"
-        )
+        expected_failure_message = "Value: 0.5 does not meet the constraint requirement! Uniqueness should be 1."
 
         self.assertEqual(failure_count, expected_failure_count)
         self.assertEqual(failure_message, expected_failure_message)

--- a/utils/validation/validation_rule_names.py
+++ b/utils/validation/validation_rule_names.py
@@ -1,0 +1,8 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class RuleNames:
+    size_of_dataset: str = "size_of_dataset"
+    complete_columns: str = "complete_columns"
+    index_columns: str = "index_columns"

--- a/utils/validation/validation_rules/merged_ind_cqc_validation_rules.py
+++ b/utils/validation/validation_rules/merged_ind_cqc_validation_rules.py
@@ -1,0 +1,35 @@
+from dataclasses import dataclass
+
+from utils.column_names.ind_cqc_pipeline_columns import (
+    IndCqcColumns,
+)
+
+
+@dataclass
+class MergedIndCqcValidationRules:
+    complete_columns = [
+        IndCqcColumns.location_id,
+        IndCqcColumns.ascwds_workplace_import_date,
+        IndCqcColumns.cqc_location_import_date,
+        IndCqcColumns.cqc_pir_import_date,
+        IndCqcColumns.care_home,
+        IndCqcColumns.provider_id,
+        IndCqcColumns.cqc_sector,
+        IndCqcColumns.registration_status,
+        IndCqcColumns.registration_date,
+        IndCqcColumns.dormancy,
+        IndCqcColumns.number_of_beds,
+        IndCqcColumns.primary_service_type,
+        IndCqcColumns.contemporary_ons_import_date,
+        IndCqcColumns.contemporary_cssr,
+        IndCqcColumns.contemporary_region,
+        IndCqcColumns.current_ons_import_date,
+        IndCqcColumns.current_cssr,
+        IndCqcColumns.current_region,
+        IndCqcColumns.current_rural_urban_indicator_2011,
+        IndCqcColumns.people_directly_employed,
+        IndCqcColumns.establishment_id,
+        IndCqcColumns.organisation_id,
+    ]
+
+    index_columns = [IndCqcColumns.location_id, IndCqcColumns.cqc_location_import_date]

--- a/utils/validation/validation_rules/merged_ind_cqc_validation_rules.py
+++ b/utils/validation/validation_rules/merged_ind_cqc_validation_rules.py
@@ -8,7 +8,6 @@ from utils.validation.validation_rule_names import RuleNames as RuleName
 
 @dataclass
 class MergedIndCqcValidationRules:
-
     rules_to_check = {
         RuleName.size_of_dataset: None,
         RuleName.complete_columns: [

--- a/utils/validation/validation_rules/merged_ind_cqc_validation_rules.py
+++ b/utils/validation/validation_rules/merged_ind_cqc_validation_rules.py
@@ -3,33 +3,40 @@ from dataclasses import dataclass
 from utils.column_names.ind_cqc_pipeline_columns import (
     IndCqcColumns,
 )
+from utils.validation.validation_rule_names import RuleNames as RuleName
 
 
 @dataclass
 class MergedIndCqcValidationRules:
-    complete_columns = [
-        IndCqcColumns.location_id,
-        IndCqcColumns.ascwds_workplace_import_date,
-        IndCqcColumns.cqc_location_import_date,
-        IndCqcColumns.cqc_pir_import_date,
-        IndCqcColumns.care_home,
-        IndCqcColumns.provider_id,
-        IndCqcColumns.cqc_sector,
-        IndCqcColumns.registration_status,
-        IndCqcColumns.registration_date,
-        IndCqcColumns.dormancy,
-        IndCqcColumns.number_of_beds,
-        IndCqcColumns.primary_service_type,
-        IndCqcColumns.contemporary_ons_import_date,
-        IndCqcColumns.contemporary_cssr,
-        IndCqcColumns.contemporary_region,
-        IndCqcColumns.current_ons_import_date,
-        IndCqcColumns.current_cssr,
-        IndCqcColumns.current_region,
-        IndCqcColumns.current_rural_urban_indicator_2011,
-        IndCqcColumns.people_directly_employed,
-        IndCqcColumns.establishment_id,
-        IndCqcColumns.organisation_id,
-    ]
 
-    index_columns = [IndCqcColumns.location_id, IndCqcColumns.cqc_location_import_date]
+    rules_to_check = {
+        RuleName.size_of_dataset: None,
+        RuleName.complete_columns: [
+            IndCqcColumns.location_id,
+            IndCqcColumns.ascwds_workplace_import_date,
+            IndCqcColumns.cqc_location_import_date,
+            IndCqcColumns.cqc_pir_import_date,
+            IndCqcColumns.care_home,
+            IndCqcColumns.provider_id,
+            IndCqcColumns.cqc_sector,
+            IndCqcColumns.registration_status,
+            IndCqcColumns.registration_date,
+            IndCqcColumns.dormancy,
+            IndCqcColumns.number_of_beds,
+            IndCqcColumns.primary_service_type,
+            IndCqcColumns.contemporary_ons_import_date,
+            IndCqcColumns.contemporary_cssr,
+            IndCqcColumns.contemporary_region,
+            IndCqcColumns.current_ons_import_date,
+            IndCqcColumns.current_cssr,
+            IndCqcColumns.current_region,
+            IndCqcColumns.current_rural_urban_indicator_2011,
+            IndCqcColumns.people_directly_employed,
+            IndCqcColumns.establishment_id,
+            IndCqcColumns.organisation_id,
+        ],
+        RuleName.index_columns: [
+            IndCqcColumns.location_id,
+            IndCqcColumns.cqc_location_import_date,
+        ],
+    }

--- a/utils/validation/validation_utils.py
+++ b/utils/validation/validation_utils.py
@@ -1,8 +1,9 @@
 from pydeequ.checks import Check, CheckLevel
-from pydeequ.verification import VerificationResult, VerificationSuite
+from pydeequ.verification import VerificationRunBuilder
 from pyspark.sql.dataframe import DataFrame
 
 from utils import utils
+from utils.validation.validation_rule_names import RuleNames as RuleToCheck
 
 
 def create_check_for_column_completeness(complete_columns: list) -> Check:
@@ -29,4 +30,25 @@ def create_check_of_size_of_dataset(expected_size: int) -> Check:
         lambda x: x == expected_size,
         f"DataFrame row count should be {expected_size}.",
     )
+    return check
+
+
+def add_checks_to_run(
+    run: VerificationRunBuilder, rules_to_check: dict
+) -> VerificationRunBuilder:
+    for rule in rules_to_check.keys():
+        check = create_check(rule, rules_to_check[rule])
+        run = run.addCheck(check)
+    return run
+
+
+def create_check(rule_name: str, rule) -> Check:
+    if rule_name == RuleToCheck.size_of_dataset:
+        check = create_check_of_size_of_dataset(rule)
+    elif rule_name == RuleToCheck.complete_columns:
+        check = create_check_for_column_completeness(rule)
+    elif rule_name == RuleToCheck.index_columns:
+        check = create_check_of_uniqueness_of_two_index_columns(rule)
+    else:
+        raise ValueError("Unknown rule to check")
     return check

--- a/utils/validation/validation_utils.py
+++ b/utils/validation/validation_utils.py
@@ -1,0 +1,32 @@
+from pydeequ.checks import Check, CheckLevel
+from pydeequ.verification import VerificationResult, VerificationSuite
+from pyspark.sql.dataframe import DataFrame
+
+from utils import utils
+
+
+def create_check_for_column_completeness(complete_columns: list) -> Check:
+    spark = utils.get_spark()
+    check = Check(spark, CheckLevel.Warning, "Column is complete")
+    for column in complete_columns:
+        check = check.isComplete(column, f"Completeness of {column} should be 1.")
+    return check
+
+
+def create_check_of_uniqueness_of_two_index_columns(column_names: list) -> Check:
+    spark = utils.get_spark()
+    check = Check(spark, CheckLevel.Warning, "Index columns are unique")
+    check = check.hasUniqueness(
+        column_names, lambda x: x == 1, "Uniqueness should be 1."
+    )
+    return check
+
+
+def create_check_of_size_of_dataset(expected_size: int) -> Check:
+    spark = utils.get_spark()
+    check = Check(spark, CheckLevel.Warning, "Size of dataset")
+    check = check.hasSize(
+        lambda x: x == expected_size,
+        f"DataFrame row count should be {expected_size}.",
+    )
+    return check

--- a/utils/validation/validation_utils.py
+++ b/utils/validation/validation_utils.py
@@ -1,5 +1,9 @@
 from pydeequ.checks import Check, CheckLevel
-from pydeequ.verification import VerificationRunBuilder
+from pydeequ.verification import (
+    VerificationRunBuilder,
+    VerificationSuite,
+    VerificationResult,
+)
 from pyspark.sql.dataframe import DataFrame
 
 from utils import utils
@@ -52,3 +56,12 @@ def create_check(rule_name: str, rule) -> Check:
     else:
         raise ValueError("Unknown rule to check")
     return check
+
+
+def validate_dataset(dataset: DataFrame, rules: dict) -> DataFrame:
+    spark = utils.get_spark()
+    verification_run = VerificationSuite(spark).onData(dataset)
+    verification_run = add_checks_to_run(verification_run, rules)
+    check_result = verification_run.run()
+    check_result_df = VerificationResult.checkResultsAsDataFrame(spark, check_result)
+    return check_result_df

--- a/utils/validation/validation_utils.py
+++ b/utils/validation/validation_utils.py
@@ -10,6 +10,36 @@ from utils import utils
 from utils.validation.validation_rule_names import RuleNames as RuleToCheck
 
 
+def validate_dataset(dataset: DataFrame, rules: dict) -> DataFrame:
+    spark = utils.get_spark()
+    verification_run = VerificationSuite(spark).onData(dataset)
+    verification_run = add_checks_to_run(verification_run, rules)
+    check_result = verification_run.run()
+    check_result_df = VerificationResult.checkResultsAsDataFrame(spark, check_result)
+    return check_result_df
+
+
+def add_checks_to_run(
+    run: VerificationRunBuilder, rules_to_check: dict
+) -> VerificationRunBuilder:
+    for rule in rules_to_check.keys():
+        check = create_check(rule, rules_to_check[rule])
+        run = run.addCheck(check)
+    return run
+
+
+def create_check(rule_name: str, rule) -> Check:
+    if rule_name == RuleToCheck.size_of_dataset:
+        check = create_check_of_size_of_dataset(rule)
+    elif rule_name == RuleToCheck.complete_columns:
+        check = create_check_for_column_completeness(rule)
+    elif rule_name == RuleToCheck.index_columns:
+        check = create_check_of_uniqueness_of_two_index_columns(rule)
+    else:
+        raise ValueError("Unknown rule to check")
+    return check
+
+
 def create_check_for_column_completeness(complete_columns: list) -> Check:
     spark = utils.get_spark()
     check = Check(spark, CheckLevel.Warning, "Column is complete")
@@ -35,33 +65,3 @@ def create_check_of_size_of_dataset(expected_size: int) -> Check:
         f"DataFrame row count should be {expected_size}.",
     )
     return check
-
-
-def add_checks_to_run(
-    run: VerificationRunBuilder, rules_to_check: dict
-) -> VerificationRunBuilder:
-    for rule in rules_to_check.keys():
-        check = create_check(rule, rules_to_check[rule])
-        run = run.addCheck(check)
-    return run
-
-
-def create_check(rule_name: str, rule) -> Check:
-    if rule_name == RuleToCheck.size_of_dataset:
-        check = create_check_of_size_of_dataset(rule)
-    elif rule_name == RuleToCheck.complete_columns:
-        check = create_check_for_column_completeness(rule)
-    elif rule_name == RuleToCheck.index_columns:
-        check = create_check_of_uniqueness_of_two_index_columns(rule)
-    else:
-        raise ValueError("Unknown rule to check")
-    return check
-
-
-def validate_dataset(dataset: DataFrame, rules: dict) -> DataFrame:
-    spark = utils.get_spark()
-    verification_run = VerificationSuite(spark).onData(dataset)
-    verification_run = add_checks_to_run(verification_run, rules)
-    check_result = verification_run.run()
-    check_result_df = VerificationResult.checkResultsAsDataFrame(spark, check_result)
-    return check_result_df


### PR DESCRIPTION
# Description
Validation and rules abstracted to allow for better testing and faster building of validation jobs.

Abstracting the functionality will allow for it all to be tested in one place, meaning that each job will not need separate tests writing.

Abstracting the ruleset for each job means that there is one centralised location in our code that defines the validation rules for each dataset. This should allow us to update and refine the rules more easily.

Overall, this code allows for the validation checks to be generated automatically based on a ruleset structure. Once this structure is finalised, we should document it for future reference.

# How to test
Unit tests passing
Execution in pipeline here: https://eu-west-2.console.aws.amazon.com/states/home?region=eu-west-2#/v2/executions/details/arn:aws:states:eu-west-2:344210435447:execution:expand-validation-for-merged-i-Ind-CQC-Filled-Post-Estimates-Pipeline:1536e7ba-415d-437a-8cfc-8863c9aff9d7

# Developer checklist
- [ ] Unit test
- [ ] Linked to Trello ticket
- [ ] Documentation up to date
