### PR TITLE
Write tests for validation utils

### DIFF
--- a/jobs/validate_merged_ind_cqc_data.py
+++ b/jobs/validate_merged_ind_cqc_data.py
@@ -38,14 +38,11 @@ def main(
     merged_ind_cqc_df = utils.read_from_parquet(
         merged_ind_cqc_source,
     )
-    spark = utils.get_spark()
-
     rules = Rules.rules_to_check
 
     rules[RuleName.size_of_dataset] = cqc_location_df.count()
 
     check_result_df = validate_dataset(merged_ind_cqc_df, rules)
-    check_result_df.show()
 
     utils.write_to_parquet(check_result_df, report_destination, mode="overwrite")
 

--- a/jobs/validate_merged_ind_cqc_data.py
+++ b/jobs/validate_merged_ind_cqc_data.py
@@ -46,21 +46,6 @@ def main(
 
     utils.write_to_parquet(check_result_df, report_destination, mode="overwrite")
 
-    parse_data_quality_errors(check_result_df)
-
-
-def parse_data_quality_errors(check_results: DataFrame):
-    failures_df = check_results.where(check_results["constraint_status"] == "Failure")
-
-    failures_count = failures_df.count()
-    if failures_count == 0:
-        return
-
-    print(f"{failures_count} data quaility failures detected, printing errors")
-
-    for failure in failures_df.collect():
-        print(failure.asDict()["constraint_message"])
-
 
 if __name__ == "__main__":
     print("Spark job 'validate_merge_ind_cqc_data' starting...")

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -3786,3 +3786,7 @@ class FlattenCQCRatings:
         ("loc_1", "estab_1", 1, "Good", "2024-01-01"),
         ("loc_2", "estab_2", 0, "Requires improvement", "2024-01-01"),
     ]
+
+@dataclass
+class ValidationUtils:
+    schema = []

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -3792,12 +3792,32 @@ class FlattenCQCRatings:
 @dataclass
 class ValidationUtils:
     size_of_dataset_rule = {RuleName.size_of_dataset: 3}
-    size_of_dataset_rows = [
+    size_of_dataset_success_rows = [
         ("loc_1",),
         ("loc_2",),
         ("loc_3",),
     ]
-    size_of_dataset_result_success_rows = [
-        ("Size of dataset", "Warning", "Success", "", "", "")
+    size_of_dataset_failure_rows = [
+        ("loc_1",),
+        ("loc_2",),
     ]
-    size_of_dataset_result_failure_rows = []
+    size_of_dataset_result_success_rows = [
+        (
+            "Size of dataset",
+            "Warning",
+            "Success",
+            "SizeConstraint(Size(None))",
+            "Success",
+            None,
+        )
+    ]
+    size_of_dataset_result_failure_rows = [
+        (
+            "Size of dataset",
+            "Warning",
+            "Failure",
+            "SizeConstraint(Size(None))",
+            "Failure",
+            "DataFrame row count should be 3.",
+        )
+    ]

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -36,6 +36,7 @@ from utils.reconciliation_utils.reconciliation_values import (
 from utils.cqc_ratings_utils.cqc_ratings_values import (
     CQCRatingsValues,
 )
+from utils.validation.validation_rule_names import RuleNames as RuleName
 
 
 @dataclass
@@ -3787,6 +3788,16 @@ class FlattenCQCRatings:
         ("loc_2", "estab_2", 0, "Requires improvement", "2024-01-01"),
     ]
 
+
 @dataclass
 class ValidationUtils:
-    schema = []
+    size_of_dataset_rule = {RuleName.size_of_dataset: 3}
+    size_of_dataset_rows = [
+        ("loc_1",),
+        ("loc_2",),
+        ("loc_3",),
+    ]
+    size_of_dataset_result_success_rows = [
+        ("Size of dataset", "Warning", "Success", "", "", "")
+    ]
+    size_of_dataset_result_failure_rows = []

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -3808,7 +3808,7 @@ class ValidationUtils:
             "Success",
             "SizeConstraint(Size(None))",
             "Success",
-            None,
+            "",
         )
     ]
     size_of_dataset_result_failure_rows = [

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -4040,3 +4040,8 @@ class ValidationUtils:
             "",
         ),
     ]
+
+    unknown_rules = {
+        RuleName.size_of_dataset: 1,
+        "unknown_rule": "some_value",
+    }

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -3054,34 +3054,6 @@ class ValidateMergedIndCqcData:
         ("1-000000001", date(2024, 1, 9), date(2024, 1, 1), date(2024, 1, 1), "Y", "name", "prov_1", "prov_name", CQCPValues.independent, CQCLValues.registered, date(2024, 1, 1), "Y", 5, ["service"], CQCLValues.care_home_only, date(2024, 1, 1), "cssr", "region", date(2024, 1, 1), "cssr", "region", "RUI", 5, "estab_1", "org_1", 5, 5),
         ("1-000000002", date(2024, 1, 9), date(2024, 1, 1), date(2024, 1, 1), "Y", "name", "prov_1", "prov_name", CQCPValues.independent, CQCLValues.registered, date(2024, 1, 1), "Y", 5, ["service"], CQCLValues.care_home_only, date(2024, 1, 1), "cssr", "region", date(2024, 1, 1), "cssr", "region", "RUI", 5, "estab_1", "org_1", 5, 5),
     ]
-
-    merged_ind_cqc_extra_row_rows = [
-        ("1-000000001", date(2024, 1, 1), date(2024, 1, 1), date(2024, 1, 1), "Y", "name", "prov_1", "prov_name", CQCPValues.independent, CQCLValues.registered, date(2024, 1, 1), "Y", 5, ["service"], CQCLValues.care_home_only, date(2024, 1, 1), "cssr", "region", date(2024, 1, 1), "cssr", "region", "RUI", 5, "estab_1", "org_1", 5, 5),
-        ("1-000000002", date(2024, 1, 1), date(2024, 1, 1), date(2024, 1, 1), "Y", "name", "prov_1", "prov_name", CQCPValues.independent, CQCLValues.registered, date(2024, 1, 1), "Y", 5, ["service"], CQCLValues.care_home_only, date(2024, 1, 1), "cssr", "region", date(2024, 1, 1), "cssr", "region", "RUI", 5, "estab_1", "org_1", 5, 5),
-        ("1-000000001", date(2024, 1, 9), date(2024, 1, 1), date(2024, 1, 1), "Y", "name", "prov_1", "prov_name", CQCPValues.independent, CQCLValues.registered, date(2024, 1, 1), "Y", 5, ["service"], CQCLValues.care_home_only, date(2024, 1, 1), "cssr", "region", date(2024, 1, 1), "cssr", "region", "RUI", 5, "estab_1", "org_1", 5, 5),
-        ("1-000000002", date(2024, 1, 9), date(2024, 1, 1), date(2024, 1, 1), "Y", "name", "prov_1", "prov_name", CQCPValues.independent, CQCLValues.registered, date(2024, 1, 1), "Y", 5, ["service"], CQCLValues.care_home_only, date(2024, 1, 1), "cssr", "region", date(2024, 1, 1), "cssr", "region", "RUI", 5, "estab_1", "org_1", 5, 5),
-        ("1-000000003", date(2024, 1, 9), date(2024, 1, 1), date(2024, 1, 1), "Y", "name", "prov_1", "prov_name", CQCPValues.independent, CQCLValues.registered, date(2024, 1, 1), "Y", 5, ["service"], CQCLValues.care_home_only, date(2024, 1, 1), "cssr", "region", date(2024, 1, 1), "cssr", "region", "RUI", 5, "estab_1", "org_1", 5, 5),
-    ]
-
-    merged_ind_cqc_missing_row_rows = [
-        ("1-000000001", date(2024, 1, 1), date(2024, 1, 1), date(2024, 1, 1), "Y", "name", "prov_1", "prov_name", CQCPValues.independent, CQCLValues.registered, date(2024, 1, 1), "Y", 5, ["service"], CQCLValues.care_home_only, date(2024, 1, 1), "cssr", "region", date(2024, 1, 1), "cssr", "region", "RUI", 5, "estab_1", "org_1", 5, 5),
-        ("1-000000002", date(2024, 1, 1), date(2024, 1, 1), date(2024, 1, 1), "Y", "name", "prov_1", "prov_name", CQCPValues.independent, CQCLValues.registered, date(2024, 1, 1), "Y", 5, ["service"], CQCLValues.care_home_only, date(2024, 1, 1), "cssr", "region", date(2024, 1, 1), "cssr", "region", "RUI", 5, "estab_1", "org_1", 5, 5),
-        ("1-000000001", date(2024, 1, 9), date(2024, 1, 1), date(2024, 1, 1), "Y", "name", "prov_1", "prov_name", CQCPValues.independent, CQCLValues.registered, date(2024, 1, 1), "Y", 5, ["service"], CQCLValues.care_home_only, date(2024, 1, 1), "cssr", "region", date(2024, 1, 1), "cssr", "region", "RUI", 5, "estab_1", "org_1", 5, 5),
-    ]
-
-    merged_ind_cqc_with_cqc_sector_null_rows = [
-        ("1-000000001", date(2024, 1, 1), date(2024, 1, 1), date(2024, 1, 1), "Y", "name", "prov_1", "prov_name", CQCPValues.independent, CQCLValues.registered, date(2024, 1, 1), "Y", 5, ["service"], CQCLValues.care_home_only, date(2024, 1, 1), "cssr", "region", date(2024, 1, 1), "cssr", "region", "RUI", 5, "estab_1", "org_1", 5, 5),
-        ("1-000000002", date(2024, 1, 1), date(2024, 1, 1), date(2024, 1, 1), "Y", "name", "prov_1", "prov_name", CQCPValues.independent, CQCLValues.registered, date(2024, 1, 1), "Y", 5, ["service"], CQCLValues.care_home_only, date(2024, 1, 1), "cssr", "region", date(2024, 1, 1), "cssr", "region", "RUI", 5, "estab_1", "org_1", 5, 5),
-        ("1-000000001", date(2024, 1, 9), date(2024, 1, 1), date(2024, 1, 1), "Y", "name", "prov_1", "prov_name", CQCPValues.independent, CQCLValues.registered, date(2024, 1, 1), "Y", 5, ["service"], CQCLValues.care_home_only, date(2024, 1, 1), "cssr", "region", date(2024, 1, 1), "cssr", "region", "RUI", 5, "estab_1", "org_1", 5, 5),
-        ("1-000000002", date(2024, 1, 9), date(2024, 1, 1), date(2024, 1, 1), "Y", "name", "prov_1", "prov_name", None, CQCLValues.registered, date(2024, 1, 1), "Y", 5, ["service"], CQCLValues.care_home_only, date(2024, 1, 1), "cssr", "region", date(2024, 1, 1), "cssr", "region", "RUI", 5, "estab_1", "org_1", 5, 5),
-    ]
-
-    merged_ind_cqc_with_duplicate_data_rows = [
-        ("1-000000001", date(2024, 1, 1), date(2024, 1, 1), date(2024, 1, 1), "Y", "name", "prov_1", "prov_name", CQCPValues.independent, CQCLValues.registered, date(2024, 1, 1), "Y", 5, ["service"], CQCLValues.care_home_only, date(2024, 1, 1), "cssr", "region", date(2024, 1, 1), "cssr", "region", "RUI", 5, "estab_1", "org_1", 5, 5),
-        ("1-000000002", date(2024, 1, 1), date(2024, 1, 1), date(2024, 1, 1), "Y", "name", "prov_1", "prov_name", CQCPValues.independent, CQCLValues.registered, date(2024, 1, 1), "Y", 5, ["service"], CQCLValues.care_home_only, date(2024, 1, 1), "cssr", "region", date(2024, 1, 1), "cssr", "region", "RUI", 5, "estab_1", "org_1", 5, 5),
-        ("1-000000002", date(2024, 1, 9), date(2024, 1, 1), date(2024, 1, 1), "Y", "name", "prov_1", "prov_name", CQCPValues.independent, CQCLValues.registered, date(2024, 1, 1), "Y", 5, ["service"], CQCLValues.care_home_only, date(2024, 1, 1), "cssr", "region", date(2024, 1, 1), "cssr", "region", "RUI", 5, "estab_1", "org_1", 5, 5),
-        ("1-000000002", date(2024, 1, 9), date(2024, 1, 1), date(2024, 1, 1), "Y", "name", "prov_1", "prov_name", CQCPValues.independent, CQCLValues.registered, date(2024, 1, 1), "Y", 5, ["service"], CQCLValues.care_home_only, date(2024, 1, 1), "cssr", "region", date(2024, 1, 1), "cssr", "region", "RUI", 5, "estab_1", "org_1", 5, 5),
-    ]
     # fmt: on
 
 

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -3797,7 +3797,13 @@ class ValidationUtils:
         ("loc_2",),
         ("loc_3",),
     ]
-    size_of_dataset_failure_rows = [
+    size_of_dataset_extra_rows = [
+        ("loc_1",),
+        ("loc_2",),
+        ("loc_3",),
+        ("loc_4",),
+    ]
+    size_of_dataset_missing_rows = [
         ("loc_1",),
         ("loc_2",),
     ]
@@ -3811,13 +3817,23 @@ class ValidationUtils:
             "",
         )
     ]
-    size_of_dataset_result_failure_rows = [
+    size_of_dataset_result_missing_rows = [
         (
             "Size of dataset",
             "Warning",
-            "Failure",
+            "Warning",
             "SizeConstraint(Size(None))",
             "Failure",
-            "DataFrame row count should be 3.",
+            "Value: 2 does not meet the constraint requirement! DataFrame row count should be 3.",
+        )
+    ]
+    size_of_dataset_result_extra_rows = [
+        (
+            "Size of dataset",
+            "Warning",
+            "Warning",
+            "SizeConstraint(Size(None))",
+            "Failure",
+            "Value: 4 does not meet the constraint requirement! DataFrame row count should be 3.",
         )
     ]

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -3888,3 +3888,105 @@ class ValidationUtils:
             "Value: 0.0 does not meet the constraint requirement! Uniqueness should be 1.",
         ),
     ]
+
+    one_complete_column_rule = {
+        RuleName.complete_columns: [
+            IndCQC.location_id,
+        ]
+    }
+    two_complete_columns_rule = {
+        RuleName.complete_columns: [
+            IndCQC.location_id,
+            IndCQC.cqc_location_import_date,
+        ]
+    }
+    one_complete_column_complete_rows = [
+        ("loc_1",),
+    ]
+    one_complete_column_incomplete_rows = [
+        (None,),
+    ]
+    two_complete_columns_both_complete_rows = [
+        ("loc_1", date(2024, 1, 1)),
+    ]
+    two_complete_columns_one_incomplete_rows = [
+        (None, date(2024, 1, 1)),
+    ]
+    two_complete_columns_both_incomplete_rows = [
+        (None, None),
+    ]
+
+    one_complete_column_result_complete_rows = [
+        (
+            "Column is complete",
+            "Warning",
+            "Success",
+            "CompletenessConstraint(Completeness(locationId,None))",
+            "Success",
+            "",
+        ),
+    ]
+    one_complete_column_result_incomplete_rows = [
+        (
+            "Column is complete",
+            "Warning",
+            "Warning",
+            "CompletenessConstraint(Completeness(locationId,None))",
+            "Failure",
+            "Value: 0.0 does not meet the constraint requirement! Completeness of locationId should be 1.",
+        ),
+    ]
+    two_complete_columns_result_both_complete_rows = [
+        (
+            "Column is complete",
+            "Warning",
+            "Success",
+            "CompletenessConstraint(Completeness(locationId,None))",
+            "Success",
+            "",
+        ),
+        (
+            "Column is complete",
+            "Warning",
+            "Success",
+            "CompletenessConstraint(Completeness(cqc_location_import_date,None))",
+            "Success",
+            "",
+        ),
+    ]
+    two_complete_columns_result_one_incomplete_rows = [
+        (
+            "Column is complete",
+            "Warning",
+            "Warning",
+            "CompletenessConstraint(Completeness(locationId,None))",
+            "Failure",
+            "Value: 0.0 does not meet the constraint requirement! Completeness of locationId should be 1.",
+        ),
+        (
+            "Column is complete",
+            "Warning",
+            "Warning",
+            "CompletenessConstraint(Completeness(cqc_location_import_date,None))",
+            "Success",
+            "",
+        ),
+    ]
+    two_complete_columns_result_both_incomplete_rows = [
+        (
+            "Column is complete",
+            "Warning",
+            "Warning",
+            "CompletenessConstraint(Completeness(locationId,None))",
+            "Failure",
+            "Value: 0.0 does not meet the constraint requirement! Completeness of locationId should be 1.",
+        ),
+        (
+            "Column is complete",
+            "Warning",
+            "Warning",
+            "CompletenessConstraint(Completeness(cqc_location_import_date,None))",
+            "Failure",
+            "Value: 0.0 does not meet the constraint requirement! Completeness of cqc_location_import_date should be 1.",
+        ),
+    ]

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -3990,3 +3990,53 @@ class ValidationUtils:
             "Value: 0.0 does not meet the constraint requirement! Completeness of cqc_location_import_date should be 1.",
         ),
     ]
+
+    multiple_rules = {
+        RuleName.size_of_dataset: 1,
+        RuleName.index_columns: [
+            IndCQC.location_id,
+            IndCQC.cqc_location_import_date,
+        ],
+        RuleName.complete_columns: [
+            IndCQC.location_id,
+            IndCQC.cqc_location_import_date,
+        ],
+    }
+
+    multiple_rules_rows = [
+        ("loc_1", date(2024, 1, 1)),
+    ]
+    multiple_rules_results_rows = [
+        (
+            "Size of dataset",
+            "Warning",
+            "Success",
+            "SizeConstraint(Size(None))",
+            "Success",
+            "",
+        ),
+        (
+            "Index columns are unique",
+            "Warning",
+            "Success",
+            "UniquenessConstraint(Uniqueness(Stream(locationId, ?),None))",
+            "Success",
+            "",
+        ),
+        (
+            "Column is complete",
+            "Warning",
+            "Success",
+            "CompletenessConstraint(Completeness(locationId,None))",
+            "Success",
+            "",
+        ),
+        (
+            "Column is complete",
+            "Warning",
+            "Success",
+            "CompletenessConstraint(Completeness(cqc_location_import_date,None))",
+            "Success",
+            "",
+        ),
+    ]

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -3837,3 +3837,54 @@ class ValidationUtils:
             "Value: 4 does not meet the constraint requirement! DataFrame row count should be 3.",
         )
     ]
+
+    unique_index_columns_rule = {
+        RuleName.index_columns: [
+            IndCQC.location_id,
+            IndCQC.cqc_location_import_date,
+        ]
+    }
+    unique_index_columns_success_rows = [
+        (
+            "loc_1",
+            date(2024, 1, 1),
+        ),
+        (
+            "loc_1",
+            date(2024, 1, 2),
+        ),
+        (
+            "loc_2",
+            date(2024, 1, 1),
+        ),
+    ]
+    unique_index_columns_not_unique_rows = [
+        (
+            "loc_1",
+            date(2024, 1, 1),
+        ),
+        (
+            "loc_1",
+            date(2024, 1, 1),
+        ),
+    ]
+    unique_index_columns_result_success_rows = [
+        (
+            "Index columns are unique",
+            "Warning",
+            "Success",
+            "UniquenessConstraint(Uniqueness(Stream(locationId, ?),None))",
+            "Success",
+            "",
+        ),
+    ]
+    unique_index_columns_result_not_unique_rows = [
+        (
+            "Index columns are unique",
+            "Warning",
+            "Warning",
+            "UniquenessConstraint(Uniqueness(Stream(locationId, ?),None))",
+            "Failure",
+            "Value: 0.0 does not meet the constraint requirement! Uniqueness should be 1.",
+        ),
+    ]

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -2787,3 +2787,7 @@ class FlattenCQCRatings:
             StructField(CQCRatings.inspection_date, StringType(), True),
         ]
     )
+
+@dataclass
+class ValidationUtils:
+    schema = []

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -2809,3 +2809,10 @@ class ValidationUtils:
             StructField(IndCQC.location_id, StringType(), True),
         ]
     )
+
+    size_of_dataset_schema = StructType(
+        [
+            StructField(IndCQC.location_id, StringType(), True),
+            StructField(IndCQC.cqc_location_import_date, DateType(), True),
+        ]
+    )

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -2810,9 +2810,12 @@ class ValidationUtils:
         ]
     )
 
-    size_of_dataset_schema = StructType(
+    index_column_schema = StructType(
         [
             StructField(IndCQC.location_id, StringType(), True),
             StructField(IndCQC.cqc_location_import_date, DateType(), True),
         ]
     )
+
+    one_column_schema = size_of_dataset_schema
+    two_column_schema = index_column_schema

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -77,6 +77,8 @@ from utils.reconciliation_utils.reconciliation_values import (
 from utils.cqc_ratings_utils.cqc_ratings_values import (
     CQCRatingsColumns as CQCRatings,
 )
+from utils.column_names.validation_table_columns import Validation
+
 
 from schemas.cqc_location_schema import LOCATION_SCHEMA
 
@@ -2788,6 +2790,22 @@ class FlattenCQCRatings:
         ]
     )
 
+
 @dataclass
 class ValidationUtils:
-    schema = []
+    validation_schema = StructType(
+        [
+            StructField(Validation.check, StringType(), True),
+            StructField(Validation.check_level, StringType(), True),
+            StructField(Validation.check_status, StringType(), True),
+            StructField(Validation.constraint, StringType(), True),
+            StructField(Validation.constraint_status, StringType(), True),
+            StructField(Validation.constraint_message, StringType(), True),
+        ]
+    )
+
+    size_of_dataset_schema = StructType(
+        [
+            StructField(IndCQC.location_id, StringType(), True),
+        ]
+    )

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -2819,3 +2819,4 @@ class ValidationUtils:
 
     one_column_schema = size_of_dataset_schema
     two_column_schema = index_column_schema
+    multiple_rules_schema = index_column_schema

--- a/tests/unit/test_validate_merged_ind_cqc_data.py
+++ b/tests/unit/test_validate_merged_ind_cqc_data.py
@@ -29,14 +29,12 @@ class ValidateMergedIndCQCDatasetTests(unittest.TestCase):
         if self.spark.sparkContext._gateway:
             self.spark.sparkContext._gateway.shutdown_callback_server()
 
-    @patch("jobs.validate_merged_ind_cqc_data.parse_data_quality_errors")
     @patch("utils.utils.write_to_parquet")
     @patch("utils.utils.read_from_parquet")
     def test_main_runs(
         self,
         read_from_parquet_patch: Mock,
         write_to_parquet_patch: Mock,
-        parse_data_quality_errors_patch: Mock,
     ):
         read_from_parquet_patch.side_effect = [
             self.test_clean_cqc_location_df,
@@ -51,7 +49,6 @@ class ValidateMergedIndCQCDatasetTests(unittest.TestCase):
 
         self.assertEqual(read_from_parquet_patch.call_count, 2)
         self.assertEqual(write_to_parquet_patch.call_count, 1)
-        self.assertEqual(parse_data_quality_errors_patch.call_count, 1)
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_validate_merged_ind_cqc_data.py
+++ b/tests/unit/test_validate_merged_ind_cqc_data.py
@@ -8,16 +8,12 @@ from tests.test_file_data import ValidateMergedIndCqcData as Data
 from tests.test_file_schemas import ValidateMergedIndCqcData as Schemas
 
 from utils import utils
-from utils.column_names.ind_cqc_pipeline_columns import (
-    PartitionKeys as Keys,
-)
 
 
 class ValidateMergedIndCQCDatasetTests(unittest.TestCase):
     TEST_CQC_LOCATION_SOURCE = "some/directory"
     TEST_MERGED_IND_CQC_SOURCE = "some/other/directory"
     TEST_DESTINATION = "some/other/other/directory"
-    partition_keys = [Keys.year, Keys.month, Keys.day, Keys.import_date]
 
     def setUp(self) -> None:
         self.spark = utils.get_spark()
@@ -28,21 +24,6 @@ class ValidateMergedIndCQCDatasetTests(unittest.TestCase):
         self.test_merged_ind_cqc_df = self.spark.createDataFrame(
             Data.merged_ind_cqc_rows, Schemas.merged_ind_cqc_schema
         )
-        self.test_merged_ind_cqc_extra_row_df = self.spark.createDataFrame(
-            Data.merged_ind_cqc_extra_row_rows, Schemas.merged_ind_cqc_schema
-        )
-        self.test_merged_ind_cqc_missing_row_df = self.spark.createDataFrame(
-            Data.merged_ind_cqc_missing_row_rows, Schemas.merged_ind_cqc_schema
-        )
-        self.test_merged_ind_cqc_with_cqc_sector_null_df = self.spark.createDataFrame(
-            Data.merged_ind_cqc_with_cqc_sector_null_rows, Schemas.merged_ind_cqc_schema
-        )
-        self.test_merged_ind_cqc_with_duplicate_data_df = self.spark.createDataFrame(
-            Data.merged_ind_cqc_with_duplicate_data_rows, Schemas.merged_ind_cqc_schema
-        )
-        self.constraint_status = "constraint_status"
-        self.constraint_message = "constraint_message"
-        self.failure_value = "Failure"
 
     def tearDown(self) -> None:
         if self.spark.sparkContext._gateway:
@@ -71,168 +52,6 @@ class ValidateMergedIndCQCDatasetTests(unittest.TestCase):
         self.assertEqual(read_from_parquet_patch.call_count, 2)
         self.assertEqual(write_to_parquet_patch.call_count, 1)
         self.assertEqual(parse_data_quality_errors_patch.call_count, 1)
-
-    @patch("utils.utils.write_to_parquet")
-    @patch("utils.utils.read_from_parquet")
-    def test_main_returns_only_successes_when_given_valid_data(
-        self,
-        read_from_parquet_patch: Mock,
-        write_to_parquet_patch: Mock,
-    ):
-        read_from_parquet_patch.side_effect = [
-            self.test_clean_cqc_location_df,
-            self.test_merged_ind_cqc_df,
-        ]
-
-        job.main(
-            self.TEST_CQC_LOCATION_SOURCE,
-            self.TEST_MERGED_IND_CQC_SOURCE,
-            self.TEST_DESTINATION,
-        )
-        validation_results = write_to_parquet_patch.call_args[0][0]
-        failure_count = validation_results.where(
-            validation_results[self.constraint_status] == self.failure_value
-        ).count()
-        expected_failure_count = 0
-
-        self.assertEqual(failure_count, expected_failure_count)
-
-    @patch("utils.utils.write_to_parquet")
-    @patch("utils.utils.read_from_parquet")
-    def test_main_returns_failure_when_given_dataframe_with_extra_row(
-        self,
-        read_from_parquet_patch: Mock,
-        write_to_parquet_patch: Mock,
-    ):
-        read_from_parquet_patch.side_effect = [
-            self.test_clean_cqc_location_df,
-            self.test_merged_ind_cqc_extra_row_df,
-        ]
-
-        job.main(
-            self.TEST_CQC_LOCATION_SOURCE,
-            self.TEST_MERGED_IND_CQC_SOURCE,
-            self.TEST_DESTINATION,
-        )
-        validation_results = write_to_parquet_patch.call_args[0][0]
-        failure_count = validation_results.where(
-            validation_results[self.constraint_status] == self.failure_value
-        ).count()
-        expected_failure_count = 1
-        failure_message = (
-            validation_results.where(
-                validation_results[self.constraint_status] == self.failure_value
-            )
-            .select(self.constraint_message)
-            .collect()[0][0]
-        )
-        expected_failure_message = "Value: 5 does not meet the constraint requirement! DataFrame row count should be 4."
-
-        self.assertEqual(failure_count, expected_failure_count)
-        self.assertEqual(failure_message, expected_failure_message)
-
-    @patch("utils.utils.write_to_parquet")
-    @patch("utils.utils.read_from_parquet")
-    def test_main_returns_failure_when_given_dataframe_with_missing_row(
-        self,
-        read_from_parquet_patch: Mock,
-        write_to_parquet_patch: Mock,
-    ):
-        read_from_parquet_patch.side_effect = [
-            self.test_clean_cqc_location_df,
-            self.test_merged_ind_cqc_missing_row_df,
-        ]
-
-        job.main(
-            self.TEST_CQC_LOCATION_SOURCE,
-            self.TEST_MERGED_IND_CQC_SOURCE,
-            self.TEST_DESTINATION,
-        )
-        validation_results = write_to_parquet_patch.call_args[0][0]
-        failure_count = validation_results.where(
-            validation_results[self.constraint_status] == self.failure_value
-        ).count()
-        expected_failure_count = 1
-        failure_message = (
-            validation_results.where(
-                validation_results[self.constraint_status] == self.failure_value
-            )
-            .select(self.constraint_message)
-            .collect()[0][0]
-        )
-        expected_failure_message = "Value: 3 does not meet the constraint requirement! DataFrame row count should be 4."
-
-        self.assertEqual(failure_count, expected_failure_count)
-        self.assertEqual(failure_message, expected_failure_message)
-
-    @patch("utils.utils.write_to_parquet")
-    @patch("utils.utils.read_from_parquet")
-    def test_main_returns_failure_when_given_null_care_home_value(
-        self,
-        read_from_parquet_patch: Mock,
-        write_to_parquet_patch: Mock,
-    ):
-        read_from_parquet_patch.side_effect = [
-            self.test_clean_cqc_location_df,
-            self.test_merged_ind_cqc_with_cqc_sector_null_df,
-        ]
-
-        job.main(
-            self.TEST_CQC_LOCATION_SOURCE,
-            self.TEST_MERGED_IND_CQC_SOURCE,
-            self.TEST_DESTINATION,
-        )
-        validation_results = write_to_parquet_patch.call_args[0][0]
-        failure_count = validation_results.where(
-            validation_results[self.constraint_status] == self.failure_value
-        ).count()
-        expected_failure_count = 1
-        failure_message = (
-            validation_results.where(
-                validation_results[self.constraint_status] == self.failure_value
-            )
-            .select(self.constraint_message)
-            .collect()[0][0]
-        )
-        expected_failure_message = "Value: 0.75 does not meet the constraint requirement! Completeness of cqc_sector should be 1."
-
-        self.assertEqual(failure_count, expected_failure_count)
-        self.assertEqual(failure_message, expected_failure_message)
-
-    @patch("utils.utils.write_to_parquet")
-    @patch("utils.utils.read_from_parquet")
-    def test_main_returns_failure_when_given_duplicate_data(
-        self,
-        read_from_parquet_patch: Mock,
-        write_to_parquet_patch: Mock,
-    ):
-        read_from_parquet_patch.side_effect = [
-            self.test_clean_cqc_location_df,
-            self.test_merged_ind_cqc_with_duplicate_data_df,
-        ]
-
-        job.main(
-            self.TEST_CQC_LOCATION_SOURCE,
-            self.TEST_MERGED_IND_CQC_SOURCE,
-            self.TEST_DESTINATION,
-        )
-        validation_results = write_to_parquet_patch.call_args[0][0]
-
-        failure_count = validation_results.where(
-            validation_results[self.constraint_status] == self.failure_value
-        ).count()
-        expected_failure_count = 1
-        failure_message = (
-            validation_results.where(
-                validation_results[self.constraint_status] == self.failure_value
-            )
-            .select(self.constraint_message)
-            .collect()[0][0]
-        )
-        expected_failure_message = "Value: 0.5 does not meet the constraint requirement! Uniqueness should be 1."
-
-        self.assertEqual(failure_count, expected_failure_count)
-        self.assertEqual(failure_message, expected_failure_message)
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_validation_utils.py
+++ b/tests/unit/test_validation_utils.py
@@ -5,6 +5,7 @@ from unittest.mock import Mock, patch
 import utils.validation.validation_utils as job
 
 from tests.test_file_data import ValidationUtils as Data
+
 from tests.test_file_schemas import ValidationUtils as Schemas
 
 from utils import utils
@@ -62,10 +63,19 @@ class CreateCheckOfUniquenessOfTwoIndexColumns(ValidateUtilsTests):
 
 class CreateCheckOfSizeOfDataset(ValidateUtilsTests):
     def setUp(self) -> None:
-        return super().setUp()
+        super().setUp()
+        self.size_of_dataset_rule = Data.size_of_dataset_rule
+        self.test_df = self.spark.createDataFrame(
+            Data.size_of_dataset_rows, Schemas.size_of_dataset_schema
+        )
+        self.expected_df = self.spark.createDataFrame(
+            Data.size_of_dataset_result_success_rows, Schemas.validation_schema
+        )
 
     def test_create_check_of_size_of_dataset(self):
-        pass
+        returned_df = job.validate_dataset(self.test_df, self.size_of_dataset_rule)
+        returned_df.show()
+        self.assertEqual(returned_df, self.expected_df)
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_validation_utils.py
+++ b/tests/unit/test_validation_utils.py
@@ -25,17 +25,23 @@ class ValidateDatasetTests(ValidateUtilsTests):
     def setUp(self) -> None:
         super().setUp()
         self.rules = Data.multiple_rules
+        self.unknown_rules = Data.unknown_rules
         self.test_df = self.spark.createDataFrame(
             Data.multiple_rules_rows, Schemas.multiple_rules_schema
         )
         self.expected_df = self.spark.createDataFrame(
             Data.multiple_rules_results_rows, Schemas.validation_schema
         )
-        self.returned_df = job.validate_dataset(self.test_df, self.rules)
-        self.returned_df.show()
 
     def test_validate_dataset_can_run_checks_with_multiple_rules(self):
+        self.returned_df = job.validate_dataset(self.test_df, self.rules)
         self.assertEqual(self.returned_df.collect(), self.expected_df.collect())
+
+    def test_validate_dataset_raises_error_with_unknown_rules(self):
+        with self.assertRaises(ValueError) as context:
+            job.validate_dataset(self.test_df, self.unknown_rules)
+
+        self.assertTrue("Unknown rule to check" in str(context.exception))
 
 
 class CheckForColumnCompletenessTests(ValidateUtilsTests):

--- a/tests/unit/test_validation_utils.py
+++ b/tests/unit/test_validation_utils.py
@@ -1,0 +1,24 @@
+import unittest
+
+from unittest.mock import Mock, patch
+
+import utils.validation.validation_utils as job
+
+from tests.test_file_data import ValidationUtils as Data
+from tests.test_file_schemas import ValidationUtils as Schemas
+
+from utils import utils
+
+
+class ValidateMergedIndCQCDatasetTests(unittest.TestCase):
+
+    def setUp(self) -> None:
+        self.spark = utils.get_spark()
+
+    def tearDown(self) -> None:
+        if self.spark.sparkContext._gateway:
+            self.spark.sparkContext._gateway.shutdown_callback_server()
+
+
+if __name__ == "__main__":
+    unittest.main(warnings="ignore")

--- a/tests/unit/test_validation_utils.py
+++ b/tests/unit/test_validation_utils.py
@@ -61,7 +61,7 @@ class CreateCheckForColumnCompletenessTests(ValidateUtilsTests):
             Data.one_complete_column_result_complete_rows, Schemas.validation_schema
         )
         returned_df = job.validate_dataset(test_df, self.one_column_rule)
-        returned_df.show(truncate=False)
+
         self.assertEqual(returned_df.collect(), expected_df.collect())
 
     def test_create_check_for_column_completeness_when_one_column_is_given_and_incomplete(
@@ -74,7 +74,7 @@ class CreateCheckForColumnCompletenessTests(ValidateUtilsTests):
             Data.one_complete_column_result_incomplete_rows, Schemas.validation_schema
         )
         returned_df = job.validate_dataset(test_df, self.one_column_rule)
-        returned_df.show(truncate=False)
+
         self.assertEqual(returned_df.collect(), expected_df.collect())
 
     def test_create_check_for_column_completeness_when_two_columns_are_given_and_both_are_complete(
@@ -88,7 +88,7 @@ class CreateCheckForColumnCompletenessTests(ValidateUtilsTests):
             Schemas.validation_schema,
         )
         returned_df = job.validate_dataset(test_df, self.two_column_rule)
-        returned_df.show(truncate=False)
+
         self.assertEqual(returned_df.collect(), expected_df.collect())
 
     def test_create_check_for_column_completeness_when_two_columns_are_given_and_one_is_incomplete(
@@ -102,7 +102,7 @@ class CreateCheckForColumnCompletenessTests(ValidateUtilsTests):
             Schemas.validation_schema,
         )
         returned_df = job.validate_dataset(test_df, self.two_column_rule)
-        returned_df.show(truncate=False)
+
         self.assertEqual(returned_df.collect(), expected_df.collect())
 
     def test_create_check_for_column_completeness_when_two_columns_are_given_and_both_are_incomplete(
@@ -116,7 +116,7 @@ class CreateCheckForColumnCompletenessTests(ValidateUtilsTests):
             Schemas.validation_schema,
         )
         returned_df = job.validate_dataset(test_df, self.two_column_rule)
-        returned_df.show(truncate=False)
+
         self.assertEqual(returned_df.collect(), expected_df.collect())
 
 
@@ -135,7 +135,6 @@ class CreateCheckOfUniquenessOfTwoIndexColumns(ValidateUtilsTests):
             Data.unique_index_columns_result_success_rows, Schemas.validation_schema
         )
         returned_df = job.validate_dataset(test_df, self.unique_columns_rule)
-        returned_df.show(truncate=False)
         self.assertEqual(returned_df.collect(), expected_df.collect())
 
     def test_create_check_of_uniqueness_of_two_index_columns_returns_failure_when_columns_are_not_unique(
@@ -148,7 +147,7 @@ class CreateCheckOfUniquenessOfTwoIndexColumns(ValidateUtilsTests):
             Data.unique_index_columns_result_not_unique_rows, Schemas.validation_schema
         )
         returned_df = job.validate_dataset(test_df, self.unique_columns_rule)
-        returned_df.show(truncate=False)
+
         self.assertEqual(returned_df.collect(), expected_df.collect())
 
 

--- a/tests/unit/test_validation_utils.py
+++ b/tests/unit/test_validation_utils.py
@@ -20,5 +20,21 @@ class ValidateUtilsTests(unittest.TestCase):
             self.spark.sparkContext._gateway.shutdown_callback_server()
 
 
+class ValidateDatasetTests(ValidateUtilsTests):
+    def setUp(self) -> None:
+        return super().setUp()
+
+    def test_validate_dataset(self):
+        pass
+
+
+class AddChecksToRunTests(ValidateUtilsTests):
+    def setUp(self) -> None:
+        return super().setUp()
+
+    def test_add_checks_to_run(self):
+        pass
+
+
 if __name__ == "__main__":
     unittest.main(warnings="ignore")

--- a/tests/unit/test_validation_utils.py
+++ b/tests/unit/test_validation_utils.py
@@ -55,10 +55,34 @@ class CreateCheckForColumnCompletenessTests(ValidateUtilsTests):
 
 class CreateCheckOfUniquenessOfTwoIndexColumns(ValidateUtilsTests):
     def setUp(self) -> None:
-        return super().setUp()
+        super().setUp()
+        self.unique_columns_rule = Data.unique_index_columns_rule
 
-    def test_create_check_of_uniqueness_of_two_index_columns(self):
-        pass
+    def test_create_check_of_uniqueness_of_two_index_columns_returns_success_when_columns_are_unique(
+        self,
+    ):
+        test_df = self.spark.createDataFrame(
+            Data.unique_index_columns_success_rows, Schemas.size_of_dataset_schema
+        )
+        expected_df = self.spark.createDataFrame(
+            Data.unique_index_columns_result_success_rows, Schemas.validation_schema
+        )
+        returned_df = job.validate_dataset(test_df, self.unique_columns_rule)
+        returned_df.show(truncate=False)
+        self.assertEqual(returned_df.collect(), expected_df.collect())
+
+    def test_create_check_of_uniqueness_of_two_index_columns_returns_failure_when_columns_are_not_unique(
+        self,
+    ):
+        test_df = self.spark.createDataFrame(
+            Data.unique_index_columns_not_unique_rows, Schemas.size_of_dataset_schema
+        )
+        expected_df = self.spark.createDataFrame(
+            Data.unique_index_columns_result_not_unique_rows, Schemas.validation_schema
+        )
+        returned_df = job.validate_dataset(test_df, self.unique_columns_rule)
+        returned_df.show(truncate=False)
+        self.assertEqual(returned_df.collect(), expected_df.collect())
 
 
 class CreateCheckOfSizeOfDataset(ValidateUtilsTests):
@@ -66,7 +90,7 @@ class CreateCheckOfSizeOfDataset(ValidateUtilsTests):
         super().setUp()
         self.size_of_dataset_rule = Data.size_of_dataset_rule
 
-    def test_create_check_of_size_of_dataset_returns_successes_with_valid_data(self):
+    def test_create_check_of_size_of_dataset_returns_success_with_valid_data(self):
         test_df = self.spark.createDataFrame(
             Data.size_of_dataset_success_rows, Schemas.size_of_dataset_schema
         )

--- a/tests/unit/test_validation_utils.py
+++ b/tests/unit/test_validation_utils.py
@@ -10,7 +10,7 @@ from tests.test_file_schemas import ValidationUtils as Schemas
 from utils import utils
 
 
-class ValidateMergedIndCQCDatasetTests(unittest.TestCase):
+class ValidateUtilsTests(unittest.TestCase):
 
     def setUp(self) -> None:
         self.spark = utils.get_spark()

--- a/tests/unit/test_validation_utils.py
+++ b/tests/unit/test_validation_utils.py
@@ -45,7 +45,7 @@ class CreateCheckTests(ValidateUtilsTests):
         pass
 
 
-class CreateCheckForColumnCompletenessTests(ValidateUtilsTests):
+class CheckForColumnCompletenessTests(ValidateUtilsTests):
     def setUp(self) -> None:
         super().setUp()
         self.one_column_rule = Data.one_complete_column_rule
@@ -120,7 +120,7 @@ class CreateCheckForColumnCompletenessTests(ValidateUtilsTests):
         self.assertEqual(returned_df.collect(), expected_df.collect())
 
 
-class CreateCheckOfUniquenessOfTwoIndexColumns(ValidateUtilsTests):
+class CheckOfUniquenessOfTwoIndexColumns(ValidateUtilsTests):
     def setUp(self) -> None:
         super().setUp()
         self.unique_columns_rule = Data.unique_index_columns_rule
@@ -151,7 +151,7 @@ class CreateCheckOfUniquenessOfTwoIndexColumns(ValidateUtilsTests):
         self.assertEqual(returned_df.collect(), expected_df.collect())
 
 
-class CreateCheckOfSizeOfDataset(ValidateUtilsTests):
+class CheckOfSizeOfDataset(ValidateUtilsTests):
     def setUp(self) -> None:
         super().setUp()
         self.size_of_dataset_rule = Data.size_of_dataset_rule

--- a/tests/unit/test_validation_utils.py
+++ b/tests/unit/test_validation_utils.py
@@ -36,5 +36,37 @@ class AddChecksToRunTests(ValidateUtilsTests):
         pass
 
 
+class CreateCheckTests(ValidateUtilsTests):
+    def setUp(self) -> None:
+        return super().setUp()
+
+    def test_create_check(self):
+        pass
+
+
+class CreateCheckForColumnCompletenessTests(ValidateUtilsTests):
+    def setUp(self) -> None:
+        return super().setUp()
+
+    def test_create_check_for_column_completeness(self):
+        pass
+
+
+class CreateCheckOfUniquenessOfTwoIndexColumns(ValidateUtilsTests):
+    def setUp(self) -> None:
+        return super().setUp()
+
+    def test_create_check_of_uniqueness_of_two_index_columns(self):
+        pass
+
+
+class CreateCheckOfSizeOfDataset(ValidateUtilsTests):
+    def setUp(self) -> None:
+        return super().setUp()
+
+    def test_create_check_of_size_of_dataset(self):
+        pass
+
+
 if __name__ == "__main__":
     unittest.main(warnings="ignore")

--- a/tests/unit/test_validation_utils.py
+++ b/tests/unit/test_validation_utils.py
@@ -23,26 +23,19 @@ class ValidateUtilsTests(unittest.TestCase):
 
 class ValidateDatasetTests(ValidateUtilsTests):
     def setUp(self) -> None:
-        return super().setUp()
+        super().setUp()
+        self.rules = Data.multiple_rules
+        self.test_df = self.spark.createDataFrame(
+            Data.multiple_rules_rows, Schemas.multiple_rules_schema
+        )
+        self.expected_df = self.spark.createDataFrame(
+            Data.multiple_rules_results_rows, Schemas.validation_schema
+        )
+        self.returned_df = job.validate_dataset(self.test_df, self.rules)
+        self.returned_df.show()
 
-    def test_validate_dataset(self):
-        pass
-
-
-class AddChecksToRunTests(ValidateUtilsTests):
-    def setUp(self) -> None:
-        return super().setUp()
-
-    def test_add_checks_to_run(self):
-        pass
-
-
-class CreateCheckTests(ValidateUtilsTests):
-    def setUp(self) -> None:
-        return super().setUp()
-
-    def test_create_check(self):
-        pass
+    def test_validate_dataset_can_run_checks_with_multiple_rules(self):
+        self.assertEqual(self.returned_df.collect(), self.expected_df.collect())
 
 
 class CheckForColumnCompletenessTests(ValidateUtilsTests):

--- a/tests/unit/test_validation_utils.py
+++ b/tests/unit/test_validation_utils.py
@@ -47,10 +47,77 @@ class CreateCheckTests(ValidateUtilsTests):
 
 class CreateCheckForColumnCompletenessTests(ValidateUtilsTests):
     def setUp(self) -> None:
-        return super().setUp()
+        super().setUp()
+        self.one_column_rule = Data.one_complete_column_rule
+        self.two_column_rule = Data.two_complete_columns_rule
 
-    def test_create_check_for_column_completeness(self):
-        pass
+    def test_create_check_for_column_completeness_when_one_column_is_given_and_complete(
+        self,
+    ):
+        test_df = self.spark.createDataFrame(
+            Data.one_complete_column_complete_rows, Schemas.one_column_schema
+        )
+        expected_df = self.spark.createDataFrame(
+            Data.one_complete_column_result_complete_rows, Schemas.validation_schema
+        )
+        returned_df = job.validate_dataset(test_df, self.one_column_rule)
+        returned_df.show(truncate=False)
+        self.assertEqual(returned_df.collect(), expected_df.collect())
+
+    def test_create_check_for_column_completeness_when_one_column_is_given_and_incomplete(
+        self,
+    ):
+        test_df = self.spark.createDataFrame(
+            Data.one_complete_column_incomplete_rows, Schemas.one_column_schema
+        )
+        expected_df = self.spark.createDataFrame(
+            Data.one_complete_column_result_incomplete_rows, Schemas.validation_schema
+        )
+        returned_df = job.validate_dataset(test_df, self.one_column_rule)
+        returned_df.show(truncate=False)
+        self.assertEqual(returned_df.collect(), expected_df.collect())
+
+    def test_create_check_for_column_completeness_when_two_columns_are_given_and_both_are_complete(
+        self,
+    ):
+        test_df = self.spark.createDataFrame(
+            Data.two_complete_columns_both_complete_rows, Schemas.two_column_schema
+        )
+        expected_df = self.spark.createDataFrame(
+            Data.two_complete_columns_result_both_complete_rows,
+            Schemas.validation_schema,
+        )
+        returned_df = job.validate_dataset(test_df, self.two_column_rule)
+        returned_df.show(truncate=False)
+        self.assertEqual(returned_df.collect(), expected_df.collect())
+
+    def test_create_check_for_column_completeness_when_two_columns_are_given_and_one_is_incomplete(
+        self,
+    ):
+        test_df = self.spark.createDataFrame(
+            Data.two_complete_columns_one_incomplete_rows, Schemas.two_column_schema
+        )
+        expected_df = self.spark.createDataFrame(
+            Data.two_complete_columns_result_one_incomplete_rows,
+            Schemas.validation_schema,
+        )
+        returned_df = job.validate_dataset(test_df, self.two_column_rule)
+        returned_df.show(truncate=False)
+        self.assertEqual(returned_df.collect(), expected_df.collect())
+
+    def test_create_check_for_column_completeness_when_two_columns_are_given_and_both_are_incomplete(
+        self,
+    ):
+        test_df = self.spark.createDataFrame(
+            Data.two_complete_columns_both_incomplete_rows, Schemas.two_column_schema
+        )
+        expected_df = self.spark.createDataFrame(
+            Data.two_complete_columns_result_both_incomplete_rows,
+            Schemas.validation_schema,
+        )
+        returned_df = job.validate_dataset(test_df, self.two_column_rule)
+        returned_df.show(truncate=False)
+        self.assertEqual(returned_df.collect(), expected_df.collect())
 
 
 class CreateCheckOfUniquenessOfTwoIndexColumns(ValidateUtilsTests):
@@ -62,7 +129,7 @@ class CreateCheckOfUniquenessOfTwoIndexColumns(ValidateUtilsTests):
         self,
     ):
         test_df = self.spark.createDataFrame(
-            Data.unique_index_columns_success_rows, Schemas.size_of_dataset_schema
+            Data.unique_index_columns_success_rows, Schemas.index_column_schema
         )
         expected_df = self.spark.createDataFrame(
             Data.unique_index_columns_result_success_rows, Schemas.validation_schema
@@ -75,7 +142,7 @@ class CreateCheckOfUniquenessOfTwoIndexColumns(ValidateUtilsTests):
         self,
     ):
         test_df = self.spark.createDataFrame(
-            Data.unique_index_columns_not_unique_rows, Schemas.size_of_dataset_schema
+            Data.unique_index_columns_not_unique_rows, Schemas.index_column_schema
         )
         expected_df = self.spark.createDataFrame(
             Data.unique_index_columns_result_not_unique_rows, Schemas.validation_schema

--- a/tests/unit/test_validation_utils.py
+++ b/tests/unit/test_validation_utils.py
@@ -12,7 +12,6 @@ from utils import utils
 
 
 class ValidateUtilsTests(unittest.TestCase):
-
     def setUp(self) -> None:
         self.spark = utils.get_spark()
 

--- a/tests/unit/test_validation_utils.py
+++ b/tests/unit/test_validation_utils.py
@@ -66,7 +66,7 @@ class CreateCheckOfSizeOfDataset(ValidateUtilsTests):
         super().setUp()
         self.size_of_dataset_rule = Data.size_of_dataset_rule
         self.test_df = self.spark.createDataFrame(
-            Data.size_of_dataset_rows, Schemas.size_of_dataset_schema
+            Data.size_of_dataset_success_rows, Schemas.size_of_dataset_schema
         )
         self.expected_df = self.spark.createDataFrame(
             Data.size_of_dataset_result_success_rows, Schemas.validation_schema
@@ -74,8 +74,8 @@ class CreateCheckOfSizeOfDataset(ValidateUtilsTests):
 
     def test_create_check_of_size_of_dataset(self):
         returned_df = job.validate_dataset(self.test_df, self.size_of_dataset_rule)
-        returned_df.show()
-        self.assertEqual(returned_df, self.expected_df)
+        returned_df.show(truncate=False)
+        self.assertEqual(returned_df.collect(), self.expected_df.collect())
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_validation_utils.py
+++ b/tests/unit/test_validation_utils.py
@@ -65,17 +65,40 @@ class CreateCheckOfSizeOfDataset(ValidateUtilsTests):
     def setUp(self) -> None:
         super().setUp()
         self.size_of_dataset_rule = Data.size_of_dataset_rule
-        self.test_df = self.spark.createDataFrame(
+
+    def test_create_check_of_size_of_dataset_returns_successes_with_valid_data(self):
+        test_df = self.spark.createDataFrame(
             Data.size_of_dataset_success_rows, Schemas.size_of_dataset_schema
         )
-        self.expected_df = self.spark.createDataFrame(
+        expected_df = self.spark.createDataFrame(
             Data.size_of_dataset_result_success_rows, Schemas.validation_schema
         )
+        returned_df = job.validate_dataset(test_df, self.size_of_dataset_rule)
+        self.assertEqual(returned_df.collect(), expected_df.collect())
 
-    def test_create_check_of_size_of_dataset(self):
-        returned_df = job.validate_dataset(self.test_df, self.size_of_dataset_rule)
-        returned_df.show(truncate=False)
-        self.assertEqual(returned_df.collect(), self.expected_df.collect())
+    def test_create_check_of_size_of_dataset_returns_failure_when_rows_are_missing(
+        self,
+    ):
+        missing_rows_df = self.spark.createDataFrame(
+            Data.size_of_dataset_missing_rows, Schemas.size_of_dataset_schema
+        )
+        expected_df = self.spark.createDataFrame(
+            Data.size_of_dataset_result_missing_rows, Schemas.validation_schema
+        )
+        returned_df = job.validate_dataset(missing_rows_df, self.size_of_dataset_rule)
+        self.assertEqual(returned_df.collect(), expected_df.collect())
+
+    def test_create_check_of_size_of_dataset_returns_failure_when_extra_rows_are_present(
+        self,
+    ):
+        extra_rows_df = self.spark.createDataFrame(
+            Data.size_of_dataset_extra_rows, Schemas.size_of_dataset_schema
+        )
+        expected_df = self.spark.createDataFrame(
+            Data.size_of_dataset_result_extra_rows, Schemas.validation_schema
+        )
+        returned_df = job.validate_dataset(extra_rows_df, self.size_of_dataset_rule)
+        self.assertEqual(returned_df.collect(), expected_df.collect())
 
 
 if __name__ == "__main__":

--- a/utils/column_names/validation_table_columns.py
+++ b/utils/column_names/validation_table_columns.py
@@ -1,0 +1,11 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class Validation:
+    check: str = "check"
+    check_level: str = "check_level"
+    check_status: str = "check_status"
+    constraint: str = "constraint"
+    constraint_status: str = "constraint_status"
+    constraint_message: str = "constraint_message"

--- a/utils/validation/validation_utils.py
+++ b/utils/validation/validation_utils.py
@@ -1,3 +1,8 @@
+import os
+import sys
+
+os.environ["SPARK_VERSION"] = "3.3"
+
 from pydeequ.checks import Check, CheckLevel
 from pydeequ.verification import (
     VerificationRunBuilder,

--- a/utils/validation/validation_utils.py
+++ b/utils/validation/validation_utils.py
@@ -1,5 +1,4 @@
 import os
-import sys
 
 os.environ["SPARK_VERSION"] = "3.3"
 


### PR DESCRIPTION
# Description
I've refactored the testing for validation so that the general functionality is tested in as part of the utils script and the job only tests that the job runs. This will make testing subsequent validation jobs easier and will keep the number of tests we need to a minimum.

In a later PR I plan to handle and test the size of dataset calculations.

I have removed the parsing of failures as we will probably not want or need this behaviour generally.

# How to test
Unit tests passing
Run in branch here: https://eu-west-2.console.aws.amazon.com/states/home?region=eu-west-2#/v2/executions/details/arn:aws:states:eu-west-2:344210435447:execution:write-tests-for-validation-uti-Ind-CQC-Filled-Post-Estimates-Pipeline:1644e368-84de-47fb-9a0d-2a622c9a372e

# Developer checklist
- [ ] Unit test
- [ ] Linked to Trello ticket
- [ ] Documentation up to date
