### PR TITLE
Drop duplicates from hybrid and la postcode count table

### DIFF
--- a/jobs/split_pa_filled_posts_into_icb_areas.py
+++ b/jobs/split_pa_filled_posts_into_icb_areas.py
@@ -109,7 +109,7 @@ def create_ratio_between_hybrid_area_and_la_area_postcode_counts(
 
 def deduplicate_ratio_between_hybrid_area_and_la_area_postcode_counts(
     postcode_directory_df: DataFrame,
-):
+) -> DataFrame:
     postcode_directory_df = postcode_directory_df.drop(
         ONSClean.postcode,
         DPColNames.COUNT_OF_DISTINCT_POSTCODES_PER_LA,

--- a/jobs/split_pa_filled_posts_into_icb_areas.py
+++ b/jobs/split_pa_filled_posts_into_icb_areas.py
@@ -54,14 +54,14 @@ def main(postcode_directory_source, pa_filled_posts_source, destination):
 
     # TODO 3 - Create column with ratio.
     postcode_directory_df = (
-        create_ratio_between_hybrid_area_and_la_area_postcode_counts(
+        create_proportion_between_hybrid_area_and_la_area_postcode_counts(
             postcode_directory_df,
         )
     )
 
     # TODO 4 - Drop duplicates.
     postcode_directory_df = (
-        deduplicate_ratio_between_hybrid_area_and_la_area_postcode_counts(
+        deduplicate_proportion_between_hybrid_area_and_la_area_postcode_counts(
             postcode_directory_df
         )
     )
@@ -95,7 +95,7 @@ def count_postcodes_per_list_of_columns(
     return postcode_directory_df
 
 
-def create_ratio_between_hybrid_area_and_la_area_postcode_counts(
+def create_proportion_between_hybrid_area_and_la_area_postcode_counts(
     postcode_directory_df: DataFrame,
 ) -> DataFrame:
     postcode_directory_df = postcode_directory_df.withColumn(
@@ -107,18 +107,17 @@ def create_ratio_between_hybrid_area_and_la_area_postcode_counts(
     return postcode_directory_df
 
 
-def deduplicate_ratio_between_hybrid_area_and_la_area_postcode_counts(
+def deduplicate_proportion_between_hybrid_area_and_la_area_postcode_counts(
     postcode_directory_df: DataFrame,
 ) -> DataFrame:
-    postcode_directory_df = postcode_directory_df.drop(
-        ONSClean.postcode,
-        DPColNames.COUNT_OF_DISTINCT_POSTCODES_PER_LA,
-        DPColNames.COUNT_OF_DISTINCT_POSTCODES_PER_HYBRID_AREA,
-    )
+    deduplicated_df = postcode_directory_df.select(
+        ONSClean.contemporary_ons_import_date,
+        ONSClean.contemporary_cssr,
+        ONSClean.contemporary_icb,
+        DPColNames.PROPORTION_OF_ICB_POSTCODES_IN_LA_AREA,
+    ).distinct()
 
-    postcode_directory_df = postcode_directory_df.distinct()
-
-    return postcode_directory_df
+    return deduplicated_df
 
 
 if __name__ == "__main__":

--- a/jobs/split_pa_filled_posts_into_icb_areas.py
+++ b/jobs/split_pa_filled_posts_into_icb_areas.py
@@ -60,6 +60,11 @@ def main(postcode_directory_source, pa_filled_posts_source, destination):
     )
 
     # TODO 4 - Drop duplicates.
+    postcode_directory_df = (
+        deduplicate_ratio_between_hybrid_area_and_la_area_postcode_counts(
+            postcode_directory_df
+        )
+    )
 
     # TODO 5 - Join pa filled posts.
 
@@ -98,6 +103,20 @@ def create_ratio_between_hybrid_area_and_la_area_postcode_counts(
         F.col(DPColNames.COUNT_OF_DISTINCT_POSTCODES_PER_HYBRID_AREA)
         / F.col(DPColNames.COUNT_OF_DISTINCT_POSTCODES_PER_LA),
     )
+
+    return postcode_directory_df
+
+
+def deduplicate_ratio_between_hybrid_area_and_la_area_postcode_counts(
+    postcode_directory_df: DataFrame,
+):
+    postcode_directory_df = postcode_directory_df.drop(
+        ONSClean.postcode,
+        DPColNames.COUNT_OF_DISTINCT_POSTCODES_PER_LA,
+        DPColNames.COUNT_OF_DISTINCT_POSTCODES_PER_HYBRID_AREA,
+    )
+
+    postcode_directory_df = postcode_directory_df.distinct()
 
     return postcode_directory_df
 

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -706,6 +706,15 @@ class PAFilledPostsByICBArea:
         ("AB10AC", date(2023,1,1), "cssr2", "icb3",3,2,0.66666), 
         ("AB10AC", date(2023,1,1), "cssr2", "icb3",3,2,0.66666),
     ]
+
+    expected_deduplicated_importdate_hybrid_and_la_and_ratio_rows = [
+        (date(2024,1,1), "cssr1", "icb1", 1.00000),
+        (date(2024,1,1), "cssr2", "icb2", 0.25000), 
+        (date(2024,1,1), "cssr2", "icb3", 0.75000), 
+        (date(2023,1,1), "cssr1", "icb1", 1.00000),
+        (date(2023,1,1), "cssr2", "icb2", 0.33333), 
+        (date(2023,1,1), "cssr2", "icb3", 0.66666),
+    ]
     # fmt: on
 
     pa_sample_filled_post_rows = [

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -657,20 +657,20 @@ class PAFilledPostsByICBArea:
     ]
 
     expected_postcode_count_per_la_icb_rows = [
-        ("AB10AA", date(2024,1,1), "cssr1", "icb1",3),
-        ("AB10AB", date(2024,1,1), "cssr1", "icb1",3),
-        ("AB10AC", date(2024,1,1), "cssr1", "icb1",3),
-        ("AB10AA", date(2024,1,1), "cssr2", "icb2",1), 
-        ("AB10AB", date(2024,1,1), "cssr2", "icb3",3), 
-        ("AB10AC", date(2024,1,1), "cssr2", "icb3",3), 
-        ("AB10AD", date(2024,1,1), "cssr2", "icb3",3), 
-        ("AB10AA", date(2023,1,1), "cssr1", "icb1",3),
-        ("AB10AB", date(2023,1,1), "cssr1", "icb1",3),
-        ("AB10AC", date(2023,1,1), "cssr1", "icb1",3),
-        ("AB10AA", date(2023,1,1), "cssr2", "icb2",1), 
-        ("AB10AB", date(2023,1,1), "cssr2", "icb3",2), 
-        ("AB10AC", date(2023,1,1), "cssr2", "icb3",2), 
-        ("AB10AC", date(2023,1,1), "cssr2", "icb3",2),
+        ("AB10AA", date(2024,1,1), "cssr1", "icb1", 3),
+        ("AB10AB", date(2024,1,1), "cssr1", "icb1", 3),
+        ("AB10AC", date(2024,1,1), "cssr1", "icb1", 3),
+        ("AB10AA", date(2024,1,1), "cssr2", "icb2", 1), 
+        ("AB10AB", date(2024,1,1), "cssr2", "icb3", 3), 
+        ("AB10AC", date(2024,1,1), "cssr2", "icb3", 3), 
+        ("AB10AD", date(2024,1,1), "cssr2", "icb3", 3), 
+        ("AB10AA", date(2023,1,1), "cssr1", "icb1", 3),
+        ("AB10AB", date(2023,1,1), "cssr1", "icb1", 3),
+        ("AB10AC", date(2023,1,1), "cssr1", "icb1", 3),
+        ("AB10AA", date(2023,1,1), "cssr2", "icb2", 1), 
+        ("AB10AB", date(2023,1,1), "cssr2", "icb3", 2), 
+        ("AB10AC", date(2023,1,1), "cssr2", "icb3", 2), 
+        ("AB10AC", date(2023,1,1), "cssr2", "icb3", 2),
     ]
 
     sample_rows_with_la_and_hybrid_area_postcode_counts = [
@@ -691,13 +691,21 @@ class PAFilledPostsByICBArea:
         ("Group6", date(2023,1,1), 3, 2, 0.66666),
     ]
 
+    full_rows_with_la_and_hybrid_area_postcode_counts = [
+        ("AB10AA", date(2024,1,1), "cssr1", "icb1", 3, 3, 1.00000),
+        ("AB10AB", date(2024,1,1), "cssr1", "icb1", 3, 3, 1.00000),
+        ("AB10AA", date(2024,1,1), "cssr2", "icb2", 4, 1, 0.25000), 
+        ("AB10AB", date(2024,1,1), "cssr2", "icb3", 4, 3, 0.75000), 
+        ("AB10AA", date(2023,1,1), "cssr1", "icb1", 3, 3, 1.00000),
+        ("AB10AB", date(2023,1,1), "cssr1", "icb1", 3, 3, 1.00000),
+        ("AB10AC", date(2023,1,1), "cssr1", "icb1", 3, 3, 1.00000),
+    ]
+
     expected_deduplicated_importdate_hybrid_and_la_and_ratio_rows = [
         (date(2024,1,1), "cssr1", "icb1", 1.00000),
         (date(2024,1,1), "cssr2", "icb2", 0.25000), 
         (date(2024,1,1), "cssr2", "icb3", 0.75000), 
         (date(2023,1,1), "cssr1", "icb1", 1.00000),
-        (date(2023,1,1), "cssr2", "icb2", 0.33333), 
-        (date(2023,1,1), "cssr2", "icb3", 0.66666),
     ]
     # fmt: on
 

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -483,7 +483,7 @@ class PAFilledPostsByICBAreaSchema:
         ]
     )
 
-    full_rows_with_la_and_hybrid_area_postcode_schema = StructType(
+    full_rows_with_la_and_hybrid_area_postcode_counts_schema = StructType(
         [
             *ons_sample_contemporary_schema,
             StructField(DP.COUNT_OF_DISTINCT_POSTCODES_PER_LA, IntegerType(), True),

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -482,6 +482,15 @@ class PAFilledPostsByICBAreaSchema:
         ]
     )
 
+    expected_deduplicated_importdate_hybrid_and_la_and_ratio_schema = StructType(
+        [
+            StructField(ONSClean.contemporary_ons_import_date, DateType(), True),
+            StructField(ONSClean.contemporary_cssr, StringType(), True),
+            StructField(ONSClean.contemporary_icb, StringType(), True),
+            StructField(DP.RATIO_HYBRID_AREA_TO_LA_AREA_POSTCODES, FloatType(), True),
+        ]
+    )
+
     pa_sample_filled_post_schema = StructType(
         [
             StructField(DP.LA_AREA, StringType(), True),

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -483,12 +483,23 @@ class PAFilledPostsByICBAreaSchema:
         ]
     )
 
+    full_rows_with_la_and_hybrid_area_postcode_schema = StructType(
+        [
+            *ons_sample_contemporary_schema,
+            StructField(DP.COUNT_OF_DISTINCT_POSTCODES_PER_LA, IntegerType(), True),
+            StructField(
+                DP.COUNT_OF_DISTINCT_POSTCODES_PER_HYBRID_AREA, IntegerType(), True
+            ),
+            StructField(DP.PROPORTION_OF_ICB_POSTCODES_IN_LA_AREA, FloatType(), True),
+        ]
+    )
+
     expected_deduplicated_importdate_hybrid_and_la_and_ratio_schema = StructType(
         [
             StructField(ONSClean.contemporary_ons_import_date, DateType(), True),
             StructField(ONSClean.contemporary_cssr, StringType(), True),
             StructField(ONSClean.contemporary_icb, StringType(), True),
-            StructField(DP.RATIO_HYBRID_AREA_TO_LA_AREA_POSTCODES, FloatType(), True),
+            StructField(DP.PROPORTION_OF_ICB_POSTCODES_IN_LA_AREA, FloatType(), True),
         ]
     )
 

--- a/tests/unit/test_dpr_split_pa_filled_posts_into_icb_areas.py
+++ b/tests/unit/test_dpr_split_pa_filled_posts_into_icb_areas.py
@@ -170,7 +170,7 @@ class DeduplicateRatioBetweenAreaCounts(SplitPAFilledPostsIntoICBAreas):
 
         self.sample_df = self.spark.createDataFrame(
             TestData.full_rows_with_la_and_hybrid_area_postcode_counts,
-            schema=TestSchema.full_rows_with_la_and_hybrid_area_postcode_schema,
+            schema=TestSchema.full_rows_with_la_and_hybrid_area_postcode_counts_schema,
         )
 
         self.returned_df = (

--- a/tests/unit/test_dpr_split_pa_filled_posts_into_icb_areas.py
+++ b/tests/unit/test_dpr_split_pa_filled_posts_into_icb_areas.py
@@ -187,7 +187,6 @@ class DeduplicateRatioBetweenAreaCounts(SplitPAFilledPostsIntoICBAreas):
     def test_deduplicate_ratio_between_hybrid_area_and_la_area_postcode_counts_returns_expected_data(
         self,
     ):
-
         returned_rows_dedupicated_on_importdate_la_area_and_hybrid_area = (
             job.deduplicate_ratio_between_hybrid_area_and_la_area_postcode_counts(
                 self.test_sample_rows_ratio_between_hybrid_area_and_la_area_postcodes_rows

--- a/tests/unit/test_dpr_split_pa_filled_posts_into_icb_areas.py
+++ b/tests/unit/test_dpr_split_pa_filled_posts_into_icb_areas.py
@@ -168,3 +168,47 @@ class CreateRatioBetweenColumns(SplitPAFilledPostsIntoICBAreas):
                 3,
                 "rows are not almost equal",
             )
+
+
+class DeduplicateRatioBetweenAreaCounts(SplitPAFilledPostsIntoICBAreas):
+    def setUp(self) -> None:
+        super().setUp()
+
+        self.test_sample_rows_ratio_between_hybrid_area_and_la_area_postcodes_rows = self.spark.createDataFrame(
+            TestData.expected_ratio_between_hybrid_area_and_la_area_postcodes_rows,
+            schema=TestSchema.expected_ratio_between_hybrid_area_and_la_area_postcodes_schema,
+        )
+
+        self.expected_rows_dedupicated_on_importdate_la_area_and_hybrid_area = self.spark.createDataFrame(
+            TestData.expected_deduplicated_importdate_hybrid_and_la_and_ratio_rows,
+            schema=TestSchema.expected_deduplicated_importdate_hybrid_and_la_and_ratio_schema,
+        )
+
+    def test_deduplicate_ratio_between_hybrid_area_and_la_area_postcode_counts_returns_expected_data(
+        self,
+    ):
+
+        returned_rows_dedupicated_on_importdate_la_area_and_hybrid_area = (
+            job.deduplicate_ratio_between_hybrid_area_and_la_area_postcode_counts(
+                self.test_sample_rows_ratio_between_hybrid_area_and_la_area_postcodes_rows
+            )
+            .sort(
+                ONSClean.contemporary_ons_import_date,
+                ONSClean.contemporary_cssr,
+                ONSClean.contemporary_icb,
+            )
+            .collect()
+        )
+
+        expected_rows = (
+            self.expected_rows_dedupicated_on_importdate_la_area_and_hybrid_area.sort(
+                ONSClean.contemporary_ons_import_date,
+                ONSClean.contemporary_cssr,
+                ONSClean.contemporary_icb,
+            ).collect()
+        )
+
+        self.assertEqual(
+            returned_rows_dedupicated_on_importdate_la_area_and_hybrid_area,
+            expected_rows,
+        )

--- a/tests/unit/test_dpr_split_pa_filled_posts_into_icb_areas.py
+++ b/tests/unit/test_dpr_split_pa_filled_posts_into_icb_areas.py
@@ -187,10 +187,7 @@ class DeduplicateRatioBetweenAreaCounts(SplitPAFilledPostsIntoICBAreas):
     def test_deduplicate_proportion_between_hybrid_area_and_la_area_postcode_counts_returns_expected_columns(
         self,
     ):
-        returned_columns = self.returned_df.columns
-        expected_columns = self.expected_df.columns
-
-        self.assertEqual(returned_columns, expected_columns)
+        self.assertEqual(self.returned_df.columns, self.expected_df.columns)
 
     def test_deduplicate_proportion_between_hybrid_area_and_la_area_postcode_counts_returns_expected_data(
         self,

--- a/tests/unit/test_dpr_split_pa_filled_posts_into_icb_areas.py
+++ b/tests/unit/test_dpr_split_pa_filled_posts_into_icb_areas.py
@@ -187,7 +187,7 @@ class DeduplicateRatioBetweenAreaCounts(SplitPAFilledPostsIntoICBAreas):
     def test_deduplicate_ratio_between_hybrid_area_and_la_area_postcode_counts_returns_expected_data(
         self,
     ):
-        returned_rows_dedupicated_on_importdate_la_area_and_hybrid_area = (
+        returned_rows = (
             job.deduplicate_ratio_between_hybrid_area_and_la_area_postcode_counts(
                 self.test_sample_rows_ratio_between_hybrid_area_and_la_area_postcodes_rows
             )
@@ -208,6 +208,6 @@ class DeduplicateRatioBetweenAreaCounts(SplitPAFilledPostsIntoICBAreas):
         )
 
         self.assertEqual(
-            returned_rows_dedupicated_on_importdate_la_area_and_hybrid_area,
+            returned_rows,
             expected_rows,
         )

--- a/tests/unit/test_dpr_split_pa_filled_posts_into_icb_areas.py
+++ b/tests/unit/test_dpr_split_pa_filled_posts_into_icb_areas.py
@@ -168,12 +168,18 @@ class DeduplicateRatioBetweenAreaCounts(SplitPAFilledPostsIntoICBAreas):
     def setUp(self) -> None:
         super().setUp()
 
-        self.test_sample_rows_ratio_between_hybrid_area_and_la_area_postcodes_rows = self.spark.createDataFrame(
-            TestData.expected_ratio_between_hybrid_area_and_la_area_postcodes_rows,
-            schema=TestSchema.expected_ratio_between_hybrid_area_and_la_area_postcodes_schema,
+        self.sample_df = self.spark.createDataFrame(
+            TestData.full_rows_with_la_and_hybrid_area_postcode_counts,
+            schema=TestSchema.full_rows_with_la_and_hybrid_area_postcode_schema,
         )
 
-        self.expected_rows_dedupicated_on_importdate_la_area_and_hybrid_area = self.spark.createDataFrame(
+        self.returned_df = (
+            job.deduplicate_ratio_between_hybrid_area_and_la_area_postcode_counts(
+                self.sample_df
+            )
+        )
+
+        self.expected_df = self.spark.createDataFrame(
             TestData.expected_deduplicated_importdate_hybrid_and_la_and_ratio_rows,
             schema=TestSchema.expected_deduplicated_importdate_hybrid_and_la_and_ratio_schema,
         )
@@ -181,25 +187,17 @@ class DeduplicateRatioBetweenAreaCounts(SplitPAFilledPostsIntoICBAreas):
     def test_deduplicate_ratio_between_hybrid_area_and_la_area_postcode_counts_returns_expected_data(
         self,
     ):
-        returned_rows = (
-            job.deduplicate_ratio_between_hybrid_area_and_la_area_postcode_counts(
-                self.test_sample_rows_ratio_between_hybrid_area_and_la_area_postcodes_rows
-            )
-            .sort(
-                ONSClean.contemporary_ons_import_date,
-                ONSClean.contemporary_cssr,
-                ONSClean.contemporary_icb,
-            )
-            .collect()
-        )
+        returned_rows = self.returned_df.sort(
+            ONSClean.contemporary_ons_import_date,
+            ONSClean.contemporary_cssr,
+            ONSClean.contemporary_icb,
+        ).collect()
 
-        expected_rows = (
-            self.expected_rows_dedupicated_on_importdate_la_area_and_hybrid_area.sort(
-                ONSClean.contemporary_ons_import_date,
-                ONSClean.contemporary_cssr,
-                ONSClean.contemporary_icb,
-            ).collect()
-        )
+        expected_rows = self.expected_df.sort(
+            ONSClean.contemporary_ons_import_date,
+            ONSClean.contemporary_cssr,
+            ONSClean.contemporary_icb,
+        ).collect()
 
         self.assertEqual(
             returned_rows,

--- a/tests/unit/test_dpr_split_pa_filled_posts_into_icb_areas.py
+++ b/tests/unit/test_dpr_split_pa_filled_posts_into_icb_areas.py
@@ -122,7 +122,7 @@ class CreateRatioBetweenColumns(SplitPAFilledPostsIntoICBAreas):
         )
 
         self.returned_df = (
-            job.create_ratio_between_hybrid_area_and_la_area_postcode_counts(
+            job.create_proportion_between_hybrid_area_and_la_area_postcode_counts(
                 self.sample_df,
             )
         )
@@ -135,7 +135,7 @@ class CreateRatioBetweenColumns(SplitPAFilledPostsIntoICBAreas):
         self.returned_rows = self.returned_df.sort("GroupID").collect()
         self.expected_rows = self.expected_df.sort("GroupID").collect()
 
-    def test_create_ratio_between_hybrid_area_and_la_area_postcode_counts_has_expected_columns(
+    def test_create_proportion_between_hybrid_area_and_la_area_postcode_counts_has_expected_columns(
         self,
     ):
         self.assertEqual(
@@ -143,12 +143,12 @@ class CreateRatioBetweenColumns(SplitPAFilledPostsIntoICBAreas):
             self.expected_df.columns,
         )
 
-    def test_create_ratio_between_hybrid_area_and_la_area_postcode_counts_has_expected_length(
+    def test_create_proportion_between_hybrid_area_and_la_area_postcode_counts_has_expected_length(
         self,
     ):
         self.assertEqual(len(self.returned_rows), len(self.expected_rows))
 
-    def test_create_ratio_between_hybrid_area_and_la_area_postcode_counts_has_expected_values_when_given_hybrid_and_la_counts(
+    def test_create_proportion_between_hybrid_area_and_la_area_postcode_counts_has_expected_values_when_given_hybrid_and_la_counts(
         self,
     ):
         for i in range(len(self.returned_rows)):
@@ -174,7 +174,7 @@ class DeduplicateRatioBetweenAreaCounts(SplitPAFilledPostsIntoICBAreas):
         )
 
         self.returned_df = (
-            job.deduplicate_ratio_between_hybrid_area_and_la_area_postcode_counts(
+            job.deduplicate_proportion_between_hybrid_area_and_la_area_postcode_counts(
                 self.sample_df
             )
         )
@@ -184,7 +184,15 @@ class DeduplicateRatioBetweenAreaCounts(SplitPAFilledPostsIntoICBAreas):
             schema=TestSchema.expected_deduplicated_importdate_hybrid_and_la_and_ratio_schema,
         )
 
-    def test_deduplicate_ratio_between_hybrid_area_and_la_area_postcode_counts_returns_expected_data(
+    def test_deduplicate_proportion_between_hybrid_area_and_la_area_postcode_counts_returns_expected_columns(
+        self,
+    ):
+        returned_columns = self.returned_df.columns
+        expected_columns = self.expected_df.columns
+
+        self.assertEqual(returned_columns, expected_columns)
+
+    def test_deduplicate_proportion_between_hybrid_area_and_la_area_postcode_counts_returns_expected_data(
         self,
     ):
         returned_rows = self.returned_df.sort(


### PR DESCRIPTION
# Description
Need to drop duplicate rows after creating a proportion of postcodes for each ICB within each LA area.
So the output is a table which has each ICB within an LA area and that ICB's % of the total postcodes in the LA.

Link to Trello:    https://trello.com/c/JBJFgqqR

# How to test

# Developer checklist
- [x] Unit test
- [x] Linked to Trello ticket
- [ ] Documentation up to date
