### PR TITLE
Join pa filled posts into hybrid ratio table

### DIFF
--- a/jobs/split_pa_filled_posts_into_icb_areas.py
+++ b/jobs/split_pa_filled_posts_into_icb_areas.py
@@ -154,6 +154,12 @@ def join_pa_filled_posts_to_hybrid_area_proportions(
         ONSClean.contemporary_ons_import_date,
     )
 
+    pa_filled_posts_df = pa_filled_posts_df.select(
+        DPColNames.LA_AREA,
+        DPColNames.ESTIMATED_TOTAL_PERSONAL_ASSISTANT_FILLED_POSTS,
+        ONSClean.contemporary_ons_import_date,
+    )
+
     pa_filled_posts_df = pa_filled_posts_df.withColumnRenamed(
         DPColNames.LA_AREA, ONSClean.contemporary_cssr
     )

--- a/jobs/split_pa_filled_posts_into_icb_areas.py
+++ b/jobs/split_pa_filled_posts_into_icb_areas.py
@@ -4,7 +4,9 @@ from pyspark.sql import (
     functions as F,
 )
 
-from utils import utils
+from datetime import date
+
+from utils import utils, cleaning_utils
 
 from utils.column_names.cleaned_data_files.ons_cleaned_values import (
     OnsCleanedColumns as ONSClean,
@@ -119,6 +121,22 @@ def deduplicate_ratio_between_hybrid_area_and_la_area_postcode_counts(
     postcode_directory_df = postcode_directory_df.distinct()
 
     return postcode_directory_df
+
+
+def join_pa_filled_posts_to_hybrid_area_proportions_table(
+    postcode_directory_df: DataFrame,
+    pa_filled_posts_df: DataFrame,
+) -> DataFrame:
+    pa_filled_posts_df = pa_filled_posts_df.withColumn(
+        DPColNames.ESTIMATE_PERIOD_AS_DATE, date(DPColNames.YEAR, 3, 31)
+    )
+
+    pa_filled_posts_df = cleaning_utils.add_aligned_date_column(
+        pa_filled_posts_df,
+        postcode_directory_df,
+        DPColNames.ESTIMATE_PERIOD_AS_DATE,
+        ONSClean.contemporary_ons_import_date,
+    )
 
 
 if __name__ == "__main__":

--- a/jobs/split_pa_filled_posts_into_icb_areas.py
+++ b/jobs/split_pa_filled_posts_into_icb_areas.py
@@ -158,7 +158,7 @@ def create_date_column_from_year_in_pa_estimates(
     return pa_filled_posts_df
 
 
-def align_dates_to_pa_filled_posts_from_postcode_proportions(
+def align_dates_from_pa_filled_posts_to_postcode_proportions(
     pa_filled_posts_df: DataFrame,
     postcode_directory_df: DataFrame,
 ) -> DataFrame:

--- a/jobs/split_pa_filled_posts_into_icb_areas.py
+++ b/jobs/split_pa_filled_posts_into_icb_areas.py
@@ -130,7 +130,7 @@ def join_pa_filled_posts_to_hybrid_area_proportions(
     pa_filled_posts_df = create_date_column_from_year_in_pa_estimates(
         pa_filled_posts_df
     )
-    pa_filled_posts_df = align_dates_to_pa_filled_posts_from_postcode_proportions(
+    pa_filled_posts_df = align_dates_from_pa_filled_posts_to_postcode_proportions(
         pa_filled_posts_df, postcode_directory_df
     )
 

--- a/jobs/split_pa_filled_posts_into_icb_areas.py
+++ b/jobs/split_pa_filled_posts_into_icb_areas.py
@@ -14,6 +14,9 @@ from utils.column_names.cleaned_data_files.ons_cleaned_values import (
 from utils.direct_payments_utils.direct_payments_column_names import (
     DirectPaymentColumnNames as DPColNames,
 )
+from utils.direct_payments_utils.direct_payments_configuration import (
+    EstimatePeriodAsDate,
+)
 
 
 def main(postcode_directory_source, pa_filled_posts_source, destination):
@@ -133,7 +136,11 @@ def create_date_column_from_year_in_pa_estimates(
 ) -> DataFrame:
     pa_filled_posts_df = pa_filled_posts_df.withColumn(
         DPColNames.ESTIMATE_PERIOD_AS_DATE,
-        F.make_date(DPColNames.YEAR, F.lit("03"), F.lit("31")),
+        F.make_date(
+            DPColNames.YEAR,
+            F.lit(EstimatePeriodAsDate.MONTH),
+            F.lit(EstimatePeriodAsDate.DAY),
+        ),
     )
 
     return pa_filled_posts_df

--- a/jobs/split_pa_filled_posts_into_icb_areas.py
+++ b/jobs/split_pa_filled_posts_into_icb_areas.py
@@ -142,10 +142,11 @@ def create_date_column_from_year_in_pa_estimates(
     return pa_filled_posts_df
 
 
-def align_dates_from_pa_filled_posts_to_postcode_proportions(
-    pa_filled_posts_df: DataFrame,
+def join_pa_filled_posts_to_hybrid_area_proportions(
     postcode_directory_df: DataFrame,
+    pa_filled_posts_df: DataFrame,
 ) -> DataFrame:
+
     pa_filled_posts_df = cleaning_utils.add_aligned_date_column(
         pa_filled_posts_df,
         postcode_directory_df,
@@ -153,13 +154,6 @@ def align_dates_from_pa_filled_posts_to_postcode_proportions(
         ONSClean.contemporary_ons_import_date,
     )
 
-    return pa_filled_posts_df
-
-
-def join_pa_filled_posts_to_hybrid_area_proportions(
-    postcode_directory_df: DataFrame,
-    pa_filled_posts_df: DataFrame,
-) -> DataFrame:
     pa_filled_posts_df = pa_filled_posts_df.withColumnRenamed(
         DPColNames.LA_AREA, ONSClean.contemporary_cssr
     )

--- a/jobs/split_pa_filled_posts_into_icb_areas.py
+++ b/jobs/split_pa_filled_posts_into_icb_areas.py
@@ -143,7 +143,6 @@ def join_pa_filled_posts_to_hybrid_area_proportions(
     postcode_directory_df: DataFrame,
     pa_filled_posts_df: DataFrame,
 ) -> DataFrame:
-
     pa_filled_posts_df = cleaning_utils.add_aligned_date_column(
         pa_filled_posts_df,
         postcode_directory_df,

--- a/jobs/split_pa_filled_posts_into_icb_areas.py
+++ b/jobs/split_pa_filled_posts_into_icb_areas.py
@@ -153,6 +153,7 @@ def join_pa_filled_posts_to_hybrid_area_proportions(
     pa_filled_posts_df = pa_filled_posts_df.select(
         DPColNames.LA_AREA,
         DPColNames.ESTIMATED_TOTAL_PERSONAL_ASSISTANT_FILLED_POSTS,
+        DPColNames.YEAR,
         ONSClean.contemporary_ons_import_date,
     )
 

--- a/jobs/split_pa_filled_posts_into_icb_areas.py
+++ b/jobs/split_pa_filled_posts_into_icb_areas.py
@@ -69,6 +69,15 @@ def main(postcode_directory_source, pa_filled_posts_source, destination):
     )
 
     # TODO 5 - Join pa filled posts.
+    pa_filled_posts_df = create_date_column_from_year_in_pa_estimates(
+        pa_filled_posts_df
+    )
+    pa_filled_posts_df = align_dates_from_pa_filled_posts_to_postcode_proportions(
+        pa_filled_posts_df, postcode_directory_df
+    )
+    postcode_directory_df = join_pa_filled_posts_to_hybrid_area_proportions(
+        postcode_directory_df, pa_filled_posts_df
+    )
 
     # TODO 6 - Apply ratio to calculate ICB filled posts.
 
@@ -123,30 +132,6 @@ def deduplicate_ratio_between_hybrid_area_and_la_area_postcode_counts(
     return postcode_directory_df
 
 
-def join_pa_filled_posts_to_hybrid_area_proportions(
-    postcode_directory_df: DataFrame,
-    pa_filled_posts_df: DataFrame,
-) -> DataFrame:
-    pa_filled_posts_df = create_date_column_from_year_in_pa_estimates(
-        pa_filled_posts_df
-    )
-    pa_filled_posts_df = align_dates_from_pa_filled_posts_to_postcode_proportions(
-        pa_filled_posts_df, postcode_directory_df
-    )
-
-    pa_filled_posts_df = pa_filled_posts_df.withColumnRenamed(
-        DPColNames.LA_AREA, ONSClean.contemporary_cssr
-    )
-
-    postcode_directory_df.join(
-        pa_filled_posts_df,
-        [ONSClean.contemporary_ons_import_date, ONSClean.contemporary_cssr],
-        "left",
-    )
-
-    return pa_filled_posts_df
-
-
 def create_date_column_from_year_in_pa_estimates(
     pa_filled_posts_df: DataFrame,
 ) -> DataFrame:
@@ -170,6 +155,23 @@ def align_dates_from_pa_filled_posts_to_postcode_proportions(
     )
 
     return pa_filled_posts_df
+
+
+def join_pa_filled_posts_to_hybrid_area_proportions(
+    postcode_directory_df: DataFrame,
+    pa_filled_posts_df: DataFrame,
+) -> DataFrame:
+    pa_filled_posts_df = pa_filled_posts_df.withColumnRenamed(
+        DPColNames.LA_AREA, ONSClean.contemporary_cssr
+    )
+
+    postcode_directory_df = postcode_directory_df.join(
+        pa_filled_posts_df,
+        [ONSClean.contemporary_ons_import_date, ONSClean.contemporary_cssr],
+        "left",
+    )
+
+    return postcode_directory_df
 
 
 if __name__ == "__main__":

--- a/jobs/split_pa_filled_posts_into_icb_areas.py
+++ b/jobs/split_pa_filled_posts_into_icb_areas.py
@@ -138,6 +138,9 @@ def join_pa_filled_posts_to_hybrid_area_proportions_table(
         ONSClean.contemporary_ons_import_date,
     )
 
+    # TODO join the pa filled posts into the postcode directory df. The column names have to the same, so do something like
+    #      "with ONSClean.date as DPColName.date"
+
 
 if __name__ == "__main__":
     (

--- a/jobs/split_pa_filled_posts_into_icb_areas.py
+++ b/jobs/split_pa_filled_posts_into_icb_areas.py
@@ -72,9 +72,6 @@ def main(postcode_directory_source, pa_filled_posts_source, destination):
     pa_filled_posts_df = create_date_column_from_year_in_pa_estimates(
         pa_filled_posts_df
     )
-    pa_filled_posts_df = align_dates_from_pa_filled_posts_to_postcode_proportions(
-        pa_filled_posts_df, postcode_directory_df
-    )
     postcode_directory_df = join_pa_filled_posts_to_hybrid_area_proportions(
         postcode_directory_df, pa_filled_posts_df
     )

--- a/jobs/split_pa_filled_posts_into_icb_areas.py
+++ b/jobs/split_pa_filled_posts_into_icb_areas.py
@@ -138,11 +138,8 @@ def create_date_column_from_year_in_pa_estimates(
         DPColNames.ESTIMATE_PERIOD_AS_DATE,
         F.to_date(
             F.concat(
-                DPColNames.YEAR,
-                F.lit("-"),
-                F.lit(EstimatePeriodAsDate.MONTH),
-                F.lit("-"),
-                F.lit(EstimatePeriodAsDate.DAY),
+                F.col(DPColNames.YEAR),
+                F.lit(f"-{EstimatePeriodAsDate.MONTH}-{EstimatePeriodAsDate.DAY}"),
             )
         ),
     )

--- a/jobs/split_pa_filled_posts_into_icb_areas.py
+++ b/jobs/split_pa_filled_posts_into_icb_areas.py
@@ -136,10 +136,14 @@ def create_date_column_from_year_in_pa_estimates(
 ) -> DataFrame:
     pa_filled_posts_df = pa_filled_posts_df.withColumn(
         DPColNames.ESTIMATE_PERIOD_AS_DATE,
-        F.make_date(
-            DPColNames.YEAR,
-            F.lit(EstimatePeriodAsDate.MONTH),
-            F.lit(EstimatePeriodAsDate.DAY),
+        F.to_date(
+            F.concat(
+                DPColNames.YEAR,
+                F.lit("-"),
+                F.lit(EstimatePeriodAsDate.MONTH),
+                F.lit("-"),
+                F.lit(EstimatePeriodAsDate.DAY),
+            )
         ),
     )
 

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -701,7 +701,7 @@ class PAFilledPostsByICBArea:
         ("AB10AC", date(2022,5,1), "cssr1", "icb1", 3, 3, 1.00000),
     ]
 
-    expected_deduplicated_importdate_hybrid_and_la_and_ratio_rows = [
+    expected_deduplicated_import_date_hybrid_and_la_and_ratio_rows = [
         (date(2023,5,1), "cssr1", "icb1", 1.00000),
         (date(2023,5,1), "cssr2", "icb2", 0.25000), 
         (date(2023,5,1), "cssr2", "icb3", 0.75000), 

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -674,21 +674,21 @@ class PAFilledPostsByICBArea:
     ]
 
     sample_rows_with_la_and_hybrid_area_postcode_counts = [
-        ("Group1", date(2024,1,1), 3, 3),
-        ("Group2", date(2024,1,1), 4, 1), 
-        ("Group3", date(2024,1,1), 4, 3), 
-        ("Group4", date(2023,1,1), 3, 3),
-        ("Group5", date(2023,1,1), 3, 1), 
-        ("Group6", date(2023,1,1), 3, 2),
+        ("1", date(2024,1,1), 3, 3),
+        ("2", date(2024,1,1), 4, 1), 
+        ("3", date(2024,1,1), 4, 3), 
+        ("4", date(2023,1,1), 3, 3),
+        ("5", date(2023,1,1), 3, 1), 
+        ("6", date(2023,1,1), 3, 2),
     ]
 
     expected_ratio_between_hybrid_area_and_la_area_postcodes_rows = [
-        ("Group1", date(2024,1,1), 3, 3, 1.00000),
-        ("Group2", date(2024,1,1), 4, 1, 0.25000), 
-        ("Group3", date(2024,1,1), 4, 3, 0.75000), 
-        ("Group4", date(2023,1,1), 3, 3, 1.00000),
-        ("Group5", date(2023,1,1), 3, 1, 0.33333), 
-        ("Group6", date(2023,1,1), 3, 2, 0.66666),
+        ("1", date(2024,1,1), 3, 3, 1.00000),
+        ("2", date(2024,1,1), 4, 1, 0.25000), 
+        ("3", date(2024,1,1), 4, 3, 0.75000), 
+        ("4", date(2023,1,1), 3, 3, 1.00000),
+        ("5", date(2023,1,1), 3, 1, 0.33333), 
+        ("6", date(2023,1,1), 3, 2, 0.66666),
     ]
 
     full_rows_with_la_and_hybrid_area_postcode_counts = [
@@ -710,36 +710,36 @@ class PAFilledPostsByICBArea:
     # fmt: on
 
     sample_pa_filled_post_rows = [
-        ("Group1", "Leeds", 100.2, "2024"),
-        ("Group2", "Bradford", 200.3, "2024"),
-        ("Group3", "Hull", 300.3, "2023"),
+        ("1", "Leeds", 100.2, "2024"),
+        ("2", "Bradford", 200.3, "2024"),
+        ("3", "Hull", 300.3, "2023"),
     ]
 
     expected_after_adding_date_from_year_column_rows = [
-        ("Group1", "Leeds", 100.2, "2024", date(2024, 3, 31)),
-        ("Group2", "Bradford", 200.3, "2024", date(2024, 3, 31)),
-        ("Group3", "Hull", 300.3, "2023", date(2023, 3, 31)),
+        ("1", "Leeds", 100.2, "2024", date(2024, 3, 31)),
+        ("2", "Bradford", 200.3, "2024", date(2024, 3, 31)),
+        ("3", "Hull", 300.3, "2023", date(2023, 3, 31)),
     ]
 
     sample_postcode_proportions_before_joining_pa_filled_posts_rows = [
-        ("Group1", date(2023, 5, 1), "Leeds", "icb1", 1.00000),
-        ("Group2", date(2023, 5, 1), "Bradford", "icb2", 0.25000),
-        ("Group3", date(2023, 5, 1), "Bradford", "icb3", 0.75000),
-        ("Group4", date(2022, 5, 1), "Hull", "icb4", 1.00000),
+        ("1", date(2023, 5, 1), "Leeds", "icb1", 1.00000),
+        ("2", date(2023, 5, 1), "Bradford", "icb2", 0.25000),
+        ("3", date(2023, 5, 1), "Bradford", "icb3", 0.75000),
+        ("4", date(2022, 5, 1), "Hull", "icb4", 1.00000),
     ]
 
-    sample_pa_filled_posts_before_being_joined_rows = [
-        ("Leeds", 100.2, "2024", date(2024, 3, 31), date(2023, 5, 1)),
-        ("Bradford", 200.3, "2024", date(2024, 3, 31), date(2023, 5, 1)),
-        ("Hull", 300.3, "2023", date(2023, 3, 31), date(2022, 5, 1)),
+    sample_pa_filled_posts_prepared_for_joining_to_postcode_proportions_rows = [
+        ("Leeds", 100.2, date(2023, 5, 1)),
+        ("Bradford", 200.3, date(2023, 5, 1)),
+        ("Hull", 300.3, date(2022, 5, 1)),
     ]
 
     # fmt: off
-    expected_after_joining_pa_filled_posts_to_postcode_proportion_rows = [
-        ("Group1", date(2023,5,1), "Leeds", "icb1", 1.00000, 100.2, "2024", date(2024, 3, 31)),
-        ("Group2", date(2023,5,1), "Bradford", "icb2", 0.25000, 200.3, "2024", date(2024, 3, 31)), 
-        ("Group3", date(2023,5,1), "Bradford", "icb3", 0.75000, 200.3, "2024", date(2024, 3, 31)), 
-        ("Group4", date(2022,5,1), "Hull", "icb4", 1.00000, 300.3, "2023", date(2023, 3, 31)),
+    expected_postcode_proportions_after_joining_pa_filled_posts_rows = [
+        ("1", date(2023,5,1), "Leeds", "icb1", 1.00000, 100.2),
+        ("2", date(2023,5,1), "Bradford", "icb2", 0.25000, 200.3), 
+        ("3", date(2023,5,1), "Bradford", "icb3", 0.75000, 200.3), 
+        ("4", date(2022,5,1), "Hull", "icb4", 1.00000, 300.3),
     ]
     # fmt: on
 

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -709,13 +709,13 @@ class PAFilledPostsByICBArea:
     ]
     # fmt: on
 
-    sample_pa_filled_post_rows = [
+    sample_pa_filled_posts_rows = [
         ("Leeds", 100.2, "2024"),
         ("Bradford", 200.3, "2024"),
         ("Hull", 300.3, "2023"),
     ]
 
-    expected_pa_filled_post_after_adding_date_from_year_column_rows = [
+    expected_pa_filled_posts_after_adding_date_from_year_column_rows = [
         ("Leeds", 100.2, "2024", date(2024, 3, 31)),
         ("Bradford", 200.3, "2024", date(2024, 3, 31)),
         ("Hull", 300.3, "2023", date(2023, 3, 31)),

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -702,10 +702,10 @@ class PAFilledPostsByICBArea:
     ]
 
     expected_deduplicated_importdate_hybrid_and_la_and_ratio_rows = [
-        (date(2024,1,1), "cssr1", "icb1", 1.00000),
-        (date(2024,1,1), "cssr2", "icb2", 0.25000), 
-        (date(2024,1,1), "cssr2", "icb3", 0.75000), 
-        (date(2023,1,1), "cssr1", "icb1", 1.00000),
+        (date(2023,5,1), "cssr1", "icb1", 1.00000),
+        (date(2023,5,1), "cssr2", "icb2", 0.25000), 
+        (date(2023,5,1), "cssr2", "icb3", 0.75000), 
+        (date(2022,5,1), "cssr1", "icb1", 1.00000),
     ]
     # fmt: on
 

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -725,13 +725,14 @@ class PAFilledPostsByICBArea:
         (date(2023, 5, 1), "Leeds", "icb1", 1.00000),
         (date(2023, 5, 1), "Bradford", "icb2", 0.25000),
         (date(2023, 5, 1), "Bradford", "icb3", 0.75000),
-        (date(2022, 5, 1), "Barking & Dagenham", "icb4", 1.00000),
         (date(2022, 5, 1), "Leeds", "icb1", 1.00000),
+        (date(2022, 5, 1), "Barking & Dagenham", "icb4", 1.00000),
     ]
 
     sample_pa_filled_posts_prepared_for_joining_to_postcode_proportions_rows = [
         ("Leeds", 100.2, "2024", date(2024, 3, 31)),
         ("Bradford", 200.3, "2024", date(2024, 3, 31)),
+        ("Leeds", 300.3, "2023", date(2023, 3, 31)),
         ("Barking and Dagenham", 300.3, "2023", date(2023, 3, 31)),
     ]
 
@@ -740,7 +741,7 @@ class PAFilledPostsByICBArea:
         (date(2023,5,1), "Leeds", "icb1", 1.00000, 100.2, "2024"),
         (date(2023,5,1), "Bradford", "icb2", 0.25000, 200.3, "2024"), 
         (date(2023,5,1), "Bradford", "icb3", 0.75000, 200.3, "2024"), 
-        (date(2022,5,1), "Leeds", "icb1", 1.00000, None, None),
+        (date(2022,5,1), "Leeds", "icb1", 1.00000, 300.3, "2023"),
         (date(2022, 5, 1), "Barking & Dagenham", "icb4", 1.00000, None, None),
     ]
     # fmt: on

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -730,18 +730,18 @@ class PAFilledPostsByICBArea:
     ]
 
     sample_pa_filled_posts_prepared_for_joining_to_postcode_proportions_rows = [
-        ("Leeds", 100.2, date(2024, 3, 31)),
-        ("Bradford", 200.3, date(2024, 3, 31)),
-        ("Barking and Dagenham", 300.3, date(2023, 3, 31)),
+        ("Leeds", 100.2, "2024", date(2024, 3, 31)),
+        ("Bradford", 200.3, "2024", date(2024, 3, 31)),
+        ("Barking and Dagenham", 300.3, "2023", date(2023, 3, 31)),
     ]
 
     # fmt: off
     expected_postcode_proportions_after_joining_pa_filled_posts_rows = [
-        (date(2023,5,1), "Leeds", "icb1", 1.00000, 100.2),
-        (date(2023,5,1), "Bradford", "icb2", 0.25000, 200.3), 
-        (date(2023,5,1), "Bradford", "icb3", 0.75000, 200.3), 
-        (date(2022,5,1), "Leeds", "icb1", 1.00000, None),
-        (date(2022, 5, 1), "Barking & Dagenham", "icb4", 1.00000, None),
+        (date(2023,5,1), "Leeds", "icb1", 1.00000, 100.2, "2024"),
+        (date(2023,5,1), "Bradford", "icb2", 0.25000, 200.3, "2024"), 
+        (date(2023,5,1), "Bradford", "icb3", 0.75000, 200.3, "2024"), 
+        (date(2022,5,1), "Leeds", "icb1", 1.00000, None, None),
+        (date(2022, 5, 1), "Barking & Dagenham", "icb4", 1.00000, None, None),
     ]
     # fmt: on
 

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -674,21 +674,21 @@ class PAFilledPostsByICBArea:
     ]
 
     sample_rows_with_la_and_hybrid_area_postcode_counts = [
-        ("1", date(2024,1,1), 3, 3),
-        ("2", date(2024,1,1), 4, 1), 
-        ("3", date(2024,1,1), 4, 3), 
-        ("4", date(2023,1,1), 3, 3),
-        ("5", date(2023,1,1), 3, 1), 
-        ("6", date(2023,1,1), 3, 2),
+        (date(2024,1,1), 3, 3),
+        (date(2024,1,1), 4, 1), 
+        (date(2024,1,1), 4, 3), 
+        (date(2023,1,1), 3, 3),
+        (date(2023,1,1), 3, 1), 
+        (date(2023,1,1), 3, 2),
     ]
 
     expected_ratio_between_hybrid_area_and_la_area_postcodes_rows = [
-        ("1", date(2024,1,1), 3, 3, 1.00000),
-        ("2", date(2024,1,1), 4, 1, 0.25000), 
-        ("3", date(2024,1,1), 4, 3, 0.75000), 
-        ("4", date(2023,1,1), 3, 3, 1.00000),
-        ("5", date(2023,1,1), 3, 1, 0.33333), 
-        ("6", date(2023,1,1), 3, 2, 0.66666),
+        (date(2024,1,1), 3, 3, 1.00000),
+        (date(2024,1,1), 4, 1, 0.25000), 
+        (date(2024,1,1), 4, 3, 0.75000), 
+        (date(2023,1,1), 3, 3, 1.00000),
+        (date(2023,1,1), 3, 1, 0.33333), 
+        (date(2023,1,1), 3, 2, 0.66666),
     ]
 
     full_rows_with_la_and_hybrid_area_postcode_counts = [
@@ -710,15 +710,15 @@ class PAFilledPostsByICBArea:
     # fmt: on
 
     sample_pa_filled_post_rows = [
-        ("1", "Leeds", 100.2, "2024"),
-        ("2", "Bradford", 200.3, "2024"),
-        ("3", "Hull", 300.3, "2023"),
+        ("Leeds", 100.2, "2024"),
+        ("Bradford", 200.3, "2024"),
+        ("Hull", 300.3, "2023"),
     ]
 
     expected_pa_filled_post_after_adding_date_from_year_column_rows = [
-        ("1", "Leeds", 100.2, "2024", date(2024, 3, 31)),
-        ("2", "Bradford", 200.3, "2024", date(2024, 3, 31)),
-        ("3", "Hull", 300.3, "2023", date(2023, 3, 31)),
+        ("Leeds", 100.2, "2024", date(2024, 3, 31)),
+        ("Bradford", 200.3, "2024", date(2024, 3, 31)),
+        ("Hull", 300.3, "2023", date(2023, 3, 31)),
     ]
 
     sample_postcode_proportions_before_joining_pa_filled_posts_rows = [

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -715,7 +715,7 @@ class PAFilledPostsByICBArea:
         ("3", "Hull", 300.3, "2023"),
     ]
 
-    expected_after_adding_date_from_year_column_rows = [
+    expected_pa_filled_post_after_adding_date_from_year_column_rows = [
         ("1", "Leeds", 100.2, "2024", date(2024, 3, 31)),
         ("2", "Bradford", 200.3, "2024", date(2024, 3, 31)),
         ("3", "Hull", 300.3, "2023", date(2023, 3, 31)),

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -722,27 +722,26 @@ class PAFilledPostsByICBArea:
     ]
 
     sample_postcode_proportions_before_joining_pa_filled_posts_rows = [
-        ("1", date(2023, 5, 1), "Leeds", "icb1", 1.00000),
-        ("2", date(2023, 5, 1), "Bradford", "icb2", 0.25000),
-        ("3", date(2023, 5, 1), "Bradford", "icb3", 0.75000),
-        ("4", date(2022, 5, 1), "Leeds", "icb1", 1.00000),
-        ("5", date(2022, 5, 1), "Barking & Dagenham", "icb4", 1.00000),
+        (date(2023, 5, 1), "Leeds", "icb1", 1.00000),
+        (date(2023, 5, 1), "Bradford", "icb2", 0.25000),
+        (date(2023, 5, 1), "Bradford", "icb3", 0.75000),
+        (date(2022, 5, 1), "Barking & Dagenham", "icb4", 1.00000),
+        (date(2022, 5, 1), "Leeds", "icb1", 1.00000),
     ]
 
     sample_pa_filled_posts_prepared_for_joining_to_postcode_proportions_rows = [
         ("Leeds", 100.2, date(2024, 3, 31)),
         ("Bradford", 200.3, date(2024, 3, 31)),
-        ("Hull", 300.3, date(2023, 3, 31)),
         ("Barking and Dagenham", 300.3, date(2023, 3, 31)),
     ]
 
     # fmt: off
     expected_postcode_proportions_after_joining_pa_filled_posts_rows = [
-        ("1", date(2023,5,1), "Leeds", "icb1", 1.00000, 100.2),
-        ("2", date(2023,5,1), "Bradford", "icb2", 0.25000, 200.3), 
-        ("3", date(2023,5,1), "Bradford", "icb3", 0.75000, 200.3), 
-        ("4", date(2022,5,1), "Leeds", "icb1", 1.00000, None),
-        ("5", date(2022, 5, 1), "Barking & Dagenham", "icb4", 1.00000, None),
+        (date(2023,5,1), "Leeds", "icb1", 1.00000, 100.2),
+        (date(2023,5,1), "Bradford", "icb2", 0.25000, 200.3), 
+        (date(2023,5,1), "Bradford", "icb3", 0.75000, 200.3), 
+        (date(2022,5,1), "Leeds", "icb1", 1.00000, None),
+        (date(2022, 5, 1), "Barking & Dagenham", "icb4", 1.00000, None),
     ]
     # fmt: on
 

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -716,15 +716,15 @@ class PAFilledPostsByICBArea:
     ]
 
     expected_after_adding_date_from_year_column_rows = [
-        (date(2024, 3, 31), "Group1", "Leeds", 100.2, "2024"),
-        (date(2024, 3, 31), "Group2", "Bradford", 200.3, "2024"),
-        (date(2023, 3, 31), "Group3", "Hull", 200.3, "2023"),
+        ("Group1", "Leeds", 100.2, "2024", date(2024, 3, 31)),
+        ("Group2", "Bradford", 200.3, "2024", date(2024, 3, 31)),
+        ("Group3", "Hull", 200.3, "2023", date(2023, 3, 31)),
     ]
 
     expected_after_adding_aligned_dates_column_rows = [
-        (date(2024, 3, 31), "Group1", "Leeds", 100.2, "2024", date(2023, 5, 1)),
-        (date(2024, 3, 31), "Group2", "Bradford", 200.3, "2024", date(2023, 5, 1)),
-        (date(2023, 3, 31), "Group3", "Hull", 200.3, "2023", date(2022, 5, 1)),
+        ("Group1", "Leeds", 100.2, "2024", date(2024, 3, 31), date(2023, 5, 1)),
+        ("Group2", "Bradford", 200.3, "2024", date(2024, 3, 31), date(2023, 5, 1)),
+        ("Group3", "Hull", 200.3, "2023", date(2023, 3, 31), date(2022, 5, 1)),
     ]
 
 

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -715,10 +715,16 @@ class PAFilledPostsByICBArea:
         ("Group3", "Hull", 200.3, "2023"),
     ]
 
-    expected_pa_filled_posts_with_year_as_date_rows = [
-        (date(2024, 3, 31), "Group1", "Leeds", 100.2, "2024", date(2024, 1, 1)),
-        (date(2024, 3, 31), "Group2", "Bradford", 200.3, "2024", date(2024, 1, 1)),
-        (date(2023, 3, 31), "Group3", "Hull", 200.3, "2023", date(2023, 1, 1)),
+    expected_after_adding_date_from_year_column_rows = [
+        (date(2024, 3, 31), "Group1", "Leeds", 100.2, "2024"),
+        (date(2024, 3, 31), "Group2", "Bradford", 200.3, "2024"),
+        (date(2023, 3, 31), "Group3", "Hull", 200.3, "2023"),
+    ]
+
+    expected_after_adding_aligned_dates_column_rows = [
+        (date(2024, 3, 31), "Group1", "Leeds", 100.2, "2024", date(2023, 5, 1)),
+        (date(2024, 3, 31), "Group2", "Bradford", 200.3, "2024", date(2023, 5, 1)),
+        (date(2023, 3, 31), "Group3", "Hull", 200.3, "2023", date(2022, 5, 1)),
     ]
 
 

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -721,12 +721,6 @@ class PAFilledPostsByICBArea:
         ("Group3", "Hull", 300.3, "2023", date(2023, 3, 31)),
     ]
 
-    expected_after_adding_aligned_dates_column_rows = [
-        ("Group1", "Leeds", 100.2, "2024", date(2024, 3, 31), date(2023, 5, 1)),
-        ("Group2", "Bradford", 200.3, "2024", date(2024, 3, 31), date(2023, 5, 1)),
-        ("Group3", "Hull", 300.3, "2023", date(2023, 3, 31), date(2022, 5, 1)),
-    ]
-
     sample_postcode_proportions_before_joining_pa_filled_posts_rows = [
         ("Group1", date(2023, 5, 1), "Leeds", "icb1", 1.00000),
         ("Group2", date(2023, 5, 1), "Bradford", "icb2", 0.25000),

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -622,7 +622,7 @@ class ONSData:
 @dataclass
 class PAFilledPostsByICBArea:
     # fmt: off
-    ons_sample_contemporary_rows = [
+    sample_ons_contemporary_rows = [
         ("AB10AA", date(2024,1,1), "cssr1", "icb1"),
         ("AB10AB", date(2024,1,1), "cssr1", "icb1"),
         ("AB10AC", date(2024,1,1), "cssr1", "icb1"),
@@ -715,7 +715,7 @@ class PAFilledPostsByICBArea:
         ("Hull", 300.3, "2023"),
     ]
 
-    expected_pa_filled_posts_after_adding_date_from_year_column_rows = [
+    expected_create_date_column_from_year_in_pa_estimates_rows = [
         ("Leeds", 100.2, "2024", date(2024, 3, 31)),
         ("Bradford", 200.3, "2024", date(2024, 3, 31)),
         ("Hull", 300.3, "2023", date(2023, 3, 31)),

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -725,13 +725,15 @@ class PAFilledPostsByICBArea:
         ("1", date(2023, 5, 1), "Leeds", "icb1", 1.00000),
         ("2", date(2023, 5, 1), "Bradford", "icb2", 0.25000),
         ("3", date(2023, 5, 1), "Bradford", "icb3", 0.75000),
-        ("4", date(2022, 5, 1), "Hull", "icb4", 1.00000),
+        ("4", date(2022, 5, 1), "Leeds", "icb1", 1.00000),
+        ("5", date(2022, 5, 1), "Barking & Dagenham", "icb4", 1.00000),
     ]
 
     sample_pa_filled_posts_prepared_for_joining_to_postcode_proportions_rows = [
         ("Leeds", 100.2, date(2024, 3, 31)),
         ("Bradford", 200.3, date(2024, 3, 31)),
         ("Hull", 300.3, date(2023, 3, 31)),
+        ("Barking and Dagenham", 300.3, date(2023, 3, 31)),
     ]
 
     # fmt: off
@@ -739,7 +741,8 @@ class PAFilledPostsByICBArea:
         ("1", date(2023,5,1), "Leeds", "icb1", 1.00000, 100.2),
         ("2", date(2023,5,1), "Bradford", "icb2", 0.25000, 200.3), 
         ("3", date(2023,5,1), "Bradford", "icb3", 0.75000, 200.3), 
-        ("4", date(2022,5,1), "Hull", "icb4", 1.00000, 300.3),
+        ("4", date(2022,5,1), "Leeds", "icb1", 1.00000, None),
+        ("5", date(2022, 5, 1), "Barking & Dagenham", "icb4", 1.00000, None),
     ]
     # fmt: on
 

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -729,9 +729,9 @@ class PAFilledPostsByICBArea:
     ]
 
     sample_pa_filled_posts_prepared_for_joining_to_postcode_proportions_rows = [
-        ("Leeds", 100.2, date(2023, 5, 1)),
-        ("Bradford", 200.3, date(2023, 5, 1)),
-        ("Hull", 300.3, date(2022, 5, 1)),
+        ("Leeds", 100.2, date(2024, 3, 31)),
+        ("Bradford", 200.3, date(2024, 3, 31)),
+        ("Hull", 300.3, date(2023, 3, 31)),
     ]
 
     # fmt: off

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -712,20 +712,42 @@ class PAFilledPostsByICBArea:
     sample_pa_filled_post_rows = [
         ("Group1", "Leeds", 100.2, "2024"),
         ("Group2", "Bradford", 200.3, "2024"),
-        ("Group3", "Hull", 200.3, "2023"),
+        ("Group3", "Hull", 300.3, "2023"),
     ]
 
     expected_after_adding_date_from_year_column_rows = [
         ("Group1", "Leeds", 100.2, "2024", date(2024, 3, 31)),
         ("Group2", "Bradford", 200.3, "2024", date(2024, 3, 31)),
-        ("Group3", "Hull", 200.3, "2023", date(2023, 3, 31)),
+        ("Group3", "Hull", 300.3, "2023", date(2023, 3, 31)),
     ]
 
     expected_after_adding_aligned_dates_column_rows = [
         ("Group1", "Leeds", 100.2, "2024", date(2024, 3, 31), date(2023, 5, 1)),
         ("Group2", "Bradford", 200.3, "2024", date(2024, 3, 31), date(2023, 5, 1)),
-        ("Group3", "Hull", 200.3, "2023", date(2023, 3, 31), date(2022, 5, 1)),
+        ("Group3", "Hull", 300.3, "2023", date(2023, 3, 31), date(2022, 5, 1)),
     ]
+
+    sample_postcode_proportions_before_joining_pa_filled_posts_rows = [
+        ("Group1", date(2023, 5, 1), "Leeds", "icb1", 1.00000),
+        ("Group2", date(2023, 5, 1), "Bradford", "icb2", 0.25000),
+        ("Group3", date(2023, 5, 1), "Bradford", "icb3", 0.75000),
+        ("Group4", date(2022, 5, 1), "Hull", "icb4", 1.00000),
+    ]
+
+    sample_pa_filled_posts_before_being_joined_rows = [
+        ("Leeds", 100.2, "2024", date(2024, 3, 31), date(2023, 5, 1)),
+        ("Bradford", 200.3, "2024", date(2024, 3, 31), date(2023, 5, 1)),
+        ("Hull", 300.3, "2023", date(2023, 3, 31), date(2022, 5, 1)),
+    ]
+
+    # fmt: off
+    expected_after_joining_pa_filled_posts_to_postcode_proportion_rows = [
+        ("Group1", date(2023,5,1), "Leeds", "icb1", 1.00000, 100.2, "2024", date(2024, 3, 31)),
+        ("Group2", date(2023,5,1), "Bradford", "icb2", 0.25000, 200.3, "2024", date(2024, 3, 31)), 
+        ("Group3", date(2023,5,1), "Bradford", "icb3", 0.75000, 200.3, "2024", date(2024, 3, 31)), 
+        ("Group4", date(2022,5,1), "Hull", "icb4", 1.00000, 300.3, "2023", date(2023, 3, 31)),
+    ]
+    # fmt: on
 
 
 @dataclass

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -709,9 +709,16 @@ class PAFilledPostsByICBArea:
     ]
     # fmt: on
 
-    pa_sample_filled_post_rows = [
-        ("Leeds", 100.2, "2024"),
-        ("Bradford", 200.3, "2024"),
+    sample_pa_filled_post_rows = [
+        ("Group1", "Leeds", 100.2, "2024"),
+        ("Group2", "Bradford", 200.3, "2024"),
+        ("Group3", "Hull", 200.3, "2023"),
+    ]
+
+    expected_pa_filled_posts_with_year_as_date_rows = [
+        (date(2024, 3, 31), "Group1", "Leeds", 100.2, "2024", date(2024, 1, 1)),
+        (date(2024, 3, 31), "Group2", "Bradford", 200.3, "2024", date(2024, 1, 1)),
+        (date(2023, 3, 31), "Group3", "Hull", 200.3, "2023", date(2023, 1, 1)),
     ]
 
 

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -692,13 +692,13 @@ class PAFilledPostsByICBArea:
     ]
 
     full_rows_with_la_and_hybrid_area_postcode_counts = [
-        ("AB10AA", date(2024,1,1), "cssr1", "icb1", 3, 3, 1.00000),
-        ("AB10AB", date(2024,1,1), "cssr1", "icb1", 3, 3, 1.00000),
-        ("AB10AA", date(2024,1,1), "cssr2", "icb2", 4, 1, 0.25000), 
-        ("AB10AB", date(2024,1,1), "cssr2", "icb3", 4, 3, 0.75000), 
-        ("AB10AA", date(2023,1,1), "cssr1", "icb1", 3, 3, 1.00000),
-        ("AB10AB", date(2023,1,1), "cssr1", "icb1", 3, 3, 1.00000),
-        ("AB10AC", date(2023,1,1), "cssr1", "icb1", 3, 3, 1.00000),
+        ("AB10AA", date(2023,5,1), "cssr1", "icb1", 3, 3, 1.00000),
+        ("AB10AB", date(2023,5,1), "cssr1", "icb1", 3, 3, 1.00000),
+        ("AB10AA", date(2023,5,1), "cssr2", "icb2", 4, 1, 0.25000), 
+        ("AB10AB", date(2023,5,1), "cssr2", "icb3", 4, 3, 0.75000), 
+        ("AB10AA", date(2022,5,1), "cssr1", "icb1", 3, 3, 1.00000),
+        ("AB10AB", date(2022,5,1), "cssr1", "icb1", 3, 3, 1.00000),
+        ("AB10AC", date(2022,5,1), "cssr1", "icb1", 3, 3, 1.00000),
     ]
 
     expected_deduplicated_importdate_hybrid_and_la_and_ratio_rows = [

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -494,7 +494,7 @@ class PAFilledPostsByICBAreaSchema:
         ]
     )
 
-    expected_deduplicated_importdate_hybrid_and_la_and_ratio_schema = StructType(
+    expected_deduplicated_import_date_hybrid_and_la_and_ratio_schema = StructType(
         [
             StructField(ONSClean.contemporary_ons_import_date, DateType(), True),
             StructField(ONSClean.contemporary_cssr, StringType(), True),
@@ -524,7 +524,7 @@ class PAFilledPostsByICBAreaSchema:
     sample_postcode_proportions_before_joining_pa_filled_posts_schema = StructType(
         [
             StructField("ordering_column", StringType(), True),
-            *expected_deduplicated_importdate_hybrid_and_la_and_ratio_schema,
+            *expected_deduplicated_import_date_hybrid_and_la_and_ratio_schema,
         ]
     )
 

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -528,19 +528,21 @@ class PAFilledPostsByICBAreaSchema:
         ]
     )
 
-    sample_pa_filled_posts_before_being_joined_schema = StructType(
-        [
-            StructField(DP.LA_AREA, StringType(), True),
-            StructField(
-                DP.ESTIMATED_TOTAL_PERSONAL_ASSISTANT_FILLED_POSTS, DoubleType(), True
-            ),
-            StructField(DP.YEAR, StringType(), True),
-            StructField(DP.ESTIMATE_PERIOD_AS_DATE, DateType(), True),
-            StructField(ONSClean.contemporary_ons_import_date, DateType(), True),
-        ]
+    sample_pa_filled_posts_prepared_for_joining_to_postcode_proportions_schema = (
+        StructType(
+            [
+                StructField(DP.LA_AREA, StringType(), True),
+                StructField(
+                    DP.ESTIMATED_TOTAL_PERSONAL_ASSISTANT_FILLED_POSTS,
+                    DoubleType(),
+                    True,
+                ),
+                StructField(ONSClean.contemporary_ons_import_date, DateType(), True),
+            ]
+        )
     )
 
-    expected_after_joining_pa_filled_posts_to_postcode_proportion_schema = StructType(
+    expected_postcode_proportions_after_joining_pa_filled_posts_schema = StructType(
         [
             *sample_postcode_proportions_before_joining_pa_filled_posts_schema,
             StructField(

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -514,10 +514,16 @@ class PAFilledPostsByICBAreaSchema:
         ]
     )
 
-    expected_pa_filled_posts_with_year_as_date_schema = StructType(
+    expected_after_adding_date_from_year_column_schema = StructType(
         [
             StructField(DP.ESTIMATE_PERIOD_AS_DATE, DateType(), True),
             *sample_pa_filled_post_schema,
+        ]
+    )
+
+    expected_after_adding_aligned_dates_column_schema = StructType(
+        [
+            *expected_after_adding_date_from_year_column_schema,
             StructField(ONSClean.contemporary_ons_import_date, DateType(), True),
         ]
     )

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -516,8 +516,8 @@ class PAFilledPostsByICBAreaSchema:
 
     expected_after_adding_date_from_year_column_schema = StructType(
         [
-            StructField(DP.ESTIMATE_PERIOD_AS_DATE, DateType(), True),
             *sample_pa_filled_post_schema,
+            StructField(DP.ESTIMATE_PERIOD_AS_DATE, DateType(), True),
         ]
     )
 

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -440,7 +440,7 @@ class ONSData:
 
 @dataclass
 class PAFilledPostsByICBAreaSchema:
-    ons_sample_contemporary_schema = StructType(
+    sample_ons_contemporary_schema = StructType(
         [
             StructField(ONSClean.postcode, StringType(), True),
             StructField(ONSClean.contemporary_ons_import_date, DateType(), True),
@@ -451,14 +451,14 @@ class PAFilledPostsByICBAreaSchema:
 
     expected_postcode_count_per_la_schema = StructType(
         [
-            *ons_sample_contemporary_schema,
+            *sample_ons_contemporary_schema,
             StructField(DP.COUNT_OF_DISTINCT_POSTCODES_PER_LA, IntegerType(), True),
         ]
     )
 
     expected_postcode_count_per_la_icb_schema = StructType(
         [
-            *ons_sample_contemporary_schema,
+            *sample_ons_contemporary_schema,
             StructField(
                 DP.COUNT_OF_DISTINCT_POSTCODES_PER_HYBRID_AREA, IntegerType(), True
             ),
@@ -484,7 +484,7 @@ class PAFilledPostsByICBAreaSchema:
 
     full_rows_with_la_and_hybrid_area_postcode_counts_schema = StructType(
         [
-            *ons_sample_contemporary_schema,
+            *sample_ons_contemporary_schema,
             StructField(DP.COUNT_OF_DISTINCT_POSTCODES_PER_LA, IntegerType(), True),
             StructField(
                 DP.COUNT_OF_DISTINCT_POSTCODES_PER_HYBRID_AREA, IntegerType(), True
@@ -512,7 +512,7 @@ class PAFilledPostsByICBAreaSchema:
         ]
     )
 
-    expected_pa_filled_posts_after_adding_date_from_year_column_schema = StructType(
+    expected_create_date_column_from_year_in_pa_estimates_schema = StructType(
         [
             *sample_pa_filled_posts_schema,
             StructField(DP.ESTIMATE_PERIOD_AS_DATE, DateType(), True),

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -523,7 +523,6 @@ class PAFilledPostsByICBAreaSchema:
 
     sample_postcode_proportions_before_joining_pa_filled_posts_schema = StructType(
         [
-            StructField("ordering_column", StringType(), True),
             *expected_deduplicated_import_date_hybrid_and_la_and_ratio_schema,
         ]
     )

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -467,7 +467,7 @@ class PAFilledPostsByICBAreaSchema:
 
     sample_rows_with_la_and_hybrid_area_postcode_counts_schema = StructType(
         [
-            StructField("GroupID", StringType(), True),
+            StructField("ordering_column", StringType(), True),
             StructField(ONSClean.contemporary_ons_import_date, DateType(), True),
             StructField(DP.COUNT_OF_DISTINCT_POSTCODES_PER_LA, IntegerType(), True),
             StructField(
@@ -505,7 +505,7 @@ class PAFilledPostsByICBAreaSchema:
 
     sample_pa_filled_post_schema = StructType(
         [
-            StructField("Group", StringType(), True),
+            StructField("ordering_column", StringType(), True),
             StructField(DP.LA_AREA, StringType(), True),
             StructField(
                 DP.ESTIMATED_TOTAL_PERSONAL_ASSISTANT_FILLED_POSTS, DoubleType(), True
@@ -523,7 +523,7 @@ class PAFilledPostsByICBAreaSchema:
 
     sample_postcode_proportions_before_joining_pa_filled_posts_schema = StructType(
         [
-            StructField("Group", StringType(), True),
+            StructField("ordering_column", StringType(), True),
             *expected_deduplicated_importdate_hybrid_and_la_and_ratio_schema,
         ]
     )

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -514,7 +514,7 @@ class PAFilledPostsByICBAreaSchema:
         ]
     )
 
-    expected_after_adding_date_from_year_column_schema = StructType(
+    expected_pa_filled_post_after_adding_date_from_year_column_schema = StructType(
         [
             *sample_pa_filled_post_schema,
             StructField(DP.ESTIMATE_PERIOD_AS_DATE, DateType(), True),

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -467,7 +467,6 @@ class PAFilledPostsByICBAreaSchema:
 
     sample_rows_with_la_and_hybrid_area_postcode_counts_schema = StructType(
         [
-            StructField("ordering_column", StringType(), True),
             StructField(ONSClean.contemporary_ons_import_date, DateType(), True),
             StructField(DP.COUNT_OF_DISTINCT_POSTCODES_PER_LA, IntegerType(), True),
             StructField(
@@ -505,7 +504,6 @@ class PAFilledPostsByICBAreaSchema:
 
     sample_pa_filled_post_schema = StructType(
         [
-            StructField("ordering_column", StringType(), True),
             StructField(DP.LA_AREA, StringType(), True),
             StructField(
                 DP.ESTIMATED_TOTAL_PERSONAL_ASSISTANT_FILLED_POSTS, DoubleType(), True

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -537,7 +537,7 @@ class PAFilledPostsByICBAreaSchema:
                     DoubleType(),
                     True,
                 ),
-                StructField(ONSClean.contemporary_ons_import_date, DateType(), True),
+                StructField(DP.ESTIMATE_PERIOD_AS_DATE, DateType(), True),
             ]
         )
     )
@@ -548,8 +548,6 @@ class PAFilledPostsByICBAreaSchema:
             StructField(
                 DP.ESTIMATED_TOTAL_PERSONAL_ASSISTANT_FILLED_POSTS, DoubleType(), True
             ),
-            StructField(DP.YEAR, StringType(), True),
-            StructField(DP.ESTIMATE_PERIOD_AS_DATE, DateType(), True),
         ]
     )
 

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -519,10 +519,8 @@ class PAFilledPostsByICBAreaSchema:
         ]
     )
 
-    sample_postcode_proportions_before_joining_pa_filled_posts_schema = StructType(
-        [
-            *expected_deduplicated_import_date_hybrid_and_la_and_ratio_schema,
-        ]
+    sample_postcode_proportions_before_joining_pa_filled_posts_schema = (
+        expected_deduplicated_import_date_hybrid_and_la_and_ratio_schema
     )
 
     sample_pa_filled_posts_prepared_for_joining_to_postcode_proportions_schema = (

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -534,6 +534,7 @@ class PAFilledPostsByICBAreaSchema:
                     DoubleType(),
                     True,
                 ),
+                StructField(DP.YEAR, StringType(), True),
                 StructField(DP.ESTIMATE_PERIOD_AS_DATE, DateType(), True),
             ]
         )
@@ -545,6 +546,7 @@ class PAFilledPostsByICBAreaSchema:
             StructField(
                 DP.ESTIMATED_TOTAL_PERSONAL_ASSISTANT_FILLED_POSTS, DoubleType(), True
             ),
+            StructField(DP.YEAR, StringType(), True),
         ]
     )
 

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -502,7 +502,7 @@ class PAFilledPostsByICBAreaSchema:
         ]
     )
 
-    sample_pa_filled_post_schema = StructType(
+    sample_pa_filled_posts_schema = StructType(
         [
             StructField(DP.LA_AREA, StringType(), True),
             StructField(
@@ -512,9 +512,9 @@ class PAFilledPostsByICBAreaSchema:
         ]
     )
 
-    expected_pa_filled_post_after_adding_date_from_year_column_schema = StructType(
+    expected_pa_filled_posts_after_adding_date_from_year_column_schema = StructType(
         [
-            *sample_pa_filled_post_schema,
+            *sample_pa_filled_posts_schema,
             StructField(DP.ESTIMATE_PERIOD_AS_DATE, DateType(), True),
         ]
     )

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -521,13 +521,6 @@ class PAFilledPostsByICBAreaSchema:
         ]
     )
 
-    expected_after_adding_aligned_dates_column_schema = StructType(
-        [
-            *expected_after_adding_date_from_year_column_schema,
-            StructField(ONSClean.contemporary_ons_import_date, DateType(), True),
-        ]
-    )
-
     sample_postcode_proportions_before_joining_pa_filled_posts_schema = StructType(
         [
             StructField("Group", StringType(), True),

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -528,6 +528,36 @@ class PAFilledPostsByICBAreaSchema:
         ]
     )
 
+    sample_postcode_proportions_before_joining_pa_filled_posts_schema = StructType(
+        [
+            StructField("Group", StringType(), True),
+            *expected_deduplicated_importdate_hybrid_and_la_and_ratio_schema,
+        ]
+    )
+
+    sample_pa_filled_posts_before_being_joined_schema = StructType(
+        [
+            StructField(DP.LA_AREA, StringType(), True),
+            StructField(
+                DP.ESTIMATED_TOTAL_PERSONAL_ASSISTANT_FILLED_POSTS, DoubleType(), True
+            ),
+            StructField(DP.YEAR, StringType(), True),
+            StructField(DP.ESTIMATE_PERIOD_AS_DATE, DateType(), True),
+            StructField(ONSClean.contemporary_ons_import_date, DateType(), True),
+        ]
+    )
+
+    expected_after_joining_pa_filled_posts_to_postcode_proportion_schema = StructType(
+        [
+            *sample_postcode_proportions_before_joining_pa_filled_posts_schema,
+            StructField(
+                DP.ESTIMATED_TOTAL_PERSONAL_ASSISTANT_FILLED_POSTS, DoubleType(), True
+            ),
+            StructField(DP.YEAR, StringType(), True),
+            StructField(DP.ESTIMATE_PERIOD_AS_DATE, DateType(), True),
+        ]
+    )
+
 
 @dataclass
 class CapacityTrackerCareHomeSchema:

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -503,13 +503,22 @@ class PAFilledPostsByICBAreaSchema:
         ]
     )
 
-    pa_sample_filled_post_schema = StructType(
+    sample_pa_filled_post_schema = StructType(
         [
+            StructField("Group", StringType(), True),
             StructField(DP.LA_AREA, StringType(), True),
             StructField(
                 DP.ESTIMATED_TOTAL_PERSONAL_ASSISTANT_FILLED_POSTS, DoubleType(), True
             ),
             StructField(DP.YEAR, StringType(), True),
+        ]
+    )
+
+    expected_pa_filled_posts_with_year_as_date_schema = StructType(
+        [
+            StructField(DP.ESTIMATE_PERIOD_AS_DATE, DateType(), True),
+            *sample_pa_filled_post_schema,
+            StructField(ONSClean.contemporary_ons_import_date, DateType(), True),
         ]
     )
 

--- a/tests/unit/test_dpr_split_pa_filled_posts_into_icb_areas.py
+++ b/tests/unit/test_dpr_split_pa_filled_posts_into_icb_areas.py
@@ -332,7 +332,6 @@ class JoinPaFilledPostsToPostcodeProportions(SplitPAFilledPostsIntoICBAreas):
     def test_join_pa_filled_posts_to_hybrid_area_proportions_has_expected_values(
         self,
     ):
-
         returned_rows = (
             self.returned_postcode_proportions_after_joining_pa_filled_posts_df.sort(
                 "Group"

--- a/tests/unit/test_dpr_split_pa_filled_posts_into_icb_areas.py
+++ b/tests/unit/test_dpr_split_pa_filled_posts_into_icb_areas.py
@@ -267,7 +267,7 @@ class JoinPaFilledPostsToPostcodeProportions(SplitPAFilledPostsIntoICBAreas):
     ):
         self.assertEqual(
             len(self.returned_df.columns),
-            len(self.sample_postcode_proportions_df.columns) + 1,
+            len(self.sample_postcode_proportions_df.columns) + 2,
         )
 
     def test_join_pa_filled_posts_to_hybrid_area_proportions_has_expected_row_count(

--- a/tests/unit/test_dpr_split_pa_filled_posts_into_icb_areas.py
+++ b/tests/unit/test_dpr_split_pa_filled_posts_into_icb_areas.py
@@ -28,9 +28,9 @@ class SplitPAFilledPostsIntoICBAreas(unittest.TestCase):
             TestData.ons_sample_contemporary_rows,
             schema=TestSchema.ons_sample_contemporary_schema,
         )
-        self.test_sample_pa_filled_post_rows = self.spark.createDataFrame(
-            TestData.sample_pa_filled_post_rows,
-            schema=TestSchema.sample_pa_filled_post_schema,
+        self.test_sample_pa_filled_posts_rows = self.spark.createDataFrame(
+            TestData.sample_pa_filled_posts_rows,
+            schema=TestSchema.sample_pa_filled_posts_schema,
         )
 
 
@@ -43,7 +43,7 @@ class MainTests(SplitPAFilledPostsIntoICBAreas):
     def test_main(self, read_from_parquet_mock: Mock, write_to_parquet_mock: Mock):
         read_from_parquet_mock.side_effect = [
             self.test_sample_ons_rows,
-            self.test_sample_pa_filled_post_rows,
+            self.test_sample_pa_filled_posts_rows,
         ]
         job.main(self.TEST_ONS_SOURCE, self.TEST_PA_SOURCE, self.TEST_DESTINATION)
         self.assertEqual(read_from_parquet_mock.call_count, 2)
@@ -215,8 +215,8 @@ class CreateDateColumnFromYearInPaFilledPosts(SplitPAFilledPostsIntoICBAreas):
         super().setUp()
 
         self.sample_pa_filled_posts_df = self.spark.createDataFrame(
-            TestData.sample_pa_filled_post_rows,
-            schema=TestSchema.sample_pa_filled_post_schema,
+            TestData.sample_pa_filled_posts_rows,
+            schema=TestSchema.sample_pa_filled_posts_schema,
         )
 
         self.returned_after_adding_date_from_year_column_df = (
@@ -226,8 +226,8 @@ class CreateDateColumnFromYearInPaFilledPosts(SplitPAFilledPostsIntoICBAreas):
         )
 
         self.expected_after_adding_date_from_year_column_df = self.spark.createDataFrame(
-            TestData.expected_pa_filled_post_after_adding_date_from_year_column_rows,
-            schema=TestSchema.expected_pa_filled_post_after_adding_date_from_year_column_schema,
+            TestData.expected_pa_filled_posts_after_adding_date_from_year_column_rows,
+            schema=TestSchema.expected_pa_filled_posts_after_adding_date_from_year_column_schema,
         )
 
     def test_create_date_column_from_year_in_pa_estimates_has_expected_values(

--- a/tests/unit/test_dpr_split_pa_filled_posts_into_icb_areas.py
+++ b/tests/unit/test_dpr_split_pa_filled_posts_into_icb_areas.py
@@ -275,7 +275,7 @@ class JoinPaFilledPostsToHybridAreaProportions(SplitPAFilledPostsIntoICBAreas):
             len(
                 self.returned_join_pa_filled_posts_to_hybrid_area_proportions_df.columns
             ),
-            len(self.sample_hybrid_area_proportions_df) + 2,
+            len(self.sample_hybrid_area_proportions_df.columns) + 2,
         )
 
     def test_join_pa_filled_posts_to_hybrid_area_proportions_does_not_add_any_rows(

--- a/tests/unit/test_dpr_split_pa_filled_posts_into_icb_areas.py
+++ b/tests/unit/test_dpr_split_pa_filled_posts_into_icb_areas.py
@@ -180,8 +180,8 @@ class DeduplicateRatioBetweenAreaCounts(SplitPAFilledPostsIntoICBAreas):
         )
 
         self.expected_df = self.spark.createDataFrame(
-            TestData.expected_deduplicated_importdate_hybrid_and_la_and_ratio_rows,
-            schema=TestSchema.expected_deduplicated_importdate_hybrid_and_la_and_ratio_schema,
+            TestData.expected_deduplicated_import_date_hybrid_and_la_and_ratio_rows,
+            schema=TestSchema.expected_deduplicated_import_date_hybrid_and_la_and_ratio_schema,
         )
 
     def test_deduplicate_proportion_between_hybrid_area_and_la_area_postcode_counts_returns_expected_columns(

--- a/tests/unit/test_dpr_split_pa_filled_posts_into_icb_areas.py
+++ b/tests/unit/test_dpr_split_pa_filled_posts_into_icb_areas.py
@@ -236,11 +236,11 @@ class CreateDateColumnFromYearInPaFilledPosts(SplitPAFilledPostsIntoICBAreas):
         self,
     ):
         returned_rows = self.returned_after_adding_date_from_year_column_df.sort(
-            "Group"
+            "ordering_column"
         ).collect()
 
         expected_rows = self.expected_after_adding_date_from_year_column_df.sort(
-            "Group"
+            "ordering_column"
         ).collect()
 
         self.assertEqual(returned_rows, expected_rows)
@@ -266,7 +266,7 @@ class JoinPaFilledPostsToPostcodeProportions(SplitPAFilledPostsIntoICBAreas):
                 self.sample_pa_filled_posts_before_being_joined_df,
             )
         ).select(
-            "Group",
+            "ordering_column",
             ONSClean.contemporary_ons_import_date,
             ONSClean.contemporary_cssr,
             ONSClean.contemporary_icb,
@@ -286,12 +286,12 @@ class JoinPaFilledPostsToPostcodeProportions(SplitPAFilledPostsIntoICBAreas):
     ):
         returned_rows = (
             self.returned_postcode_proportions_after_joining_pa_filled_posts_df.sort(
-                "Group"
+                "ordering_column"
             ).collect()
         )
         expected_rows = (
             self.expected_after_joining_pa_filled_posts_to_postcode_proportion_df.sort(
-                "Group"
+                "ordering_column"
             ).collect()
         )
         self.assertEqual(returned_rows, expected_rows)

--- a/tests/unit/test_dpr_split_pa_filled_posts_into_icb_areas.py
+++ b/tests/unit/test_dpr_split_pa_filled_posts_into_icb_areas.py
@@ -132,8 +132,8 @@ class CreateRatioBetweenColumns(SplitPAFilledPostsIntoICBAreas):
             schema=TestSchema.expected_ratio_between_hybrid_area_and_la_area_postcodes_schema,
         )
 
-        self.returned_rows = self.returned_df.sort("GroupID").collect()
-        self.expected_rows = self.expected_df.sort("GroupID").collect()
+        self.returned_rows = self.returned_df.sort("ordering_column").collect()
+        self.expected_rows = self.expected_df.sort("ordering_column").collect()
 
     def test_create_proportion_between_hybrid_area_and_la_area_postcode_counts_has_expected_columns(
         self,
@@ -225,11 +225,9 @@ class CreateDateColumnFromYearInPaFilledPosts(SplitPAFilledPostsIntoICBAreas):
             )
         )
 
-        self.expected_after_adding_date_from_year_column_df = (
-            self.spark.createDataFrame(
-                TestData.expected_after_adding_date_from_year_column_rows,
-                schema=TestSchema.expected_after_adding_date_from_year_column_schema,
-            )
+        self.expected_after_adding_date_from_year_column_df = self.spark.createDataFrame(
+            TestData.expected_pa_filled_post_after_adding_date_from_year_column_rows,
+            schema=TestSchema.expected_pa_filled_post_after_adding_date_from_year_column_schema,
         )
 
     def test_create_date_column_from_year_in_pa_estimates_has_expected_values(
@@ -256,8 +254,8 @@ class JoinPaFilledPostsToPostcodeProportions(SplitPAFilledPostsIntoICBAreas):
         )
 
         self.sample_pa_filled_posts_before_being_joined_df = self.spark.createDataFrame(
-            TestData.sample_pa_filled_posts_before_being_joined_rows,
-            schema=TestSchema.sample_pa_filled_posts_before_being_joined_schema,
+            TestData.sample_pa_filled_posts_prepared_for_joining_to_postcode_proportions_rows,
+            schema=TestSchema.sample_pa_filled_posts_prepared_for_joining_to_postcode_proportions_schema,
         )
 
         self.returned_postcode_proportions_after_joining_pa_filled_posts_df = (
@@ -277,8 +275,8 @@ class JoinPaFilledPostsToPostcodeProportions(SplitPAFilledPostsIntoICBAreas):
         )
 
         self.expected_after_joining_pa_filled_posts_to_postcode_proportion_df = self.spark.createDataFrame(
-            TestData.expected_after_joining_pa_filled_posts_to_postcode_proportion_rows,
-            schema=TestSchema.expected_after_joining_pa_filled_posts_to_postcode_proportion_schema,
+            TestData.expected_postcode_proportions_after_joining_pa_filled_posts_rows,
+            schema=TestSchema.expected_postcode_proportions_after_joining_pa_filled_posts_schema,
         )
 
     def test_join_pa_filled_posts_to_hybrid_area_proportions_has_expected_values(

--- a/tests/unit/test_dpr_split_pa_filled_posts_into_icb_areas.py
+++ b/tests/unit/test_dpr_split_pa_filled_posts_into_icb_areas.py
@@ -24,11 +24,11 @@ class SplitPAFilledPostsIntoICBAreas(unittest.TestCase):
 
     def setUp(self) -> None:
         self.spark = utils.get_spark()
-        self.test_sample_ons_rows = self.spark.createDataFrame(
-            TestData.ons_sample_contemporary_rows,
-            schema=TestSchema.ons_sample_contemporary_schema,
+        self.sample_ons_contemporary_df = self.spark.createDataFrame(
+            TestData.sample_ons_contemporary_rows,
+            schema=TestSchema.sample_ons_contemporary_schema,
         )
-        self.test_sample_pa_filled_posts_rows = self.spark.createDataFrame(
+        self.sample_pa_filled_posts_df = self.spark.createDataFrame(
             TestData.sample_pa_filled_posts_rows,
             schema=TestSchema.sample_pa_filled_posts_schema,
         )
@@ -42,8 +42,8 @@ class MainTests(SplitPAFilledPostsIntoICBAreas):
     @patch("utils.utils.read_from_parquet")
     def test_main(self, read_from_parquet_mock: Mock, write_to_parquet_mock: Mock):
         read_from_parquet_mock.side_effect = [
-            self.test_sample_ons_rows,
-            self.test_sample_pa_filled_posts_rows,
+            self.sample_ons_contemporary_df,
+            self.sample_pa_filled_posts_df,
         ]
         job.main(self.TEST_ONS_SOURCE, self.TEST_PA_SOURCE, self.TEST_DESTINATION)
         self.assertEqual(read_from_parquet_mock.call_count, 2)
@@ -59,15 +59,15 @@ class CountPostcodesPerListOfColumns(SplitPAFilledPostsIntoICBAreas):
     def setUp(self) -> None:
         super().setUp()
 
-        self.returned_postcode_count_by_la = job.count_postcodes_per_list_of_columns(
-            self.test_sample_ons_rows,
+        self.returned_postcode_count_by_la_df = job.count_postcodes_per_list_of_columns(
+            self.sample_ons_contemporary_df,
             [ONSClean.contemporary_ons_import_date, ONSClean.contemporary_cssr],
             DPColNames.COUNT_OF_DISTINCT_POSTCODES_PER_LA,
         ).sort([ONSClean.postcode, ONSClean.contemporary_ons_import_date])
 
-        self.returned_postcode_count_by_la_and_icb = (
+        self.returned_postcode_count_by_la_and_icb_df = (
             job.count_postcodes_per_list_of_columns(
-                self.test_sample_ons_rows,
+                self.sample_ons_contemporary_df,
                 [
                     ONSClean.contemporary_ons_import_date,
                     ONSClean.contemporary_cssr,
@@ -82,33 +82,33 @@ class CountPostcodesPerListOfColumns(SplitPAFilledPostsIntoICBAreas):
     ):
         self.assertTrue(
             DPColNames.COUNT_OF_DISTINCT_POSTCODES_PER_LA
-            in self.returned_postcode_count_by_la.columns
+            in self.returned_postcode_count_by_la_df.columns
         )
 
     def test_count_postcodes_per_list_of_columns_has_expected_values_when_grouped_by_import_date_and_la(
         self,
     ):
-        expected_postcode_count_per_la_rows = self.spark.createDataFrame(
+        expected_df = self.spark.createDataFrame(
             TestData.expected_postcode_count_per_la_rows,
             schema=TestSchema.expected_postcode_count_per_la_schema,
         ).sort([ONSClean.postcode, ONSClean.contemporary_ons_import_date])
 
         self.assertEqual(
-            self.returned_postcode_count_by_la.collect(),
-            expected_postcode_count_per_la_rows.collect(),
+            self.returned_postcode_count_by_la_df.collect(),
+            expected_df.collect(),
         )
 
     def test_count_postcodes_per_list_of_columns_has_expected_values_when_grouped_by_import_date_and_la_and_icb(
         self,
     ):
-        expected_postcode_count_per_la_icb_rows = self.spark.createDataFrame(
+        expected_df = self.spark.createDataFrame(
             TestData.expected_postcode_count_per_la_icb_rows,
             schema=TestSchema.expected_postcode_count_per_la_icb_schema,
         ).sort([ONSClean.postcode, ONSClean.contemporary_ons_import_date])
 
         self.assertEqual(
-            self.returned_postcode_count_by_la_and_icb.collect(),
-            expected_postcode_count_per_la_icb_rows.collect(),
+            self.returned_postcode_count_by_la_and_icb_df.collect(),
+            expected_df.collect(),
         )
 
 
@@ -219,30 +219,34 @@ class CreateDateColumnFromYearInPaFilledPosts(SplitPAFilledPostsIntoICBAreas):
             schema=TestSchema.sample_pa_filled_posts_schema,
         )
 
-        self.returned_after_adding_date_from_year_column_df = (
+        self.returned_create_date_column_from_year_in_pa_estimates_df = (
             job.create_date_column_from_year_in_pa_estimates(
                 self.sample_pa_filled_posts_df
             )
         )
 
-        self.expected_after_adding_date_from_year_column_df = self.spark.createDataFrame(
-            TestData.expected_pa_filled_posts_after_adding_date_from_year_column_rows,
-            schema=TestSchema.expected_pa_filled_posts_after_adding_date_from_year_column_schema,
+        self.expected_create_date_column_from_year_in_pa_estimates_df = self.spark.createDataFrame(
+            TestData.expected_create_date_column_from_year_in_pa_estimates_rows,
+            schema=TestSchema.expected_create_date_column_from_year_in_pa_estimates_schema,
         )
 
     def test_create_date_column_from_year_in_pa_estimates_has_expected_values(
         self,
     ):
-        returned_rows = self.returned_after_adding_date_from_year_column_df.collect()
-        expected_rows = self.expected_after_adding_date_from_year_column_df.collect()
+        returned_rows = (
+            self.returned_create_date_column_from_year_in_pa_estimates_df.collect()
+        )
+        expected_rows = (
+            self.expected_create_date_column_from_year_in_pa_estimates_df.collect()
+        )
         self.assertEqual(returned_rows, expected_rows)
 
 
-class JoinPaFilledPostsToPostcodeProportions(SplitPAFilledPostsIntoICBAreas):
+class JoinPaFilledPostsToHybridAreaProportions(SplitPAFilledPostsIntoICBAreas):
     def setUp(self) -> None:
         super().setUp()
 
-        self.sample_postcode_proportions_df = self.spark.createDataFrame(
+        self.sample_hybrid_area_proportions_df = self.spark.createDataFrame(
             TestData.sample_postcode_proportions_before_joining_pa_filled_posts_rows,
             schema=TestSchema.sample_postcode_proportions_before_joining_pa_filled_posts_schema,
         )
@@ -252,43 +256,60 @@ class JoinPaFilledPostsToPostcodeProportions(SplitPAFilledPostsIntoICBAreas):
             schema=TestSchema.sample_pa_filled_posts_prepared_for_joining_to_postcode_proportions_schema,
         )
 
-        self.returned_df = job.join_pa_filled_posts_to_hybrid_area_proportions(
-            self.sample_postcode_proportions_df,
-            self.sample_pa_filled_posts_df,
+        self.returned_join_pa_filled_posts_to_hybrid_area_proportions_df = (
+            job.join_pa_filled_posts_to_hybrid_area_proportions(
+                self.sample_hybrid_area_proportions_df,
+                self.sample_pa_filled_posts_df,
+            )
         )
 
-        self.expected_df = self.spark.createDataFrame(
+        self.expected_join_pa_filled_posts_to_hybrid_area_proportions_df = self.spark.createDataFrame(
             TestData.expected_postcode_proportions_after_joining_pa_filled_posts_rows,
             schema=TestSchema.expected_postcode_proportions_after_joining_pa_filled_posts_schema,
         )
 
-    def test_join_pa_filled_posts_to_hybrid_area_proportions_has_expected_column_count(
+    def test_join_pa_filled_posts_to_hybrid_area_proportions_adds_2_columns(
         self,
     ):
         self.assertEqual(
-            len(self.returned_df.columns),
-            len(self.sample_postcode_proportions_df.columns) + 2,
+            len(
+                self.returned_join_pa_filled_posts_to_hybrid_area_proportions_df.columns
+            ),
+            len(self.sample_hybrid_area_proportions_df) + 2,
         )
 
-    def test_join_pa_filled_posts_to_hybrid_area_proportions_has_expected_row_count(
+    def test_join_pa_filled_posts_to_hybrid_area_proportions_does_not_add_any_rows(
         self,
     ):
         self.assertEqual(
-            self.returned_df.count(), self.sample_postcode_proportions_df.count()
+            self.returned_join_pa_filled_posts_to_hybrid_area_proportions_df.count(),
+            self.sample_hybrid_area_proportions_df.count(),
         )
 
     def test_join_pa_filled_posts_to_hybrid_area_proportions_has_no_duplicate_columns(
         self,
     ):
         self.assertEqual(
-            sorted(self.returned_df.columns),
-            sorted(list(set(self.returned_df.columns))),
+            sorted(
+                self.returned_join_pa_filled_posts_to_hybrid_area_proportions_df.columns
+            ),
+            sorted(
+                list(
+                    set(
+                        self.returned_join_pa_filled_posts_to_hybrid_area_proportions_df.columns
+                    )
+                )
+            ),
         )
 
     def test_join_pa_filled_posts_to_hybrid_area_proportions_has_expected_values(
         self,
     ):
-        returned_df = self.returned_df.select(self.expected_df.columns)
+        returned_sorted_join_pa_filled_posts_to_hybrid_area_proportions_df = (
+            self.returned_join_pa_filled_posts_to_hybrid_area_proportions_df.select(
+                self.expected_join_pa_filled_posts_to_hybrid_area_proportions_df.columns
+            )
+        )
 
         sort_by_list = [
             ONSClean.contemporary_ons_import_date,
@@ -296,6 +317,14 @@ class JoinPaFilledPostsToPostcodeProportions(SplitPAFilledPostsIntoICBAreas):
             ONSClean.contemporary_icb,
         ]
 
-        returned_rows = returned_df.sort(sort_by_list).collect()
-        expected_rows = self.expected_df.sort(sort_by_list).collect()
+        returned_rows = (
+            returned_sorted_join_pa_filled_posts_to_hybrid_area_proportions_df.sort(
+                sort_by_list
+            ).collect()
+        )
+        expected_rows = (
+            self.expected_join_pa_filled_posts_to_hybrid_area_proportions_df.sort(
+                sort_by_list
+            ).collect()
+        )
         self.assertEqual(returned_rows, expected_rows)

--- a/tests/unit/test_dpr_split_pa_filled_posts_into_icb_areas.py
+++ b/tests/unit/test_dpr_split_pa_filled_posts_into_icb_areas.py
@@ -219,19 +219,46 @@ class JoinPaFilledPostsToPostcodeProportions(SplitPAFilledPostsIntoICBAreas):
             schema=TestSchema.expected_deduplicated_importdate_hybrid_and_la_and_ratio_schema,
         )
 
-        self.returned_df = job.join_pa_filled_posts_to_hybrid_area_proportions(
-            self.sample_proportions_df, self.sample_pa_filled_posts_df
+        self.returned_after_adding_date_from_year_column = (
+            job.create_date_column_from_year_in_pa_estimates(
+                self.sample_pa_filled_posts_df
+            )
         )
 
-        self.expected_df = self.spark.createDataFrame(
-            TestData.expected_pa_filled_posts_with_year_as_date_rows,
-            schema=TestSchema.expected_pa_filled_posts_with_year_as_date_schema,
+        self.expected_after_adding_date_from_year_column = self.spark.createDataFrame(
+            TestData.expected_after_adding_date_from_year_column_rows,
+            schema=TestSchema.expected_after_adding_date_from_year_column_schema,
         )
 
-    def test_join_pa_filled_posts_to_hybrid_area_proportions_creates_date_column(
+        self.returned_after_adding_aligned_dates_column = (
+            job.align_dates_from_pa_filled_posts_to_postcode_proportions(
+                self.sample_pa_filled_posts_df, self.sample_proportions_df
+            )
+        )
+
+        self.expected_after_adding_aligned_dates_column = self.spark.createDataFrame(
+            TestData.expected_after_adding_aligned_dates_column_rows,
+            schema=TestSchema.expected_after_adding_aligned_dates_column_schema,
+        )
+
+    def test_create_date_column_from_year_in_pa_estimates_has_expected_values(
         self,
     ):
-        self.returned_df.show()
-        returned_rows = self.returned_df.sort("Group").collect()
-        expected_rows = self.expected_df.sort("Group").collect()
+        returned_rows = self.returned_after_adding_date_from_year_column.sort(
+            "Group"
+        ).collect()
+        expected_rows = self.expected_after_adding_date_from_year_column.sort(
+            "Group"
+        ).collect()
+        self.assertEqual(returned_rows, expected_rows)
+
+    def test_align_dates_from_pa_filled_posts_to_postcode_proportions(
+        self,
+    ):
+        returned_rows = self.returned_after_adding_aligned_dates_column.sort(
+            "Group"
+        ).collect()
+        expected_rows = self.expected_after_adding_aligned_dates_column.sort(
+            "Group"
+        ).collect()
         self.assertEqual(returned_rows, expected_rows)

--- a/tests/unit/test_dpr_split_pa_filled_posts_into_icb_areas.py
+++ b/tests/unit/test_dpr_split_pa_filled_posts_into_icb_areas.py
@@ -132,8 +132,8 @@ class CreateRatioBetweenColumns(SplitPAFilledPostsIntoICBAreas):
             schema=TestSchema.expected_ratio_between_hybrid_area_and_la_area_postcodes_schema,
         )
 
-        self.returned_rows = self.returned_df.sort("ordering_column").collect()
-        self.expected_rows = self.expected_df.sort("ordering_column").collect()
+        self.returned_rows = self.returned_df.collect()
+        self.expected_rows = self.expected_df.collect()
 
     def test_create_proportion_between_hybrid_area_and_la_area_postcode_counts_has_expected_columns(
         self,
@@ -233,14 +233,8 @@ class CreateDateColumnFromYearInPaFilledPosts(SplitPAFilledPostsIntoICBAreas):
     def test_create_date_column_from_year_in_pa_estimates_has_expected_values(
         self,
     ):
-        returned_rows = self.returned_after_adding_date_from_year_column_df.sort(
-            "ordering_column"
-        ).collect()
-
-        expected_rows = self.expected_after_adding_date_from_year_column_df.sort(
-            "ordering_column"
-        ).collect()
-
+        returned_rows = self.returned_after_adding_date_from_year_column_df.collect()
+        expected_rows = self.expected_after_adding_date_from_year_column_df.collect()
         self.assertEqual(returned_rows, expected_rows)
 
 

--- a/tests/unit/test_dpr_split_pa_filled_posts_into_icb_areas.py
+++ b/tests/unit/test_dpr_split_pa_filled_posts_into_icb_areas.py
@@ -271,7 +271,14 @@ class JoinPaFilledPostsToPostcodeProportions(SplitPAFilledPostsIntoICBAreas):
     def test_join_pa_filled_posts_to_hybrid_area_proportions_has_expected_values(
         self,
     ):
+        # get the test to pass.
+        # remove the ordering column and use the date, la and icb.
+        # add test for number of columns is as expected.
+        # add test for number of rows is as expected.
         returned_df = self.returned_df.select(self.expected_df.columns)
+
+        returned_df.show()
+        self.expected_df.show()
 
         returned_rows = returned_df.sort("ordering_column").collect()
         expected_rows = self.expected_df.sort("ordering_column").collect()

--- a/tests/unit/test_dpr_split_pa_filled_posts_into_icb_areas.py
+++ b/tests/unit/test_dpr_split_pa_filled_posts_into_icb_areas.py
@@ -1,7 +1,6 @@
 import unittest
 import warnings
 from unittest.mock import ANY, Mock, patch
-from pyspark.sql import functions as F
 
 from utils import utils
 

--- a/tests/unit/test_dpr_split_pa_filled_posts_into_icb_areas.py
+++ b/tests/unit/test_dpr_split_pa_filled_posts_into_icb_areas.py
@@ -246,59 +246,6 @@ class CreateDateColumnFromYearInPaFilledPosts(SplitPAFilledPostsIntoICBAreas):
         self.assertEqual(returned_rows, expected_rows)
 
 
-class AddAlignedDatesToPaFilledPostsFromPostcodeProportions(
-    SplitPAFilledPostsIntoICBAreas
-):
-    def setUp(self) -> None:
-        super().setUp()
-
-        self.sample_after_adding_date_from_year_column_df = self.spark.createDataFrame(
-            TestData.expected_after_adding_date_from_year_column_rows,
-            schema=TestSchema.expected_after_adding_date_from_year_column_schema,
-        )
-
-        self.sample_proportions_df = self.spark.createDataFrame(
-            TestData.expected_deduplicated_importdate_hybrid_and_la_and_ratio_rows,
-            schema=TestSchema.expected_deduplicated_importdate_hybrid_and_la_and_ratio_schema,
-        )
-
-        self.returned_after_adding_aligned_dates_column_df = (
-            job.align_dates_from_pa_filled_posts_to_postcode_proportions(
-                self.sample_after_adding_date_from_year_column_df,
-                self.sample_proportions_df,
-            )
-        )
-
-        self.expected_after_adding_aligned_dates_column_df = self.spark.createDataFrame(
-            TestData.expected_after_adding_aligned_dates_column_rows,
-            schema=TestSchema.expected_after_adding_aligned_dates_column_schema,
-        )
-
-    def test_align_dates_from_pa_filled_posts_to_postcode_proportions_has_expected_values(
-        self,
-    ):
-        self.returned_after_adding_aligned_dates_column_df = (
-            self.returned_after_adding_aligned_dates_column_df.select(
-                "Group",
-                DPColNames.LA_AREA,
-                DPColNames.ESTIMATED_TOTAL_PERSONAL_ASSISTANT_FILLED_POSTS,
-                DPColNames.YEAR,
-                DPColNames.ESTIMATE_PERIOD_AS_DATE,
-                ONSClean.contemporary_ons_import_date,
-            )
-        )
-
-        returned_rows = self.returned_after_adding_aligned_dates_column_df.sort(
-            "Group"
-        ).collect()
-
-        expected_rows = self.expected_after_adding_aligned_dates_column_df.sort(
-            "Group"
-        ).collect()
-
-        self.assertEqual(returned_rows, expected_rows)
-
-
 class JoinPaFilledPostsToPostcodeProportions(SplitPAFilledPostsIntoICBAreas):
     def setUp(self) -> None:
         super().setUp()

--- a/utils/direct_payments_utils/direct_payments_column_names.py
+++ b/utils/direct_payments_utils/direct_payments_column_names.py
@@ -167,6 +167,7 @@ class DirectPaymentColumnNames:
     PROPORTION_OF_ICB_POSTCODES_IN_LA_AREA: str = (
         "proportion_of_ICB_postcodes_in_la_area"
     )
+    ESTIMATE_PERIOD_AS_DATE: str = "estimate_period_as_date"
 
 
 @dataclass

--- a/utils/direct_payments_utils/direct_payments_configuration.py
+++ b/utils/direct_payments_utils/direct_payments_configuration.py
@@ -51,3 +51,9 @@ class DirectPaymentsMissingPARatios:
             ),
         ]
     )
+
+
+@dataclass
+class EstimatePeriodAsDate:
+    MONTH: str = "03"
+    DAY: str = "31"


### PR DESCRIPTION
# Description
Added three new functions to PA estimates split by ICB area job.
One adds a date column to the PA estimates (set to 31st March then estimate year).
One gets the appropriate date for joining the PA estimates to the postcode proportions table (Contemporary geographies as at PA estimate year).
Then PA estimates (right) are joined to the table of postcode proportions (left) based on contemporary import date and LA area, using left join.

Tests are passing.

Runs sucessfully in branch:
https://eu-west-2.console.aws.amazon.com/gluestudio/home?region=eu-west-2#/editor/job/join-pa-filled-posts-into-hybr-split_pa_filled_posts_into_icb_areas_job/runs

Trello ticket:   https://trello.com/c/lVLiXspR

# How to test

# Developer checklist
- [x] Unit test
- [x] Linked to Trello ticket
- [ ] Documentation up to date
