### PR TITLE
Apply ratio to calc icb filled posts

### DIFF
--- a/jobs/split_pa_filled_posts_into_icb_areas.py
+++ b/jobs/split_pa_filled_posts_into_icb_areas.py
@@ -61,7 +61,7 @@ def main(postcode_directory_source, pa_filled_posts_source, destination):
         )
     )
 
-    postcode_directory_df = (
+    proportion_of_postcodes_per_hybrid_area_df = (
         deduplicate_proportion_between_hybrid_area_and_la_area_postcode_counts(
             postcode_directory_df
         )
@@ -70,16 +70,21 @@ def main(postcode_directory_source, pa_filled_posts_source, destination):
     pa_filled_posts_df = create_date_column_from_year_in_pa_estimates(
         pa_filled_posts_df
     )
-    postcode_directory_df = join_pa_filled_posts_to_hybrid_area_proportions(
-        postcode_directory_df, pa_filled_posts_df
+
+    proportion_of_postcodes_per_hybrid_area_with_pa_filled_posts_df = (
+        join_pa_filled_posts_to_hybrid_area_proportions(
+            proportion_of_postcodes_per_hybrid_area_df, pa_filled_posts_df
+        )
     )
 
-    postcode_directory_df = apply_icb_proportions_to_pa_filled_posts(
-        postcode_directory_df
+    proportion_of_postcodes_per_hybrid_area_with_pa_filled_posts_df = (
+        apply_icb_proportions_to_pa_filled_posts(
+            proportion_of_postcodes_per_hybrid_area_with_pa_filled_posts_df
+        )
     )
 
     utils.write_to_parquet(
-        postcode_directory_df,
+        proportion_of_postcodes_per_hybrid_area_with_pa_filled_posts_df,
         destination,
         mode="overwrite",
         partitionKeys=[ONSClean.contemporary_cssr],
@@ -118,14 +123,14 @@ def create_proportion_between_hybrid_area_and_la_area_postcode_counts(
 def deduplicate_proportion_between_hybrid_area_and_la_area_postcode_counts(
     postcode_directory_df: DataFrame,
 ) -> DataFrame:
-    deduplicated_df = postcode_directory_df.select(
+    proportion_of_postcodes_per_hybrid_area_df = postcode_directory_df.select(
         ONSClean.contemporary_ons_import_date,
         ONSClean.contemporary_cssr,
         ONSClean.contemporary_icb,
         DPColNames.PROPORTION_OF_ICB_POSTCODES_IN_LA_AREA,
     ).distinct()
 
-    return deduplicated_df
+    return proportion_of_postcodes_per_hybrid_area_df
 
 
 def create_date_column_from_year_in_pa_estimates(
@@ -166,13 +171,15 @@ def join_pa_filled_posts_to_hybrid_area_proportions(
         DPColNames.LA_AREA, ONSClean.contemporary_cssr
     )
 
-    postcode_directory_df = postcode_directory_df.join(
-        pa_filled_posts_df,
-        [ONSClean.contemporary_ons_import_date, ONSClean.contemporary_cssr],
-        "left",
+    proportion_of_postcodes_per_hybrid_area_with_pa_filled_posts_df = (
+        postcode_directory_df.join(
+            pa_filled_posts_df,
+            [ONSClean.contemporary_ons_import_date, ONSClean.contemporary_cssr],
+            "left",
+        )
     )
 
-    return postcode_directory_df
+    return proportion_of_postcodes_per_hybrid_area_with_pa_filled_posts_df
 
 
 def apply_icb_proportions_to_pa_filled_posts(

--- a/jobs/split_pa_filled_posts_into_icb_areas.py
+++ b/jobs/split_pa_filled_posts_into_icb_areas.py
@@ -187,8 +187,8 @@ def apply_icb_proportions_to_pa_filled_posts(
 ) -> DataFrame:
     postcode_directory_df = postcode_directory_df.withColumn(
         DPColNames.ESTIMATED_TOTAL_PERSONAL_ASSISTANT_FILLED_POSTS_PER_ICB,
-        F.col(DPColNames.PROPORTION_OF_ICB_POSTCODES_IN_LA_AREA)
-        * F.col(DPColNames.ESTIMATED_TOTAL_PERSONAL_ASSISTANT_FILLED_POSTS),
+        F.col(DPColNames.ESTIMATED_TOTAL_PERSONAL_ASSISTANT_FILLED_POSTS)
+        * F.col(DPColNames.PROPORTION_OF_ICB_POSTCODES_IN_LA_AREA),
     )
 
     return postcode_directory_df

--- a/jobs/split_pa_filled_posts_into_icb_areas.py
+++ b/jobs/split_pa_filled_posts_into_icb_areas.py
@@ -77,9 +77,13 @@ def main(postcode_directory_source, pa_filled_posts_source, destination):
     )
 
     # TODO 6 - Apply ratio to calculate ICB filled posts.
+    postcode_directory_df = apply_icb_proportions_to_pa_filled_posts(
+        postcode_directory_df
+    )
 
+    # Need to create year in the proportions table so it can used as a partition key.
     utils.write_to_parquet(
-        pa_filled_posts_df,
+        postcode_directory_df,
         destination,
         mode="overwrite",
         partitionKeys=[DPColNames.YEAR],
@@ -164,6 +168,18 @@ def join_pa_filled_posts_to_hybrid_area_proportions(
         pa_filled_posts_df,
         [ONSClean.contemporary_ons_import_date, ONSClean.contemporary_cssr],
         "left",
+    )
+
+    return postcode_directory_df
+
+
+def apply_icb_proportions_to_pa_filled_posts(
+    postcode_directory_df: DataFrame,
+) -> DataFrame:
+    postcode_directory_df = postcode_directory_df.withColumn(
+        DPColNames.ESTIMATED_TOTAL_PERSONAL_ASSISTANT_FILLED_POSTS_PER_ICB,
+        F.col(DPColNames.PROPORTION_OF_ICB_POSTCODES_IN_LA_AREA)
+        * F.col(DPColNames.ESTIMATED_TOTAL_PERSONAL_ASSISTANT_FILLED_POSTS),
     )
 
     return postcode_directory_df

--- a/jobs/split_pa_filled_posts_into_icb_areas.py
+++ b/jobs/split_pa_filled_posts_into_icb_areas.py
@@ -82,7 +82,7 @@ def main(postcode_directory_source, pa_filled_posts_source, destination):
         postcode_directory_df,
         destination,
         mode="overwrite",
-        partitionKeys=[DPColNames.YEAR],
+        partitionKeys=[ONSClean.contemporary_cssr],
     )
 
 

--- a/jobs/split_pa_filled_posts_into_icb_areas.py
+++ b/jobs/split_pa_filled_posts_into_icb_areas.py
@@ -39,14 +39,12 @@ def main(postcode_directory_source, pa_filled_posts_source, destination):
         ],
     )
 
-    # TODO 1 - Create column with count of postcodes by LA.
     postcode_directory_df = count_postcodes_per_list_of_columns(
         postcode_directory_df,
         [ONSClean.contemporary_ons_import_date, ONSClean.contemporary_cssr],
         DPColNames.COUNT_OF_DISTINCT_POSTCODES_PER_LA,
     )
 
-    # TODO 2 - Create column with count of postcodes by hybrid area.
     postcode_directory_df = count_postcodes_per_list_of_columns(
         postcode_directory_df,
         [
@@ -57,21 +55,18 @@ def main(postcode_directory_source, pa_filled_posts_source, destination):
         DPColNames.COUNT_OF_DISTINCT_POSTCODES_PER_HYBRID_AREA,
     )
 
-    # TODO 3 - Create column with ratio.
     postcode_directory_df = (
         create_proportion_between_hybrid_area_and_la_area_postcode_counts(
             postcode_directory_df,
         )
     )
 
-    # TODO 4 - Drop duplicates.
     postcode_directory_df = (
         deduplicate_proportion_between_hybrid_area_and_la_area_postcode_counts(
             postcode_directory_df
         )
     )
 
-    # TODO 5 - Join pa filled posts.
     pa_filled_posts_df = create_date_column_from_year_in_pa_estimates(
         pa_filled_posts_df
     )
@@ -79,12 +74,10 @@ def main(postcode_directory_source, pa_filled_posts_source, destination):
         postcode_directory_df, pa_filled_posts_df
     )
 
-    # TODO 6 - Apply ratio to calculate ICB filled posts.
     postcode_directory_df = apply_icb_proportions_to_pa_filled_posts(
         postcode_directory_df
     )
 
-    # Need to create year in the proportions table so it can used as a partition key.
     utils.write_to_parquet(
         postcode_directory_df,
         destination,

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -630,7 +630,7 @@ class ONSData:
 
 
 @dataclass
-class PAFilledPostsByICBArea:
+class PAFilledPostsByIcbArea:
     # fmt: off
     sample_ons_contemporary_rows = [
         ("AB10AA", date(2024,1,1), "cssr1", "icb1"),

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -756,17 +756,17 @@ class PAFilledPostsByICBArea:
     ]
 
     sample_proportions_and_pa_filled_posts_rows = [
-        (1.00000, 100.2),
-        (0.25000, 200.3),
-        (0.75000, 200.3),
-        (1.00000, None),
+        (0.25000, 100.2),
+        (None, 200.3),
+        (0.75000, None),
+        (None, None),
     ]
 
     expected_pa_filled_posts_after_applying_proportions_rows = [
-        (1.00000, 100.2, 100.2),
-        (0.25000, 200.3, 50.07500),
-        (0.75000, 200.3, 150.22500),
-        (1.00000, None, None),
+        (0.25000, 100.2, 25.05000),
+        (None, 200.3, None),
+        (0.75000, None, None),
+        (None, None, None),
     ]
     # fmt: on
 

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -743,6 +743,20 @@ class PAFilledPostsByICBArea:
         (date(2022,5,1), "Leeds", "icb1", 1.00000, None),
         (date(2022, 5, 1), "Barking & Dagenham", "icb4", 1.00000, None),
     ]
+
+    sample_proportions_and_pa_filled_posts_rows = [
+        (1.00000, 100.2),
+        (0.25000, 200.3),
+        (0.75000, 200.3),
+        (1.00000, None),
+    ]
+
+    expected_pa_filled_posts_after_applying_proportions_rows = [
+        (1.00000, 100.2, 100.2),
+        (0.25000, 200.3, 50.07500),
+        (0.75000, 200.3, 150.22500),
+        (1.00000, None, None),
+    ]
     # fmt: on
 
 

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -447,7 +447,7 @@ class ONSData:
 
 
 @dataclass
-class PAFilledPostsByICBAreaSchema:
+class PAFilledPostsByIcbAreaSchema:
     sample_ons_contemporary_schema = StructType(
         [
             StructField(ONSClean.postcode, StringType(), True),

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -548,6 +548,26 @@ class PAFilledPostsByICBAreaSchema:
         ]
     )
 
+    sample_proportions_and_pa_filled_posts_schema = StructType(
+        [
+            StructField(DP.PROPORTION_OF_ICB_POSTCODES_IN_LA_AREA, FloatType(), True),
+            StructField(
+                DP.ESTIMATED_TOTAL_PERSONAL_ASSISTANT_FILLED_POSTS, DoubleType(), True
+            ),
+        ]
+    )
+
+    expected_pa_filled_posts_after_applying_proportions_schema = StructType(
+        [
+            *sample_proportions_and_pa_filled_posts_schema,
+            StructField(
+                DP.ESTIMATED_TOTAL_PERSONAL_ASSISTANT_FILLED_POSTS_PER_ICB,
+                DoubleType(),
+                True,
+            ),
+        ]
+    )
+
 
 @dataclass
 class CapacityTrackerCareHomeSchema:

--- a/tests/unit/test_dpr_split_pa_filled_posts_into_icb_areas.py
+++ b/tests/unit/test_dpr_split_pa_filled_posts_into_icb_areas.py
@@ -378,6 +378,14 @@ class ApplyIcbProportionsToPAEstimates(SplitPAFilledPostsIntoIcbAreas):
             self.expected_apply_icb_proportions_to_pa_filled_posts_df.collect()
         )
 
-        self.assertAlmostEqual(
-            returned_rows, expected_rows, 3, "rows are not almost equal"
-        )
+        for i in range(len(returned_rows)):
+            self.assertAlmostEqual(
+                returned_rows[i][
+                    DPColNames.ESTIMATED_TOTAL_PERSONAL_ASSISTANT_FILLED_POSTS_PER_ICB
+                ],
+                expected_rows[i][
+                    DPColNames.ESTIMATED_TOTAL_PERSONAL_ASSISTANT_FILLED_POSTS_PER_ICB
+                ],
+                3,
+                "rows are not almost equal",
+            )

--- a/tests/unit/test_dpr_split_pa_filled_posts_into_icb_areas.py
+++ b/tests/unit/test_dpr_split_pa_filled_posts_into_icb_areas.py
@@ -322,6 +322,14 @@ class ApplyIcbProportionsToPAEstimates(SplitPAFilledPostsIntoICBAreas):
     ):
         self.assertEqual(len(self.returned_df.columns), len(self.sample_df.columns) + 1)
 
+    def test_apply_icb_proportions_to_pa_filled_posts_adds_given_column(
+        self,
+    ):
+        self.assertTrue(
+            DPColNames.ESTIMATED_TOTAL_PERSONAL_ASSISTANT_FILLED_POSTS_PER_ICB
+            in self.returned_df.columns
+        )
+
     def test_apply_icb_proportions_to_pa_filled_posts_has_expected_values(
         self,
     ):

--- a/tests/unit/test_dpr_split_pa_filled_posts_into_icb_areas.py
+++ b/tests/unit/test_dpr_split_pa_filled_posts_into_icb_areas.py
@@ -51,7 +51,7 @@ class MainTests(SplitPAFilledPostsIntoICBAreas):
             ANY,
             self.TEST_DESTINATION,
             mode="overwrite",
-            partitionKeys=[DPColNames.YEAR],
+            partitionKeys=[ONSClean.contemporary_cssr],
         )
 
 

--- a/tests/unit/test_dpr_split_pa_filled_posts_into_icb_areas.py
+++ b/tests/unit/test_dpr_split_pa_filled_posts_into_icb_areas.py
@@ -378,14 +378,6 @@ class ApplyIcbProportionsToPAEstimates(SplitPAFilledPostsIntoIcbAreas):
             self.expected_apply_icb_proportions_to_pa_filled_posts_df.collect()
         )
 
-        for i in range(len(returned_rows)):
-            self.assertAlmostEqual(
-                returned_rows[i][
-                    DPColNames.ESTIMATED_TOTAL_PERSONAL_ASSISTANT_FILLED_POSTS_PER_ICB
-                ],
-                expected_rows[i][
-                    DPColNames.ESTIMATED_TOTAL_PERSONAL_ASSISTANT_FILLED_POSTS_PER_ICB
-                ],
-                3,
-                "rows are not almost equal",
-            )
+        self.assertAlmostEqual(
+            returned_rows, expected_rows, 3, "rows are not almost equal"
+        )

--- a/tests/unit/test_dpr_split_pa_filled_posts_into_icb_areas.py
+++ b/tests/unit/test_dpr_split_pa_filled_posts_into_icb_areas.py
@@ -4,8 +4,8 @@ from unittest.mock import ANY, Mock, patch
 
 from utils import utils
 
-from tests.test_file_data import PAFilledPostsByICBArea as TestData
-from tests.test_file_schemas import PAFilledPostsByICBAreaSchema as TestSchema
+from tests.test_file_data import PAFilledPostsByIcbArea as TestData
+from tests.test_file_schemas import PAFilledPostsByIcbAreaSchema as TestSchema
 
 from utils.direct_payments_utils.direct_payments_column_names import (
     DirectPaymentColumnNames as DPColNames,
@@ -17,7 +17,7 @@ from utils.column_names.cleaned_data_files.ons_cleaned_values import (
 import jobs.split_pa_filled_posts_into_icb_areas as job
 
 
-class SplitPAFilledPostsIntoICBAreas(unittest.TestCase):
+class SplitPAFilledPostsIntoIcbAreas(unittest.TestCase):
     TEST_ONS_SOURCE = "some/directory"
     TEST_PA_SOURCE = "some/directory"
     TEST_DESTINATION = "some/directory"
@@ -34,7 +34,7 @@ class SplitPAFilledPostsIntoICBAreas(unittest.TestCase):
         )
 
 
-class MainTests(SplitPAFilledPostsIntoICBAreas):
+class MainTests(SplitPAFilledPostsIntoIcbAreas):
     def setUp(self) -> None:
         super().setUp()
 
@@ -55,7 +55,7 @@ class MainTests(SplitPAFilledPostsIntoICBAreas):
         )
 
 
-class CountPostcodesPerListOfColumns(SplitPAFilledPostsIntoICBAreas):
+class CountPostcodesPerListOfColumns(SplitPAFilledPostsIntoIcbAreas):
     def setUp(self) -> None:
         super().setUp()
 
@@ -112,7 +112,7 @@ class CountPostcodesPerListOfColumns(SplitPAFilledPostsIntoICBAreas):
         )
 
 
-class CreateRatioBetweenColumns(SplitPAFilledPostsIntoICBAreas):
+class CreateRatioBetweenColumns(SplitPAFilledPostsIntoIcbAreas):
     def setUp(self) -> None:
         super().setUp()
 
@@ -164,7 +164,7 @@ class CreateRatioBetweenColumns(SplitPAFilledPostsIntoICBAreas):
             )
 
 
-class DeduplicateRatioBetweenAreaCounts(SplitPAFilledPostsIntoICBAreas):
+class DeduplicateRatioBetweenAreaCounts(SplitPAFilledPostsIntoIcbAreas):
     def setUp(self) -> None:
         super().setUp()
 
@@ -210,7 +210,7 @@ class DeduplicateRatioBetweenAreaCounts(SplitPAFilledPostsIntoICBAreas):
         )
 
 
-class CreateDateColumnFromYearInPaFilledPosts(SplitPAFilledPostsIntoICBAreas):
+class CreateDateColumnFromYearInPaFilledPosts(SplitPAFilledPostsIntoIcbAreas):
     def setUp(self) -> None:
         super().setUp()
 
@@ -242,7 +242,7 @@ class CreateDateColumnFromYearInPaFilledPosts(SplitPAFilledPostsIntoICBAreas):
         self.assertEqual(returned_rows, expected_rows)
 
 
-class JoinPaFilledPostsToHybridAreaProportions(SplitPAFilledPostsIntoICBAreas):
+class JoinPaFilledPostsToHybridAreaProportions(SplitPAFilledPostsIntoIcbAreas):
     def setUp(self) -> None:
         super().setUp()
 
@@ -330,7 +330,7 @@ class JoinPaFilledPostsToHybridAreaProportions(SplitPAFilledPostsIntoICBAreas):
         self.assertEqual(returned_rows, expected_rows)
 
 
-class ApplyIcbProportionsToPAEstimates(SplitPAFilledPostsIntoICBAreas):
+class ApplyIcbProportionsToPAEstimates(SplitPAFilledPostsIntoIcbAreas):
     def setUp(self) -> None:
         super().setUp()
 

--- a/tests/unit/test_dpr_split_pa_filled_posts_into_icb_areas.py
+++ b/tests/unit/test_dpr_split_pa_filled_posts_into_icb_areas.py
@@ -334,36 +334,49 @@ class ApplyIcbProportionsToPAEstimates(SplitPAFilledPostsIntoICBAreas):
     def setUp(self) -> None:
         super().setUp()
 
-        self.sample_df = self.spark.createDataFrame(
-            TestData.sample_proportions_and_pa_filled_posts_rows,
-            schema=TestSchema.sample_proportions_and_pa_filled_posts_schema,
+        self.sample_apply_icb_proportions_to_pa_filled_posts_df = (
+            self.spark.createDataFrame(
+                TestData.sample_proportions_and_pa_filled_posts_rows,
+                schema=TestSchema.sample_proportions_and_pa_filled_posts_schema,
+            )
         )
 
-        self.returned_df = job.apply_icb_proportions_to_pa_filled_posts(self.sample_df)
+        self.returned_apply_icb_proportions_to_pa_filled_posts_df = (
+            job.apply_icb_proportions_to_pa_filled_posts(
+                self.sample_apply_icb_proportions_to_pa_filled_posts_df
+            )
+        )
 
-        self.expected_df = self.spark.createDataFrame(
+        self.expected_apply_icb_proportions_to_pa_filled_posts_df = self.spark.createDataFrame(
             TestData.expected_pa_filled_posts_after_applying_proportions_rows,
             schema=TestSchema.expected_pa_filled_posts_after_applying_proportions_schema,
         )
 
-    def test_apply_icb_proportions_to_pa_filled_posts_has_expected_column_count(
+    def test_apply_icb_proportions_to_pa_filled_posts_adds_1_column(
         self,
     ):
-        self.assertEqual(len(self.returned_df.columns), len(self.sample_df.columns) + 1)
+        self.assertEqual(
+            len(self.returned_apply_icb_proportions_to_pa_filled_posts_df.columns),
+            len(self.sample_apply_icb_proportions_to_pa_filled_posts_df.columns) + 1,
+        )
 
-    def test_apply_icb_proportions_to_pa_filled_posts_adds_given_column(
+    def test_apply_icb_proportions_to_pa_filled_posts_adds_given_column_name(
         self,
     ):
         self.assertTrue(
             DPColNames.ESTIMATED_TOTAL_PERSONAL_ASSISTANT_FILLED_POSTS_PER_ICB
-            in self.returned_df.columns
+            in self.returned_apply_icb_proportions_to_pa_filled_posts_df.columns
         )
 
     def test_apply_icb_proportions_to_pa_filled_posts_has_expected_values(
         self,
     ):
-        returned_rows = self.returned_df.collect()
-        expected_rows = self.expected_df.collect()
+        returned_rows = (
+            self.returned_apply_icb_proportions_to_pa_filled_posts_df.collect()
+        )
+        expected_rows = (
+            self.expected_apply_icb_proportions_to_pa_filled_posts_df.collect()
+        )
 
         for i in range(len(returned_rows)):
             self.assertAlmostEqual(

--- a/utils/direct_payments_utils/direct_payments_column_names.py
+++ b/utils/direct_payments_utils/direct_payments_column_names.py
@@ -168,6 +168,9 @@ class DirectPaymentColumnNames:
         "proportion_of_ICB_postcodes_in_la_area"
     )
     ESTIMATE_PERIOD_AS_DATE: str = "estimate_period_as_date"
+    ESTIMATED_TOTAL_PERSONAL_ASSISTANT_FILLED_POSTS_PER_ICB: str = (
+        "estimated_total_personal_assistant_filled_posts_per_icb"
+    )
 
 
 @dataclass


### PR DESCRIPTION
# Description
Added a function to create a new column with the estimated number of PA's in each ICB. The column is the estimate of PA's in each CSSR multiplied by the proportion of postcodes per ICB within each CSSR.

There is an issue with the join, leading to blank rows in the joined columns. The issue is caused by the CSSR names being different in the PA estimates to the cleaned postcode file.
One of the joined columns is used as a partition key when writing to parquet, and because this has blanks, this causes the job to run very slowly (but succeeds).

# How to test
Tests are passing.
It runs successfully in branch, but takes ~25 minutes.
Link to run:
https://eu-west-2.console.aws.amazon.com/gluestudio/home?region=eu-west-2#/editor/job/apply-ratio-to-calc-icb-filled-split_pa_filled_posts_into_icb_areas_job/runs

Link to Trello:    https://trello.com/c/CiBeY4ja

# Developer checklist
- [x] Unit test
- [x] Linked to Trello ticket
- [ ] Documentation up to date
