### PR TITLE
Fix bug with multiple checks

### DIFF
--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -4289,6 +4289,13 @@ class ValidationUtils:
         }
     }
 
+    distinct_values_multiple_columns_rule = {
+        RuleName.distinct_values: {
+            IndCQC.cqc_sector: 2,
+            IndCQC.care_home: 2,
+        }
+    }
+
     distinct_values_success_rows = [
         ("loc_1", CQCLValues.independent),
         ("loc_2", CQCLValues.local_authority),
@@ -4301,6 +4308,11 @@ class ValidationUtils:
         ("loc_1", CQCLValues.independent),
         ("loc_2", CQCLValues.local_authority),
         ("loc_3", None),
+    ]
+    distinct_values_multiple_columns_rows = [
+        ("loc_1", CQCLValues.independent, "Y"),
+        ("loc_2", CQCLValues.local_authority, "N"),
+        ("loc_3", None, "Y"),
     ]
 
     distinct_values_result_success_rows = [
@@ -4331,5 +4343,23 @@ class ValidationUtils:
             "HistogramBinConstraint(Histogram(cqc_sector,null,2,None,false,Count))",
             "Failure",
             "Value: 3 does not meet the constraint requirement! The number of distinct values in cqc_sector should be 2.",
+        ),
+    ]
+    distinct_values_result_multiple_columns_rows = [
+        (
+            "Column contains correct number of distinct values",
+            "Warning",
+            "Warning",
+            "HistogramBinConstraint(Histogram(cqc_sector,null,2,None,false,Count))",
+            "Failure",
+            "Value: 3.0 does not meet the constraint requirement! The number of distinct values in cqc_sector should be 2.",
+        ),
+        (
+            "Column contains correct number of distinct values",
+            "Warning",
+            "Success",
+            "HistogramBinConstraint(Histogram(care_home,null,2,None,false,Count))",
+            "Success",
+            "",
         ),
     ]

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -4292,7 +4292,7 @@ class ValidationUtils:
     distinct_values_multiple_columns_rule = {
         RuleName.distinct_values: {
             IndCQC.cqc_sector: 2,
-            IndCQC.care_home: 2,
+            IndCQC.dormancy: 3,
         }
     }
 
@@ -4312,7 +4312,7 @@ class ValidationUtils:
     distinct_values_multiple_columns_rows = [
         ("loc_1", CQCLValues.independent, "Y"),
         ("loc_2", CQCLValues.local_authority, "N"),
-        ("loc_3", None, "Y"),
+        ("loc_3", None, None),
     ]
 
     distinct_values_result_success_rows = [
@@ -4352,13 +4352,13 @@ class ValidationUtils:
             "Warning",
             "HistogramBinConstraint(Histogram(cqc_sector,null,2,None,false,Count))",
             "Failure",
-            "Value: 3.0 does not meet the constraint requirement! The number of distinct values in cqc_sector should be 2.",
+            "Value: 3 does not meet the constraint requirement! The number of distinct values in cqc_sector should be 2.",
         ),
         (
             "Column contains correct number of distinct values",
             "Warning",
             "Success",
-            "HistogramBinConstraint(Histogram(care_home,null,2,None,false,Count))",
+            "HistogramBinConstraint(Histogram(dormancy,null,3,None,false,Count))",
             "Success",
             "",
         ),

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -4122,6 +4122,12 @@ class ValidationUtils:
             IndCQC.number_of_beds: 1,
         }
     }
+    min_values_multiple_columns_rule = {
+        RuleName.min_values: {
+            IndCQC.number_of_beds: 1,
+            IndCQC.people_directly_employed: 0,
+        }
+    }
     min_values_below_minimum_rows = [
         ("loc_1", 0),
     ]
@@ -4130,6 +4136,9 @@ class ValidationUtils:
     ]
     min_values_above_minimum_rows = [
         ("loc_1", 2),
+    ]
+    min_values_multiple_columns_rows = [
+        ("loc_1", 0, 0),
     ]
 
     min_values_result_success_rows = [
@@ -4150,6 +4159,24 @@ class ValidationUtils:
             "MinimumConstraint(Minimum(numberOfBeds,None))",
             "Failure",
             "Value: 0.0 does not meet the constraint requirement! The minimum value for numberOfBeds should be 1.",
+        ),
+    ]
+    min_values_result_multiple_columns_rows = [
+        (
+            "Min value in column",
+            "Warning",
+            "Warning",
+            "MinimumConstraint(Minimum(numberOfBeds,None))",
+            "Failure",
+            "Value: 0.0 does not meet the constraint requirement! The minimum value for numberOfBeds should be 1.",
+        ),
+        (
+            "Min value in column",
+            "Warning",
+            "Success",
+            "MinimumConstraint(Minimum(people_directly_employed,None))",
+            "Success",
+            "",
         ),
     ]
 

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -4185,6 +4185,12 @@ class ValidationUtils:
             IndCQC.number_of_beds: 10,
         }
     }
+    max_values_multiple_columns_rule = {
+        RuleName.max_values: {
+            IndCQC.number_of_beds: 10,
+            IndCQC.people_directly_employed: 20,
+        }
+    }
     max_values_below_maximum_rows = [
         ("loc_1", 9),
     ]
@@ -4193,6 +4199,9 @@ class ValidationUtils:
     ]
     max_values_above_maximum_rows = [
         ("loc_1", 11),
+    ]
+    max_values_multiple_columns_rows = [
+        ("loc_1", 20, 20),
     ]
 
     max_values_result_success_rows = [
@@ -4213,6 +4222,24 @@ class ValidationUtils:
             "MaximumConstraint(Maximum(numberOfBeds,None))",
             "Failure",
             "Value: 11.0 does not meet the constraint requirement! The maximum value for numberOfBeds should be 10.",
+        ),
+    ]
+    max_values_result_multiple_columns_rows = [
+        (
+            "Max value in column",
+            "Warning",
+            "Warning",
+            "MaximumConstraint(Maximum(numberOfBeds,None))",
+            "Failure",
+            "Value: 20.0 does not meet the constraint requirement! The maximum value for numberOfBeds should be 10.",
+        ),
+        (
+            "Max value in column",
+            "Warning",
+            "Success",
+            "MaximumConstraint(Maximum(people_directly_employed,None))",
+            "Success",
+            "",
         ),
     ]
 

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -2925,12 +2925,8 @@ class ValidationUtils:
         ]
     )
 
-    max_values_schema = StructType(
-        [
-            StructField(IndCQC.location_id, StringType(), True),
-            StructField(IndCQC.number_of_beds, IntegerType(), True),
-        ]
-    )
+    max_values_schema = min_values_schema
+    max_values_multiple_columns_schema = min_values_multiple_columns_schema
 
     one_column_schema = size_of_dataset_schema
     two_column_schema = index_column_schema

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -2950,6 +2950,6 @@ class ValidationUtils:
         [
             StructField(IndCQC.location_id, StringType(), True),
             StructField(IndCQC.cqc_sector, StringType(), True),
-            StructField(IndCQC.care_home, StringType(), True),
+            StructField(IndCQC.dormancy, StringType(), True),
         ]
     )

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -2917,6 +2917,13 @@ class ValidationUtils:
             StructField(IndCQC.number_of_beds, IntegerType(), True),
         ]
     )
+    min_values_multiple_columns_schema = StructType(
+        [
+            StructField(IndCQC.location_id, StringType(), True),
+            StructField(IndCQC.number_of_beds, IntegerType(), True),
+            StructField(IndCQC.people_directly_employed, IntegerType(), True),
+        ]
+    )
 
     max_values_schema = StructType(
         [

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -2945,3 +2945,11 @@ class ValidationUtils:
             StructField(IndCQC.cqc_sector, StringType(), True),
         ]
     )
+
+    distinct_values_multiple_columns_schema = StructType(
+        [
+            StructField(IndCQC.location_id, StringType(), True),
+            StructField(IndCQC.cqc_sector, StringType(), True),
+            StructField(IndCQC.care_home, StringType(), True),
+        ]
+    )

--- a/tests/unit/test_validation_utils.py
+++ b/tests/unit/test_validation_utils.py
@@ -193,6 +193,7 @@ class CheckOfMinValues(ValidateUtilsTests):
     def setUp(self) -> None:
         super().setUp()
         self.min_values_rule = Data.min_values_rule
+        self.min_values_multiple_columns_rule = Data.min_values_multiple_columns_rule
 
     def test_create_check_of_min_values_returns_success_when_values_are_above_minimum(
         self,
@@ -228,6 +229,23 @@ class CheckOfMinValues(ValidateUtilsTests):
             Data.min_values_result_below_minimum_rows, Schemas.validation_schema
         )
         returned_df = job.validate_dataset(test_df, self.min_values_rule)
+        self.assertEqual(returned_df.collect(), expected_df.collect())
+
+    def test_create_check_of_min_values_returns_correct_results_when_multiple_columns_supplied(
+        self,
+    ):
+        test_df = self.spark.createDataFrame(
+            Data.min_values_multiple_columns_rows,
+            Schemas.min_values_multiple_columns_schema,
+        )
+        expected_df = self.spark.createDataFrame(
+            Data.min_values_result_multiple_columns_rows, Schemas.validation_schema
+        )
+        returned_df = job.validate_dataset(
+            test_df, self.min_values_multiple_columns_rule
+        )
+        expected_df.show(truncate=False)
+        returned_df.show(truncate=False)
         self.assertEqual(returned_df.collect(), expected_df.collect())
 
 

--- a/tests/unit/test_validation_utils.py
+++ b/tests/unit/test_validation_utils.py
@@ -352,6 +352,9 @@ class CheckOfNumberOfDistinctValuesInColumns(ValidateUtilsTests):
     def setUp(self) -> None:
         super().setUp()
         self.distinct_values_rule = Data.distinct_values_rule
+        self.distinct_values_multiple_columns_rule = (
+            Data.distinct_values_multiple_columns_rule
+        )
 
     def test_create_check_of_number_of_distinct_values_returns_success_when_column_has_correct_number_of_distinct_values(
         self,
@@ -387,6 +390,23 @@ class CheckOfNumberOfDistinctValuesInColumns(ValidateUtilsTests):
             Data.more_distinct_values_result_rows, Schemas.validation_schema
         )
         returned_df = job.validate_dataset(test_df, self.distinct_values_rule)
+        self.assertEqual(returned_df.collect(), expected_df.collect())
+
+    def test_create_check_of_number_of_distinct_values_returns_correct_results_when_multiple_columns_supplied(
+        self,
+    ):
+        test_df = self.spark.createDataFrame(
+            Data.distinct_values_multiple_columns_rows,
+            Schemas.distinct_values_multiple_columns_schema,
+        )
+        expected_df = self.spark.createDataFrame(
+            Data.distinct_values_result_multiple_columns_rows, Schemas.validation_schema
+        )
+        returned_df = job.validate_dataset(
+            test_df, self.distinct_values_multiple_columns_rule
+        )
+        expected_df.show(truncate=False)
+        returned_df.show(truncate=False)
         self.assertEqual(returned_df.collect(), expected_df.collect())
 
 

--- a/tests/unit/test_validation_utils.py
+++ b/tests/unit/test_validation_utils.py
@@ -244,8 +244,6 @@ class CheckOfMinValues(ValidateUtilsTests):
         returned_df = job.validate_dataset(
             test_df, self.min_values_multiple_columns_rule
         )
-        expected_df.show(truncate=False)
-        returned_df.show(truncate=False)
         self.assertEqual(returned_df.collect(), expected_df.collect())
 
 
@@ -253,6 +251,7 @@ class CheckOfMaxValues(ValidateUtilsTests):
     def setUp(self) -> None:
         super().setUp()
         self.max_values_rule = Data.max_values_rule
+        self.max_values_multiple_columns_rule = Data.max_values_multiple_columns_rule
 
     def test_create_check_of_max_values_returns_success_when_values_are_below_maximum(
         self,
@@ -288,6 +287,21 @@ class CheckOfMaxValues(ValidateUtilsTests):
             Data.max_values_result_above_maximum_rows, Schemas.validation_schema
         )
         returned_df = job.validate_dataset(test_df, self.max_values_rule)
+        self.assertEqual(returned_df.collect(), expected_df.collect())
+
+    def test_create_check_of_max_values_returns_correct_results_when_multiple_columns_supplied(
+        self,
+    ):
+        test_df = self.spark.createDataFrame(
+            Data.max_values_multiple_columns_rows,
+            Schemas.max_values_multiple_columns_schema,
+        )
+        expected_df = self.spark.createDataFrame(
+            Data.max_values_result_multiple_columns_rows, Schemas.validation_schema
+        )
+        returned_df = job.validate_dataset(
+            test_df, self.max_values_multiple_columns_rule
+        )
         self.assertEqual(returned_df.collect(), expected_df.collect())
 
 

--- a/utils/validation/validation_utils.py
+++ b/utils/validation/validation_utils.py
@@ -26,34 +26,34 @@ def validate_dataset(dataset: DataFrame, rules: dict) -> DataFrame:
 def add_checks_to_run(
     run: VerificationRunBuilder, rules_to_check: dict
 ) -> VerificationRunBuilder:
-    for rule in rules_to_check.keys():
-        check = create_check(run, rule, rules_to_check[rule])
-        run = run.addCheck(check)
+    for rule_name in rules_to_check.keys():
+        rule = rules_to_check[rule_name]
+        if rule_name == RuleToCheck.size_of_dataset:
+            check = create_check_of_size_of_dataset(rule)
+            run = run.addCheck(check)
+        elif rule_name == RuleToCheck.complete_columns:
+            check = create_check_for_column_completeness(rule)
+            run = run.addCheck(check)
+        elif rule_name == RuleToCheck.index_columns:
+            check = create_check_of_uniqueness_of_two_index_columns(rule)
+            run = run.addCheck(check)
+        elif rule_name == RuleToCheck.min_values:
+            for column_name in rule.keys():
+                check = create_check_of_min_values(column_name, rule[column_name])
+                run = run.addCheck(check)
+        elif rule_name == RuleToCheck.max_values:
+            for column_name in rule.keys():
+                check = create_check_of_max_values(column_name, rule[column_name])
+                run = run.addCheck(check)
+        elif rule_name == RuleToCheck.categorical_values_in_columns:
+            check = create_check_of_categorical_values_in_columns(rule)
+            run = run.addCheck(check)
+        elif rule_name == RuleToCheck.distinct_values:
+            check = create_check_of_number_of_distinct_values(rule)
+            run = run.addCheck(check)
+        else:
+            raise ValueError("Unknown rule to check")
     return run
-
-
-def create_check(run: VerificationRunBuilder, rule_name: str, rule) -> Check:
-    if rule_name == RuleToCheck.size_of_dataset:
-        check = create_check_of_size_of_dataset(rule)
-    elif rule_name == RuleToCheck.complete_columns:
-        check = create_check_for_column_completeness(rule)
-    elif rule_name == RuleToCheck.index_columns:
-        check = create_check_of_uniqueness_of_two_index_columns(rule)
-    elif rule_name == RuleToCheck.min_values:
-        for column_name in rule.keys():
-            check = create_check_of_min_values(column_name, rule[column_name])
-            run = run.addCheck(check)
-    elif rule_name == RuleToCheck.max_values:
-        for column_name in rule.keys():
-            check = create_check_of_max_values(column_name, rule[column_name])
-            run = run.addCheck(check)
-    elif rule_name == RuleToCheck.categorical_values_in_columns:
-        check = create_check_of_categorical_values_in_columns(rule)
-    elif rule_name == RuleToCheck.distinct_values:
-        check = create_check_of_number_of_distinct_values(rule)
-    else:
-        raise ValueError("Unknown rule to check")
-    return check
 
 
 def create_check_for_column_completeness(complete_columns: list) -> Check:

--- a/utils/validation/validation_utils.py
+++ b/utils/validation/validation_utils.py
@@ -44,7 +44,9 @@ def create_check(run: VerificationRunBuilder, rule_name: str, rule) -> Check:
             check = create_check_of_min_values(column_name, rule[column_name])
             run = run.addCheck(check)
     elif rule_name == RuleToCheck.max_values:
-        check = create_check_of_max_values(rule)
+        for column_name in rule.keys():
+            check = create_check_of_max_values(column_name, rule[column_name])
+            run = run.addCheck(check)
     elif rule_name == RuleToCheck.categorical_values_in_columns:
         check = create_check_of_categorical_values_in_columns(rule)
     elif rule_name == RuleToCheck.distinct_values:
@@ -92,15 +94,14 @@ def create_check_of_min_values(column_name: str, min_value: int) -> Check:
     return check
 
 
-def create_check_of_max_values(column_maximums: dict) -> Check:
+def create_check_of_max_values(column_name: str, max_value: int) -> Check:
     spark = utils.get_spark()
     check = Check(spark, CheckLevel.Warning, "Max value in column")
-    for column in column_maximums.keys():
-        check = check.hasMax(
-            column,
-            lambda x: x <= column_maximums[column],
-            f"The maximum value for {column} should be {column_maximums[column]}.",
-        )
+    check = check.hasMax(
+        column_name,
+        lambda x: x <= max_value,
+        f"The maximum value for {column_name} should be {max_value}.",
+    )
     return check
 
 

--- a/utils/validation/validation_utils.py
+++ b/utils/validation/validation_utils.py
@@ -49,8 +49,11 @@ def add_checks_to_run(
             check = create_check_of_categorical_values_in_columns(rule)
             run = run.addCheck(check)
         elif rule_name == RuleToCheck.distinct_values:
-            check = create_check_of_number_of_distinct_values(rule)
-            run = run.addCheck(check)
+            for column_name in rule.keys():
+                check = create_check_of_number_of_distinct_values(
+                    column_name, rule[column_name]
+                )
+                run = run.addCheck(check)
         else:
             raise ValueError("Unknown rule to check")
     return run
@@ -119,17 +122,18 @@ def create_check_of_categorical_values_in_columns(categorical_values: dict) -> C
     return check
 
 
-def create_check_of_number_of_distinct_values(distinct_values: dict) -> Check:
+def create_check_of_number_of_distinct_values(
+    column_name: str, distinct_values: int
+) -> Check:
     spark = utils.get_spark()
     check = Check(
         spark, CheckLevel.Warning, "Column contains correct number of distinct values"
     )
-    for column in distinct_values.keys():
-        check = check.hasNumberOfDistinctValues(
-            column=column,
-            assertion=lambda x: x == distinct_values[column],
-            binningUdf=None,
-            maxBins=distinct_values[column],
-            hint=f"The number of distinct values in {column} should be {distinct_values[column]}.",
-        )
+    check = check.hasNumberOfDistinctValues(
+        column=column_name,
+        assertion=lambda x: x == distinct_values,
+        binningUdf=None,
+        maxBins=distinct_values,
+        hint=f"The number of distinct values in {column_name} should be {distinct_values}.",
+    )
     return check

--- a/utils/validation/validation_utils.py
+++ b/utils/validation/validation_utils.py
@@ -26,30 +26,34 @@ def validate_dataset(dataset: DataFrame, rules: dict) -> DataFrame:
 def add_checks_to_run(
     run: VerificationRunBuilder, rules_to_check: dict
 ) -> VerificationRunBuilder:
-    for rule in rules_to_check.keys():
-        check = create_check(rule, rules_to_check[rule])
-        run = run.addCheck(check)
+    for rule_name in rules_to_check.keys():
+        rule = rules_to_check[rule_name]
+        if rule_name == RuleToCheck.size_of_dataset:
+            check = create_check_of_size_of_dataset(rule)
+            run = run.addCheck(check)
+        elif rule_name == RuleToCheck.complete_columns:
+            check = create_check_for_column_completeness(rule)
+            run = run.addCheck(check)
+        elif rule_name == RuleToCheck.index_columns:
+            check = create_check_of_uniqueness_of_two_index_columns(rule)
+            run = run.addCheck(check)
+        elif rule_name == RuleToCheck.min_values:
+            for column_name in rule.keys():
+                check = create_check_of_min_values(column_name, rule[column_name])
+                run = run.addCheck(check)
+        elif rule_name == RuleToCheck.max_values:
+            for column_name in rule.keys():
+                check = create_check_of_max_values(column_name, rule[column_name])
+                run = run.addCheck(check)
+        elif rule_name == RuleToCheck.categorical_values_in_columns:
+            check = create_check_of_categorical_values_in_columns(rule)
+            run = run.addCheck(check)
+        elif rule_name == RuleToCheck.distinct_values:
+            check = create_check_of_number_of_distinct_values(rule)
+            run = run.addCheck(check)
+        else:
+            raise ValueError("Unknown rule to check")
     return run
-
-
-def create_check(rule_name: str, rule) -> Check:
-    if rule_name == RuleToCheck.size_of_dataset:
-        check = create_check_of_size_of_dataset(rule)
-    elif rule_name == RuleToCheck.complete_columns:
-        check = create_check_for_column_completeness(rule)
-    elif rule_name == RuleToCheck.index_columns:
-        check = create_check_of_uniqueness_of_two_index_columns(rule)
-    elif rule_name == RuleToCheck.min_values:
-        check = create_check_of_min_values(rule)
-    elif rule_name == RuleToCheck.max_values:
-        check = create_check_of_max_values(rule)
-    elif rule_name == RuleToCheck.categorical_values_in_columns:
-        check = create_check_of_categorical_values_in_columns(rule)
-    elif rule_name == RuleToCheck.distinct_values:
-        check = create_check_of_number_of_distinct_values(rule)
-    else:
-        raise ValueError("Unknown rule to check")
-    return check
 
 
 def create_check_for_column_completeness(complete_columns: list) -> Check:
@@ -79,27 +83,25 @@ def create_check_of_size_of_dataset(expected_size: int) -> Check:
     return check
 
 
-def create_check_of_min_values(column_minimums: dict) -> Check:
+def create_check_of_min_values(column_name: str, min_value: int) -> Check:
     spark = utils.get_spark()
-    check = Check(spark, CheckLevel.Warning, "Min value in column")
-    for column in column_minimums.keys():
-        check = check.hasMin(
-            column,
-            lambda x: x >= column_minimums[column],
-            f"The minimum value for {column} should be {column_minimums[column]}.",
-        )
+    check = Check(spark, CheckLevel.Warning, f"Min value in column")
+    check = check.hasMin(
+        column_name,
+        lambda x: x >= min_value,
+        f"The minimum value for {column_name} should be {min_value}.",
+    )
     return check
 
 
-def create_check_of_max_values(column_maximums: dict) -> Check:
+def create_check_of_max_values(column_name: str, max_value: int) -> Check:
     spark = utils.get_spark()
     check = Check(spark, CheckLevel.Warning, "Max value in column")
-    for column in column_maximums.keys():
-        check = check.hasMax(
-            column,
-            lambda x: x <= column_maximums[column],
-            f"The maximum value for {column} should be {column_maximums[column]}.",
-        )
+    check = check.hasMax(
+        column_name,
+        lambda x: x <= max_value,
+        f"The maximum value for {column_name} should be {max_value}.",
+    )
     return check
 
 


### PR DESCRIPTION
# Description
These changes fix a bug where adding multiple checks of the same type was producing incorrect results.

The bug occurred when constraints of the same type, but with different integer values were added to checks and produced different results depending on the order in which they were checked. By adding each constraint as a separate check to the run, I was able to avoid this problem.

# How to test
Unit tests passing
Run in branch: https://eu-west-2.console.aws.amazon.com/gluestudio/home?region=eu-west-2#/editor/job/fix-bug-with-multiple-checks-validate_merged_ind_cqc_data_job/runs


