### PR TITLE
Fix la names in pa estimates

### DIFF
--- a/jobs/estimate_direct_payments.py
+++ b/jobs/estimate_direct_payments.py
@@ -4,6 +4,9 @@ from utils import utils
 from utils.direct_payments_utils.direct_payments_column_names import (
     DirectPaymentColumnNames as DP,
 )
+from utils.direct_payments_utils.prepare_direct_payments.fix_la_names import (
+    change_la_names_to_match_ons_cleaned,
+)
 from utils.direct_payments_utils.estimate_direct_payments.estimate_service_users_employing_staff import (
     estimate_service_users_employing_staff,
 )
@@ -36,6 +39,7 @@ def main(
         DP.FILLED_POSTS_PER_EMPLOYER,
     )
 
+    direct_payments_df = change_la_names_to_match_ons_cleaned(direct_payments_df)
     direct_payments_df = estimate_service_users_employing_staff(direct_payments_df)
     direct_payments_df = calculate_remaining_variables(direct_payments_df)
     summary_direct_payments_df = create_summary_table(direct_payments_df)

--- a/jobs/split_pa_filled_posts_into_icb_areas.py
+++ b/jobs/split_pa_filled_posts_into_icb_areas.py
@@ -87,7 +87,7 @@ def main(postcode_directory_source, pa_filled_posts_source, destination):
         proportion_of_postcodes_per_hybrid_area_with_pa_filled_posts_df,
         destination,
         mode="overwrite",
-        partitionKeys=[ONSClean.contemporary_cssr],
+        partitionKeys=[DPColNames.YEAR],
     )
 
 

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -770,6 +770,18 @@ class PAFilledPostsByIcbArea:
     ]
     # fmt: on
 
+    sample_la_name_rows = [
+        ("Bath & N E Somerset"),
+        ("Bedford"),
+        (None),
+    ]
+
+    expected_la_names_with_correct_spelling_rows = [
+        ("Bath & N E Somerset", "Bath and North East Somerset"),
+        ("Bedford", "Bedford"),
+        (None, None),
+    ]
+
 
 @dataclass
 class CapacityTrackerCareHomeData:

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -771,15 +771,17 @@ class PAFilledPostsByIcbArea:
     # fmt: on
 
     sample_la_name_rows = [
-        ("Bath & N E Somerset"),
-        ("Bedford"),
-        (None),
+        ("Bath & N E Somerset",),
+        ("Southend",),
+        ("Bedford",),
+        (None,),
     ]
 
     expected_la_names_with_correct_spelling_rows = [
-        ("Bath & N E Somerset", "Bath and North East Somerset"),
-        ("Bedford", "Bedford"),
-        (None, None),
+        ("Bath and North East Somerset",),
+        ("Southend on Sea",),
+        ("Bedford",),
+        (None,),
     ]
 
 

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -579,11 +579,7 @@ class PAFilledPostsByIcbAreaSchema:
         ]
     )
 
-    sample_la_name_schema = StructType(
-        [
-            StructField(DP.LA_AREA, StringType(), True)
-        ]
-    )
+    sample_la_name_schema = StructType(StructField(DP.LA_AREA, StringType(), True))
 
     expected_la_names_with_correct_spelling_schema = sample_la_name_schema
 

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -581,16 +581,11 @@ class PAFilledPostsByIcbAreaSchema:
 
     sample_la_name_schema = StructType(
         [
-            StructField(DP.LA_AREA, StringType(), None)
+            StructField(DP.LA_AREA, StringType(), True)
         ]
     )
 
-    expected_la_names_with_correct_spelling_schema = StructType(
-        [
-            *sample_la_name_schema,
-            StructField(DP.LA_AREA_SPELLED_CORRECTLY, StringType(), None)
-        ]
-    )
+    expected_la_names_with_correct_spelling_schema = sample_la_name_schema
 
 
 @dataclass

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -579,7 +579,7 @@ class PAFilledPostsByIcbAreaSchema:
         ]
     )
 
-    sample_la_name_schema = StructType(StructField(DP.LA_AREA, StringType(), True))
+    sample_la_name_schema = StructType([StructField(DP.LA_AREA, StringType(), True)])
 
     expected_la_names_with_correct_spelling_schema = sample_la_name_schema
 

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -579,6 +579,19 @@ class PAFilledPostsByIcbAreaSchema:
         ]
     )
 
+    sample_la_name_schema = StructType(
+        [
+            StructField(DP.LA_AREA, StringType(), None)
+        ]
+    )
+
+    expected_la_names_with_correct_spelling_schema = StructType(
+        [
+            *sample_la_name_schema,
+            StructField(DP.LA_AREA_SPELLED_CORRECTLY, StringType(), None)
+        ]
+    )
+
 
 @dataclass
 class CapacityTrackerCareHomeSchema:

--- a/tests/unit/test_dpr_fix_la_names.py
+++ b/tests/unit/test_dpr_fix_la_names.py
@@ -1,0 +1,15 @@
+import unittest
+
+from utils import utils
+
+from tests.test_file_data import PAFilledPostsByIcbArea as TestData
+from tests.test_file_schemas import PAFilledPostsByIcbAreaSchema as TestSchema
+
+from utils.direct_payments_utils.direct_payments_column_names import (
+    DirectPaymentColumnNames as DPColNames,
+)
+from utils.column_names.cleaned_data_files.ons_cleaned_values import (
+    OnsCleanedColumns as ONSClean,
+)
+
+import utils.direct_payments_utils.prepare_direct_payments.fix_la_names as job

--- a/tests/unit/test_dpr_fix_la_names.py
+++ b/tests/unit/test_dpr_fix_la_names.py
@@ -5,11 +5,32 @@ from utils import utils
 from tests.test_file_data import PAFilledPostsByIcbArea as TestData
 from tests.test_file_schemas import PAFilledPostsByIcbAreaSchema as TestSchema
 
-from utils.direct_payments_utils.direct_payments_column_names import (
-    DirectPaymentColumnNames as DPColNames,
-)
-from utils.column_names.cleaned_data_files.ons_cleaned_values import (
-    OnsCleanedColumns as ONSClean,
-)
-
 import utils.direct_payments_utils.prepare_direct_payments.fix_la_names as job
+
+
+class ChangeLaNamesToMatchOnsCleanedLaNames(unittest.TestCase):
+    def setUp(self):
+        self.spark = utils.get_spark()
+
+        self.sample_df = self.spark.createDataFrame(
+            TestData.sample_la_name_rows, schema=TestSchema.sample_la_name_schema
+        )
+
+        self.returned_df = job.change_la_names_to_match_ons_cleaned(self.sample_df)
+
+        self.expected_df = self.spark.createDataFrame(
+            TestData.expected_la_names_with_correct_spelling_rows,
+            schema=TestSchema.expected_la_names_with_correct_spelling_schema,
+        )
+
+    def test_change_la_names_to_match_ons_cleaned_does_not_add_any_columns(self):
+        self.assertEqual(self.returned_df.columns, self.expected_df.columns)
+
+    def test_change_la_names_to_match_ons_cleaned_does_not_add_any_rows(self):
+        self.assertEqual(self.returned_df.count(), self.expected_df.count())
+
+    def test_change_la_names_to_match_ons_cleaned_has_expected_values(self):
+        returned_rows = self.returned_df.collect()
+        expected_rows = self.expected_df.collect()
+
+        self.assertEqual(returned_rows, expected_rows)

--- a/tests/unit/test_dpr_split_pa_filled_posts_into_icb_areas.py
+++ b/tests/unit/test_dpr_split_pa_filled_posts_into_icb_areas.py
@@ -51,7 +51,7 @@ class MainTests(SplitPAFilledPostsIntoIcbAreas):
             ANY,
             self.TEST_DESTINATION,
             mode="overwrite",
-            partitionKeys=[ONSClean.contemporary_cssr],
+            partitionKeys=[DPColNames.YEAR],
         )
 
 

--- a/tests/unit/test_dpr_split_pa_filled_posts_into_icb_areas.py
+++ b/tests/unit/test_dpr_split_pa_filled_posts_into_icb_areas.py
@@ -17,6 +17,7 @@ from utils.column_names.cleaned_data_files.ons_cleaned_values import (
 import jobs.split_pa_filled_posts_into_icb_areas as job
 
 
+# test
 class SplitPAFilledPostsIntoIcbAreas(unittest.TestCase):
     TEST_ONS_SOURCE = "some/directory"
     TEST_PA_SOURCE = "some/directory"

--- a/tests/unit/test_dpr_split_pa_filled_posts_into_icb_areas.py
+++ b/tests/unit/test_dpr_split_pa_filled_posts_into_icb_areas.py
@@ -17,7 +17,6 @@ from utils.column_names.cleaned_data_files.ons_cleaned_values import (
 import jobs.split_pa_filled_posts_into_icb_areas as job
 
 
-# test
 class SplitPAFilledPostsIntoIcbAreas(unittest.TestCase):
     TEST_ONS_SOURCE = "some/directory"
     TEST_PA_SOURCE = "some/directory"

--- a/utils/direct_payments_utils/direct_payments_column_names.py
+++ b/utils/direct_payments_utils/direct_payments_column_names.py
@@ -172,9 +172,6 @@ class DirectPaymentColumnNames:
         "estimated_total_personal_assistant_filled_posts_per_icb"
     )
 
-    # Make DPR LA names match ONS Cleaned LA names.
-    LA_AREA_SPELLED_CORRECTLY: str = "la_area_spelled_correctly"
-
 
 @dataclass
 class DirectPaymentColumnValues:

--- a/utils/direct_payments_utils/direct_payments_column_names.py
+++ b/utils/direct_payments_utils/direct_payments_column_names.py
@@ -172,6 +172,9 @@ class DirectPaymentColumnNames:
         "estimated_total_personal_assistant_filled_posts_per_icb"
     )
 
+    # Make DPR LA names match ONS Cleaned LA names.
+    LA_AREA_SPELLED_CORRECTLY: str = "la_area_spelled_correctly"
+
 
 @dataclass
 class DirectPaymentColumnValues:

--- a/utils/direct_payments_utils/direct_payments_configuration.py
+++ b/utils/direct_payments_utils/direct_payments_configuration.py
@@ -57,3 +57,24 @@ class DirectPaymentsMissingPARatios:
 class EstimatePeriodAsDate:
     MONTH: str = "03"
     DAY: str = "31"
+
+
+@dataclass
+class DirectPaymentsMisspelledLaNames:
+    LIST_OF_INCORRECT_LA_NAMES = [
+        "Bath & N E Somerset",
+        "Blackburn",
+        "Bournemouth, Christchurch and Poole",
+        "East Riding",
+        "Medway Towns",
+        "Southend",
+    ]
+
+    LIST_OF_CORRECT_LA_NAMES = [
+        "Bath and North East Somerset",
+        "Blackburn with Darwen",
+        "Bournemouth Christchurch and Poole",
+        "East Riding of Yorkshire",
+        "Medway",
+        "Southend on Sea",
+    ]

--- a/utils/direct_payments_utils/prepare_direct_payments/fix_la_names.py
+++ b/utils/direct_payments_utils/prepare_direct_payments/fix_la_names.py
@@ -1,0 +1,18 @@
+from pyspark.sql import (
+    DataFrame,
+    functions as F,
+)
+
+from utils import utils
+
+from utils.column_names.cleaned_data_files.ons_cleaned_values import (
+    OnsCleanedColumns as ONSClean,
+)
+from utils.direct_payments_utils.direct_payments_column_names import (
+    DirectPaymentColumnNames as DPColNames,
+)
+
+
+def change_la_names_to_match_ons_cleaned_la_names(
+    direct_payments_df: DataFrame,
+) -> DataFrame: ...

--- a/utils/direct_payments_utils/prepare_direct_payments/fix_la_names.py
+++ b/utils/direct_payments_utils/prepare_direct_payments/fix_la_names.py
@@ -1,18 +1,22 @@
 from pyspark.sql import (
     DataFrame,
-    functions as F,
 )
 
-from utils import utils
-
-from utils.column_names.cleaned_data_files.ons_cleaned_values import (
-    OnsCleanedColumns as ONSClean,
-)
 from utils.direct_payments_utils.direct_payments_column_names import (
     DirectPaymentColumnNames as DPColNames,
 )
+from utils.direct_payments_utils.direct_payments_configuration import (
+    DirectPaymentsMisspelledLaNames as LaNames,
+)
 
 
-def change_la_names_to_match_ons_cleaned_la_names(
+def change_la_names_to_match_ons_cleaned(
     direct_payments_df: DataFrame,
-) -> DataFrame: ...
+) -> DataFrame:
+    direct_payments_df = direct_payments_df.replace(
+        LaNames.LIST_OF_INCORRECT_LA_NAMES,
+        LaNames.LIST_OF_CORRECT_LA_NAMES,
+        DPColNames.LA_AREA,
+    )
+
+    return direct_payments_df


### PR DESCRIPTION
# Description
Some LA names are spelled differently in the PA estimates compared to the ONS cleaned postcode directory.
For example, the PA estimates has "Bath and N.E Somerset".
The LA names in the PA estimates need to be spelled as they are in the ONS, so that the datasets can be joined correctly.

I've added a new script in direct payment utils which replaces a given list with another list. The lists are stored in direct_payments_configuration.
Then inserted this function into the start of the estimate_direct_payments script.

Direct payments step function runs successfully in branch:
https://eu-west-2.console.aws.amazon.com/states/home?region=eu-west-2#/v2/executions/details/arn:aws:states:eu-west-2:344210435447:execution:fix-la-names-in-pa-estimates-DirectPaymentRecipientsPipeline:b5c4195a-575a-4e73-aa3a-bd1d595de76e

Job to split PA estimates into ICB's also runs successfully, however still has partition key issues:
https://eu-west-2.console.aws.amazon.com/gluestudio/home?region=eu-west-2#/editor/job/fix-la-names-in-pa-estimates-split_pa_filled_posts_into_icb_areas_job/runs

Link to Trello:
https://trello.com/c/KhAh7ncX

# How to test

# Developer checklist
- [x] Unit test
- [x] Linked to Trello ticket
- [ ] Documentation up to date
