### PR TITLE
Rename coverage df

### DIFF
--- a/jobs/clean_ascwds_workplace_data.py
+++ b/jobs/clean_ascwds_workplace_data.py
@@ -74,9 +74,10 @@ def main(
         add_as_new_column=False,
     )
 
-    ascwds_workplace_df, reconciliation_df = (
-        create_purged_dfs_for_reconciliation_and_data(ascwds_workplace_df)
-    )
+    (
+        ascwds_workplace_df,
+        reconciliation_df,
+    ) = create_purged_dfs_for_reconciliation_and_data(ascwds_workplace_df)
 
     ascwds_workplace_df = remove_workplaces_with_duplicate_location_ids(
         ascwds_workplace_df

--- a/jobs/clean_ascwds_workplace_data.py
+++ b/jobs/clean_ascwds_workplace_data.py
@@ -47,7 +47,7 @@ cols_required_for_reconciliation_df = [
 def main(
     ascwds_workplace_source: str,
     cleaned_ascwds_workplace_destination: str,
-    reconciliation_file_destination: str,
+    workplace_for_reconciliation_destination: str,
 ):
     ascwds_workplace_df = utils.read_from_parquet(ascwds_workplace_source)
 
@@ -102,11 +102,11 @@ def main(
     reconciliation_df = select_columns_required_for_reconciliation_df(reconciliation_df)
 
     print(
-        f"Exporting ascwds workplace reconciliation data as parquet to {reconciliation_file_destination}"
+        f"Exporting ascwds workplace reconciliation data as parquet to {workplace_for_reconciliation_destination}"
     )
     utils.write_to_parquet(
         reconciliation_df,
-        reconciliation_file_destination,
+        workplace_for_reconciliation_destination,
         mode="overwrite",
         partitionKeys=partition_keys,
     )
@@ -243,7 +243,7 @@ if __name__ == "__main__":
     (
         ascwds_workplace_source,
         cleaned_ascwds_workplace_destination,
-        reconciliation_file_destination,
+        workplace_for_reconciliation_destination,
     ) = utils.collect_arguments(
         (
             "--ascwds_workplace_source",
@@ -254,14 +254,14 @@ if __name__ == "__main__":
             "Destination s3 directory for cleaned parquet ascwds workplace dataset",
         ),
         (
-            "--reconciliation_file_destination",
+            "--workplace_for_reconciliation_destination",
             "Destination s3 directory for ascwds reconciliation dataset",
         ),
     )
     main(
         ascwds_workplace_source,
         cleaned_ascwds_workplace_destination,
-        reconciliation_file_destination,
+        workplace_for_reconciliation_destination,
     )
 
     print("Spark job 'clean_ascwds_workplace_data' complete")

--- a/jobs/reconciliation.py
+++ b/jobs/reconciliation.py
@@ -36,7 +36,7 @@ cqc_locations_columns_to_import = [
 
 def main(
     cqc_location_api_source: str,
-    ascwds_coverage_source: str,
+    ascwds_reconciliation_source: str,
     reconciliation_single_and_subs_destination: str,
     reconciliation_parents_destination: str,
 ):
@@ -46,7 +46,7 @@ def main(
     cqc_location_df = utils.read_from_parquet(
         cqc_location_api_source, cqc_locations_columns_to_import
     )
-    ascwds_workplace_df = utils.read_from_parquet(ascwds_coverage_source)
+    ascwds_workplace_df = utils.read_from_parquet(ascwds_reconciliation_source)
 
     cqc_location_df = prepare_most_recent_cqc_location_df(cqc_location_df)
     (
@@ -421,7 +421,7 @@ if __name__ == "__main__":
 
     (
         cqc_location_api_source,
-        ascwds_coverage_source,
+        ascwds_reconciliation_source,
         reconciliation_single_and_subs_destination,
         reconciliation_parents_destination,
     ) = utils.collect_arguments(
@@ -430,8 +430,8 @@ if __name__ == "__main__":
             "Source s3 directory for initial CQC location api dataset",
         ),
         (
-            "--ascwds_coverage_source",
-            "Source s3 directory for ASCWDS coverage parquet dataset",
+            "--ascwds_reconciliation_source",
+            "Source s3 directory for ASCWDS reconciliation parquet dataset",
         ),
         (
             "--reconciliation_single_and_subs_destination",
@@ -444,7 +444,7 @@ if __name__ == "__main__":
     )
     main(
         cqc_location_api_source,
-        ascwds_coverage_source,
+        ascwds_reconciliation_source,
         reconciliation_single_and_subs_destination,
         reconciliation_parents_destination,
     )

--- a/terraform/pipeline/glue.tf
+++ b/terraform/pipeline/glue.tf
@@ -117,7 +117,7 @@ module "clean_ascwds_workplace_job" {
   job_parameters = {
     "--ascwds_workplace_source"              = "${module.datasets_bucket.bucket_uri}/domain=ASCWDS/dataset=workplace/"
     "--cleaned_ascwds_workplace_destination" = "${module.datasets_bucket.bucket_uri}/domain=ASCWDS/dataset=workplace_cleaned/"
-    "--reconciliation_file_destination"      = "${module.datasets_bucket.bucket_uri}/domain=SfC/dataset=workplace_for_reconciliation/"
+    "--workplace_for_reconciliation_destination"      = "${module.datasets_bucket.bucket_uri}/domain=SfC/dataset=workplace_for_reconciliation/"
   }
 }
 

--- a/terraform/pipeline/glue.tf
+++ b/terraform/pipeline/glue.tf
@@ -117,7 +117,7 @@ module "clean_ascwds_workplace_job" {
   job_parameters = {
     "--ascwds_workplace_source"              = "${module.datasets_bucket.bucket_uri}/domain=ASCWDS/dataset=workplace/"
     "--cleaned_ascwds_workplace_destination" = "${module.datasets_bucket.bucket_uri}/domain=ASCWDS/dataset=workplace_cleaned/"
-    "--reconciliation_file_destination"            = "${module.datasets_bucket.bucket_uri}/domain=SfC/dataset=workplace_for_reconciliation/"
+    "--reconciliation_file_destination"      = "${module.datasets_bucket.bucket_uri}/domain=SfC/dataset=workplace_for_reconciliation/"
   }
 }
 
@@ -355,7 +355,7 @@ module "reconciliation_job" {
 
   job_parameters = {
     "--cqc_location_api_source"                    = "${module.datasets_bucket.bucket_uri}/domain=CQC/dataset=locations_api/"
-    "--ascwds_coverage_source"                     = "${module.datasets_bucket.bucket_uri}/domain=SfC/dataset=coverage/"
+    "--ascwds_reconciliation_source"               = "${module.datasets_bucket.bucket_uri}/domain=SfC/dataset=workplace_for_reconciliation/"
     "--reconciliation_single_and_subs_destination" = "${module.datasets_bucket.bucket_uri}/domain=SfC/dataset=reconciliation/singles_and_subs"
     "--reconciliation_parents_destination"         = "${module.datasets_bucket.bucket_uri}/domain=SfC/dataset=reconciliation/parents"
   }

--- a/terraform/pipeline/glue.tf
+++ b/terraform/pipeline/glue.tf
@@ -117,7 +117,7 @@ module "clean_ascwds_workplace_job" {
   job_parameters = {
     "--ascwds_workplace_source"              = "${module.datasets_bucket.bucket_uri}/domain=ASCWDS/dataset=workplace/"
     "--cleaned_ascwds_workplace_destination" = "${module.datasets_bucket.bucket_uri}/domain=ASCWDS/dataset=workplace_cleaned/"
-    "--coverage_file_destination"            = "${module.datasets_bucket.bucket_uri}/domain=SfC/dataset=coverage/"
+    "--reconciliation_file_destination"            = "${module.datasets_bucket.bucket_uri}/domain=SfC/dataset=workplace_for_reconciliation/"
   }
 }
 

--- a/terraform/pipeline/glue.tf
+++ b/terraform/pipeline/glue.tf
@@ -115,9 +115,9 @@ module "clean_ascwds_workplace_job" {
   glue_version    = "3.0"
 
   job_parameters = {
-    "--ascwds_workplace_source"              = "${module.datasets_bucket.bucket_uri}/domain=ASCWDS/dataset=workplace/"
-    "--cleaned_ascwds_workplace_destination" = "${module.datasets_bucket.bucket_uri}/domain=ASCWDS/dataset=workplace_cleaned/"
-    "--workplace_for_reconciliation_destination"      = "${module.datasets_bucket.bucket_uri}/domain=SfC/dataset=workplace_for_reconciliation/"
+    "--ascwds_workplace_source"                  = "${module.datasets_bucket.bucket_uri}/domain=ASCWDS/dataset=workplace/"
+    "--cleaned_ascwds_workplace_destination"     = "${module.datasets_bucket.bucket_uri}/domain=ASCWDS/dataset=workplace_cleaned/"
+    "--workplace_for_reconciliation_destination" = "${module.datasets_bucket.bucket_uri}/domain=SfC/dataset=workplace_for_reconciliation/"
   }
 }
 

--- a/terraform/pipeline/step-functions/IndCqcFilledPostEstimatePipeline-StepFunction.json
+++ b/terraform/pipeline/step-functions/IndCqcFilledPostEstimatePipeline-StepFunction.json
@@ -16,7 +16,7 @@
                 "Arguments": {
                   "--ascwds_workplace_source": "${dataset_bucket_uri}/domain=ASCWDS/dataset=workplace/",
                   "--cleaned_ascwds_workplace_destination": "${dataset_bucket_uri}/domain=ASCWDS/dataset=workplace_cleaned/",
-                  "--coverage_file_destination": "${dataset_bucket_uri}/domain=SfC/dataset=coverage/"
+                  "--reconciliation_file_destination": "${dataset_bucket_uri}/domain=SfC/dataset=workplace_for_reconciliation/"
                 }
               },
               "Next": "Clean ASCWDS worker and SfC Reconciliation Parallel"
@@ -52,7 +52,7 @@
                         "JobName": "${reconciliation_job_name}",
                         "Arguments": {
                           "--cqc_location_api_source": "${dataset_bucket_uri}/domain=CQC/dataset=locations_api/",
-                          "--ascwds_coverage_source": "${dataset_bucket_uri}/domain=SfC/dataset=coverage/",
+                          "--ascwds_reconciliation_source": "${dataset_bucket_uri}/domain=SfC/dataset=workplace_for_reconciliation/",
                           "--reconciliation_single_and_subs_destination": "${dataset_bucket_uri}/domain=SfC/dataset=reconciliation/singles_and_subs",
                           "--reconciliation_parents_destination": "${dataset_bucket_uri}/domain=SfC/dataset=reconciliation/parents"
                         }

--- a/terraform/pipeline/step-functions/IndCqcFilledPostEstimatePipeline-StepFunction.json
+++ b/terraform/pipeline/step-functions/IndCqcFilledPostEstimatePipeline-StepFunction.json
@@ -16,7 +16,7 @@
                 "Arguments": {
                   "--ascwds_workplace_source": "${dataset_bucket_uri}/domain=ASCWDS/dataset=workplace/",
                   "--cleaned_ascwds_workplace_destination": "${dataset_bucket_uri}/domain=ASCWDS/dataset=workplace_cleaned/",
-                  "--reconciliation_file_destination": "${dataset_bucket_uri}/domain=SfC/dataset=workplace_for_reconciliation/"
+                  "--workplace_for_reconciliation_destination": "${dataset_bucket_uri}/domain=SfC/dataset=workplace_for_reconciliation/"
                 }
               },
               "Next": "Clean ASCWDS worker and SfC Reconciliation Parallel"


### PR DESCRIPTION
# Description
Rename the coverage dataframe and dataset to reflect that it feeds reconciliation and not coverage tasks

# How to test
Unit tests passing
Run in branch: https://eu-west-2.console.aws.amazon.com/states/home?region=eu-west-2#/v2/executions/details/arn:aws:states:eu-west-2:344210435447:execution:rename-coverage-df-Ind-CQC-Filled-Post-Estimates-Pipeline:117a55aa-e5b0-4d02-bd57-4ec365f23337

# Developer checklist
- [ ] Unit test
- [ ] Linked to Trello ticket
- [ ] Documentation up to date
