### PR TITLE
Create merge job for coverage

### DIFF
--- a/jobs/clean_ascwds_workplace_data.py
+++ b/jobs/clean_ascwds_workplace_data.py
@@ -37,6 +37,8 @@ cols_required_for_reconciliation_df = [
     AWPClean.main_service_id,
     AWPClean.establishment_name,
     AWPClean.region_id,
+    AWPClean.total_staff,
+    AWPClean.worker_records,
     Keys.year,
     Keys.month,
     Keys.day,

--- a/jobs/merge_coverage_data.py
+++ b/jobs/merge_coverage_data.py
@@ -1,0 +1,156 @@
+import sys
+
+from pyspark.sql.dataframe import DataFrame
+
+from utils import utils
+import utils.cleaning_utils as cUtils
+from utils.column_names.cleaned_data_files.cqc_location_cleaned import (
+    CqcLocationCleanedColumns as CQCLClean,
+)
+from utils.column_names.cleaned_data_files.ons_cleaned import (
+    OnsCleanedColumns as ONSClean,
+)
+from utils.column_names.cleaned_data_files.ascwds_workplace_cleaned import (
+    AscwdsWorkplaceCleanedColumns as AWPClean,
+)
+from utils.column_names.ind_cqc_pipeline_columns import (
+    PartitionKeys as Keys,
+)
+
+PartitionKeys = [Keys.year, Keys.month, Keys.day, Keys.import_date]
+
+cleaned_cqc_locations_columns_to_import = [
+    CQCLClean.cqc_location_import_date,
+    CQCLClean.location_id,
+    CQCLClean.name,
+    CQCLClean.provider_id,
+    CQCLClean.provider_name,
+    CQCLClean.cqc_sector,
+    CQCLClean.registration_status,
+    CQCLClean.registration_date,
+    CQCLClean.dormancy,
+    CQCLClean.care_home,
+    CQCLClean.number_of_beds,
+    CQCLClean.regulated_activities,
+    CQCLClean.gac_service_types,
+    CQCLClean.services_offered,
+    CQCLClean.specialisms,
+    CQCLClean.primary_service_type,
+    ONSClean.contemporary_ons_import_date,
+    ONSClean.contemporary_cssr,
+    ONSClean.contemporary_icb,
+    ONSClean.contemporary_region,
+    ONSClean.current_ons_import_date,
+    ONSClean.current_cssr,
+    ONSClean.current_icb,
+    ONSClean.current_region,
+    ONSClean.current_rural_urban_ind_11,
+    Keys.year,
+    Keys.month,
+    Keys.day,
+    Keys.import_date,
+]
+cleaned_ascwds_workplace_columns_to_import = [
+    AWPClean.ascwds_workplace_import_date,
+    AWPClean.location_id,
+    AWPClean.establishment_id,
+    AWPClean.organisation_id,
+    AWPClean.total_staff_bounded,
+    AWPClean.worker_records_bounded,
+]
+
+
+def main(
+    cleaned_cqc_location_source: str,
+    workplace_for_reconciliation_source: str,
+    merged_coverage_destination: str,
+):
+    spark = utils.get_spark()
+    spark.sql(
+        "set spark.sql.broadcastTimeout = 2000"
+    )  # TODO: Test if this is needed still
+
+    cqc_location_df = utils.read_from_parquet(
+        cleaned_cqc_location_source,
+        selected_columns=cleaned_cqc_locations_columns_to_import,
+    )
+
+    ascwds_workplace_df = utils.read_from_parquet(
+        workplace_for_reconciliation_source,
+        selected_columns=cleaned_ascwds_workplace_columns_to_import,
+    )
+
+    merged_coverage_df = join_ascwds_data_into_cqc_location_df(
+        cqc_location_df,
+        ascwds_workplace_df,
+        CQCLClean.cqc_location_import_date,
+        AWPClean.ascwds_workplace_import_date,
+    )
+
+    utils.write_to_parquet(
+        merged_coverage_df,
+        merged_coverage_destination,
+        mode="overwrite",
+        partitionKeys=PartitionKeys,
+    )
+
+
+def join_ascwds_data_into_cqc_location_df(
+    cqc_location_df: DataFrame,
+    ascwds_workplace_df: DataFrame,
+    cqc_location_import_date_column: str,
+    ascwds_workplace_import_date_column: str,
+) -> DataFrame:
+    merged_coverage_ascwds_df_with_ascwds_workplace_import_date = (
+        cUtils.add_aligned_date_column(
+            cqc_location_df,
+            ascwds_workplace_df,
+            cqc_location_import_date_column,
+            ascwds_workplace_import_date_column,
+        )
+    )
+
+    formatted_ascwds_workplace_df = ascwds_workplace_df.withColumnRenamed(
+        AWPClean.location_id, CQCLClean.location_id
+    )
+
+    merged_coverage_df = (
+        merged_coverage_ascwds_df_with_ascwds_workplace_import_date.join(
+            formatted_ascwds_workplace_df,
+            [CQCLClean.location_id, AWPClean.ascwds_workplace_import_date],
+            how="left",
+        )
+    )
+
+    return merged_coverage_df
+
+
+if __name__ == "__main__":
+    print("Spark job 'merge_coverage_data' starting...")
+    print(f"Job parameters: {sys.argv}")
+
+    (
+        cleaned_cqc_location_source,
+        workplace_for_reconciliation_source,
+        merged_coverage_destination,
+    ) = utils.collect_arguments(
+        (
+            "--cleaned_cqc_location_source",
+            "Source s3 directory for parquet CQC locations cleaned dataset",
+        ),
+        (
+            "--workplace_for_reconciliation_source",
+            "Source s3 directory for parquet ASCWDS workplace for reconciliation dataset",
+        ),
+        (
+            "--merged_coverage_destination",
+            "Destination s3 directory for parquet",
+        ),
+    )
+    main(
+        cleaned_cqc_location_source,
+        workplace_for_reconciliation_source,
+        merged_coverage_destination,
+    )
+
+    print("Spark job 'merge_coverage_data' complete")

--- a/jobs/merge_coverage_data.py
+++ b/jobs/merge_coverage_data.py
@@ -36,10 +36,6 @@ cleaned_cqc_locations_columns_to_import = [
     CQCLClean.services_offered,
     CQCLClean.specialisms,
     CQCLClean.primary_service_type,
-    ONSClean.contemporary_ons_import_date,
-    ONSClean.contemporary_cssr,
-    ONSClean.contemporary_icb,
-    ONSClean.contemporary_region,
     ONSClean.current_ons_import_date,
     ONSClean.current_cssr,
     ONSClean.current_icb,
@@ -55,8 +51,8 @@ cleaned_ascwds_workplace_columns_to_import = [
     AWPClean.location_id,
     AWPClean.establishment_id,
     AWPClean.organisation_id,
-    AWPClean.total_staff_bounded,
-    AWPClean.worker_records_bounded,
+    AWPClean.total_staff,
+    AWPClean.worker_records,
 ]
 
 

--- a/terraform/pipeline/glue.tf
+++ b/terraform/pipeline/glue.tf
@@ -380,12 +380,12 @@ module "merge_ind_cqc_data_job" {
 }
 
 module "merge_coverage_data_job" {
-  source            = "../modules/glue-job"
-  script_name       = "merge_coverage_data.py"
-  glue_role         = aws_iam_role.sfc_glue_service_iam_role
-  resource_bucket   = module.pipeline_resources
-  datasets_bucket   = module.datasets_bucket
-  glue_version      = "3.0"
+  source          = "../modules/glue-job"
+  script_name     = "merge_coverage_data.py"
+  glue_role       = aws_iam_role.sfc_glue_service_iam_role
+  resource_bucket = module.pipeline_resources
+  datasets_bucket = module.datasets_bucket
+  glue_version    = "3.0"
 
   job_parameters = {
     "--cleaned_cqc_location_source"         = "${module.datasets_bucket.bucket_uri}/domain=CQC/dataset=locations_api_cleaned/"

--- a/terraform/pipeline/glue.tf
+++ b/terraform/pipeline/glue.tf
@@ -379,6 +379,23 @@ module "merge_ind_cqc_data_job" {
   }
 }
 
+module "merge_coverage_data_job" {
+  source            = "../modules/glue-job"
+  script_name       = "merge_coverage_data.py"
+  glue_role         = aws_iam_role.sfc_glue_service_iam_role
+  resource_bucket   = module.pipeline_resources
+  datasets_bucket   = module.datasets_bucket
+  glue_version      = "3.0"
+  worker_type       = "G.2X"
+  number_of_workers = 5
+
+  job_parameters = {
+    "--cleaned_cqc_location_source"         = "${module.datasets_bucket.bucket_uri}/domain=CQC/dataset=locations_api_cleaned/"
+    "--workplace_for_reconciliation_source" = "${module.datasets_bucket.bucket_uri}/domain=SfC/dataset=workplace_for_reconciliation/"
+    "--merged_coverage_destination"         = "${module.datasets_bucket.bucket_uri}/domain=SfC/dataset=merged_coverage_data/"
+  }
+}
+
 module "validate_locations_api_cleaned_data_job" {
   source          = "../modules/glue-job"
   script_name     = "validate_locations_api_cleaned_data.py"

--- a/terraform/pipeline/glue.tf
+++ b/terraform/pipeline/glue.tf
@@ -386,8 +386,6 @@ module "merge_coverage_data_job" {
   resource_bucket   = module.pipeline_resources
   datasets_bucket   = module.datasets_bucket
   glue_version      = "3.0"
-  worker_type       = "G.2X"
-  number_of_workers = 5
 
   job_parameters = {
     "--cleaned_cqc_location_source"         = "${module.datasets_bucket.bucket_uri}/domain=CQC/dataset=locations_api_cleaned/"

--- a/terraform/pipeline/step-function.tf
+++ b/terraform/pipeline/step-function.tf
@@ -13,6 +13,7 @@ resource "aws_sfn_state_machine" "ind-cqc-filled-post-estimates-pipeline-state-m
     clean_ons_data_job_name                                       = module.clean_ons_data_job.job_name
     reconciliation_job_name                                       = module.reconciliation_job.job_name
     merge_ind_cqc_data_job_name                                   = module.merge_ind_cqc_data_job.job_name
+    merge_coverage_data_job_name                                  = module.merge_coverage_data_job.job_name
     clean_ind_cqc_filled_posts_job_name                           = module.clean_ind_cqc_filled_posts_job.job_name
     validate_merged_ind_cqc_data_job_name                         = module.validate_merged_ind_cqc_data_job.job_name
     prepare_care_home_ind_cqc_features_job_name                   = module.prepare_care_home_ind_cqc_features_job.job_name

--- a/terraform/pipeline/step-functions/IndCqcFilledPostEstimatePipeline-StepFunction.json
+++ b/terraform/pipeline/step-functions/IndCqcFilledPostEstimatePipeline-StepFunction.json
@@ -318,7 +318,15 @@
                   "--merged_coverage_destination": "${dataset_bucket_uri}/domain=SfC/dataset=merged_coverage_data/"
                 }
               },
-              "End": true
+              "Next": "Run sfc crawler"
+            },
+            "Run sfc crawler": {
+              "Type": "Task",
+              "End": true,
+              "Parameters": {
+                "Name": "${sfc_crawler_name}"
+              },
+              "Resource": "arn:aws:states:::aws-sdk:glue:startCrawler"
             }
           }
         },
@@ -356,19 +364,6 @@
               "End": true,
               "Parameters": {
                 "Name": "${cqc_crawler_name}"
-              },
-              "Resource": "arn:aws:states:::aws-sdk:glue:startCrawler"
-            }
-          }
-        },
-        {
-          "StartAt": "Run sfc crawler",
-          "States": {
-            "Run sfc crawler": {
-              "Type": "Task",
-              "End": true,
-              "Parameters": {
-                "Name": "${sfc_crawler_name}"
               },
               "Resource": "arn:aws:states:::aws-sdk:glue:startCrawler"
             }

--- a/terraform/pipeline/step-functions/IndCqcFilledPostEstimatePipeline-StepFunction.json
+++ b/terraform/pipeline/step-functions/IndCqcFilledPostEstimatePipeline-StepFunction.json
@@ -305,6 +305,24 @@
           }
         },
         {
+          "StartAt": "Run merge coverage data job",
+          "States": {
+            "Run merge coverage data job": {
+              "Type": "Task",
+              "Resource": "arn:aws:states:::glue:startJobRun.sync",
+              "Parameters": {
+                "JobName": "${merge_coverage_data_job_name}",
+                "Arguments": {
+                  "--cleaned_cqc_location_source": "${dataset_bucket_uri}/domain=CQC/dataset=locations_api_cleaned/",
+                  "--workplace_for_reconciliation_source": "${dataset_bucket_uri}/domain=SfC/dataset=workplace_for_reconciliation/",
+                  "--merged_coverage_destination": "${dataset_bucket_uri}/domain=SfC/dataset=merged_coverage_data/"
+                }
+              },
+              "End": true
+            }
+          }
+        },
+        {
           "StartAt": "Run ascwds crawler",
           "States": {
             "Run ascwds crawler": {

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -1944,6 +1944,48 @@ class MergeIndCQCData:
 
 
 @dataclass
+class MergeCoverageData:
+    # fmt: off
+    clean_cqc_location_for_merge_rows = [
+        (date(2024, 1, 1), "1-000000001", "Independent", "Y", 10,),
+        (date(2024, 1, 1), "1-000000002", "Independent", "N", None,),
+        (date(2024, 1, 1), "1-000000003", "Independent", "N", None,),
+        (date(2024, 2, 1), "1-000000001", "Independent", "Y", 10,),
+        (date(2024, 2, 1), "1-000000002", "Independent", "N", None,),
+        (date(2024, 2, 1), "1-000000003", "Independent", "N", None,),
+        (date(2024, 3, 1), "1-000000001", "Independent", "Y", 10,),
+        (date(2024, 3, 1), "1-000000002", "Independent", "N", None,),
+        (date(2024, 3, 1), "1-000000003", "Independent", "N", None,),
+    ]
+    # fmt: on
+
+    # fmt: off
+    clean_ascwds_workplace_for_merge_rows = [
+        (date(2024, 1, 1), "1-000000001", "1", 1,),
+        (date(2024, 1, 1), "1-000000003", "3", 2,),
+        (date(2024, 1, 5), "1-000000001", "1", 3,),
+        (date(2024, 1, 9), "1-000000001", "1", 4,),
+        (date(2024, 1, 9), "1-000000003", "3", 5,),
+        (date(2024, 3, 1), "1-000000003", "4", 6,),
+    ]
+    # fmt: on
+
+    # fmt: off
+    expected_cqc_and_ascwds_merged_rows = [
+        ("1-000000001", date(2024, 1, 1), date(2024, 1, 1), "Independent", "Y", 10, "1", 1,),
+        ("1-000000002", date(2024, 1, 1), date(2024, 1, 1), "Independent", "N", None, None, None,),
+        ("1-000000003", date(2024, 1, 1), date(2024, 1, 1), "Independent", "N", None, "3", 2,),
+        ("1-000000001", date(2024, 1, 9), date(2024, 2, 1), "Independent", "Y", 10, "1", 4,),
+        ("1-000000002", date(2024, 1, 9), date(2024, 2, 1), "Independent", "N", None, None, None,),
+        ("1-000000003", date(2024, 1, 9), date(2024, 2, 1), "Independent", "N", None, "3", 5,),
+        ("1-000000001", date(2024, 3, 1), date(2024, 3, 1), "Independent", "Y", 10, None, None,),
+        ("1-000000002", date(2024, 3, 1), date(2024, 3, 1), "Independent", "N", None, None, None,),
+        ("1-000000003", date(2024, 3, 1), date(2024, 3, 1), "Independent", "N", None, "4", 6,),
+    ]
+    # fmt: on
+
+
+@dataclass
 class IndCQCDataUtils:
     input_rows_for_adding_estimate_filled_posts_and_source = [
         ("1-000001", 10.0, None, 80.0),

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -1412,7 +1412,6 @@ class MergeIndCQCData:
     )
 
 
-
 @dataclass
 class MergeCoverageData:
     clean_cqc_location_for_merge_schema = StructType(

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -1412,6 +1412,42 @@ class MergeIndCQCData:
     )
 
 
+
+@dataclass
+class MergeCoverageData:
+    clean_cqc_location_for_merge_schema = StructType(
+        [
+            StructField(CQCLClean.cqc_location_import_date, DateType(), True),
+            StructField(CQCLClean.location_id, StringType(), True),
+            StructField(CQCLClean.cqc_sector, StringType(), True),
+            StructField(CQCLClean.care_home, StringType(), True),
+            StructField(CQCLClean.number_of_beds, IntegerType(), True),
+        ]
+    )
+
+    clean_ascwds_workplace_for_merge_schema = StructType(
+        [
+            StructField(AWPClean.ascwds_workplace_import_date, DateType(), True),
+            StructField(AWPClean.location_id, StringType(), True),
+            StructField(AWPClean.establishment_id, StringType(), True),
+            StructField(AWPClean.total_staff, IntegerType(), True),
+        ]
+    )
+
+    expected_cqc_and_ascwds_merged_schema = StructType(
+        [
+            StructField(CQCLClean.location_id, StringType(), True),
+            StructField(AWPClean.ascwds_workplace_import_date, DateType(), True),
+            StructField(CQCLClean.cqc_location_import_date, DateType(), True),
+            StructField(CQCLClean.cqc_sector, StringType(), True),
+            StructField(CQCLClean.care_home, StringType(), True),
+            StructField(CQCLClean.number_of_beds, IntegerType(), True),
+            StructField(AWPClean.establishment_id, StringType(), True),
+            StructField(AWPClean.total_staff, IntegerType(), True),
+        ]
+    )
+
+
 @dataclass
 class IndCQCDataUtils:
     input_schema_for_adding_estimate_filled_posts_and_source = StructType(

--- a/tests/unit/test_merge_coverage_data.py
+++ b/tests/unit/test_merge_coverage_data.py
@@ -1,0 +1,146 @@
+import unittest
+
+from unittest.mock import ANY, Mock, patch
+
+import jobs.merge_ind_cqc_data as job
+
+from tests.test_file_data import MergeIndCQCData as Data
+from tests.test_file_schemas import MergeIndCQCData as Schemas
+
+from utils import utils
+from utils.column_names.ind_cqc_pipeline_columns import (
+    PartitionKeys as Keys,
+)
+from utils.column_names.cleaned_data_files.cqc_location_cleaned import (
+    CqcLocationCleanedColumns as CQCLClean,
+)
+from utils.column_names.cleaned_data_files.ascwds_workplace_cleaned import (
+    AscwdsWorkplaceCleanedColumns as AWPClean,
+)
+
+
+class MergeIndCQCDatasetTests(unittest.TestCase):
+    TEST_CQC_LOCATION_SOURCE = "some/directory"
+    TEST_CQC_PIR_SOURCE = "some/other/directory"
+    TEST_ASCWDS_WORKPLACE_SOURCE = "some/other/directory"
+    TEST_DESTINATION = "some/other/directory"
+    partition_keys = [Keys.year, Keys.month, Keys.day, Keys.import_date]
+
+    def setUp(self) -> None:
+        self.spark = utils.get_spark()
+        self.test_clean_cqc_location_df = self.spark.createDataFrame(
+            Data.clean_cqc_location_for_merge_rows,
+            Schemas.clean_cqc_location_for_merge_schema,
+        )
+        self.test_clean_cqc_pir_df = self.spark.createDataFrame(
+            Data.clean_cqc_pir_rows, Schemas.clean_cqc_pir_schema
+        )
+        self.test_clean_ascwds_workplace_df = self.spark.createDataFrame(
+            Data.clean_ascwds_workplace_for_merge_rows,
+            Schemas.clean_ascwds_workplace_for_merge_schema,
+        )
+
+    @patch("jobs.merge_ind_cqc_data.join_ascwds_data_into_merged_df")
+    @patch(
+        "jobs.merge_ind_cqc_data.filter_df_to_independent_sector_only",
+        wraps=job.filter_df_to_independent_sector_only,
+    )
+    @patch("utils.utils.write_to_parquet")
+    @patch("utils.utils.read_from_parquet")
+    def test_main_runs(
+        self,
+        read_from_parquet_patch: Mock,
+        write_to_parquet_patch: Mock,
+        filter_df_to_independent_sector_only: Mock,
+        join_ascwds_data_into_merged_df: Mock,
+    ):
+        read_from_parquet_patch.side_effect = [
+            self.test_clean_cqc_location_df,
+            self.test_clean_ascwds_workplace_df,
+            self.test_clean_cqc_pir_df,
+        ]
+
+        job.main(
+            self.TEST_CQC_LOCATION_SOURCE,
+            self.TEST_CQC_PIR_SOURCE,
+            self.TEST_ASCWDS_WORKPLACE_SOURCE,
+            self.TEST_DESTINATION,
+        )
+
+        self.assertEqual(read_from_parquet_patch.call_count, 3)
+
+        filter_df_to_independent_sector_only.assert_called_once_with(
+            self.test_clean_cqc_location_df
+        )
+        join_ascwds_data_into_merged_df.assert_called_once()
+
+        write_to_parquet_patch.assert_called_once_with(
+            ANY,
+            self.TEST_DESTINATION,
+            mode="overwrite",
+            partitionKeys=self.partition_keys,
+        )
+
+    def test_filter_df_to_independent_sector_only_keeps_independent_locations(
+        self,
+    ):
+        test_df = self.spark.createDataFrame(
+            Data.cqc_sector_rows, Schemas.cqc_sector_schema
+        )
+
+        returned_ind_cqc_df = job.filter_df_to_independent_sector_only(test_df)
+        returned_ind_cqc_data = returned_ind_cqc_df.collect()
+
+        expected_ind_cqc_data = self.spark.createDataFrame(
+            Data.expected_cqc_sector_rows, Schemas.cqc_sector_schema
+        ).collect()
+
+        self.assertEqual(returned_ind_cqc_data, expected_ind_cqc_data)
+
+    def test_join_ascwds_data_into_merged_df(self):
+        returned_df = job.join_ascwds_data_into_merged_df(
+            self.test_clean_cqc_location_df,
+            self.test_clean_ascwds_workplace_df,
+            CQCLClean.cqc_location_import_date,
+            AWPClean.ascwds_workplace_import_date,
+        )
+
+        expected_merged_df = self.spark.createDataFrame(
+            Data.expected_cqc_and_ascwds_merged_rows,
+            Schemas.expected_cqc_and_ascwds_merged_schema,
+        )
+
+        returned_data = returned_df.sort(
+            CQCLClean.cqc_location_import_date, CQCLClean.location_id
+        ).collect()
+        expected_data = expected_merged_df.sort(
+            CQCLClean.cqc_location_import_date, CQCLClean.location_id
+        ).collect()
+
+        self.assertEqual(returned_data, expected_data)
+
+    def test_join_pir_data_into_merged_df(self):
+        returned_df = job.join_pir_data_into_merged_df(
+            self.test_clean_cqc_location_df,
+            self.test_clean_cqc_pir_df,
+        )
+
+        expected_merged_df = self.spark.createDataFrame(
+            Data.expected_merged_cqc_and_pir,
+            Schemas.expected_cqc_and_pir_merged_schema,
+        )
+
+        returned_data = returned_df.sort(
+            CQCLClean.cqc_location_import_date, CQCLClean.location_id
+        ).collect()
+        expected_data = (
+            expected_merged_df.select(returned_df.columns)
+            .sort(CQCLClean.cqc_location_import_date, CQCLClean.location_id)
+            .collect()
+        )
+
+        self.assertEqual(returned_data, expected_data)
+
+
+if __name__ == "__main__":
+    unittest.main(warnings="ignore")

--- a/tests/unit/test_merge_coverage_data.py
+++ b/tests/unit/test_merge_coverage_data.py
@@ -2,10 +2,10 @@ import unittest
 
 from unittest.mock import ANY, Mock, patch
 
-import jobs.merge_ind_cqc_data as job
+import jobs.merge_coverage_data as job
 
-from tests.test_file_data import MergeIndCQCData as Data
-from tests.test_file_schemas import MergeIndCQCData as Schemas
+from tests.test_file_data import MergeCoverageData as Data
+from tests.test_file_schemas import MergeCoverageData as Schemas
 
 from utils import utils
 from utils.column_names.ind_cqc_pipeline_columns import (
@@ -19,9 +19,8 @@ from utils.column_names.cleaned_data_files.ascwds_workplace_cleaned import (
 )
 
 
-class MergeIndCQCDatasetTests(unittest.TestCase):
+class MergeCoverageDatasetTests(unittest.TestCase):
     TEST_CQC_LOCATION_SOURCE = "some/directory"
-    TEST_CQC_PIR_SOURCE = "some/other/directory"
     TEST_ASCWDS_WORKPLACE_SOURCE = "some/other/directory"
     TEST_DESTINATION = "some/other/directory"
     partition_keys = [Keys.year, Keys.month, Keys.day, Keys.import_date]
@@ -32,47 +31,34 @@ class MergeIndCQCDatasetTests(unittest.TestCase):
             Data.clean_cqc_location_for_merge_rows,
             Schemas.clean_cqc_location_for_merge_schema,
         )
-        self.test_clean_cqc_pir_df = self.spark.createDataFrame(
-            Data.clean_cqc_pir_rows, Schemas.clean_cqc_pir_schema
-        )
         self.test_clean_ascwds_workplace_df = self.spark.createDataFrame(
             Data.clean_ascwds_workplace_for_merge_rows,
             Schemas.clean_ascwds_workplace_for_merge_schema,
         )
 
-    @patch("jobs.merge_ind_cqc_data.join_ascwds_data_into_merged_df")
-    @patch(
-        "jobs.merge_ind_cqc_data.filter_df_to_independent_sector_only",
-        wraps=job.filter_df_to_independent_sector_only,
-    )
+    @patch("jobs.merge_coverage_data.join_ascwds_data_into_cqc_location_df")
     @patch("utils.utils.write_to_parquet")
     @patch("utils.utils.read_from_parquet")
     def test_main_runs(
         self,
         read_from_parquet_patch: Mock,
         write_to_parquet_patch: Mock,
-        filter_df_to_independent_sector_only: Mock,
-        join_ascwds_data_into_merged_df: Mock,
+        join_ascwds_data_into_cqc_location_df: Mock,
     ):
         read_from_parquet_patch.side_effect = [
             self.test_clean_cqc_location_df,
             self.test_clean_ascwds_workplace_df,
-            self.test_clean_cqc_pir_df,
         ]
 
         job.main(
             self.TEST_CQC_LOCATION_SOURCE,
-            self.TEST_CQC_PIR_SOURCE,
             self.TEST_ASCWDS_WORKPLACE_SOURCE,
             self.TEST_DESTINATION,
         )
 
         self.assertEqual(read_from_parquet_patch.call_count, 3)
 
-        filter_df_to_independent_sector_only.assert_called_once_with(
-            self.test_clean_cqc_location_df
-        )
-        join_ascwds_data_into_merged_df.assert_called_once()
+        join_ascwds_data_into_cqc_location_df.assert_called_once()
 
         write_to_parquet_patch.assert_called_once_with(
             ANY,
@@ -81,24 +67,8 @@ class MergeIndCQCDatasetTests(unittest.TestCase):
             partitionKeys=self.partition_keys,
         )
 
-    def test_filter_df_to_independent_sector_only_keeps_independent_locations(
-        self,
-    ):
-        test_df = self.spark.createDataFrame(
-            Data.cqc_sector_rows, Schemas.cqc_sector_schema
-        )
-
-        returned_ind_cqc_df = job.filter_df_to_independent_sector_only(test_df)
-        returned_ind_cqc_data = returned_ind_cqc_df.collect()
-
-        expected_ind_cqc_data = self.spark.createDataFrame(
-            Data.expected_cqc_sector_rows, Schemas.cqc_sector_schema
-        ).collect()
-
-        self.assertEqual(returned_ind_cqc_data, expected_ind_cqc_data)
-
-    def test_join_ascwds_data_into_merged_df(self):
-        returned_df = job.join_ascwds_data_into_merged_df(
+    def test_join_ascwds_data_into_cqc_location_df(self):
+        returned_df = job.join_ascwds_data_into_cqc_location_df(
             self.test_clean_cqc_location_df,
             self.test_clean_ascwds_workplace_df,
             CQCLClean.cqc_location_import_date,
@@ -116,28 +86,6 @@ class MergeIndCQCDatasetTests(unittest.TestCase):
         expected_data = expected_merged_df.sort(
             CQCLClean.cqc_location_import_date, CQCLClean.location_id
         ).collect()
-
-        self.assertEqual(returned_data, expected_data)
-
-    def test_join_pir_data_into_merged_df(self):
-        returned_df = job.join_pir_data_into_merged_df(
-            self.test_clean_cqc_location_df,
-            self.test_clean_cqc_pir_df,
-        )
-
-        expected_merged_df = self.spark.createDataFrame(
-            Data.expected_merged_cqc_and_pir,
-            Schemas.expected_cqc_and_pir_merged_schema,
-        )
-
-        returned_data = returned_df.sort(
-            CQCLClean.cqc_location_import_date, CQCLClean.location_id
-        ).collect()
-        expected_data = (
-            expected_merged_df.select(returned_df.columns)
-            .sort(CQCLClean.cqc_location_import_date, CQCLClean.location_id)
-            .collect()
-        )
 
         self.assertEqual(returned_data, expected_data)
 

--- a/tests/unit/test_merge_coverage_data.py
+++ b/tests/unit/test_merge_coverage_data.py
@@ -56,7 +56,7 @@ class MergeCoverageDatasetTests(unittest.TestCase):
             self.TEST_DESTINATION,
         )
 
-        self.assertEqual(read_from_parquet_patch.call_count, 3)
+        self.assertEqual(read_from_parquet_patch.call_count, 2)
 
         join_ascwds_data_into_cqc_location_df.assert_called_once()
 


### PR DESCRIPTION
# Description
Create a job to merge the reconciliation dataset with cqc locations data to create data for coverage

# How to test
Unit tests passing
Run in branch: https://eu-west-2.console.aws.amazon.com/states/home?region=eu-west-2#/v2/executions/details/arn:aws:states:eu-west-2:344210435447:execution:create-merge-job-for-coverage-Ind-CQC-Filled-Post-Estimates-Pipeline:357d3d02-141c-4598-ada7-336502ed27b7

# Developer checklist
- [ ] Unit test
- [ ] Linked to Trello ticket
- [ ] Documentation up to date
