### PR TITLE
Optimise dpr by icb job

### DIFF
--- a/jobs/split_pa_filled_posts_into_icb_areas.py
+++ b/jobs/split_pa_filled_posts_into_icb_areas.py
@@ -102,7 +102,7 @@ def count_postcodes_per_list_of_columns(
 
     postcode_directory_df = postcode_directory_df.withColumn(
         new_column_name,
-        F.size(F.collect_set(ONSClean.postcode).over(w)),
+        F.approx_count_distinct(ONSClean.postcode).over(w),
     )
 
     return postcode_directory_df

--- a/jobs/split_pa_filled_posts_into_icb_areas.py
+++ b/jobs/split_pa_filled_posts_into_icb_areas.py
@@ -6,6 +6,8 @@ from pyspark.sql import (
 
 from datetime import date
 
+from pyspark.sql.types import StringType
+
 from utils import utils, cleaning_utils
 
 from utils.column_names.cleaned_data_files.ons_cleaned import (
@@ -36,6 +38,7 @@ def main(postcode_directory_source, pa_filled_posts_source, destination):
             DPColNames.LA_AREA,
             DPColNames.ESTIMATED_TOTAL_PERSONAL_ASSISTANT_FILLED_POSTS,
             DPColNames.YEAR,
+            DPColNames.YEAR_AS_INTEGER,
         ],
     )
 
@@ -140,7 +143,7 @@ def create_date_column_from_year_in_pa_estimates(
         DPColNames.ESTIMATE_PERIOD_AS_DATE,
         F.to_date(
             F.concat(
-                F.col(DPColNames.YEAR),
+                F.lit(F.col(DPColNames.YEAR_AS_INTEGER) + 1).cast(StringType()),
                 F.lit(f"-{EstimatePeriodAsDate.MONTH}-{EstimatePeriodAsDate.DAY}"),
             )
         ),

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -729,15 +729,15 @@ class PAFilledPostsByIcbArea:
     # fmt: on
 
     sample_pa_filled_posts_rows = [
-        ("Leeds", 100.2, "2024"),
-        ("Bradford", 200.3, "2024"),
-        ("Hull", 300.3, "2023"),
+        ("Leeds", 100.2, 2023),
+        ("Bradford", 200.3, 2023),
+        ("Hull", 300.3, 2022),
     ]
 
     expected_create_date_column_from_year_in_pa_estimates_rows = [
-        ("Leeds", 100.2, "2024", date(2024, 3, 31)),
-        ("Bradford", 200.3, "2024", date(2024, 3, 31)),
-        ("Hull", 300.3, "2023", date(2023, 3, 31)),
+        ("Leeds", 100.2, 2023, date(2024, 3, 31)),
+        ("Bradford", 200.3, 2023, date(2024, 3, 31)),
+        ("Hull", 300.3, 2022, date(2023, 3, 31)),
     ]
 
     sample_postcode_proportions_before_joining_pa_filled_posts_rows = [
@@ -749,18 +749,18 @@ class PAFilledPostsByIcbArea:
     ]
 
     sample_pa_filled_posts_prepared_for_joining_to_postcode_proportions_rows = [
-        ("Leeds", 100.2, "2024", date(2024, 3, 31)),
-        ("Bradford", 200.3, "2024", date(2024, 3, 31)),
-        ("Leeds", 300.3, "2023", date(2023, 3, 31)),
-        ("Barking and Dagenham", 300.3, "2023", date(2023, 3, 31)),
+        ("Leeds", 100.2, 2023, date(2024, 3, 31)),
+        ("Bradford", 200.3, 2023, date(2024, 3, 31)),
+        ("Leeds", 300.3, 2022, date(2023, 3, 31)),
+        ("Barking and Dagenham", 300.3, 2022, date(2023, 3, 31)),
     ]
 
     # fmt: off
     expected_postcode_proportions_after_joining_pa_filled_posts_rows = [
-        (date(2023,5,1), "Leeds", "icb1", 1.00000, 100.2, "2024"),
-        (date(2023,5,1), "Bradford", "icb2", 0.25000, 200.3, "2024"), 
-        (date(2023,5,1), "Bradford", "icb3", 0.75000, 200.3, "2024"), 
-        (date(2022,5,1), "Leeds", "icb1", 1.00000, 300.3, "2023"),
+        (date(2023,5,1), "Leeds", "icb1", 1.00000, 100.2, 2023),
+        (date(2023,5,1), "Bradford", "icb2", 0.25000, 200.3, 2023), 
+        (date(2023,5,1), "Bradford", "icb3", 0.75000, 200.3, 2023), 
+        (date(2022,5,1), "Leeds", "icb1", 1.00000, 300.3, 2022),
         (date(2022, 5, 1), "Barking & Dagenham", "icb4", 1.00000, None, None),
     ]
 

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -749,18 +749,18 @@ class PAFilledPostsByIcbArea:
     ]
 
     sample_pa_filled_posts_prepared_for_joining_to_postcode_proportions_rows = [
-        ("Leeds", 100.2, 2023, date(2024, 3, 31)),
-        ("Bradford", 200.3, 2023, date(2024, 3, 31)),
-        ("Leeds", 300.3, 2022, date(2023, 3, 31)),
-        ("Barking and Dagenham", 300.3, 2022, date(2023, 3, 31)),
+        ("Leeds", 100.2, "2023", date(2024, 3, 31)),
+        ("Bradford", 200.3, "2023", date(2024, 3, 31)),
+        ("Leeds", 300.3, "2022", date(2023, 3, 31)),
+        ("Barking and Dagenham", 300.3, "2022", date(2023, 3, 31)),
     ]
 
     # fmt: off
     expected_postcode_proportions_after_joining_pa_filled_posts_rows = [
-        (date(2023,5,1), "Leeds", "icb1", 1.00000, 100.2, 2023),
-        (date(2023,5,1), "Bradford", "icb2", 0.25000, 200.3, 2023), 
-        (date(2023,5,1), "Bradford", "icb3", 0.75000, 200.3, 2023), 
-        (date(2022,5,1), "Leeds", "icb1", 1.00000, 300.3, 2022),
+        (date(2023,5,1), "Leeds", "icb1", 1.00000, 100.2, "2023"),
+        (date(2023,5,1), "Bradford", "icb2", 0.25000, 200.3, "2023"), 
+        (date(2023,5,1), "Bradford", "icb3", 0.75000, 200.3, "2023"), 
+        (date(2022,5,1), "Leeds", "icb1", 1.00000, 300.3, "2022"),
         (date(2022, 5, 1), "Barking & Dagenham", "icb4", 1.00000, None, None),
     ]
 

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -729,15 +729,15 @@ class PAFilledPostsByIcbArea:
     # fmt: on
 
     sample_pa_filled_posts_rows = [
-        ("Leeds", 100.2, 2023),
-        ("Bradford", 200.3, 2023),
-        ("Hull", 300.3, 2022),
+        ("Leeds", 100.2, 2023, "2023"),
+        ("Bradford", 200.3, 2023, "2023"),
+        ("Hull", 300.3, 2022, "2023"),
     ]
 
     expected_create_date_column_from_year_in_pa_estimates_rows = [
-        ("Leeds", 100.2, 2023, date(2024, 3, 31)),
-        ("Bradford", 200.3, 2023, date(2024, 3, 31)),
-        ("Hull", 300.3, 2022, date(2023, 3, 31)),
+        ("Leeds", 100.2, 2023, "2023", date(2024, 3, 31)),
+        ("Bradford", 200.3, 2023, "2023", date(2024, 3, 31)),
+        ("Hull", 300.3, 2022, "2023", date(2023, 3, 31)),
     ]
 
     sample_postcode_proportions_before_joining_pa_filled_posts_rows = [

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -520,6 +520,7 @@ class PAFilledPostsByIcbAreaSchema:
                 DP.ESTIMATED_TOTAL_PERSONAL_ASSISTANT_FILLED_POSTS, DoubleType(), True
             ),
             StructField(DP.YEAR_AS_INTEGER, IntegerType(), True),
+            StructField(DP.YEAR, StringType(), True),
         ]
     )
 
@@ -543,7 +544,7 @@ class PAFilledPostsByIcbAreaSchema:
                     DoubleType(),
                     True,
                 ),
-                StructField(DP.YEAR, IntegerType(), True),
+                StructField(DP.YEAR, StringType(), True),
                 StructField(DP.ESTIMATE_PERIOD_AS_DATE, DateType(), True),
             ]
         )
@@ -555,7 +556,7 @@ class PAFilledPostsByIcbAreaSchema:
             StructField(
                 DP.ESTIMATED_TOTAL_PERSONAL_ASSISTANT_FILLED_POSTS, DoubleType(), True
             ),
-            StructField(DP.YEAR, IntegerType(), True),
+            StructField(DP.YEAR, StringType(), True),
         ]
     )
 

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -519,7 +519,7 @@ class PAFilledPostsByIcbAreaSchema:
             StructField(
                 DP.ESTIMATED_TOTAL_PERSONAL_ASSISTANT_FILLED_POSTS, DoubleType(), True
             ),
-            StructField(DP.YEAR, StringType(), True),
+            StructField(DP.YEAR_AS_INTEGER, IntegerType(), True),
         ]
     )
 
@@ -535,18 +535,7 @@ class PAFilledPostsByIcbAreaSchema:
     )
 
     sample_pa_filled_posts_prepared_for_joining_to_postcode_proportions_schema = (
-        StructType(
-            [
-                StructField(DP.LA_AREA, StringType(), True),
-                StructField(
-                    DP.ESTIMATED_TOTAL_PERSONAL_ASSISTANT_FILLED_POSTS,
-                    DoubleType(),
-                    True,
-                ),
-                StructField(DP.YEAR, StringType(), True),
-                StructField(DP.ESTIMATE_PERIOD_AS_DATE, DateType(), True),
-            ]
-        )
+        expected_create_date_column_from_year_in_pa_estimates_schema
     )
 
     expected_postcode_proportions_after_joining_pa_filled_posts_schema = StructType(
@@ -555,7 +544,7 @@ class PAFilledPostsByIcbAreaSchema:
             StructField(
                 DP.ESTIMATED_TOTAL_PERSONAL_ASSISTANT_FILLED_POSTS, DoubleType(), True
             ),
-            StructField(DP.YEAR, StringType(), True),
+            StructField(DP.YEAR_AS_INTEGER, IntegerType(), True),
         ]
     )
 

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -535,7 +535,18 @@ class PAFilledPostsByIcbAreaSchema:
     )
 
     sample_pa_filled_posts_prepared_for_joining_to_postcode_proportions_schema = (
-        expected_create_date_column_from_year_in_pa_estimates_schema
+        StructType(
+            [
+                StructField(DP.LA_AREA, StringType(), True),
+                StructField(
+                    DP.ESTIMATED_TOTAL_PERSONAL_ASSISTANT_FILLED_POSTS,
+                    DoubleType(),
+                    True,
+                ),
+                StructField(DP.YEAR, IntegerType(), True),
+                StructField(DP.ESTIMATE_PERIOD_AS_DATE, DateType(), True),
+            ]
+        )
     )
 
     expected_postcode_proportions_after_joining_pa_filled_posts_schema = StructType(
@@ -544,7 +555,7 @@ class PAFilledPostsByIcbAreaSchema:
             StructField(
                 DP.ESTIMATED_TOTAL_PERSONAL_ASSISTANT_FILLED_POSTS, DoubleType(), True
             ),
-            StructField(DP.YEAR_AS_INTEGER, IntegerType(), True),
+            StructField(DP.YEAR, IntegerType(), True),
         ]
     )
 


### PR DESCRIPTION
# Description
Changed the function to count postcodes per list of columns so it uses a pyspark friendly method, rather than set from collect.
Changed test data and test schema to match real DPR data (latest year of DPR estimates is 2023, so I removed references to 2024).
Changed the function to create an estimate period date to give the correct dates. For example, 2023 = 2024-03-31
So when this is used later in the assign dates before joining to postcode directory, it now joins to the correct postcode period.
For example, 2024-03-31 is assigned the date 2023-05-01

Link to Trello:
https://trello.com/c/5pnnHvPp

# How to test
Link to successful glue run:
https://eu-west-2.console.aws.amazon.com/gluestudio/home?region=eu-west-2#/editor/job/optimise-dpr-by-icb-job-split_pa_filled_posts_into_icb_areas_job/runs

# Developer checklist
- [x] Unit test
- [x] Linked to Trello ticket
- [ ] Documentation up to date
