### PR TITLE
Clean registration date column

### DIFF
--- a/jobs/clean_cqc_location_data.py
+++ b/jobs/clean_cqc_location_data.py
@@ -126,6 +126,9 @@ def create_cleaned_registration_date_column(cqc_df: DataFrame) -> DataFrame:
 
 
 def remove_time_from_date_column(df: DataFrame, column_name: str) -> DataFrame:
+    df = df.withColumn(
+        CQCL.registration_date, F.substring(CQCL.registration_date, 1, 10)
+    )
     return df
 
 

--- a/jobs/clean_cqc_location_data.py
+++ b/jobs/clean_cqc_location_data.py
@@ -1,6 +1,5 @@
 import sys
 import warnings
-from typing import Tuple
 
 from utils import utils
 import utils.cleaning_utils as cUtils

--- a/jobs/clean_cqc_location_data.py
+++ b/jobs/clean_cqc_location_data.py
@@ -126,9 +126,7 @@ def create_cleaned_registration_date_column(cqc_df: DataFrame) -> DataFrame:
 
 
 def remove_time_from_date_column(df: DataFrame, column_name: str) -> DataFrame:
-    df = df.withColumn(
-        CQCL.registration_date, F.substring(CQCL.registration_date, 1, 10)
-    )
+    df = df.withColumn(column_name, F.substring(column_name, 1, 10))
     return df
 
 

--- a/jobs/clean_cqc_location_data.py
+++ b/jobs/clean_cqc_location_data.py
@@ -134,6 +134,7 @@ def remove_time_from_date_column(df: DataFrame, column_name: str) -> DataFrame:
 
 
 def impute_missing_registration_dates(df: DataFrame) -> DataFrame:
+
     return df
 
 

--- a/jobs/clean_cqc_location_data.py
+++ b/jobs/clean_cqc_location_data.py
@@ -120,7 +120,10 @@ def main(
 
 
 def create_cleaned_registration_date_column(cqc_df: DataFrame) -> DataFrame:
-    cqc_df = remove_time_from_date_column(cqc_df, CQCL.registration_date)
+    cqc_df = cqc_df.withColumn(
+        CQCLClean.imputed_registration_date, cqc_df[CQCL.registration_date]
+    )
+    cqc_df = remove_time_from_date_column(cqc_df, CQCLClean.imputed_registration_date)
     cqc_df = impute_missing_registration_dates(cqc_df)
     return cqc_df
 

--- a/jobs/clean_cqc_location_data.py
+++ b/jobs/clean_cqc_location_data.py
@@ -83,6 +83,8 @@ def main(
         cleaned_ons_postcode_directory_source, selected_columns=ons_cols_to_import
     )
 
+    cqc_location_df = create_cleaned_registration_date_column(cqc_location_df)
+
     cqc_location_df = remove_non_social_care_locations(cqc_location_df)
     cqc_location_df = utils.format_date_fields(
         cqc_location_df,
@@ -115,6 +117,20 @@ def main(
         mode="overwrite",
         partitionKeys=cqcPartitionKeys,
     )
+
+
+def create_cleaned_registration_date_column(cqc_df: DataFrame) -> DataFrame:
+    cqc_df = remove_time_from_date_column(cqc_df, CQCL.registration_date)
+    cqc_df = impute_missing_registration_dates(cqc_df)
+    return cqc_df
+
+
+def remove_time_from_date_column(df: DataFrame, column_name: str) -> DataFrame:
+    return df
+
+
+def impute_missing_registration_dates(df: DataFrame) -> DataFrame:
+    return df
 
 
 def remove_non_social_care_locations(df: DataFrame) -> DataFrame:

--- a/jobs/clean_cqc_location_data.py
+++ b/jobs/clean_cqc_location_data.py
@@ -143,6 +143,17 @@ def impute_missing_registration_dates(df: DataFrame) -> DataFrame:
             ),
         ).otherwise(df[CQCLClean.imputed_registration_date]),
     )
+    df = df.withColumn(
+        CQCLClean.imputed_registration_date,
+        F.when(
+            df[CQCLClean.imputed_registration_date].isNull(),
+            F.regexp_replace(
+                F.min(Keys.import_date).over(Window.partitionBy(CQCL.location_id)),
+                "(\d{4})(\d{2})(\d{2})",
+                "$1-$2-$3",
+            ),
+        ).otherwise(df[CQCLClean.imputed_registration_date]),
+    )
     return df
 
 

--- a/jobs/merge_coverage_data.py
+++ b/jobs/merge_coverage_data.py
@@ -27,7 +27,7 @@ cleaned_cqc_locations_columns_to_import = [
     CQCLClean.provider_name,
     CQCLClean.cqc_sector,
     CQCLClean.registration_status,
-    CQCLClean.registration_date,
+    CQCLClean.imputed_registration_date,
     CQCLClean.dormancy,
     CQCLClean.care_home,
     CQCLClean.number_of_beds,

--- a/jobs/merge_ind_cqc_data.py
+++ b/jobs/merge_ind_cqc_data.py
@@ -38,7 +38,7 @@ cleaned_cqc_locations_columns_to_import = [
     CQCLClean.provider_name,
     CQCLClean.cqc_sector,
     CQCLClean.registration_status,
-    CQCLClean.registration_date,
+    CQCLClean.imputed_registration_date,
     CQCLClean.dormancy,
     CQCLClean.care_home,
     CQCLClean.number_of_beds,

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -1661,6 +1661,16 @@ class CQCLocationsData:
             ["Care home service without nursing", "Fake service"],
         ),
     ]
+    remove_time_from_date_column_rows =[
+        ("loc_1", "2018-01-01", "20240101"),
+        ("loc_1", "2018-01-01 00:00:00", "20231201"),
+        ("loc_1", None, "202311201"),
+    ]
+    expected_remove_time_from_date_column_rows =[
+        ("loc_1", "2018-01-01", "20240101"),
+        ("loc_1", "2018-01-01", "20231201"),
+        ("loc_1", None, "20231101"),
+    ]
 
 
 @dataclass

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -1661,16 +1661,42 @@ class CQCLocationsData:
             ["Care home service without nursing", "Fake service"],
         ),
     ]
+    # fmt: off
     remove_time_from_date_column_rows = [
+        ("loc_1", "2018-01-01", "20240101", "2018-01-01"),
+        ("loc_1", "2018-01-01 00:00:00", "20231201", "2018-01-01 00:00:00"),
+        ("loc_1", None, "20231101", None),
+        ("loc_2", None, "20240101", None),
+        ("loc_2", None, "20231201", None),
+        ("loc_2", None, "20231101", None),
+    ]
+    expected_remove_time_from_date_column_rows = [
+        ("loc_1", "2018-01-01", "20240101", "2018-01-01"),
+        ("loc_1", "2018-01-01 00:00:00", "20231201", "2018-01-01"),
+        ("loc_1", None, "20231101", None),
+        ("loc_2", None, "20240101", None),
+        ("loc_2", None, "20231201", None),
+        ("loc_2", None, "20231101", None),
+    ]
+    clean_registration_date_column_rows = [
         ("loc_1", "2018-01-01", "20240101"),
         ("loc_1", "2018-01-01 00:00:00", "20231201"),
         ("loc_1", None, "20231101"),
+        ("loc_2", None, "20240101"),
+        ("loc_2", None, "20231201"),
+        ("loc_2", None, "20231101"),
     ]
-    expected_remove_time_from_date_column_rows = [
-        ("loc_1", "2018-01-01", "20240101"),
-        ("loc_1", "2018-01-01", "20231201"),
-        ("loc_1", None, "20231101"),
+    expected_clean_registration_date_column_rows = [
+        ("loc_1", "2018-01-01", "20240101", "2018-01-01"),
+        ("loc_1", "2018-01-01 00:00:00", "20231201", "2018-01-01"),
+        ("loc_1", None, "20231101", "2018-01-01"),
+        ("loc_2", None, "20240101", "2023-11-01"),
+        ("loc_2", None, "20231201", "2023-11-01"),
+        ("loc_2", None, "20231101", "2023-11-01"),
     ]
+    impute_missing_registration_dates_rows=expected_remove_time_from_date_column_rows
+    expected_impute_missing_registration_dates_rows=expected_clean_registration_date_column_rows
+    # fmt: on
 
 
 @dataclass

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -1666,17 +1666,11 @@ class CQCLocationsData:
         ("loc_1", "2018-01-01", "20240101", "2018-01-01"),
         ("loc_1", "2018-01-01 00:00:00", "20231201", "2018-01-01 00:00:00"),
         ("loc_1", None, "20231101", None),
-        ("loc_2", None, "20240101", None),
-        ("loc_2", None, "20231201", None),
-        ("loc_2", None, "20231101", None),
     ]
     expected_remove_time_from_date_column_rows = [
         ("loc_1", "2018-01-01", "20240101", "2018-01-01"),
         ("loc_1", "2018-01-01 00:00:00", "20231201", "2018-01-01"),
         ("loc_1", None, "20231101", None),
-        ("loc_2", None, "20240101", None),
-        ("loc_2", None, "20231201", None),
-        ("loc_2", None, "20231101", None),
     ]
     clean_registration_date_column_rows = [
         ("loc_1", "2018-01-01", "20240101"),
@@ -1696,6 +1690,26 @@ class CQCLocationsData:
     ]
     impute_missing_registration_dates_rows=expected_remove_time_from_date_column_rows
     expected_impute_missing_registration_dates_rows=expected_clean_registration_date_column_rows
+    impute_missing_registration_dates_different_rows=[
+        ("loc_1", "2018-01-01", "20240101", "2018-01-01"),
+        ("loc_1", "2017-01-01 00:00:00", "20231201", "2017-01-01"),
+        ("loc_1", None, "20231101", None),
+    ]
+    expected_impute_missing_registration_dates_different_rows=[
+        ("loc_1", "2018-01-01", "20240101", "2018-01-01"),
+        ("loc_1", "2017-01-01 00:00:00", "20231201", "2017-01-01"),
+        ("loc_1", None, "20231101", "2017-01-01"),
+    ]
+    impute_missing_registration_dates_missing_rows=[
+        ("loc_2", None, "20240101", None),
+        ("loc_2", None, "20231201", None),
+        ("loc_2", None, "20231101", None),
+    ]
+    expected_impute_missing_registration_dates_missing_rows=[
+        ("loc_2", None, "20240101", "2023-11-01"),
+        ("loc_2", None, "20231201", "2023-11-01"),
+        ("loc_2", None, "20231101", "2023-11-01"),
+    ]
     # fmt: on
 
 

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -1698,13 +1698,11 @@ class CQCLocationsData:
         ("loc_1", "2018-01-01", "20240101", "2018-01-01"),
         ("loc_1", "2017-01-01 00:00:00", "20231201", "2017-01-01"),
         ("loc_1", None, "20231101", None),
-        ("loc_2", None, "20231101", None),
     ]
     expected_impute_missing_registration_dates_different_rows=[
         ("loc_1", "2018-01-01", "20240101", "2018-01-01"),
         ("loc_1", "2017-01-01 00:00:00", "20231201", "2017-01-01"),
         ("loc_1", None, "20231101", "2017-01-01"),
-        ("loc_2", None, "20231101", None),
     ]
     impute_missing_registration_dates_missing_rows=[
         ("loc_2", None, "20240101", None),

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -1689,16 +1689,22 @@ class CQCLocationsData:
         ("loc_2", None, "20231101", "2023-11-01"),
     ]
     impute_missing_registration_dates_rows=expected_remove_time_from_date_column_rows
-    expected_impute_missing_registration_dates_rows=expected_clean_registration_date_column_rows
+    expected_impute_missing_registration_dates_rows=[
+        ("loc_1", "2018-01-01", "20240101", "2018-01-01"),
+        ("loc_1", "2018-01-01 00:00:00", "20231201", "2018-01-01"),
+        ("loc_1", None, "20231101", "2018-01-01"),
+    ]
     impute_missing_registration_dates_different_rows=[
         ("loc_1", "2018-01-01", "20240101", "2018-01-01"),
         ("loc_1", "2017-01-01 00:00:00", "20231201", "2017-01-01"),
         ("loc_1", None, "20231101", None),
+        ("loc_2", None, "20231101", None),
     ]
     expected_impute_missing_registration_dates_different_rows=[
         ("loc_1", "2018-01-01", "20240101", "2018-01-01"),
         ("loc_1", "2017-01-01 00:00:00", "20231201", "2017-01-01"),
         ("loc_1", None, "20231101", "2017-01-01"),
+        ("loc_2", None, "20231101", None),
     ]
     impute_missing_registration_dates_missing_rows=[
         ("loc_2", None, "20240101", None),

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -1661,12 +1661,12 @@ class CQCLocationsData:
             ["Care home service without nursing", "Fake service"],
         ),
     ]
-    remove_time_from_date_column_rows =[
+    remove_time_from_date_column_rows = [
         ("loc_1", "2018-01-01", "20240101"),
         ("loc_1", "2018-01-01 00:00:00", "20231201"),
-        ("loc_1", None, "202311201"),
+        ("loc_1", None, "20231101"),
     ]
-    expected_remove_time_from_date_column_rows =[
+    expected_remove_time_from_date_column_rows = [
         ("loc_1", "2018-01-01", "20240101"),
         ("loc_1", "2018-01-01", "20231201"),
         ("loc_1", None, "20231101"),

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -1125,6 +1125,14 @@ class CQCLocationsSchema:
         ]
     )
 
+    clean_registration_column_schema = StructType(
+        [
+            StructField(CQCL.location_id, StringType(), True),
+            StructField(CQCL.registration_date, StringType(), True),
+            StructField(Keys.import_date, StringType(), True),
+        ]
+    )
+
 
 @dataclass
 class UtilsSchema:

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -1133,6 +1133,15 @@ class CQCLocationsSchema:
         ]
     )
 
+    expected_clean_registration_column_schema = StructType(
+        [
+            StructField(CQCL.location_id, StringType(), True),
+            StructField(CQCL.registration_date, StringType(), True),
+            StructField(Keys.import_date, StringType(), True),
+            StructField(CQCLClean.imputed_registration_date, StringType(), True),
+        ]
+    )
+
 
 @dataclass
 class UtilsSchema:

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -2244,7 +2244,7 @@ class ValidateMergedIndCqcData:
             StructField(IndCQC.provider_name, StringType(), True),
             StructField(IndCQC.cqc_sector, StringType(), True),
             StructField(IndCQC.registration_status, StringType(), True),
-            StructField(IndCQC.registration_date, DateType(), True),
+            StructField(IndCQC.imputed_registration_date, DateType(), True),
             StructField(IndCQC.dormancy, StringType(), True),
             StructField(IndCQC.number_of_beds, IntegerType(), True),
             StructField(
@@ -3069,7 +3069,7 @@ class ValidateLocationsAPICleanedData:
             StructField(CQCLClean.provider_name, StringType(), True),
             StructField(CQCLClean.cqc_sector, StringType(), True),
             StructField(CQCLClean.registration_status, StringType(), True),
-            StructField(CQCLClean.registration_date, DateType(), True),
+            StructField(CQCLClean.imputed_registration_date, DateType(), True),
             StructField(CQCLClean.dormancy, StringType(), True),
             StructField(CQCLClean.number_of_beds, IntegerType(), True),
             StructField(CQCLClean.primary_service_type, StringType(), True),
@@ -3193,7 +3193,7 @@ class ValidateCleanedIndCqcData:
             StructField(IndCQC.provider_name, StringType(), True),
             StructField(IndCQC.cqc_sector, StringType(), True),
             StructField(IndCQC.registration_status, StringType(), True),
-            StructField(IndCQC.registration_date, DateType(), True),
+            StructField(IndCQC.imputed_registration_date, DateType(), True),
             StructField(IndCQC.dormancy, StringType(), True),
             StructField(IndCQC.number_of_beds, IntegerType(), True),
             StructField(

--- a/tests/unit/test_clean_cqc_location_data.py
+++ b/tests/unit/test_clean_cqc_location_data.py
@@ -99,6 +99,23 @@ class MainTests(CleanCQCLocationDatasetTests):
             self.assertIn(col, expected_cols)
 
 
+class CleanRegistrationDateTests(CleanCQCLocationDatasetTests):
+    def setUp(self) -> None:
+        super().setUp()
+
+    def test_remove_time_from_date_column(self):
+        test_df = self.spark.createDataFrame(
+            Data.remove_time_from_date_column_rows,
+            Schemas.clean_registration_column_schema,
+        )
+        expected_df = self.spark.createDataFrame(
+            Data.expected_remove_time_from_date_column_rows,
+            Schemas.clean_registration_column_schema,
+        )
+        returned_df = job.remove_time_from_date_column(test_df, CQCL.registration_date)
+        self.assertEqual(expected_df.collect(), returned_df.collect())
+
+
 class RemovedNonSocialCareLocationsTests(CleanCQCLocationDatasetTests):
     def setUp(self) -> None:
         super().setUp()

--- a/tests/unit/test_clean_cqc_location_data.py
+++ b/tests/unit/test_clean_cqc_location_data.py
@@ -103,16 +103,44 @@ class CleanRegistrationDateTests(CleanCQCLocationDatasetTests):
     def setUp(self) -> None:
         super().setUp()
 
-    def test_remove_time_from_date_column(self):
+    def test_create_cleaned_registration_date_column(self):
         test_df = self.spark.createDataFrame(
-            Data.remove_time_from_date_column_rows,
+            Data.clean_registration_date_column_rows,
             Schemas.clean_registration_column_schema,
         )
         expected_df = self.spark.createDataFrame(
-            Data.expected_remove_time_from_date_column_rows,
-            Schemas.clean_registration_column_schema,
+            Data.expected_clean_registration_date_column_rows,
+            Schemas.expected_clean_registration_column_schema,
         )
-        returned_df = job.remove_time_from_date_column(test_df, CQCL.registration_date)
+        returned_df = job.create_cleaned_registration_date_column(test_df)
+        self.assertEqual(expected_df.collect(), returned_df.collect())
+
+    def test_remove_time_from_date_column(self):
+        test_df = self.spark.createDataFrame(
+            Data.remove_time_from_date_column_rows,
+            Schemas.expected_clean_registration_column_schema,
+        )
+        expected_df = self.spark.createDataFrame(
+            Data.expected_remove_time_from_date_column_rows,
+            Schemas.expected_clean_registration_column_schema,
+        )
+        returned_df = job.remove_time_from_date_column(
+            test_df, CQCLCleaned.imputed_registration_date
+        )
+        expected_df.show()
+        returned_df.show()
+        self.assertEqual(expected_df.collect(), returned_df.collect())
+
+    def test_impute_missing_registration_dates(self):
+        test_df = self.spark.createDataFrame(
+            Data.impute_missing_registration_dates_rows,
+            Schemas.expected_clean_registration_column_schema,
+        )
+        expected_df = self.spark.createDataFrame(
+            Data.expected_impute_missing_registration_dates_rows,
+            Schemas.expected_clean_registration_column_schema,
+        )
+        returned_df = job.impute_missing_registration_dates(test_df)
         self.assertEqual(expected_df.collect(), returned_df.collect())
 
 

--- a/tests/unit/test_clean_cqc_location_data.py
+++ b/tests/unit/test_clean_cqc_location_data.py
@@ -113,6 +113,8 @@ class CleanRegistrationDateTests(CleanCQCLocationDatasetTests):
             Schemas.expected_clean_registration_column_schema,
         )
         returned_df = job.create_cleaned_registration_date_column(test_df)
+        expected_df.show()
+        returned_df.show()
         self.assertEqual(expected_df.collect(), returned_df.collect())
 
     def test_remove_time_from_date_column(self):
@@ -141,6 +143,8 @@ class CleanRegistrationDateTests(CleanCQCLocationDatasetTests):
             Schemas.expected_clean_registration_column_schema,
         )
         returned_df = job.impute_missing_registration_dates(test_df)
+        expected_df.show()
+        returned_df.show()
         self.assertEqual(expected_df.collect(), returned_df.collect())
 
     def test_impute_missing_registration_dates_where_dates_are_different_return_min_registration_date(
@@ -155,6 +159,9 @@ class CleanRegistrationDateTests(CleanCQCLocationDatasetTests):
             Schemas.expected_clean_registration_column_schema,
         )
         returned_df = job.impute_missing_registration_dates(test_df)
+        test_df.show()
+        expected_df.show()
+        returned_df.show()
         self.assertEqual(expected_df.collect(), returned_df.collect())
 
     def test_impute_missing_registration_dates_where_dates_are_all_missing_returns_min_import_date(
@@ -169,6 +176,8 @@ class CleanRegistrationDateTests(CleanCQCLocationDatasetTests):
             Schemas.expected_clean_registration_column_schema,
         )
         returned_df = job.impute_missing_registration_dates(test_df)
+        expected_df.show()
+        returned_df.show()
         self.assertEqual(expected_df.collect(), returned_df.collect())
 
 

--- a/tests/unit/test_clean_cqc_location_data.py
+++ b/tests/unit/test_clean_cqc_location_data.py
@@ -131,13 +131,41 @@ class CleanRegistrationDateTests(CleanCQCLocationDatasetTests):
         returned_df.show()
         self.assertEqual(expected_df.collect(), returned_df.collect())
 
-    def test_impute_missing_registration_dates(self):
+    def test_impute_missing_registration_dates_where_dates_are_the_same(self):
         test_df = self.spark.createDataFrame(
             Data.impute_missing_registration_dates_rows,
             Schemas.expected_clean_registration_column_schema,
         )
         expected_df = self.spark.createDataFrame(
             Data.expected_impute_missing_registration_dates_rows,
+            Schemas.expected_clean_registration_column_schema,
+        )
+        returned_df = job.impute_missing_registration_dates(test_df)
+        self.assertEqual(expected_df.collect(), returned_df.collect())
+
+    def test_impute_missing_registration_dates_where_dates_are_different_return_min_registration_date(
+        self,
+    ):
+        test_df = self.spark.createDataFrame(
+            Data.impute_missing_registration_dates_different_rows,
+            Schemas.expected_clean_registration_column_schema,
+        )
+        expected_df = self.spark.createDataFrame(
+            Data.expected_impute_missing_registration_dates_different_rows,
+            Schemas.expected_clean_registration_column_schema,
+        )
+        returned_df = job.impute_missing_registration_dates(test_df)
+        self.assertEqual(expected_df.collect(), returned_df.collect())
+
+    def test_impute_missing_registration_dates_where_dates_are_all_missing_returns_min_import_date(
+        self,
+    ):
+        test_df = self.spark.createDataFrame(
+            Data.impute_missing_registration_dates_missing_rows,
+            Schemas.expected_clean_registration_column_schema,
+        )
+        expected_df = self.spark.createDataFrame(
+            Data.expected_impute_missing_registration_dates_missing_rows,
             Schemas.expected_clean_registration_column_schema,
         )
         returned_df = job.impute_missing_registration_dates(test_df)

--- a/tests/unit/test_clean_cqc_location_data.py
+++ b/tests/unit/test_clean_cqc_location_data.py
@@ -113,8 +113,6 @@ class CleanRegistrationDateTests(CleanCQCLocationDatasetTests):
             Schemas.expected_clean_registration_column_schema,
         )
         returned_df = job.create_cleaned_registration_date_column(test_df)
-        expected_df.show()
-        returned_df.show()
         self.assertEqual(expected_df.collect(), returned_df.collect())
 
     def test_remove_time_from_date_column(self):
@@ -129,8 +127,6 @@ class CleanRegistrationDateTests(CleanCQCLocationDatasetTests):
         returned_df = job.remove_time_from_date_column(
             test_df, CQCLCleaned.imputed_registration_date
         )
-        expected_df.show()
-        returned_df.show()
         self.assertEqual(expected_df.collect(), returned_df.collect())
 
     def test_impute_missing_registration_dates_where_dates_are_the_same(self):
@@ -143,8 +139,6 @@ class CleanRegistrationDateTests(CleanCQCLocationDatasetTests):
             Schemas.expected_clean_registration_column_schema,
         )
         returned_df = job.impute_missing_registration_dates(test_df)
-        expected_df.show()
-        returned_df.show()
         self.assertEqual(expected_df.collect(), returned_df.collect())
 
     def test_impute_missing_registration_dates_where_dates_are_different_return_min_registration_date(
@@ -159,9 +153,6 @@ class CleanRegistrationDateTests(CleanCQCLocationDatasetTests):
             Schemas.expected_clean_registration_column_schema,
         )
         returned_df = job.impute_missing_registration_dates(test_df)
-        test_df.show()
-        expected_df.show()
-        returned_df.show()
         self.assertEqual(expected_df.collect(), returned_df.collect())
 
     def test_impute_missing_registration_dates_where_dates_are_all_missing_returns_min_import_date(
@@ -176,8 +167,6 @@ class CleanRegistrationDateTests(CleanCQCLocationDatasetTests):
             Schemas.expected_clean_registration_column_schema,
         )
         returned_df = job.impute_missing_registration_dates(test_df)
-        expected_df.show()
-        returned_df.show()
         self.assertEqual(expected_df.collect(), returned_df.collect())
 
 

--- a/utils/column_names/cleaned_data_files/cqc_location_cleaned.py
+++ b/utils/column_names/cleaned_data_files/cqc_location_cleaned.py
@@ -22,3 +22,4 @@ class CqcLocationCleanedColumns(NewCqcLocationApiColumns, ONSClean):
     cqc_provider_import_date: str = CQCPClean.cqc_provider_import_date
     ons_contemporary_import_date: str = ONSClean.contemporary_ons_import_date
     ons_current_import_date: str = ONSClean.current_ons_import_date
+    imputed_registration_date: str = "imputed_registration_date"

--- a/utils/column_names/ind_cqc_pipeline_columns.py
+++ b/utils/column_names/ind_cqc_pipeline_columns.py
@@ -32,6 +32,7 @@ class IndCqcColumns:
     cqc_sector: str = CQCLClean.cqc_sector
     registration_status: str = CQCLClean.registration_status
     registration_date: str = CQCLClean.registration_date
+    imputed_registration_date: str = CQCLClean.imputed_registration_date
     dormancy: str = CQCLClean.dormancy
     care_home: str = CQCLClean.care_home
     number_of_beds: str = CQCLClean.number_of_beds

--- a/utils/validation/validation_rules/cleaned_ind_cqc_validation_rules.py
+++ b/utils/validation/validation_rules/cleaned_ind_cqc_validation_rules.py
@@ -21,7 +21,7 @@ class CleanedIndCqcValidationRules:
             IndCqcColumns.provider_id,
             IndCqcColumns.cqc_sector,
             IndCqcColumns.registration_status,
-            IndCqcColumns.registration_date,
+            IndCqcColumns.imputed_registration_date,
             IndCqcColumns.primary_service_type,
             IndCqcColumns.number_of_beds,
             IndCqcColumns.contemporary_ons_import_date,

--- a/utils/validation/validation_rules/locations_api_cleaned_validation_rules.py
+++ b/utils/validation/validation_rules/locations_api_cleaned_validation_rules.py
@@ -21,7 +21,7 @@ class LocationsAPICleanedValidationRules:
             CQCLClean.provider_id,
             CQCLClean.cqc_sector,
             CQCLClean.registration_status,
-            CQCLClean.registration_date,
+            CQCLClean.imputed_registration_date,
             CQCLClean.primary_service_type,
             CQCLClean.name,
             CQCLClean.provider_name,

--- a/utils/validation/validation_rules/locations_api_raw_validation_rules.py
+++ b/utils/validation/validation_rules/locations_api_raw_validation_rules.py
@@ -21,7 +21,6 @@ class LocationsAPIRawValidationRules:
             CQCL.care_home,
             CQCL.provider_id,
             CQCL.registration_status,
-            CQCL.registration_date,
             CQCL.name,
         ],
         RuleName.index_columns: [

--- a/utils/validation/validation_rules/merged_ind_cqc_validation_rules.py
+++ b/utils/validation/validation_rules/merged_ind_cqc_validation_rules.py
@@ -21,7 +21,7 @@ class MergedIndCqcValidationRules:
             IndCqcColumns.provider_id,
             IndCqcColumns.cqc_sector,
             IndCqcColumns.registration_status,
-            IndCqcColumns.registration_date,
+            IndCqcColumns.imputed_registration_date,
             IndCqcColumns.primary_service_type,
             IndCqcColumns.contemporary_ons_import_date,
             IndCqcColumns.contemporary_cssr,


### PR DESCRIPTION
# Description
Create a new column with a cleaned and imputed registration date value

# How to test
Unit tests passing
Run in branch: 
https://eu-west-2.console.aws.amazon.com/states/home?region=eu-west-2#/v2/executions/details/arn:aws:states:eu-west-2:344210435447:execution:remove-registration-date-times-Bronze-Validation-Pipeline:4dc09b75-b82a-47a0-92ac-ead9844923cc
https://eu-west-2.console.aws.amazon.com/states/home?region=eu-west-2#/v2/executions/details/arn:aws:states:eu-west-2:344210435447:execution:remove-registration-date-times-Ind-CQC-Filled-Post-Estimates-Pipeline:08d2fe9e-da1a-44ce-9949-3e61f2c6dfb0
[WIP] https://eu-west-2.console.aws.amazon.com/states/home?region=eu-west-2#/statemachines/view/arn%3Aaws%3Astates%3Aeu-west-2%3A344210435447%3AstateMachine%3Aremove-registration-date-times-Silver-Validation-Pipeline

