### PR TITLE
Improve dpr to icb job

### DIFF
--- a/jobs/split_pa_filled_posts_into_icb_areas.py
+++ b/jobs/split_pa_filled_posts_into_icb_areas.py
@@ -86,12 +86,6 @@ def main(postcode_directory_source, pa_filled_posts_source, destination):
         )
     )
 
-    proportion_of_postcodes_per_hybrid_area_with_pa_filled_posts_df = (
-        proportion_of_postcodes_per_hybrid_area_with_pa_filled_posts_df.drop(
-            DPColNames.ESTIMATED_TOTAL_PERSONAL_ASSISTANT_FILLED_POSTS
-        )
-    )
-
     utils.write_to_parquet(
         proportion_of_postcodes_per_hybrid_area_with_pa_filled_posts_df,
         destination,
@@ -198,6 +192,10 @@ def apply_icb_proportions_to_pa_filled_posts(
         DPColNames.ESTIMATED_TOTAL_PERSONAL_ASSISTANT_FILLED_POSTS_PER_HYBRID_AREA,
         F.col(DPColNames.ESTIMATED_TOTAL_PERSONAL_ASSISTANT_FILLED_POSTS)
         * F.col(DPColNames.PROPORTION_OF_ICB_POSTCODES_IN_LA_AREA),
+    )
+
+    postcode_directory_df = postcode_directory_df.drop(
+        DPColNames.ESTIMATED_TOTAL_PERSONAL_ASSISTANT_FILLED_POSTS
     )
 
     return postcode_directory_df

--- a/jobs/split_pa_filled_posts_into_icb_areas.py
+++ b/jobs/split_pa_filled_posts_into_icb_areas.py
@@ -189,7 +189,7 @@ def apply_icb_proportions_to_pa_filled_posts(
     postcode_directory_df: DataFrame,
 ) -> DataFrame:
     postcode_directory_df = postcode_directory_df.withColumn(
-        DPColNames.ESTIMATED_TOTAL_PERSONAL_ASSISTANT_FILLED_POSTS_PER_ICB,
+        DPColNames.ESTIMATED_TOTAL_PERSONAL_ASSISTANT_FILLED_POSTS_PER_HYBRID_AREA,
         F.col(DPColNames.ESTIMATED_TOTAL_PERSONAL_ASSISTANT_FILLED_POSTS)
         * F.col(DPColNames.PROPORTION_OF_ICB_POSTCODES_IN_LA_AREA),
     )

--- a/jobs/split_pa_filled_posts_into_icb_areas.py
+++ b/jobs/split_pa_filled_posts_into_icb_areas.py
@@ -86,6 +86,12 @@ def main(postcode_directory_source, pa_filled_posts_source, destination):
         )
     )
 
+    proportion_of_postcodes_per_hybrid_area_with_pa_filled_posts_df = (
+        proportion_of_postcodes_per_hybrid_area_with_pa_filled_posts_df.drop(
+            DPColNames.ESTIMATED_TOTAL_PERSONAL_ASSISTANT_FILLED_POSTS
+        )
+    )
+
     utils.write_to_parquet(
         proportion_of_postcodes_per_hybrid_area_with_pa_filled_posts_df,
         destination,

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -772,10 +772,10 @@ class PAFilledPostsByIcbArea:
     ]
 
     expected_pa_filled_posts_after_applying_proportions_rows = [
-        (0.25000, 100.2, 25.05000),
-        (None, 200.3, None),
-        (0.75000, None, None),
-        (None, None, None),
+        (0.25000, 25.05000),
+        (None, None),
+        (0.75000, None),
+        (None, None),
     ]
     # fmt: on
 

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -571,7 +571,7 @@ class PAFilledPostsByIcbAreaSchema:
 
     expected_pa_filled_posts_after_applying_proportions_schema = StructType(
         [
-            *sample_proportions_and_pa_filled_posts_schema,
+            StructField(DP.PROPORTION_OF_ICB_POSTCODES_IN_LA_AREA, FloatType(), True),
             StructField(
                 DP.ESTIMATED_TOTAL_PERSONAL_ASSISTANT_FILLED_POSTS_PER_HYBRID_AREA,
                 DoubleType(),

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -573,7 +573,7 @@ class PAFilledPostsByIcbAreaSchema:
         [
             *sample_proportions_and_pa_filled_posts_schema,
             StructField(
-                DP.ESTIMATED_TOTAL_PERSONAL_ASSISTANT_FILLED_POSTS_PER_ICB,
+                DP.ESTIMATED_TOTAL_PERSONAL_ASSISTANT_FILLED_POSTS_PER_HYBRID_AREA,
                 DoubleType(),
                 True,
             ),

--- a/tests/unit/test_dpr_split_pa_filled_posts_into_icb_areas.py
+++ b/tests/unit/test_dpr_split_pa_filled_posts_into_icb_areas.py
@@ -364,7 +364,7 @@ class ApplyIcbProportionsToPAEstimates(SplitPAFilledPostsIntoIcbAreas):
         self,
     ):
         self.assertTrue(
-            DPColNames.ESTIMATED_TOTAL_PERSONAL_ASSISTANT_FILLED_POSTS_PER_ICB
+            DPColNames.ESTIMATED_TOTAL_PERSONAL_ASSISTANT_FILLED_POSTS_PER_HYBRID_AREA
             in self.returned_apply_icb_proportions_to_pa_filled_posts_df.columns
         )
 
@@ -381,10 +381,10 @@ class ApplyIcbProportionsToPAEstimates(SplitPAFilledPostsIntoIcbAreas):
         for i in range(len(returned_rows)):
             self.assertAlmostEqual(
                 returned_rows[i][
-                    DPColNames.ESTIMATED_TOTAL_PERSONAL_ASSISTANT_FILLED_POSTS_PER_ICB
+                    DPColNames.ESTIMATED_TOTAL_PERSONAL_ASSISTANT_FILLED_POSTS_PER_HYBRID_AREA
                 ],
                 expected_rows[i][
-                    DPColNames.ESTIMATED_TOTAL_PERSONAL_ASSISTANT_FILLED_POSTS_PER_ICB
+                    DPColNames.ESTIMATED_TOTAL_PERSONAL_ASSISTANT_FILLED_POSTS_PER_HYBRID_AREA
                 ],
                 3,
                 "rows are not almost equal",

--- a/tests/unit/test_dpr_split_pa_filled_posts_into_icb_areas.py
+++ b/tests/unit/test_dpr_split_pa_filled_posts_into_icb_areas.py
@@ -352,12 +352,16 @@ class ApplyIcbProportionsToPAEstimates(SplitPAFilledPostsIntoIcbAreas):
             schema=TestSchema.expected_pa_filled_posts_after_applying_proportions_schema,
         )
 
-    def test_apply_icb_proportions_to_pa_filled_posts_adds_1_column(
+    def test_apply_icb_proportions_to_pa_filled_posts_drops_given_column(
         self,
     ):
-        self.assertEqual(
-            len(self.returned_apply_icb_proportions_to_pa_filled_posts_df.columns),
-            len(self.sample_apply_icb_proportions_to_pa_filled_posts_df.columns) + 1,
+        self.assertIn(
+            DPColNames.ESTIMATED_TOTAL_PERSONAL_ASSISTANT_FILLED_POSTS,
+            self.sample_apply_icb_proportions_to_pa_filled_posts_df.columns,
+        )
+        self.assertNotIn(
+            DPColNames.ESTIMATED_TOTAL_PERSONAL_ASSISTANT_FILLED_POSTS,
+            self.returned_apply_icb_proportions_to_pa_filled_posts_df.columns,
         )
 
     def test_apply_icb_proportions_to_pa_filled_posts_adds_given_column_name(

--- a/utils/direct_payments_utils/direct_payments_column_names.py
+++ b/utils/direct_payments_utils/direct_payments_column_names.py
@@ -168,8 +168,8 @@ class DirectPaymentColumnNames:
         "proportion_of_ICB_postcodes_in_la_area"
     )
     ESTIMATE_PERIOD_AS_DATE: str = "estimate_period_as_date"
-    ESTIMATED_TOTAL_PERSONAL_ASSISTANT_FILLED_POSTS_PER_ICB: str = (
-        "estimated_total_personal_assistant_filled_posts_per_icb"
+    ESTIMATED_TOTAL_PERSONAL_ASSISTANT_FILLED_POSTS_PER_HYBRID_AREA: str = (
+        "estimated_total_personal_assistant_filled_posts_per_hybrid_area"
     )
 
 

--- a/utils/direct_payments_utils/direct_payments_configuration.py
+++ b/utils/direct_payments_utils/direct_payments_configuration.py
@@ -61,20 +61,11 @@ class EstimatePeriodAsDate:
 
 @dataclass
 class DirectPaymentsMisspelledLaNames:
-    LIST_OF_INCORRECT_LA_NAMES = [
-        "Bath & N E Somerset",
-        "Blackburn",
-        "Bournemouth, Christchurch and Poole",
-        "East Riding",
-        "Medway Towns",
-        "Southend",
-    ]
-
-    LIST_OF_CORRECT_LA_NAMES = [
-        "Bath and North East Somerset",
-        "Blackburn with Darwen",
-        "Bournemouth Christchurch and Poole",
-        "East Riding of Yorkshire",
-        "Medway",
-        "Southend on Sea",
-    ]
+    DICT_TO_CORRECT_LA_NAMES = {
+        "Bath & N E Somerset": "Bath and North East Somerset",
+        "Blackburn": "Blackburn with Darwen",
+        "Bournemouth, Christchurch and Poole": "Bournemouth Christchurch and Poole",
+        "East Riding": "East Riding of Yorkshire",
+        "Medway Towns": "Medway",
+        "Southend": "Southend on Sea",
+    }

--- a/utils/direct_payments_utils/prepare_direct_payments/fix_la_names.py
+++ b/utils/direct_payments_utils/prepare_direct_payments/fix_la_names.py
@@ -14,8 +14,8 @@ def change_la_names_to_match_ons_cleaned(
     direct_payments_df: DataFrame,
 ) -> DataFrame:
     direct_payments_df = direct_payments_df.replace(
-        LaNames.LIST_OF_INCORRECT_LA_NAMES,
-        LaNames.LIST_OF_CORRECT_LA_NAMES,
+        LaNames.DICT_TO_CORRECT_LA_NAMES,
+        None,
         DPColNames.LA_AREA,
     )
 


### PR DESCRIPTION
# Description
Made two quality changes to this job.

Changed the column name for the PA estimates by ICB to be "by hybrid area" which is the correct name. The final dataframe isn't a unique list of ICB's, it's hybrid area.

Dropped the original column of PA estimates by LA area. It has duplicate values and it's no longer needed.

Changed the LA name fixing function to use a dict instead of two lists. 

Links to Trello:
https://trello.com/c/KTaqnAbR
https://trello.com/c/KhAh7ncX

# How to test
Runs successfully in branch in 2 minutes.
https://eu-west-2.console.aws.amazon.com/gluestudio/home?region=eu-west-2#/editor/job/improve-dpr-to-icb-job-split_pa_filled_posts_into_icb_areas_job/runs

I checked that the correct column had been dropped in Athena.

# Developer checklist
- [x] Unit test
- [x] Linked to Trello ticket
- [ ] Documentation up to date
