### PR TITLE
Clean provider id in locations job

### DIFF
--- a/jobs/clean_cqc_location_data.py
+++ b/jobs/clean_cqc_location_data.py
@@ -83,6 +83,7 @@ def main(
     )
 
     cqc_location_df = create_cleaned_registration_date_column(cqc_location_df)
+    cqc_location_df = clean_provider_id_column(cqc_location_df)
 
     cqc_location_df = remove_non_social_care_locations(cqc_location_df)
     cqc_location_df = utils.format_date_fields(
@@ -116,6 +117,22 @@ def main(
         mode="overwrite",
         partitionKeys=cqcPartitionKeys,
     )
+
+
+def clean_provider_id_column(cqc_df: DataFrame) -> DataFrame:
+    return cqc_df
+
+
+def remove_provider_ids_with_too_many_characters(cqc_df: DataFrame) -> DataFrame:
+    return cqc_df
+
+
+def fill_missing_provider_ids_from_other_rows(cqc_df: DataFrame) -> DataFrame:
+    return cqc_df
+
+
+def remove_rows_that_cannot_be_imputed(cqc_df: DataFrame) -> DataFrame:
+    return cqc_df
 
 
 def create_cleaned_registration_date_column(cqc_df: DataFrame) -> DataFrame:

--- a/jobs/clean_cqc_location_data.py
+++ b/jobs/clean_cqc_location_data.py
@@ -132,6 +132,15 @@ def remove_provider_ids_with_too_many_characters(cqc_df: DataFrame) -> DataFrame
 
 
 def fill_missing_provider_ids_from_other_rows(cqc_df: DataFrame) -> DataFrame:
+    cqc_df = cqc_df.withColumn(
+        CQCL.provider_id,
+        F.when(
+            cqc_df[CQCL.provider_id].isNull(),
+            F.first(CQCL.provider_id, ignorenulls=True).over(
+                Window.partitionBy(CQCL.location_id)
+            ),
+        ).otherwise(cqc_df[CQCL.provider_id]),
+    )
     return cqc_df
 
 

--- a/jobs/clean_cqc_location_data.py
+++ b/jobs/clean_cqc_location_data.py
@@ -144,7 +144,8 @@ def fill_missing_provider_ids_from_other_rows(cqc_df: DataFrame) -> DataFrame:
     return cqc_df
 
 
-def remove_rows_that_cannot_be_imputed(cqc_df: DataFrame) -> DataFrame:
+def remove_remaining_rows_without_a_provider_id(cqc_df: DataFrame) -> DataFrame:
+    cqc_df = cqc_df.where(cqc_df[CQCL.provider_id].isNotNull())
     return cqc_df
 
 

--- a/jobs/clean_cqc_location_data.py
+++ b/jobs/clean_cqc_location_data.py
@@ -124,6 +124,10 @@ def clean_provider_id_column(cqc_df: DataFrame) -> DataFrame:
 
 
 def remove_provider_ids_with_too_many_characters(cqc_df: DataFrame) -> DataFrame:
+    cqc_df = cqc_df.withColumn(
+        CQCL.provider_id,
+        F.when(F.length(CQCL.provider_id) <= 14, cqc_df[CQCL.provider_id]),
+    )
     return cqc_df
 
 

--- a/jobs/clean_cqc_location_data.py
+++ b/jobs/clean_cqc_location_data.py
@@ -120,6 +120,9 @@ def main(
 
 
 def clean_provider_id_column(cqc_df: DataFrame) -> DataFrame:
+    cqc_df = remove_provider_ids_with_too_many_characters(cqc_df)
+    cqc_df = fill_missing_provider_ids_from_other_rows(cqc_df)
+    cqc_df = remove_remaining_rows_without_a_provider_id(cqc_df)
     return cqc_df
 
 

--- a/jobs/clean_cqc_location_data.py
+++ b/jobs/clean_cqc_location_data.py
@@ -122,7 +122,6 @@ def main(
 def clean_provider_id_column(cqc_df: DataFrame) -> DataFrame:
     cqc_df = remove_provider_ids_with_too_many_characters(cqc_df)
     cqc_df = fill_missing_provider_ids_from_other_rows(cqc_df)
-    cqc_df = remove_remaining_rows_without_a_provider_id(cqc_df)
     return cqc_df
 
 
@@ -144,11 +143,6 @@ def fill_missing_provider_ids_from_other_rows(cqc_df: DataFrame) -> DataFrame:
             ),
         ).otherwise(cqc_df[CQCL.provider_id]),
     )
-    return cqc_df
-
-
-def remove_remaining_rows_without_a_provider_id(cqc_df: DataFrame) -> DataFrame:
-    cqc_df = cqc_df.where(cqc_df[CQCL.provider_id].isNotNull())
     return cqc_df
 
 

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -1716,6 +1716,59 @@ class CQCLocationsData:
     ]
     # fmt: on
 
+    clean_provider_id_column_rows = [
+        ("loc_1", None, "20240101"),
+        ("loc_1", "123456789", "20240201"),
+        ("loc_1", None, "20240201"),
+        ("loc_2", "223456789 223456789", "20240101"),
+        ("loc_2", "223456789", "20240201"),
+        ("loc_2", None, "20240301"),
+        ("loc_3", None, "20240101"),
+        ("loc_3", None, "20240201"),
+        ("loc_3", None, "20240301"),
+    ]
+    expected_clean_provider_id_column_rows = [
+        ("loc_1", "123456789", "20240101"),
+        ("loc_1", "123456789", "20240201"),
+        ("loc_1", "123456789", "20240201"),
+        ("loc_2", "223456789", "20240101"),
+        ("loc_2", "223456789", "20240201"),
+        ("loc_2", "223456789", "20240301"),
+    ]
+    long_provider_id_column_rows = [
+        ("loc_2", "223456789 223456789", "20240101"),
+        ("loc_2", "223456789", "20240201"),
+        ("loc_2", None, "20240301"),
+    ]
+    expected_long_provider_id_column_rows = [
+        ("loc_2", None, "20240101"),
+        ("loc_2", "223456789", "20240201"),
+        ("loc_2", None, "20240301"),
+    ]
+    fill_missing_provider_id_column_rows = [
+        ("loc_1", None, "20240101"),
+        ("loc_1", "123456789", "20240201"),
+        ("loc_1", None, "20240201"),
+    ]
+    expected_fill_missing_provider_id_column_rows = [
+        ("loc_1", "123456789", "20240101"),
+        ("loc_1", "123456789", "20240201"),
+        ("loc_1", "123456789", "20240201"),
+    ]
+    remove_unknown_provider_id_column_rows = [
+        ("loc_1", "123456789", "20240201"),
+        ("loc_1", None, "20240101"),
+        ("loc_2", "223456789", "20240201"),
+        ("loc_3", None, "20240101"),
+        ("loc_3", None, "20240201"),
+        ("loc_3", None, "20240301"),
+    ]
+    expected_remove_unknown_provider_id_column_rows = [
+        ("loc_1", "123456789", "20240201"),
+        ("loc_1", None, "20240101"),
+        ("loc_2", "223456789", "20240201"),
+    ]
+
 
 @dataclass
 class UtilsData:

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -1757,7 +1757,6 @@ class CQCLocationsData:
     ]
     remove_unknown_provider_id_column_rows = [
         ("loc_1", "123456789", "20240201"),
-        ("loc_1", None, "20240101"),
         ("loc_2", "223456789", "20240201"),
         ("loc_3", None, "20240101"),
         ("loc_3", None, "20240201"),
@@ -1765,7 +1764,6 @@ class CQCLocationsData:
     ]
     expected_remove_unknown_provider_id_column_rows = [
         ("loc_1", "123456789", "20240201"),
-        ("loc_1", None, "20240101"),
         ("loc_2", "223456789", "20240201"),
     ]
 

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -1755,17 +1755,6 @@ class CQCLocationsData:
         ("loc_1", "123456789", "20240201"),
         ("loc_1", "123456789", "20240201"),
     ]
-    remove_unknown_provider_id_column_rows = [
-        ("loc_1", "123456789", "20240201"),
-        ("loc_2", "223456789", "20240201"),
-        ("loc_3", None, "20240101"),
-        ("loc_3", None, "20240201"),
-        ("loc_3", None, "20240301"),
-    ]
-    expected_remove_unknown_provider_id_column_rows = [
-        ("loc_1", "123456789", "20240201"),
-        ("loc_2", "223456789", "20240201"),
-    ]
 
 
 @dataclass

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -1723,9 +1723,6 @@ class CQCLocationsData:
         ("loc_2", "223456789 223456789", "20240101"),
         ("loc_2", "223456789", "20240201"),
         ("loc_2", None, "20240301"),
-        ("loc_3", None, "20240101"),
-        ("loc_3", None, "20240201"),
-        ("loc_3", None, "20240301"),
     ]
     expected_clean_provider_id_column_rows = [
         ("loc_1", "123456789", "20240101"),

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -1141,6 +1141,13 @@ class CQCLocationsSchema:
             StructField(CQCLClean.imputed_registration_date, StringType(), True),
         ]
     )
+    clean_provider_id_column_schema = StructType(
+        [
+            StructField(CQCL.location_id, StringType(), True),
+            StructField(CQCL.provider_id, StringType(), True),
+            StructField(Keys.import_date, StringType(), True),
+        ]
+    )
 
 
 @dataclass

--- a/tests/unit/test_clean_cqc_location_data.py
+++ b/tests/unit/test_clean_cqc_location_data.py
@@ -497,5 +497,56 @@ class RaiseErrorIfCQCPostcodeWasNotFoundInONSDataset(CleanCQCLocationDatasetTest
             )
 
 
+class CleanProviderIdColumn(CleanCQCLocationDatasetTests):
+    def setUp(self) -> None:
+        super().setUp()
+
+    def test_clean_provider_id_column(self):
+        test_df = self.spark.createDataFrame(
+            Data.clean_provider_id_column_rows, Schemas.clean_provider_id_column_schema
+        )
+        expected_df = self.spark.createDataFrame(
+            Data.expected_clean_provider_id_column_rows,
+            Schemas.clean_provider_id_column_schema,
+        )
+        returned_df = job.clean_provider_id_column(test_df)
+        self.assertEqual(expected_df.collect(), returned_df.collect())
+
+    def test_remove_values_with_too_many_characters(self):
+        test_df = self.spark.createDataFrame(
+            Data.long_provider_id_column_rows, Schemas.clean_provider_id_column_schema
+        )
+        expected_df = self.spark.createDataFrame(
+            Data.expected_long_provider_id_column_rows,
+            Schemas.clean_provider_id_column_schema,
+        )
+        returned_df = job.remove_provider_ids_with_too_many_characters(test_df)
+        self.assertEqual(expected_df.collect(), returned_df.collect())
+
+    def test_fill_missing_values_if_present_in_other_rows(self):
+        test_df = self.spark.createDataFrame(
+            Data.fill_missing_provider_id_column_rows,
+            Schemas.clean_provider_id_column_schema,
+        )
+        expected_df = self.spark.createDataFrame(
+            Data.expected_fill_missing_provider_id_column_rows,
+            Schemas.clean_provider_id_column_schema,
+        )
+        returned_df = job.fill_missing_provider_ids_from_other_rows(test_df)
+        self.assertEqual(expected_df.collect(), returned_df.collect())
+
+    def test_remove_rows_that_cannot_be_imputed(self):
+        test_df = self.spark.createDataFrame(
+            Data.remove_unknown_provider_id_column_rows,
+            Schemas.clean_provider_id_column_schema,
+        )
+        expected_df = self.spark.createDataFrame(
+            Data.expected_remove_unknown_provider_id_column_rows,
+            Schemas.clean_provider_id_column_schema,
+        )
+        returned_df = job.remove_rows_that_cannot_be_imputed(test_df)
+        self.assertEqual(expected_df.collect(), returned_df.collect())
+
+
 if __name__ == "__main__":
     unittest.main(warnings="ignore")

--- a/tests/unit/test_clean_cqc_location_data.py
+++ b/tests/unit/test_clean_cqc_location_data.py
@@ -535,18 +535,6 @@ class CleanProviderIdColumn(CleanCQCLocationDatasetTests):
         returned_df = job.fill_missing_provider_ids_from_other_rows(test_df)
         self.assertEqual(expected_df.collect(), returned_df.collect())
 
-    def test_remove_remaining_rows_without_a_provider_id(self):
-        test_df = self.spark.createDataFrame(
-            Data.remove_unknown_provider_id_column_rows,
-            Schemas.clean_provider_id_column_schema,
-        )
-        expected_df = self.spark.createDataFrame(
-            Data.expected_remove_unknown_provider_id_column_rows,
-            Schemas.clean_provider_id_column_schema,
-        )
-        returned_df = job.remove_remaining_rows_without_a_provider_id(test_df)
-        self.assertEqual(expected_df.collect(), returned_df.collect())
-
 
 if __name__ == "__main__":
     unittest.main(warnings="ignore")

--- a/tests/unit/test_clean_cqc_location_data.py
+++ b/tests/unit/test_clean_cqc_location_data.py
@@ -535,7 +535,7 @@ class CleanProviderIdColumn(CleanCQCLocationDatasetTests):
         returned_df = job.fill_missing_provider_ids_from_other_rows(test_df)
         self.assertEqual(expected_df.collect(), returned_df.collect())
 
-    def test_remove_rows_that_cannot_be_imputed(self):
+    def test_remove_remaining_rows_without_a_provider_id(self):
         test_df = self.spark.createDataFrame(
             Data.remove_unknown_provider_id_column_rows,
             Schemas.clean_provider_id_column_schema,
@@ -544,7 +544,7 @@ class CleanProviderIdColumn(CleanCQCLocationDatasetTests):
             Data.expected_remove_unknown_provider_id_column_rows,
             Schemas.clean_provider_id_column_schema,
         )
-        returned_df = job.remove_rows_that_cannot_be_imputed(test_df)
+        returned_df = job.remove_remaining_rows_without_a_provider_id(test_df)
         self.assertEqual(expected_df.collect(), returned_df.collect())
 
 

--- a/utils/validation/validation_rules/locations_api_raw_validation_rules.py
+++ b/utils/validation/validation_rules/locations_api_raw_validation_rules.py
@@ -20,7 +20,6 @@ class LocationsAPIRawValidationRules:
             CQCL.location_id,
             Keys.import_date,
             CQCL.care_home,
-            CQCL.provider_id,
             CQCL.registration_status,
             CQCL.name,
         ],


### PR DESCRIPTION
# Description
Add function and unittests to clean the provider id column in the locations api dataset.
Removed test for completeness of provider id in raw data.

# How to test
Unit tests passing
Run in branch: https://eu-west-2.console.aws.amazon.com/gluestudio/home?region=eu-west-2#/editor/job/clean-prov-id-part-two-clean_cqc_location_data_job/runs
