### PR TITLE
Remove raw PIR rules that accidentally got merged back in

### DIFF
--- a/utils/validation/validation_rules/pir_raw_validation_rules.py
+++ b/utils/validation/validation_rules/pir_raw_validation_rules.py
@@ -15,15 +15,6 @@ class PIRRawValidationRules:
         RuleName.complete_columns: [
             Keys.import_date,
             CQCPIR.location_id,
-            CQCPIR.people_directly_employed,
-            CQCPIR.pir_type,
-            CQCPIR.pir_submission_date,
-        ],
-        RuleName.index_columns: [
-            CQCPIR.location_id,
-            Keys.import_date,
-            CQCPIR.pir_type,
-            CQCPIR.pir_submission_date,
         ],
         RuleName.max_values: {
             CQCPIR.people_directly_employed: 10000,


### PR DESCRIPTION
# Description
Removes Validation rules that were accidentally merged back in

# How to test
Unit tests passing
Run successfully in branch: https://eu-west-2.console.aws.amazon.com/gluestudio/home?region=eu-west-2#/editor/job/test-raw-pir-validate_pir_raw_data_job/runs

