### PR TITLE
Impute missing provider data

### DIFF
--- a/jobs/clean_cqc_location_data.py
+++ b/jobs/clean_cqc_location_data.py
@@ -251,13 +251,16 @@ def allocate_primary_service_type(df: DataFrame):
 def impute_missing_data_from_provider_dataset(
     locations_df: DataFrame, column_name: str
 ) -> DataFrame:
+    w = (
+        Window.partitionBy(CQCL.provider_id)
+        .orderBy(CQCLClean.cqc_location_import_date)
+        .rowsBetween(Window.unboundedPreceding, Window.unboundedFollowing)
+    )
     locations_df = locations_df.withColumn(
         column_name,
         F.when(
             locations_df[column_name].isNull(),
-            F.first(column_name, ignorenulls=True).over(
-                Window.partitionBy(CQCL.provider_id)
-            ),
+            F.first(column_name, ignorenulls=True).over(w),
         ).otherwise(locations_df[column_name]),
     )
     return locations_df

--- a/jobs/clean_cqc_location_data.py
+++ b/jobs/clean_cqc_location_data.py
@@ -248,6 +248,12 @@ def allocate_primary_service_type(df: DataFrame):
     return df
 
 
+def impute_missing_data_from_provider_dataset(
+    locations_df: DataFrame, column_name: str
+) -> DataFrame:
+    return locations_df
+
+
 def join_cqc_provider_data(locations_df: DataFrame, provider_df: DataFrame):
     locations_df = cUtils.add_aligned_date_column(
         locations_df,

--- a/jobs/clean_cqc_location_data.py
+++ b/jobs/clean_cqc_location_data.py
@@ -251,6 +251,15 @@ def allocate_primary_service_type(df: DataFrame):
 def impute_missing_data_from_provider_dataset(
     locations_df: DataFrame, column_name: str
 ) -> DataFrame:
+    locations_df = locations_df.withColumn(
+        column_name,
+        F.when(
+            locations_df[column_name].isNull(),
+            F.first(column_name, ignorenulls=True).over(
+                Window.partitionBy(CQCL.provider_id)
+            ),
+        ).otherwise(locations_df[column_name]),
+    )
     return locations_df
 
 

--- a/jobs/clean_cqc_location_data.py
+++ b/jobs/clean_cqc_location_data.py
@@ -104,6 +104,13 @@ def main(
         registered_locations_df, cqc_provider_df
     )
 
+    registered_locations_df = impute_missing_data_from_provider_dataset(
+        registered_locations_df, CQCLClean.provider_name
+    )
+    registered_locations_df = impute_missing_data_from_provider_dataset(
+        registered_locations_df, CQCLClean.cqc_sector
+    )
+
     registered_locations_df = join_ons_postcode_data_into_cqc_df(
         registered_locations_df, ons_postcode_directory_df
     )

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -1782,8 +1782,8 @@ class CQCLocationsData:
 
     impute_missing_data_from_provider_dataset_multiple_values_rows = [
         ("prov_1", None, "20240101"),
-        ("prov_1", Sector.local_authority, "20240201"),
         ("prov_1", Sector.independent, "20240301"),
+        ("prov_1", Sector.local_authority, "20240201"),
     ]
 
     expected_impute_missing_data_from_provider_dataset_multiple_values_rows = [

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -1769,27 +1769,75 @@ class CQCLocationsData:
     ]
 
     impute_missing_data_from_provider_dataset_single_value_rows = [
-        ("prov_1", None, "20240101"),
-        ("prov_1", Sector.independent, "20240201"),
-        ("prov_1", Sector.independent, "20240301"),
+        (
+            "prov_1",
+            None,
+            date(2024, 1, 1),
+        ),
+        (
+            "prov_1",
+            Sector.independent,
+            date(2024, 2, 1),
+        ),
+        (
+            "prov_1",
+            Sector.independent,
+            date(2024, 3, 1),
+        ),
     ]
 
     expected_impute_missing_data_from_provider_dataset_rows = [
-        ("prov_1", Sector.independent, "20240101"),
-        ("prov_1", Sector.independent, "20240201"),
-        ("prov_1", Sector.independent, "20240301"),
+        (
+            "prov_1",
+            Sector.independent,
+            date(2024, 1, 1),
+        ),
+        (
+            "prov_1",
+            Sector.independent,
+            date(2024, 2, 1),
+        ),
+        (
+            "prov_1",
+            Sector.independent,
+            date(2024, 3, 1),
+        ),
     ]
 
     impute_missing_data_from_provider_dataset_multiple_values_rows = [
-        ("prov_1", None, "20240101"),
-        ("prov_1", Sector.independent, "20240301"),
-        ("prov_1", Sector.local_authority, "20240201"),
+        (
+            "prov_1",
+            None,
+            date(2024, 1, 1),
+        ),
+        (
+            "prov_1",
+            Sector.independent,
+            date(2024, 3, 1),
+        ),
+        (
+            "prov_1",
+            Sector.local_authority,
+            date(2024, 2, 1),
+        ),
     ]
 
     expected_impute_missing_data_from_provider_dataset_multiple_values_rows = [
-        ("prov_1", Sector.local_authority, "20240101"),
-        ("prov_1", Sector.local_authority, "20240201"),
-        ("prov_1", Sector.independent, "20240301"),
+        (
+            "prov_1",
+            Sector.local_authority,
+            date(2024, 1, 1),
+        ),
+        (
+            "prov_1",
+            Sector.local_authority,
+            date(2024, 2, 1),
+        ),
+        (
+            "prov_1",
+            Sector.independent,
+            date(2024, 3, 1),
+        ),
     ]
 
 

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -1761,10 +1761,35 @@ class CQCLocationsData:
         ("loc_1", "123456789", "20240201"),
         ("loc_1", None, "20240201"),
     ]
+
     expected_fill_missing_provider_id_column_rows = [
         ("loc_1", "123456789", "20240101"),
         ("loc_1", "123456789", "20240201"),
         ("loc_1", "123456789", "20240201"),
+    ]
+
+    impute_missing_data_from_provider_dataset_single_value_rows = [
+        ("prov_1", None, "20240101"),
+        ("prov_1", Sector.independent, "20240201"),
+        ("prov_1", Sector.independent, "20240301"),
+    ]
+
+    expected_impute_missing_data_from_provider_dataset_rows = [
+        ("prov_1", Sector.independent, "20240101"),
+        ("prov_1", Sector.independent, "20240201"),
+        ("prov_1", Sector.independent, "20240301"),
+    ]
+
+    impute_missing_data_from_provider_dataset_multiple_values_rows = [
+        ("prov_1", None, "20240101"),
+        ("prov_1", Sector.local_authority, "20240201"),
+        ("prov_1", Sector.independent, "20240301"),
+    ]
+
+    expected_impute_missing_data_from_provider_dataset_multiple_values_rows = [
+        ("prov_1", Sector.local_authority, "20240101"),
+        ("prov_1", Sector.local_authority, "20240201"),
+        ("prov_1", Sector.independent, "20240301"),
     ]
 
 

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -1150,6 +1150,14 @@ class CQCLocationsSchema:
         ]
     )
 
+    impute_missing_data_from_provider_dataset_schema = StructType(
+        [
+            StructField(CQCL.provider_id, StringType(), True),
+            StructField(CQCLClean.cqc_sector, StringType(), True),
+            StructField(Keys.import_date, StringType(), True),
+        ]
+    )
+
 
 @dataclass
 class UtilsSchema:

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -1154,7 +1154,7 @@ class CQCLocationsSchema:
         [
             StructField(CQCL.provider_id, StringType(), True),
             StructField(CQCLClean.cqc_sector, StringType(), True),
-            StructField(Keys.import_date, StringType(), True),
+            StructField(CQCLClean.cqc_location_import_date, DateType(), True),
         ]
     )
 

--- a/tests/unit/test_clean_cqc_location_data.py
+++ b/tests/unit/test_clean_cqc_location_data.py
@@ -555,8 +555,6 @@ class ImputeMissingDataFromProviderDataset(CleanCQCLocationDatasetTests):
         returned_df = job.impute_missing_data_from_provider_dataset(
             test_df, self.column_to_impute
         )
-        expected_df.show()
-        returned_df.show()
         self.assertEqual(expected_df.collect(), returned_df.collect())
 
     def test_impute_missing_data_from_provider_dataset_returns_correct_values_when_column_values_change_over_time(
@@ -573,8 +571,6 @@ class ImputeMissingDataFromProviderDataset(CleanCQCLocationDatasetTests):
         returned_df = job.impute_missing_data_from_provider_dataset(
             test_df, self.column_to_impute
         ).sort(CQCLCleaned.cqc_location_import_date)
-        expected_df.show()
-        returned_df.show()
         self.assertEqual(expected_df.collect(), returned_df.collect())
 
 

--- a/tests/unit/test_clean_cqc_location_data.py
+++ b/tests/unit/test_clean_cqc_location_data.py
@@ -555,6 +555,8 @@ class ImputeMissingDataFromProviderDataset(CleanCQCLocationDatasetTests):
         returned_df = job.impute_missing_data_from_provider_dataset(
             test_df, self.column_to_impute
         )
+        expected_df.show()
+        returned_df.show()
         self.assertEqual(expected_df.collect(), returned_df.collect())
 
     def test_impute_missing_data_from_provider_dataset_returns_correct_values_when_column_values_change_over_time(
@@ -567,10 +569,12 @@ class ImputeMissingDataFromProviderDataset(CleanCQCLocationDatasetTests):
         expected_df = self.spark.createDataFrame(
             Data.expected_impute_missing_data_from_provider_dataset_rows,
             Schemas.impute_missing_data_from_provider_dataset_schema,
-        )
+        ).sort(Keys.import_date)
         returned_df = job.impute_missing_data_from_provider_dataset(
             test_df, self.column_to_impute
-        )
+        ).sort(Keys.import_date)
+        expected_df.show()
+        returned_df.show()
         self.assertEqual(expected_df.collect(), returned_df.collect())
 
 

--- a/tests/unit/test_clean_cqc_location_data.py
+++ b/tests/unit/test_clean_cqc_location_data.py
@@ -567,12 +567,12 @@ class ImputeMissingDataFromProviderDataset(CleanCQCLocationDatasetTests):
             Schemas.impute_missing_data_from_provider_dataset_schema,
         )
         expected_df = self.spark.createDataFrame(
-            Data.expected_impute_missing_data_from_provider_dataset_rows,
+            Data.expected_impute_missing_data_from_provider_dataset_multiple_values_rows,
             Schemas.impute_missing_data_from_provider_dataset_schema,
-        ).sort(Keys.import_date)
+        ).sort(CQCLCleaned.cqc_location_import_date)
         returned_df = job.impute_missing_data_from_provider_dataset(
             test_df, self.column_to_impute
-        ).sort(Keys.import_date)
+        ).sort(CQCLCleaned.cqc_location_import_date)
         expected_df.show()
         returned_df.show()
         self.assertEqual(expected_df.collect(), returned_df.collect())

--- a/tests/unit/test_clean_cqc_location_data.py
+++ b/tests/unit/test_clean_cqc_location_data.py
@@ -536,5 +536,38 @@ class CleanProviderIdColumn(CleanCQCLocationDatasetTests):
         self.assertEqual(expected_df.collect(), returned_df.collect())
 
 
+class ImputeMissingDataFromProviderDataset(CleanCQCLocationDatasetTests):
+    def setUp(self) -> None:
+        super().setUp()
+
+    def test_impute_missing_data_from_provider_dataset_returns_correct_values_when_column_has_the_same_values(
+        self,
+    ):
+        test_df = self.spark.createDataFrame(
+            Data.impute_missing_data_from_provider_dataset_single_value_rows,
+            Schemas.impute_missing_data_from_provider_dataset_schema,
+        )
+        expected_df = self.spark.createDataFrame(
+            Data.expected_impute_missing_data_from_provider_dataset_rows,
+            Schemas.impute_missing_data_from_provider_dataset_schema,
+        )
+        returned_df = job.impute_missing_data_from_provider_dataset(test_df)
+        self.assertEqual(expected_df.collect(), returned_df.collect())
+
+    def test_impute_missing_data_from_provider_dataset_returns_correct_values_when_column_values_change_over_time(
+        self,
+    ):
+        test_df = self.spark.createDataFrame(
+            Data.impute_missing_data_from_provider_dataset_multiple_values_rows,
+            Schemas.impute_missing_data_from_provider_dataset_schema,
+        )
+        expected_df = self.spark.createDataFrame(
+            Data.expected_impute_missing_data_from_provider_dataset_rows,
+            Schemas.impute_missing_data_from_provider_dataset_schema,
+        )
+        returned_df = job.impute_missing_data_from_provider_dataset(test_df)
+        self.assertEqual(expected_df.collect(), returned_df.collect())
+
+
 if __name__ == "__main__":
     unittest.main(warnings="ignore")

--- a/tests/unit/test_clean_cqc_location_data.py
+++ b/tests/unit/test_clean_cqc_location_data.py
@@ -539,6 +539,7 @@ class CleanProviderIdColumn(CleanCQCLocationDatasetTests):
 class ImputeMissingDataFromProviderDataset(CleanCQCLocationDatasetTests):
     def setUp(self) -> None:
         super().setUp()
+        self.column_to_impute = CQCLCleaned.cqc_sector
 
     def test_impute_missing_data_from_provider_dataset_returns_correct_values_when_column_has_the_same_values(
         self,
@@ -551,7 +552,9 @@ class ImputeMissingDataFromProviderDataset(CleanCQCLocationDatasetTests):
             Data.expected_impute_missing_data_from_provider_dataset_rows,
             Schemas.impute_missing_data_from_provider_dataset_schema,
         )
-        returned_df = job.impute_missing_data_from_provider_dataset(test_df)
+        returned_df = job.impute_missing_data_from_provider_dataset(
+            test_df, self.column_to_impute
+        )
         self.assertEqual(expected_df.collect(), returned_df.collect())
 
     def test_impute_missing_data_from_provider_dataset_returns_correct_values_when_column_values_change_over_time(
@@ -565,7 +568,9 @@ class ImputeMissingDataFromProviderDataset(CleanCQCLocationDatasetTests):
             Data.expected_impute_missing_data_from_provider_dataset_rows,
             Schemas.impute_missing_data_from_provider_dataset_schema,
         )
-        returned_df = job.impute_missing_data_from_provider_dataset(test_df)
+        returned_df = job.impute_missing_data_from_provider_dataset(
+            test_df, self.column_to_impute
+        )
         self.assertEqual(expected_df.collect(), returned_df.collect())
 
 


### PR DESCRIPTION
# Description
Add a function that will fill in blanks in provider api columns after they have been joined into locations data. These exist because the location appears in the location api earlier than the corresponding provider appears in the provider api.

The function finds the earliest value and imputes that, in case the value has changed over time.
https://trello.com/c/wQm9L4vZ/498-impute-missing-early-provider-data-in-cleaned-locations-dataset

# How to test
Unit tests passing
Run in branch: https://eu-west-2.console.aws.amazon.com/gluestudio/home?region=eu-west-2#/editor/job/impute-missing-provider-data-clean_cqc_location_data_job/runs


