### PR TITLE
Add dpr icb to step function

### DIFF
--- a/terraform/pipeline/glue.tf
+++ b/terraform/pipeline/glue.tf
@@ -287,7 +287,7 @@ module "estimate_direct_payments_job" {
   }
 }
 
-module "split_pa_filled_posts_into_icb_areas" {
+module "split_pa_filled_posts_into_icb_areas_job" {
   source          = "../modules/glue-job"
   script_name     = "split_pa_filled_posts_into_icb_areas.py"
   glue_role       = aws_iam_role.sfc_glue_service_iam_role

--- a/terraform/pipeline/step-function.tf
+++ b/terraform/pipeline/step-function.tf
@@ -72,14 +72,14 @@ resource "aws_sfn_state_machine" "direct-payments-state-machine" {
   role_arn = aws_iam_role.step_function_iam_role.arn
   type     = "STANDARD"
   definition = templatefile("step-functions/DirectPaymentRecipientsPipeline-StepFunction.json", {
-    prepare_dpr_external_job_name     = module.prepare_dpr_external_data_job.job_name
-    prepare_dpr_survey_job_name       = module.prepare_dpr_survey_data_job.job_name
-    merge_dpr_data_job_name           = module.merge_dpr_data_job.job_name
-    estimate_direct_payments_job_name = module.estimate_direct_payments_job.job_name
+    prepare_dpr_external_job_name                 = module.prepare_dpr_external_data_job.job_name
+    prepare_dpr_survey_job_name                   = module.prepare_dpr_survey_data_job.job_name
+    merge_dpr_data_job_name                       = module.merge_dpr_data_job.job_name
+    estimate_direct_payments_job_name             = module.estimate_direct_payments_job.job_name
     split_pa_filled_posts_into_icb_areas_job_name = module.split_pa_filled_posts_into_icb_areas_job.job_name
-    data_engineering_crawler_name     = module.data_engineering_crawler.crawler_name
-    dataset_bucket_uri                = module.datasets_bucket.bucket_uri
-    run_crawler_state_machine_arn     = aws_sfn_state_machine.run_crawler.arn
+    data_engineering_crawler_name                 = module.data_engineering_crawler.crawler_name
+    dataset_bucket_uri                            = module.datasets_bucket.bucket_uri
+    run_crawler_state_machine_arn                 = aws_sfn_state_machine.run_crawler.arn
   })
 
   logging_configuration {

--- a/terraform/pipeline/step-function.tf
+++ b/terraform/pipeline/step-function.tf
@@ -76,6 +76,7 @@ resource "aws_sfn_state_machine" "direct-payments-state-machine" {
     prepare_dpr_survey_job_name       = module.prepare_dpr_survey_data_job.job_name
     merge_dpr_data_job_name           = module.merge_dpr_data_job.job_name
     estimate_direct_payments_job_name = module.estimate_direct_payments_job.job_name
+    split_pa_filled_posts_into_icb_areas_job_name = module.split_pa_filled_posts_into_icb_areas_job.job_name
     data_engineering_crawler_name     = module.data_engineering_crawler.crawler_name
     dataset_bucket_uri                = module.datasets_bucket.bucket_uri
     run_crawler_state_machine_arn     = aws_sfn_state_machine.run_crawler.arn

--- a/terraform/pipeline/step-functions/DirectPaymentRecipientsPipeline-StepFunction.json
+++ b/terraform/pipeline/step-functions/DirectPaymentRecipientsPipeline-StepFunction.json
@@ -1,108 +1,97 @@
 {
-    "Comment": "A description of my state machine",
-    "StartAt": "Prepare data in paralell",
-    "States": {
-      "Prepare data in paralell": {
-        "Type": "Parallel",
-        "Next": "Run data engineering crawler",
-        "Branches": [
-          {
-            "StartAt": "Prepare DPR survey data",
-            "States": {
-              "Prepare DPR survey data": {
-                "Type": "Task",
-                "Resource": "arn:aws:states:::glue:startJobRun.sync",
-                "Parameters": {
-                  "JobName": "${prepare_dpr_survey_job_name}",
-                  "Arguments": {
-                    "--survey_data_source": "${dataset_bucket_uri}/domain=DPR/dataset=direct_payments_survey/version=2024.01/",
-                    "--destination": "${dataset_bucket_uri}/domain=data_engineering/dataset=direct_payments_survey_prepared/version=2024.01/"
-                  }
-                },
-                "End": true
-              }
-            }
-          },
-          {
-            "StartAt": "Prepare DPR external data",
-            "States": {
-              "Prepare DPR external data": {
-                "Type": "Task",
-                "Resource": "arn:aws:states:::glue:startJobRun.sync",
-                "Parameters": {
-                  "JobName": "${prepare_dpr_external_job_name}",
-                  "Arguments": {
-                    "--direct_payments_source": "${dataset_bucket_uri}/domain=DPR/dataset=direct_payments_external/version=2024.01/",
-                    "--destination": "${dataset_bucket_uri}/domain=data_engineering/dataset=direct_payments_external_prepared/version=2024.01/"
-                  }
-                },
-                "End": true
-              }
+  "Comment": "A description of my state machine",
+  "StartAt": "Prepare data in paralell",
+  "States": {
+    "Prepare data in paralell": {
+      "Type": "Parallel",
+      "Next": "Merge DPR data",
+      "Branches": [
+        {
+          "StartAt": "Prepare DPR survey data",
+          "States": {
+            "Prepare DPR survey data": {
+              "Type": "Task",
+              "Resource": "arn:aws:states:::glue:startJobRun.sync",
+              "Parameters": {
+                "JobName": "${prepare_dpr_survey_job_name}",
+                "Arguments": {
+                  "--survey_data_source": "${dataset_bucket_uri}/domain=DPR/dataset=direct_payments_survey/version=2024.01/",
+                  "--destination": "${dataset_bucket_uri}/domain=data_engineering/dataset=direct_payments_survey_prepared/version=2024.01/"
+                }
+              },
+              "End": true
             }
           }
-        ]
-      },
-      "Run data engineering crawler": {
-        "Type": "Task",
-        "Resource": "arn:aws:states:::states:startExecution.sync:2",
-        "Parameters": {
-          "StateMachineArn": "arn:aws:states:eu-west-2:344210435447:stateMachine:main-RunCrawler",
-          "Input": {
-            "crawler_name": "${data_engineering_crawler_name}",
-            "AWS_STEP_FUNCTIONS_STARTED_BY_EXECUTION_ID.$": "$$.Execution.Id"
-          }
         },
-        "Next": "Merge DPR data"
-      },
-      "Merge DPR data": {
-        "Type": "Task",
-        "Resource": "arn:aws:states:::glue:startJobRun.sync",
-        "Parameters": {
-          "JobName": "${merge_dpr_data_job_name}",
-          "Arguments": {
-            "--direct_payments_external_data_source": "${dataset_bucket_uri}/domain=data_engineering/dataset=direct_payments_external_prepared/version=2024.01/",
-            "--direct_payments_survey_data_source": "${dataset_bucket_uri}/domain=data_engineering/dataset=direct_payments_survey_prepared/version=2024.01/",
-            "--destination": "${dataset_bucket_uri}/domain=data_engineering/dataset=direct_payments_merged/version=2024.01/"
+        {
+          "StartAt": "Prepare DPR external data",
+          "States": {
+            "Prepare DPR external data": {
+              "Type": "Task",
+              "Resource": "arn:aws:states:::glue:startJobRun.sync",
+              "Parameters": {
+                "JobName": "${prepare_dpr_external_job_name}",
+                "Arguments": {
+                  "--direct_payments_source": "${dataset_bucket_uri}/domain=DPR/dataset=direct_payments_external/version=2024.01/",
+                  "--destination": "${dataset_bucket_uri}/domain=data_engineering/dataset=direct_payments_external_prepared/version=2024.01/"
+                }
+              },
+              "End": true
+            }
           }
-        },
-        "Next": "Run data engineering crawler (1)"
+        }
+      ]
+    },
+    "Merge DPR data": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::glue:startJobRun.sync",
+      "Parameters": {
+        "JobName": "${merge_dpr_data_job_name}",
+        "Arguments": {
+          "--direct_payments_external_data_source": "${dataset_bucket_uri}/domain=data_engineering/dataset=direct_payments_external_prepared/version=2024.01/",
+          "--direct_payments_survey_data_source": "${dataset_bucket_uri}/domain=data_engineering/dataset=direct_payments_survey_prepared/version=2024.01/",
+          "--destination": "${dataset_bucket_uri}/domain=data_engineering/dataset=direct_payments_merged/version=2024.01/"
+        }
       },
-      "Run data engineering crawler (1)": {
-        "Type": "Task",
-        "Resource": "arn:aws:states:::states:startExecution.sync:2",
-        "Parameters": {
-          "StateMachineArn": "arn:aws:states:eu-west-2:344210435447:stateMachine:main-RunCrawler",
-          "Input": {
-            "crawler_name": "${data_engineering_crawler_name}",
-            "AWS_STEP_FUNCTIONS_STARTED_BY_EXECUTION_ID.$": "$$.Execution.Id"
-          }
-        },
-        "Next": "estimate direct payments"
+      "Next": "estimate direct payments"
+    },
+    "estimate direct payments": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::glue:startJobRun.sync",
+      "Parameters": {
+        "JobName": "${estimate_direct_payments_job_name}",
+        "Arguments": {
+          "--direct_payments_merged_source": "${dataset_bucket_uri}/domain=data_engineering/dataset=direct_payments_merged/version=2024.01/",
+          "--destination": "${dataset_bucket_uri}/domain=data_engineering/dataset=direct_payments_estimates/version=2024.01/",
+          "--summary_destination": "${dataset_bucket_uri}/domain=data_engineering/dataset=direct_payments_estimates_summary/version=2024.01/"
+        }
       },
-      "estimate direct payments": {
-        "Type": "Task",
-        "Resource": "arn:aws:states:::glue:startJobRun.sync",
-        "Parameters": {
-          "JobName": "${estimate_direct_payments_job_name}",
-          "Arguments": {
-            "--direct_payments_merged_source": "${dataset_bucket_uri}/domain=data_engineering/dataset=direct_payments_merged/version=2024.01/",
-            "--destination": "${dataset_bucket_uri}/domain=data_engineering/dataset=direct_payments_estimates/version=2024.01/",
-            "--summary_destination": "${dataset_bucket_uri}/domain=data_engineering/dataset=direct_payments_estimates_summary/version=2024.01/"
-          }
-        },
-        "Next": "Run data engineering crawler (2)"
+      "Next": "Split pa estimates into hybrid areas"
+    },
+    "Split pa estimates into hybrid areas": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::glue:startJobRun.sync",
+      "Parameters": {
+        "JobName": "${split_pa_filled_posts_into_icb_areas_job_name}",
+        "Arguments":{
+          "--postcode_directory_source": "${dataset_bucket_uri}/domain=ONS/dataset=postcode_directory_cleaned/",
+          "--pa_filled_posts_souce": "${dataset_bucket_uri}/domain=data_engineering/dataset=direct_payments_estimates/version=2024.01/",
+          "--destination": "${dataset_bucket_uri}/domain=data_engineering/dataset=direct_payments_estimates_by_icb/version=2024.01/"
+        } 
       },
-      "Run data engineering crawler (2)": {
-        "Type": "Task",
-        "Resource": "arn:aws:states:::states:startExecution.sync:2",
-        "Parameters": {
-          "StateMachineArn": "arn:aws:states:eu-west-2:344210435447:stateMachine:main-RunCrawler",
-          "Input": {
-            "crawler_name": "${data_engineering_crawler_name}",
-            "AWS_STEP_FUNCTIONS_STARTED_BY_EXECUTION_ID.$": "$$.Execution.Id"
-          }
-        },
-        "End": true
-      }
+      "Next": "Run data engineering crawler"
+    },
+    "Run data engineering crawler": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::states:startExecution.sync:2",
+      "Parameters": {
+        "StateMachineArn": "arn:aws:states:eu-west-2:344210435447:stateMachine:main-RunCrawler",
+        "Input": {
+          "crawler_name": "${data_engineering_crawler_name}",
+          "AWS_STEP_FUNCTIONS_STARTED_BY_EXECUTION_ID.$": "$$.Execution.Id"
+        }
+      },
+      "End": true
     }
   }
+}


### PR DESCRIPTION
# Description
Added split pa estimates into icb areas into the dpr step function.
Removed crawler execution from midway through script.

# How to test
Successfull run:
https://eu-west-2.console.aws.amazon.com/states/home?region=eu-west-2#/v2/executions/details/arn:aws:states:eu-west-2:344210435447:execution:add-dpr-icb-to-step-function-DirectPaymentRecipientsPipeline:715c8c2b-ddb5-43c4-8966-2479d9d2bfa1

# Developer checklist
- [ ] Unit test
- [ ] Linked to Trello ticket
- [ ] Documentation up to date
