### PR TITLE
Update number of beds rule

### DIFF
--- a/utils/validation/validation_rules/locations_api_cleaned_validation_rules.py
+++ b/utils/validation/validation_rules/locations_api_cleaned_validation_rules.py
@@ -41,7 +41,7 @@ class LocationsAPICleanedValidationRules:
             CQCLClean.cqc_location_import_date,
         ],
         RuleName.min_values: {
-            CQCLClean.number_of_beds: 1,
+            CQCLClean.number_of_beds: 0,
             Validation.location_id_length: 3,
             Validation.provider_id_length: 3,
         },

--- a/utils/validation/validation_rules/merged_ind_cqc_validation_rules.py
+++ b/utils/validation/validation_rules/merged_ind_cqc_validation_rules.py
@@ -36,7 +36,7 @@ class MergedIndCqcValidationRules:
             IndCqcColumns.cqc_location_import_date,
         ],
         RuleName.min_values: {
-            IndCqcColumns.number_of_beds: 1,
+            IndCqcColumns.number_of_beds: 0,
             IndCqcColumns.people_directly_employed: 1,
             IndCqcColumns.total_staff_bounded: 1,
             IndCqcColumns.worker_records_bounded: 1,


### PR DESCRIPTION
# Description
Updates the minimum number of beds rules for validation in the locations api cleaned dataset and the merged ind cqc dataset

# How to test
Unit tests passing
Run in branch: https://eu-west-2.console.aws.amazon.com/gluestudio/home?region=eu-west-2#/editor/job/update-number-of-beds-rules-validate_locations_api_cleaned_data_job/runs
https://eu-west-2.console.aws.amazon.com/gluestudio/home?region=eu-west-2#/editor/job/update-number-of-beds-rules-validate_merged_ind_cqc_data_job/runs
