### PR TITLE
Remove Isles of Scilly from CSSR lists in merged ind cqc dataset and …

### DIFF
--- a/utils/column_values/categorical_columns_by_dataset.py
+++ b/utils/column_values/categorical_columns_by_dataset.py
@@ -113,8 +113,12 @@ class MergedIndCQCCategoricalValues:
     current_region_column_values = Region(IndCQC.current_region)
     contemporary_region_column_values = Region(IndCQC.contemporary_region)
     current_rui_column_values = RUI(IndCQC.current_rural_urban_indicator_2011)
-    current_cssr_column_values = CurrentCSSR(IndCQC.current_cssr)
-    contemporary_cssr_column_values = ContemporaryCSSR(IndCQC.contemporary_cssr)
+    current_cssr_column_values = CurrentCSSR(
+        IndCQC.current_cssr, value_to_remove=CurrentCSSR.isles_of_scilly
+    )
+    contemporary_cssr_column_values = ContemporaryCSSR(
+        IndCQC.contemporary_cssr, value_to_remove=ContemporaryCSSR.isles_of_scilly
+    )
 
 
 @dataclass
@@ -132,8 +136,12 @@ class CleanedIndCQCCategoricalValues:
     current_region_column_values = Region(IndCQC.current_region)
     contemporary_region_column_values = Region(IndCQC.contemporary_region)
     current_rui_column_values = RUI(IndCQC.current_rural_urban_indicator_2011)
-    current_cssr_column_values = CurrentCSSR(IndCQC.current_cssr)
-    contemporary_cssr_column_values = ContemporaryCSSR(IndCQC.contemporary_cssr)
+    current_cssr_column_values = CurrentCSSR(
+        IndCQC.current_cssr, value_to_remove=CurrentCSSR.isles_of_scilly
+    )
+    contemporary_cssr_column_values = ContemporaryCSSR(
+        IndCQC.contemporary_cssr, value_to_remove=ContemporaryCSSR.isles_of_scilly
+    )
     ascwds_filled_posts_source_column_values = ASCWDSFilledPostsSource(
         IndCQC.ascwds_filled_posts_source, contains_null_values=True
     )
@@ -153,7 +161,9 @@ class EstimatedIndCQCFilledPostsCategoricalValues:
     care_home_column_values = CareHome(IndCQC.care_home)
     primary_service_type_column_values = PrimaryServiceType(IndCQC.primary_service_type)
     current_region_column_values = Region(IndCQC.current_region)
-    current_cssr_column_values = CurrentCSSR(IndCQC.current_cssr)
+    current_cssr_column_values = CurrentCSSR(
+        IndCQC.current_cssr, value_to_remove=CurrentCSSR.isles_of_scilly
+    )
     ascwds_filled_posts_source_column_values = ASCWDSFilledPostsSource(
         IndCQC.ascwds_filled_posts_source, contains_null_values=True
     )


### PR DESCRIPTION
…downstream

# Description
There are no Isles of Scilly Independant sector locations so we should remove them from validation checks in this section of the pipeline

# How to test
Unit tests passing
Run in branch: https://eu-west-2.console.aws.amazon.com/gluestudio/home?region=eu-west-2#/editor/job/remove-isles-of-scilly-validate_merged_ind_cqc_data_job/runs

# Developer checklist
- [ ] Unit test
- [ ] Linked to Trello ticket
- [ ] Documentation up to date
