### PR TITLE
Update ascwds source to bounded values

### DIFF
--- a/utils/column_values/categorical_column_values.py
+++ b/utils/column_values/categorical_column_values.py
@@ -77,7 +77,9 @@ class Services(ColumnValues):
     hospice_services: str = "Hospice services"
     domiciliary_care_service: str = "Domiciliary care service"
     remote_clinical_advice_service: str = "Remote clinical advice service"
-    acute_services_without_overnight_beds: str = "Acute services without overnight beds / listed acute services with or without overnight beds"
+    acute_services_without_overnight_beds: str = (
+        "Acute services without overnight beds / listed acute services with or without overnight beds"
+    )
     specialist_college_service: str = "Specialist college service"
     ambulance_service: str = "Ambulance service"
     extra_care_housing_services: str = "Extra Care housing services"
@@ -107,7 +109,9 @@ class Services(ColumnValues):
     rehabilitation_services: str = "Rehabilitation services"
     doctors_treatment_service: str = "Doctors treatment service"
     hospice_services_at_home: str = "Hospice services at home"
-    hospital_services_for_people_with_mental_health_needs: str = "Hospital services for people with mental health needs, learning disabilities and problems with substance misuse"
+    hospital_services_for_people_with_mental_health_needs: str = (
+        "Hospital services for people with mental health needs, learning disabilities and problems with substance misuse"
+    )
 
 
 @dataclass
@@ -432,11 +436,13 @@ class ContemporaryCSSR(CurrentCSSR):
 class ASCWDSFilledPostsSource(ColumnValues):
     """The possible values of the ASCWDS filled posts source column in the independent CQC estimates pipeline"""
 
-    worker_records_and_total_staff: str = "worker records and total staff were the same"
+    worker_records_and_total_staff: str = (
+        "wkrrecs_bounded and totalstaff_bounded were the same"
+    )
     only_total_staff: str = "only totalstaff_bounded was provided"
     only_worker_records: str = "only wkrrecs_bounded was provided"
     average_of_total_staff_and_worker_records: str = (
-        "average of total staff and worker records as both were similar"
+        "average of totalstaff_bounded and wkrrecs_bounded as both were similar"
     )
 
 

--- a/utils/column_values/categorical_column_values.py
+++ b/utils/column_values/categorical_column_values.py
@@ -77,7 +77,9 @@ class Services(ColumnValues):
     hospice_services: str = "Hospice services"
     domiciliary_care_service: str = "Domiciliary care service"
     remote_clinical_advice_service: str = "Remote clinical advice service"
-    acute_services_without_overnight_beds: str = "Acute services without overnight beds / listed acute services with or without overnight beds"
+    acute_services_without_overnight_beds: str = (
+        "Acute services without overnight beds / listed acute services with or without overnight beds"
+    )
     specialist_college_service: str = "Specialist college service"
     ambulance_service: str = "Ambulance service"
     extra_care_housing_services: str = "Extra Care housing services"
@@ -107,7 +109,9 @@ class Services(ColumnValues):
     rehabilitation_services: str = "Rehabilitation services"
     doctors_treatment_service: str = "Doctors treatment service"
     hospice_services_at_home: str = "Hospice services at home"
-    hospital_services_for_people_with_mental_health_needs: str = "Hospital services for people with mental health needs, learning disabilities and problems with substance misuse"
+    hospital_services_for_people_with_mental_health_needs: str = (
+        "Hospital services for people with mental health needs, learning disabilities and problems with substance misuse"
+    )
 
 
 @dataclass
@@ -433,8 +437,8 @@ class ASCWDSFilledPostsSource(ColumnValues):
     """The possible values of the ASCWDS filled posts source column in the independent CQC estimates pipeline"""
 
     worker_records_and_total_staff: str = "worker records and total staff were the same"
-    only_total_staff: str = "only totalstaff was provided"
-    only_worker_records: str = "only wkrrecs was provided"
+    only_total_staff: str = "only totalstaff_bounded was provided"
+    only_worker_records: str = "only wkrrecs_bounded was provided"
     average_of_total_staff_and_worker_records: str = (
         "average of total staff and worker records as both were similar"
     )

--- a/utils/column_values/categorical_column_values.py
+++ b/utils/column_values/categorical_column_values.py
@@ -77,9 +77,7 @@ class Services(ColumnValues):
     hospice_services: str = "Hospice services"
     domiciliary_care_service: str = "Domiciliary care service"
     remote_clinical_advice_service: str = "Remote clinical advice service"
-    acute_services_without_overnight_beds: str = (
-        "Acute services without overnight beds / listed acute services with or without overnight beds"
-    )
+    acute_services_without_overnight_beds: str = "Acute services without overnight beds / listed acute services with or without overnight beds"
     specialist_college_service: str = "Specialist college service"
     ambulance_service: str = "Ambulance service"
     extra_care_housing_services: str = "Extra Care housing services"
@@ -109,9 +107,7 @@ class Services(ColumnValues):
     rehabilitation_services: str = "Rehabilitation services"
     doctors_treatment_service: str = "Doctors treatment service"
     hospice_services_at_home: str = "Hospice services at home"
-    hospital_services_for_people_with_mental_health_needs: str = (
-        "Hospital services for people with mental health needs, learning disabilities and problems with substance misuse"
-    )
+    hospital_services_for_people_with_mental_health_needs: str = "Hospital services for people with mental health needs, learning disabilities and problems with substance misuse"
 
 
 @dataclass

--- a/utils/ind_cqc_filled_posts_utils/ascwds_filled_posts_calculator/calculate_ascwds_filled_posts_absolute_difference_within_range.py
+++ b/utils/ind_cqc_filled_posts_utils/ascwds_filled_posts_calculator/calculate_ascwds_filled_posts_absolute_difference_within_range.py
@@ -1,5 +1,8 @@
 from pyspark.sql import DataFrame, functions as F
 
+from utils.column_values.categorical_column_values import (
+    ASCWDSFilledPostsSource as Source,
+)
 from utils.ind_cqc_filled_posts_utils.ascwds_filled_posts_calculator.common_checks import (
     ascwds_filled_posts_is_null,
     selected_column_is_at_least_the_min_permitted_value,
@@ -11,8 +14,8 @@ from utils.ind_cqc_filled_posts_utils.utils import (
     add_source_description_to_source_column,
 )
 
-ascwds_filled_posts_absolute_difference_within_range_source_description: str = (
-    "average of total staff and worker records as both were similar"
+ascwds_filled_posts_absolute_difference_within_range_source_description = (
+    Source.average_of_total_staff_and_worker_records
 )
 
 

--- a/utils/ind_cqc_filled_posts_utils/ascwds_filled_posts_calculator/calculate_ascwds_filled_posts_return_worker_record_count_if_equal_to_total_staff.py
+++ b/utils/ind_cqc_filled_posts_utils/ascwds_filled_posts_calculator/calculate_ascwds_filled_posts_return_worker_record_count_if_equal_to_total_staff.py
@@ -1,5 +1,8 @@
 from pyspark.sql import DataFrame, functions as F
 
+from utils.column_values.categorical_column_values import (
+    ASCWDSFilledPostsSource as Source,
+)
 from utils.ind_cqc_filled_posts_utils.ascwds_filled_posts_calculator.common_checks import (
     ascwds_filled_posts_is_null,
     two_cols_are_equal_and_at_least_minimum_permitted_value,
@@ -8,8 +11,8 @@ from utils.ind_cqc_filled_posts_utils.utils import (
     add_source_description_to_source_column,
 )
 
-ascwds_filled_posts_totalstaff_equal_wkrrecs_source_description: str = (
-    "worker records and total staff were the same"
+ascwds_filled_posts_totalstaff_equal_wkrrecs_source_description = (
+    Source.worker_records_and_total_staff
 )
 
 


### PR DESCRIPTION
# Description
ASCWDS filled posts source checks were failing because the list of values referred to the raw total staff and worker records columns instead of bounded values. This change fixes this.

# How to test
Unit tests passing
Run in branch: https://eu-west-2.console.aws.amazon.com/gluestudio/home?region=eu-west-2#/editor/job/update-ascwds-source-to-bounde-validate_cleaned_ind_cqc_data_job/runs


