### PR TITLE
Remove number of beds completeness check from datasets which include …

### DIFF
--- a/utils/validation/validation_rules/cleaned_ind_cqc_validation_rules.py
+++ b/utils/validation/validation_rules/cleaned_ind_cqc_validation_rules.py
@@ -23,7 +23,6 @@ class CleanedIndCqcValidationRules:
             IndCqcColumns.registration_status,
             IndCqcColumns.imputed_registration_date,
             IndCqcColumns.primary_service_type,
-            IndCqcColumns.number_of_beds,
             IndCqcColumns.contemporary_ons_import_date,
             IndCqcColumns.contemporary_cssr,
             IndCqcColumns.contemporary_region,

--- a/utils/validation/validation_rules/estimated_ind_cqc_filled_posts_validation_rules.py
+++ b/utils/validation/validation_rules/estimated_ind_cqc_filled_posts_validation_rules.py
@@ -20,7 +20,6 @@ class EstimatedIndCqcFilledPostsValidationRules:
             IndCqcColumns.cqc_location_import_date,
             IndCqcColumns.care_home,
             IndCqcColumns.primary_service_type,
-            IndCqcColumns.number_of_beds,
             IndCqcColumns.current_ons_import_date,
             IndCqcColumns.current_cssr,
             IndCqcColumns.current_region,


### PR DESCRIPTION
…non residential data

# Description
Updates which validation jobs include the rule to check that number of beds is complete. It should only be complete when the dataset doesn't contain non-residential data, otherwise it will be incomplete

# How to test
Unit tests passing
Run in branch: https://eu-west-2.console.aws.amazon.com/gluestudio/home?region=eu-west-2#/editor/job/remove-completeness-check-from-validate_estimated_ind_cqc_filled_posts_data_job/runs
https://eu-west-2.console.aws.amazon.com/gluestudio/home?region=eu-west-2#/editor/job/remove-completeness-check-from-validate_cleaned_ind_cqc_data_job/runs

