### PR TITLE
Remove not care home value from feature engineering values

### DIFF
--- a/utils/column_values/categorical_columns_by_dataset.py
+++ b/utils/column_values/categorical_columns_by_dataset.py
@@ -145,7 +145,9 @@ class FeatureEngineeringCategoricalValues:
     services_column_values = Services(IndCQC.gac_service_types)
     current_rui_column_values = RUI(IndCQC.current_rural_urban_indicator_2011)
     dormancy_column_values = Dormancy(IndCQC.dormancy, contains_null_values=True)
-    care_home_column_values = CareHome(IndCQC.care_home)
+    care_home_column_values = CareHome(
+        IndCQC.care_home, value_to_remove=CareHome.not_care_home
+    )
 
 
 @dataclass


### PR DESCRIPTION
# Description
Remove the not care home value as a possible value in the care home features validation checks

# How to test
Unit tests passing
Run in branch: https://eu-west-2.console.aws.amazon.com/gluestudio/home?region=eu-west-2#/editor/job/update-care-hom-column-rule-fo-validate_care_home_ind_cqc_features_data_job/runs
