### PR TITLE
Clean people directly employed

### DIFF
--- a/jobs/clean_ind_cqc_filled_posts.py
+++ b/jobs/clean_ind_cqc_filled_posts.py
@@ -43,6 +43,7 @@ def main(
     )
 
     locations_df = null_ascwds_filled_post_outliers(locations_df)
+    locations_df = clean_people_directly_employed(locations_df)
 
     locations_df = create_column_with_repeated_values_removed(
         locations_df,
@@ -63,6 +64,14 @@ def main(
         mode="overwrite",
         partitionKeys=PartitionKeys,
     )
+
+
+def clean_people_directly_employed(df: DataFrame) -> DataFrame:
+    return df
+
+
+def replace_zero_people_with_one(df: DataFrame) -> DataFrame:
+    return df
 
 
 def replace_zero_beds_with_null(df: DataFrame) -> DataFrame:

--- a/jobs/clean_ind_cqc_filled_posts.py
+++ b/jobs/clean_ind_cqc_filled_posts.py
@@ -70,12 +70,12 @@ def clean_people_directly_employed(df: DataFrame) -> DataFrame:
     df = df.withColumn(
         IndCQC.people_directly_employed_clean, df[IndCQC.people_directly_employed]
     )
-    df = replace_zero_people_with_one(df)
+    df = replace_zero_people_with_none(df)
     return df
 
 
-def replace_zero_people_with_one(df: DataFrame) -> DataFrame:
-    return df.replace(0, 1, IndCQC.people_directly_employed_clean)
+def replace_zero_people_with_none(df: DataFrame) -> DataFrame:
+    return df.replace(0, None, IndCQC.people_directly_employed_clean)
 
 
 def replace_zero_beds_with_null(df: DataFrame) -> DataFrame:

--- a/jobs/clean_ind_cqc_filled_posts.py
+++ b/jobs/clean_ind_cqc_filled_posts.py
@@ -52,8 +52,8 @@ def main(
     )
     locations_df = create_column_with_repeated_values_removed(
         locations_df,
-        IndCQC.people_directly_employed,
-        IndCQC.people_directly_employed_dedup,
+        IndCQC.people_directly_employed_clean,
+        IndCQC.people_directly_employed_clean_dedup,
     )
 
     print(f"Exporting as parquet to {cleaned_ind_cqc_destination}")
@@ -67,6 +67,7 @@ def main(
 
 
 def clean_people_directly_employed(df: DataFrame) -> DataFrame:
+
     return df
 
 

--- a/jobs/clean_ind_cqc_filled_posts.py
+++ b/jobs/clean_ind_cqc_filled_posts.py
@@ -67,12 +67,15 @@ def main(
 
 
 def clean_people_directly_employed(df: DataFrame) -> DataFrame:
-
+    df = df.withColumn(
+        IndCQC.people_directly_employed_clean, df[IndCQC.people_directly_employed]
+    )
+    df = replace_zero_people_with_one(df)
     return df
 
 
 def replace_zero_people_with_one(df: DataFrame) -> DataFrame:
-    return df
+    return df.replace(0, 1, IndCQC.people_directly_employed_clean)
 
 
 def replace_zero_beds_with_null(df: DataFrame) -> DataFrame:

--- a/jobs/clean_ind_cqc_filled_posts.py
+++ b/jobs/clean_ind_cqc_filled_posts.py
@@ -31,7 +31,9 @@ def main(
 
     locations_df = utils.read_from_parquet(merged_ind_cqc_source)
 
-    locations_df = replace_zero_beds_with_null(locations_df)
+    locations_df = replace_zero_value_in_column_with_none(
+        locations_df, IndCQC.number_of_beds
+    )
     locations_df = populate_missing_care_home_number_of_beds(locations_df)
 
     locations_df = calculate_ascwds_filled_posts(
@@ -70,16 +72,16 @@ def clean_people_directly_employed(df: DataFrame) -> DataFrame:
     df = df.withColumn(
         IndCQC.people_directly_employed_clean, df[IndCQC.people_directly_employed]
     )
-    df = replace_zero_people_with_none(df)
+    df = replace_zero_value_in_column_with_none(
+        df, IndCQC.people_directly_employed_clean
+    )
     return df
 
 
-def replace_zero_people_with_none(df: DataFrame) -> DataFrame:
-    return df.replace(0, None, IndCQC.people_directly_employed_clean)
-
-
-def replace_zero_beds_with_null(df: DataFrame) -> DataFrame:
-    return df.replace(0, None, IndCQC.number_of_beds)
+def replace_zero_value_in_column_with_none(
+    df: DataFrame, column_name: str
+) -> DataFrame:
+    return df.replace(0, None, column_name)
 
 
 def populate_missing_care_home_number_of_beds(

--- a/jobs/estimate_ind_cqc_filled_posts.py
+++ b/jobs/estimate_ind_cqc_filled_posts.py
@@ -30,7 +30,7 @@ cleaned_ind_cqc_columns = [
     IndCQC.number_of_beds,
     IndCQC.cqc_pir_import_date,
     IndCQC.people_directly_employed,
-    IndCQC.people_directly_employed_dedup,
+    IndCQC.people_directly_employed_clean_dedup,
     IndCQC.ascwds_workplace_import_date,
     IndCQC.ascwds_filled_posts,
     IndCQC.ascwds_filled_posts_source,

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -2213,13 +2213,13 @@ class CleanIndCQCData:
         ("loc_1", 0, None),
         ("loc_1", None, None),
     ]
-    replace_zero_people_with_none_rows = [
+    replace_zero_value_in_column_with_none_rows = [
         ("loc_1", 2, 2),
         ("loc_1", 1, 1),
         ("loc_1", 0, 0),
         ("loc_1", None, None),
     ]
-    expected_replace_zero_people_with_none_rows = (
+    expected_replace_zero_value_in_column_with_none_rows = (
         expected_clean_people_directly_employed_rows
     )
 

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -2201,6 +2201,28 @@ class CleanIndCQCData:
         ("2", 3, date(2024, 2, 1), None),
     ]
 
+    clean_people_directly_employed_rows = [
+        ("loc_1", 2),
+        ("loc_1", 1),
+        ("loc_1", 0),
+        ("loc_1", None),
+    ]
+    expected_clean_people_directly_employed_rows = [
+        ("loc_1", 2, 2),
+        ("loc_1", 1, 1),
+        ("loc_1", 0, 1),
+        ("loc_1", None, None),
+    ]
+    replace_zero_people_with_one_rows = [
+        ("loc_1", 2, 2),
+        ("loc_1", 1, 1),
+        ("loc_1", 0, 0),
+        ("loc_1", None, None),
+    ]
+    expected_replace_zero_people_with_one_rows = (
+        expected_clean_people_directly_employed_rows
+    )
+
 
 @dataclass
 class ReconciliationData:

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -2210,16 +2210,16 @@ class CleanIndCQCData:
     expected_clean_people_directly_employed_rows = [
         ("loc_1", 2, 2),
         ("loc_1", 1, 1),
-        ("loc_1", 0, 1),
+        ("loc_1", 0, None),
         ("loc_1", None, None),
     ]
-    replace_zero_people_with_one_rows = [
+    replace_zero_people_with_none_rows = [
         ("loc_1", 2, 2),
         ("loc_1", 1, 1),
         ("loc_1", 0, 0),
         ("loc_1", None, None),
     ]
-    expected_replace_zero_people_with_one_rows = (
+    expected_replace_zero_people_with_none_rows = (
         expected_clean_people_directly_employed_rows
     )
 

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -1555,6 +1555,21 @@ class CleanIndCQCData:
         ]
     )
 
+    clean_people_directly_employed_schema = StructType(
+        [
+            StructField(IndCQC.location_id, StringType(), True),
+            StructField(IndCQC.people_directly_employed, IntegerType(), True),
+        ]
+    )
+    expected_clean_people_directly_employed_schema = StructType(
+        [
+            StructField(IndCQC.location_id, StringType(), True),
+            StructField(IndCQC.people_directly_employed, IntegerType(), True),
+            StructField(IndCQC.people_directly_employed_clean, IntegerType(), True),
+        ]
+    )
+    replace_zero_people_with_one_schema = expected_clean_people_directly_employed_schema
+
 
 @dataclass
 class ReconciliationSchema:

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -3263,7 +3263,9 @@ class ValidateCleanedIndCqcData:
             StructField(IndCQC.ascwds_filled_posts, DoubleType(), True),
             StructField(IndCQC.ascwds_filled_posts_clean, DoubleType(), True),
             StructField(IndCQC.ascwds_filled_posts_dedup_clean, DoubleType(), True),
-            StructField(IndCQC.people_directly_employed_dedup, IntegerType(), True),
+            StructField(
+                IndCQC.people_directly_employed_clean_dedup, IntegerType(), True
+            ),
         ]
     )
     calculate_expected_size_schema = merged_ind_cqc_schema
@@ -3340,7 +3342,9 @@ class ValidateEstimatedIndCqcFilledPostsData:
             StructField(IndCQC.ascwds_filled_posts_source, StringType(), True),
             StructField(IndCQC.ascwds_filled_posts, DoubleType(), True),
             StructField(IndCQC.ascwds_filled_posts_dedup_clean, DoubleType(), True),
-            StructField(IndCQC.people_directly_employed_dedup, IntegerType(), True),
+            StructField(
+                IndCQC.people_directly_employed_clean_dedup, IntegerType(), True
+            ),
             StructField(IndCQC.unix_time, IntegerType(), True),
             StructField(IndCQC.estimate_filled_posts, DoubleType(), True),
             StructField(IndCQC.estimate_filled_posts_source, StringType(), True),

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -1568,7 +1568,9 @@ class CleanIndCQCData:
             StructField(IndCQC.people_directly_employed_clean, IntegerType(), True),
         ]
     )
-    replace_zero_people_with_one_schema = expected_clean_people_directly_employed_schema
+    replace_zero_people_with_none_schema = (
+        expected_clean_people_directly_employed_schema
+    )
 
 
 @dataclass

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -1568,7 +1568,7 @@ class CleanIndCQCData:
             StructField(IndCQC.people_directly_employed_clean, IntegerType(), True),
         ]
     )
-    replace_zero_people_with_none_schema = (
+    replace_zero_value_in_column_with_none_schema = (
         expected_clean_people_directly_employed_schema
     )
 

--- a/tests/unit/test_clean_ind_cqc_filled_posts.py
+++ b/tests/unit/test_clean_ind_cqc_filled_posts.py
@@ -280,5 +280,34 @@ class AddColumnWithRepeatedValuesRemovedTests(CleanIndFilledPostsTests):
         self.assertEqual(self.returned_df.count(), self.test_purge_outdated_df.count())
 
 
+class CleanPeopleDirectlyEmployedColumn(CleanIndFilledPostsTests):
+    def setUp(self):
+        super().setUp()
+
+    def test_clean_people_directly_employed(self):
+        test_df = self.spark.createDataFrame(
+            Data.clean_people_directly_employed_rows,
+            Schemas.clean_people_directly_employed_schema,
+        )
+        expected_df = self.spark.createDataFrame(
+            Data.expected_clean_people_directly_employed_rows,
+            Schemas.expected_clean_people_directly_employed_schema,
+        )
+        returned_df = job.clean_people_directly_employed(test_df)
+        self.assertEqual(expected_df.collect(), returned_df.collect())
+
+    def test_replace_zero_people_with_one(self):
+        test_df = self.spark.createDataFrame(
+            Data.replace_zero_people_with_one_rows,
+            Schemas.replace_zero_people_with_one_schema,
+        )
+        expected_df = self.spark.createDataFrame(
+            Data.expected_replace_zero_people_with_one_rows,
+            Schemas.replace_zero_people_with_one_schema,
+        )
+        returned_df = job.replace_zero_people_with_one(test_df)
+        self.assertEqual(expected_df.collect(), returned_df.collect())
+
+
 if __name__ == "__main__":
     unittest.main(warnings="ignore")

--- a/tests/unit/test_clean_ind_cqc_filled_posts.py
+++ b/tests/unit/test_clean_ind_cqc_filled_posts.py
@@ -71,26 +71,6 @@ class MainTests(CleanIndFilledPostsTests):
             partitionKeys=self.partition_keys,
         )
 
-    def test_replace_zero_beds_with_null(self):
-        columns = [
-            IndCQC.location_id,
-            IndCQC.number_of_beds,
-        ]
-        rows = [
-            ("1-000000001", None),
-            ("1-000000002", 0),
-            ("1-000000003", 1),
-        ]
-        df = self.spark.createDataFrame(rows, columns)
-
-        df = job.replace_zero_beds_with_null(df)
-        self.assertEqual(df.count(), 3)
-
-        df = df.collect()
-        self.assertEqual(df[0][IndCQC.number_of_beds], None)
-        self.assertEqual(df[1][IndCQC.number_of_beds], None)
-        self.assertEqual(df[2][IndCQC.number_of_beds], 1)
-
     def test_populate_missing_care_home_number_of_beds(self):
         schema = StructType(
             [
@@ -296,16 +276,23 @@ class CleanPeopleDirectlyEmployedColumn(CleanIndFilledPostsTests):
         returned_df = job.clean_people_directly_employed(test_df)
         self.assertEqual(expected_df.collect(), returned_df.collect())
 
-    def test_replace_zero_people_with_none(self):
+
+class ReplaceZeroValueInColumnWithNone(CleanIndFilledPostsTests):
+    def setUp(self):
+        super().setUp()
+
+    def test_replace_zero_value_in_column_with_none(self):
         test_df = self.spark.createDataFrame(
-            Data.replace_zero_people_with_none_rows,
-            Schemas.replace_zero_people_with_none_schema,
+            Data.replace_zero_value_in_column_with_none_rows,
+            Schemas.replace_zero_value_in_column_with_none_schema,
         )
         expected_df = self.spark.createDataFrame(
-            Data.expected_replace_zero_people_with_none_rows,
-            Schemas.replace_zero_people_with_none_schema,
+            Data.expected_replace_zero_value_in_column_with_none_rows,
+            Schemas.replace_zero_value_in_column_with_none_schema,
         )
-        returned_df = job.replace_zero_people_with_none(test_df)
+        returned_df = job.replace_zero_value_in_column_with_none(
+            test_df, IndCQC.people_directly_employed_clean
+        )
         self.assertEqual(expected_df.collect(), returned_df.collect())
 
 

--- a/tests/unit/test_clean_ind_cqc_filled_posts.py
+++ b/tests/unit/test_clean_ind_cqc_filled_posts.py
@@ -296,16 +296,16 @@ class CleanPeopleDirectlyEmployedColumn(CleanIndFilledPostsTests):
         returned_df = job.clean_people_directly_employed(test_df)
         self.assertEqual(expected_df.collect(), returned_df.collect())
 
-    def test_replace_zero_people_with_one(self):
+    def test_replace_zero_people_with_none(self):
         test_df = self.spark.createDataFrame(
-            Data.replace_zero_people_with_one_rows,
-            Schemas.replace_zero_people_with_one_schema,
+            Data.replace_zero_people_with_none_rows,
+            Schemas.replace_zero_people_with_none_schema,
         )
         expected_df = self.spark.createDataFrame(
-            Data.expected_replace_zero_people_with_one_rows,
-            Schemas.replace_zero_people_with_one_schema,
+            Data.expected_replace_zero_people_with_none_rows,
+            Schemas.replace_zero_people_with_none_schema,
         )
-        returned_df = job.replace_zero_people_with_one(test_df)
+        returned_df = job.replace_zero_people_with_none(test_df)
         self.assertEqual(expected_df.collect(), returned_df.collect())
 
 

--- a/utils/column_names/ind_cqc_pipeline_columns.py
+++ b/utils/column_names/ind_cqc_pipeline_columns.py
@@ -52,7 +52,7 @@ class IndCqcColumns:
         CQCPIRClean.people_directly_employed + "_clean"
     )
     people_directly_employed_clean_dedup: str = (
-        CQCPIRClean.people_directly_employed_clean + "_deduplicated"
+        people_directly_employed_clean + "_deduplicated"
     )
     contemporary_ons_import_date: str = ONSClean.contemporary_ons_import_date
     contemporary_cssr: str = ONSClean.contemporary_cssr

--- a/utils/column_names/ind_cqc_pipeline_columns.py
+++ b/utils/column_names/ind_cqc_pipeline_columns.py
@@ -48,8 +48,11 @@ class IndCqcColumns:
     worker_records_bounded: str = AWPClean.worker_records_bounded
     cqc_pir_import_date: str = CQCPIRClean.cqc_pir_import_date
     people_directly_employed: str = CQCPIRClean.people_directly_employed
-    people_directly_employed_dedup: str = (
-        CQCPIRClean.people_directly_employed + "_deduplicated"
+    people_directly_employed_clean: str = (
+        CQCPIRClean.people_directly_employed + "_clean"
+    )
+    people_directly_employed_clean_dedup: str = (
+        CQCPIRClean.people_directly_employed_clean + "_deduplicated"
     )
     contemporary_ons_import_date: str = ONSClean.contemporary_ons_import_date
     contemporary_cssr: str = ONSClean.contemporary_cssr

--- a/utils/validation/validation_rules/estimated_ind_cqc_filled_posts_validation_rules.py
+++ b/utils/validation/validation_rules/estimated_ind_cqc_filled_posts_validation_rules.py
@@ -51,7 +51,7 @@ class EstimatedIndCqcFilledPostsValidationRules:
             IndCqcColumns.people_directly_employed: 10000,
             IndCqcColumns.unix_time: int(time.time()),  # current unix time
             IndCqcColumns.estimate_filled_posts: 3000.0,
-            IndCqcColumns.people_directly_employed_dedup: 10000,
+            IndCqcColumns.people_directly_employed_clean_dedup: 10000,
             IndCqcColumns.ascwds_filled_posts: 3000.0,
             IndCqcColumns.ascwds_filled_posts_dedup_clean: 3000.0,
             IndCqcColumns.rolling_average_model: 3000.0,

--- a/utils/validation/validation_rules/estimated_ind_cqc_filled_posts_validation_rules.py
+++ b/utils/validation/validation_rules/estimated_ind_cqc_filled_posts_validation_rules.py
@@ -37,7 +37,7 @@ class EstimatedIndCqcFilledPostsValidationRules:
             IndCqcColumns.people_directly_employed: 1,
             IndCqcColumns.unix_time: 1262304000,  # 1st Jan 2010 in unix time
             IndCqcColumns.estimate_filled_posts: 1.0,
-            IndCqcColumns.people_directly_employed_dedup: 1,
+            IndCqcColumns.people_directly_employed_clean_dedup: 1,
             IndCqcColumns.ascwds_filled_posts: 1.0,
             IndCqcColumns.ascwds_filled_posts_dedup_clean: 1.0,
             IndCqcColumns.rolling_average_model: 0.0,


### PR DESCRIPTION
# Description
Clean people directly employed value by converting all zeros into ones. We may decide we want to clean this column further in future.

# How to test
Unit tests passing
Run in branch : https://eu-west-2.console.aws.amazon.com/gluestudio/home?region=eu-west-2#/editor/job/clean-people-directly-employed-clean_ind_cqc_filled_posts_job/runs
