### PR TITLE
Remove specifc rows from locations dataset

### DIFF
--- a/jobs/clean_cqc_location_data.py
+++ b/jobs/clean_cqc_location_data.py
@@ -29,7 +29,7 @@ from utils.column_names.cleaned_data_files.ons_cleaned import (
     current_geography_columns,
 )
 from utils.cqc_location_dictionaries import InvalidPostcodes
-from utils.raw_data_adjustments import remove_dental_practice_from_locations_data
+from utils.raw_data_adjustments import remove_records_from_locations_data
 
 
 cqcPartitionKeys = [Keys.year, Keys.month, Keys.day, Keys.import_date]
@@ -87,7 +87,7 @@ def main(
     cqc_location_df = clean_provider_id_column(cqc_location_df)
 
     cqc_location_df = remove_non_social_care_locations(cqc_location_df)
-    cqc_location_df = remove_dental_practice_from_locations_data(cqc_location_df)
+    cqc_location_df = remove_records_from_locations_data(cqc_location_df)
     cqc_location_df = utils.format_date_fields(
         cqc_location_df,
         date_column_identifier=CQCLClean.registration_date,  # This will format both registration date and deregistration date

--- a/jobs/validate_locations_api_cleaned_data.py
+++ b/jobs/validate_locations_api_cleaned_data.py
@@ -68,6 +68,10 @@ def calculate_expected_size_of_cleaned_cqc_locations_dataset(
     expected_size = raw_location_df.where(
         (raw_location_df[CQCL.type] == LocationType.social_care_identifier)
         & (raw_location_df[CQCL.registration_status] == RegistrationStatus.registered)
+        & (
+            (raw_location_df[CQCL.location_id] != "1-12082335777")
+            | (raw_location_df[Keys.import_date] != "20220207")
+        )
     ).count()
     return expected_size
 

--- a/jobs/validate_locations_api_cleaned_data.py
+++ b/jobs/validate_locations_api_cleaned_data.py
@@ -16,6 +16,7 @@ from utils.column_values.categorical_column_values import (
     LocationType,
     RegistrationStatus,
 )
+from utils.raw_data_adjustments import RecordsToRemoveInLocationsData
 from utils.validation.validation_rules.locations_api_cleaned_validation_rules import (
     LocationsAPICleanedValidationRules as Rules,
 )
@@ -69,8 +70,12 @@ def calculate_expected_size_of_cleaned_cqc_locations_dataset(
         (raw_location_df[CQCL.type] == LocationType.social_care_identifier)
         & (raw_location_df[CQCL.registration_status] == RegistrationStatus.registered)
         & (
-            (raw_location_df[CQCL.location_id] != "1-12082335777")
-            | (raw_location_df[Keys.import_date] != "20220207")
+            raw_location_df[CQCL.location_id]
+            != RecordsToRemoveInLocationsData.dental_practice
+        )
+        & (
+            raw_location_df[CQCL.location_id]
+            != RecordsToRemoveInLocationsData.temp_registration
         )
     ).count()
     return expected_size

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -44,6 +44,7 @@ from utils.ind_cqc_filled_posts_utils.ascwds_filled_posts_calculator.calculate_a
 from utils.ind_cqc_filled_posts_utils.ascwds_filled_posts_calculator.calculate_ascwds_filled_posts_return_worker_record_count_if_equal_to_total_staff import (
     ascwds_filled_posts_totalstaff_equal_wkrrecs_source_description,
 )
+from utils.raw_data_adjustments import RecordsToRemoveInLocationsData
 from utils.validation.validation_rule_names import RuleNames as RuleName
 
 
@@ -4557,13 +4558,14 @@ class ValidateLocationsAPICleanedData:
     
 
     calculate_expected_size_rows = [
-        ("loc_1", LocationType.social_care_identifier, RegistrationStatus.registered, "20240101"),
-        ("loc_2", "non social care org", RegistrationStatus.registered, "20240101"),
-        ("loc_3", None, RegistrationStatus.registered, "20240101"),
-        ("loc_4", LocationType.social_care_identifier, RegistrationStatus.deregistered, "20240101"),
-        ("loc_5", "non social care org", RegistrationStatus.deregistered, "20240101"),
-        ("loc_6", None, RegistrationStatus.deregistered, "20240101"),
-        ("1-12082335777", LocationType.social_care_identifier, RegistrationStatus.registered, "20220207"), # miscoded dentist
+        ("loc_1", LocationType.social_care_identifier, RegistrationStatus.registered),
+        ("loc_2", "non social care org", RegistrationStatus.registered),
+        ("loc_3", None, RegistrationStatus.registered),
+        ("loc_4", LocationType.social_care_identifier, RegistrationStatus.deregistered),
+        ("loc_5", "non social care org", RegistrationStatus.deregistered),
+        ("loc_6", None, RegistrationStatus.deregistered),
+        (RecordsToRemoveInLocationsData.dental_practice, LocationType.social_care_identifier, RegistrationStatus.registered),
+        (RecordsToRemoveInLocationsData.temp_registration, LocationType.social_care_identifier, RegistrationStatus.registered),
     ]
     # fmt: on
 
@@ -4926,16 +4928,16 @@ class RawDataAdjustments:
 
     locations_data_with_multiple_rows_to_remove = [
         ("loc_1", "other"),
-        ("1-12082335777", "other"),
-        ("1-12082335777", "something else"),
+        (RecordsToRemoveInLocationsData.dental_practice, "other"),
+        (RecordsToRemoveInLocationsData.dental_practice, "something else"),
+        (RecordsToRemoveInLocationsData.temp_registration, "other"),
+        (RecordsToRemoveInLocationsData.temp_registration, "something else"),
     ]
 
     locations_data_with_single_rows_to_remove = [
         ("loc_1", "other"),
-        ("1-12082335777", "other"),
-        ("1-12082335777", "other"),
-        ("1-127367030", "other"),
-        ("1-127367030", "other"),
+        (RecordsToRemoveInLocationsData.dental_practice, "other"),
+        (RecordsToRemoveInLocationsData.temp_registration, "other"),
     ]
 
     locations_data_without_rows_to_remove = [

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -4925,24 +4925,21 @@ class RawDataAdjustments:
     pir_data_without_rows_to_remove = expected_pir_data
 
     locations_data_with_multiple_rows_to_remove = [
-        ("loc_1", "20240101", "other"),
-        ("1-12082335777", "20220207", "other"),
-        ("loc_1", "20220207", "other"),
-        ("1-12082335777", "20240101", "other"),
-        ("1-12082335777", "20220207", "something else"),
+        ("loc_1", "other"),
+        ("1-12082335777", "other"),
+        ("1-12082335777", "something else"),
     ]
 
-    locations_data_with_single_row_to_remove = [
-        ("loc_1", "20240101", "other"),
-        ("1-12082335777", "20220207", "other"),
-        ("loc_1", "20220207", "other"),
-        ("1-12082335777", "20240101", "other"),
+    locations_data_with_single_rows_to_remove = [
+        ("loc_1", "other"),
+        ("1-12082335777", "other"),
+        ("1-12082335777", "other"),
+        ("1-127367030", "other"),
+        ("1-127367030", "other"),
     ]
 
     locations_data_without_rows_to_remove = [
-        ("loc_1", "20240101", "other"),
-        ("loc_1", "20220207", "other"),
-        ("1-12082335777", "20240101", "other"),
+        ("loc_1", "other"),
     ]
 
     expected_locations_data = locations_data_without_rows_to_remove

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -4554,16 +4554,18 @@ class ValidateLocationsAPICleanedData:
         ("1-000000001", date(2024, 1, 9), date(2024, 1, 1), "Y", "name", "prov_1", "prov_name", Sector.independent, RegistrationStatus.registered, date(2024, 1, 1), "Y", 5, PrimaryServiceType.care_home_only, date(2024, 1, 1), "cssr", "region", date(2024, 1, 1), "cssr", "region", "RUI"),
         ("1-000000002", date(2024, 1, 9), date(2024, 1, 1), "Y", "name", "prov_1", "prov_name", Sector.independent, RegistrationStatus.registered, date(2024, 1, 1), "Y", 5, PrimaryServiceType.care_home_only, date(2024, 1, 1), "cssr", "region", date(2024, 1, 1), "cssr", "region", "RUI"),
     ]
-    # fmt: on
+    
 
     calculate_expected_size_rows = [
-        ("loc_1", LocationType.social_care_identifier, RegistrationStatus.registered),
-        ("loc_2", "non social care org", RegistrationStatus.registered),
-        ("loc_3", None, RegistrationStatus.registered),
-        ("loc_4", LocationType.social_care_identifier, RegistrationStatus.deregistered),
-        ("loc_5", "non social care org", RegistrationStatus.deregistered),
-        ("loc_6", None, RegistrationStatus.deregistered),
+        ("loc_1", LocationType.social_care_identifier, RegistrationStatus.registered, "20240101"),
+        ("loc_2", "non social care org", RegistrationStatus.registered, "20240101"),
+        ("loc_3", None, RegistrationStatus.registered, "20240101"),
+        ("loc_4", LocationType.social_care_identifier, RegistrationStatus.deregistered, "20240101"),
+        ("loc_5", "non social care org", RegistrationStatus.deregistered, "20240101"),
+        ("loc_6", None, RegistrationStatus.deregistered, "20240101"),
+        ("1-12082335777", LocationType.social_care_identifier, RegistrationStatus.registered, "20220207"), # miscoded dentist
     ]
+    # fmt: on
 
 
 @dataclass

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -3123,7 +3123,6 @@ class ValidateLocationsAPICleanedData:
             StructField(CQCL.location_id, StringType(), True),
             StructField(CQCL.type, StringType(), True),
             StructField(CQCL.registration_status, StringType(), True),
-            StructField(Keys.import_date, StringType(), True),
         ]
     )
 

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -3464,7 +3464,6 @@ class RawDataAdjustments:
     locations_data_schema = StructType(
         [
             StructField(CQCL.location_id, StringType(), True),
-            StructField(Keys.import_date, StringType(), True),
             StructField("other_column", StringType(), True),
         ]
     )

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -3123,6 +3123,7 @@ class ValidateLocationsAPICleanedData:
             StructField(CQCL.location_id, StringType(), True),
             StructField(CQCL.type, StringType(), True),
             StructField(CQCL.registration_status, StringType(), True),
+            StructField(Keys.import_date, StringType(), True),
         ]
     )
 

--- a/tests/unit/test_raw_data_adjustments.py
+++ b/tests/unit/test_raw_data_adjustments.py
@@ -107,15 +107,16 @@ class RemoveDuplicatePIRTests(TestRawDataAdjustments):
         self.assertEqual(self.expected_df.collect(), returned_df.collect())
 
 
-class RemoveDentalPracticeFromLocationsDataTests(TestRawDataAdjustments):
+class RemoveRecordsFromLocationsDataTests(TestRawDataAdjustments):
     def setUp(self) -> None:
         super().setUp()
         self.test_with_multiple_rows_to_remove_df = self.spark.createDataFrame(
             Data.locations_data_with_multiple_rows_to_remove,
             Schemas.locations_data_schema,
         )
-        self.test_with_single_row_to_remove_df = self.spark.createDataFrame(
-            Data.locations_data_with_single_row_to_remove, Schemas.locations_data_schema
+        self.test_with_single_rows_to_remove_df = self.spark.createDataFrame(
+            Data.locations_data_with_single_rows_to_remove,
+            Schemas.locations_data_schema,
         )
         self.test_without_rows_to_remove_df = self.spark.createDataFrame(
             Data.locations_data_without_rows_to_remove, Schemas.locations_data_schema
@@ -124,30 +125,30 @@ class RemoveDentalPracticeFromLocationsDataTests(TestRawDataAdjustments):
             Data.expected_locations_data, Schemas.locations_data_schema
         )
 
-    def test_remove_dental_practice_from_locations_data_removes_multiple_rows_when_they_match_the_criteria(
+    def test_remove_records_from_locations_data_removes_multiple_rows_when_they_match_the_criteria(
         self,
     ):
-        returned_df = job.remove_dental_practice_from_locations_data(
+        returned_df = job.remove_records_from_locations_data(
             self.test_with_multiple_rows_to_remove_df,
         )
 
         self.assertIsNotNone(returned_df)
         self.assertEqual(self.expected_df.collect(), returned_df.collect())
 
-    def test_remove_dental_practice_from_locations_data_removes_single_row_when_it_matches_the_criteria(
+    def test_remove_records_from_locations_data_removes_single_rows_when_it_matches_the_criteria(
         self,
     ):
-        returned_df = job.remove_dental_practice_from_locations_data(
-            self.test_with_single_row_to_remove_df,
+        returned_df = job.remove_records_from_locations_data(
+            self.test_with_single_rows_to_remove_df,
         )
 
         self.assertIsNotNone(returned_df)
         self.assertEqual(self.expected_df.collect(), returned_df.collect())
 
-    def test_remove_dental_practice_from_locations_data_does_not_remove_rows_when_they_do_not_match_the_criteria(
+    def test_remove_records_from_locations_data_does_not_remove_rows_when_they_do_not_match_the_criteria(
         self,
     ):
-        returned_df = job.remove_dental_practice_from_locations_data(
+        returned_df = job.remove_records_from_locations_data(
             self.test_without_rows_to_remove_df,
         )
 

--- a/utils/raw_data_adjustments.py
+++ b/utils/raw_data_adjustments.py
@@ -78,13 +78,13 @@ class RecordsToRemoveInLocationsData:
     Dental Practice:
     The location is listed once as a social care org in the locations
     dataset but is lited as Primary Dental Care on every other row and
-    in the providers dataset. The location ID and import date are enough
+    in the providers dataset. The location ID is enough
     to identify and remove this row.
 
     Temporary Registration:
     The location is listed once as registered in the locations dataset,
     but conatins barely any data and appears to have deregistered very
-    quickly. The location ID and import date are enough
+    quickly. The location ID is enough
     to identify and remove this row.
     """
 

--- a/utils/raw_data_adjustments.py
+++ b/utils/raw_data_adjustments.py
@@ -78,14 +78,13 @@ class RecordsToRemoveInLocationsData:
     Dental Practice:
     The location is listed once as a social care org in the locations
     dataset but is lited as Primary Dental Care on every other row and
-    in the providers dataset. The location ID is enough
-    to identify and remove this row.
+    in the providers dataset. The location ID is enough to identify
+    and remove this row.
 
     Temporary Registration:
     The location is listed once as registered in the locations dataset,
     but conatins barely any data and appears to have deregistered very
-    quickly. The location ID is enough
-    to identify and remove this row.
+    quickly. The location ID is enough to identify and remove this row.
     """
 
     dental_practice: str = "1-12082335777"


### PR DESCRIPTION
# Description
Refactors raw data adjustment to remove two locations from raw locations data
Updates the validation row count to account for these locations as well.

# How to test
Unit tests passing
Run in branch: 
https://eu-west-2.console.aws.amazon.com/gluestudio/home?region=eu-west-2#/editor/job/reduce-locations-size-by-one-clean_cqc_location_data_job/runs
https://eu-west-2.console.aws.amazon.com/gluestudio/home?region=eu-west-2#/editor/job/reduce-locations-size-by-one-validate_locations_api_cleaned_data_job/runs

