### PR TITLE
Changed postcount function to use count instead of approx count disti…

### DIFF
--- a/jobs/split_pa_filled_posts_into_icb_areas.py
+++ b/jobs/split_pa_filled_posts_into_icb_areas.py
@@ -42,6 +42,8 @@ def main(postcode_directory_source, pa_filled_posts_source, destination):
         ],
     )
 
+    check_for_duplicate_postcodes(postcode_directory_df)
+
     postcode_directory_df = count_postcodes_per_list_of_columns(
         postcode_directory_df,
         [ONSClean.contemporary_ons_import_date, ONSClean.contemporary_cssr],

--- a/jobs/split_pa_filled_posts_into_icb_areas.py
+++ b/jobs/split_pa_filled_posts_into_icb_areas.py
@@ -94,6 +94,19 @@ def main(postcode_directory_source, pa_filled_posts_source, destination):
     )
 
 
+def check_for_duplicate_postcodes(
+    postcode_directory_df: DataFrame,
+) -> int:
+    duplicate_postcode_count = (
+        postcode_directory_df.count() - postcode_directory_df.distinct().count()
+    )
+
+    if duplicate_postcode_count > 0:
+        raise ValueError(f"Postcode directory has 1 or more duplicates")
+
+    return duplicate_postcode_count
+
+
 def count_postcodes_per_list_of_columns(
     postcode_directory_df: DataFrame,
     list_of_columns_to_group_by: list,

--- a/jobs/split_pa_filled_posts_into_icb_areas.py
+++ b/jobs/split_pa_filled_posts_into_icb_areas.py
@@ -105,7 +105,7 @@ def count_postcodes_per_list_of_columns(
 
     postcode_directory_df = postcode_directory_df.withColumn(
         new_column_name,
-        F.approx_count_distinct(ONSClean.postcode).over(w),
+        F.count(ONSClean.postcode).over(w),
     )
 
     return postcode_directory_df

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -640,6 +640,13 @@ class ONSData:
 @dataclass
 class PAFilledPostsByIcbArea:
     # fmt: off
+    sample_ons_contemporary_with_duplicates_rows = [
+        ("AB10AA", date(2024,1,1), "cssr1", "icb1"),
+        ("AB10AB", date(2024,1,1), "cssr1", "icb1"),
+        ("AB10AC", date(2024,1,1), "cssr1", "icb1"),
+        ("AB10AC", date(2024,1,1), "cssr1", "icb1"),
+    ]
+
     sample_ons_contemporary_rows = [
         ("AB10AA", date(2024,1,1), "cssr1", "icb1"),
         ("AB10AB", date(2024,1,1), "cssr1", "icb1"),
@@ -654,7 +661,6 @@ class PAFilledPostsByIcbArea:
         ("AB10AA", date(2023,1,1), "cssr2", "icb2"), 
         ("AB10AB", date(2023,1,1), "cssr2", "icb3"), 
         ("AB10AC", date(2023,1,1), "cssr2", "icb3"), 
-        ("AB10AC", date(2023,1,1), "cssr2", "icb3"), 
     ]
 
     expected_postcode_count_per_la_rows = [
@@ -668,10 +674,9 @@ class PAFilledPostsByIcbArea:
         ("AB10AA", date(2023,1,1), "cssr1", "icb1",3),
         ("AB10AB", date(2023,1,1), "cssr1", "icb1",3),
         ("AB10AC", date(2023,1,1), "cssr1", "icb1",3),
-        ("AB10AA", date(2023,1,1), "cssr2", "icb2",4), 
-        ("AB10AB", date(2023,1,1), "cssr2", "icb3",4), 
-        ("AB10AC", date(2023,1,1), "cssr2", "icb3",4), 
-        ("AB10AC", date(2023,1,1), "cssr2", "icb3",4), 
+        ("AB10AA", date(2023,1,1), "cssr2", "icb2",3), 
+        ("AB10AB", date(2023,1,1), "cssr2", "icb3",3), 
+        ("AB10AC", date(2023,1,1), "cssr2", "icb3",3), 
     ]
 
     expected_postcode_count_per_la_icb_rows = [
@@ -686,9 +691,8 @@ class PAFilledPostsByIcbArea:
         ("AB10AB", date(2023,1,1), "cssr1", "icb1", 3),
         ("AB10AC", date(2023,1,1), "cssr1", "icb1", 3),
         ("AB10AA", date(2023,1,1), "cssr2", "icb2", 1), 
-        ("AB10AB", date(2023,1,1), "cssr2", "icb3", 3), 
-        ("AB10AC", date(2023,1,1), "cssr2", "icb3", 3), 
-        ("AB10AC", date(2023,1,1), "cssr2", "icb3", 3),
+        ("AB10AB", date(2023,1,1), "cssr2", "icb3", 2), 
+        ("AB10AC", date(2023,1,1), "cssr2", "icb3", 2), 
     ]
 
     sample_rows_with_la_and_hybrid_area_postcode_counts = [

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -668,10 +668,10 @@ class PAFilledPostsByIcbArea:
         ("AB10AA", date(2023,1,1), "cssr1", "icb1",3),
         ("AB10AB", date(2023,1,1), "cssr1", "icb1",3),
         ("AB10AC", date(2023,1,1), "cssr1", "icb1",3),
-        ("AB10AA", date(2023,1,1), "cssr2", "icb2",3), 
-        ("AB10AB", date(2023,1,1), "cssr2", "icb3",3), 
-        ("AB10AC", date(2023,1,1), "cssr2", "icb3",3), 
-        ("AB10AC", date(2023,1,1), "cssr2", "icb3",3), 
+        ("AB10AA", date(2023,1,1), "cssr2", "icb2",4), 
+        ("AB10AB", date(2023,1,1), "cssr2", "icb3",4), 
+        ("AB10AC", date(2023,1,1), "cssr2", "icb3",4), 
+        ("AB10AC", date(2023,1,1), "cssr2", "icb3",4), 
     ]
 
     expected_postcode_count_per_la_icb_rows = [
@@ -686,9 +686,9 @@ class PAFilledPostsByIcbArea:
         ("AB10AB", date(2023,1,1), "cssr1", "icb1", 3),
         ("AB10AC", date(2023,1,1), "cssr1", "icb1", 3),
         ("AB10AA", date(2023,1,1), "cssr2", "icb2", 1), 
-        ("AB10AB", date(2023,1,1), "cssr2", "icb3", 2), 
-        ("AB10AC", date(2023,1,1), "cssr2", "icb3", 2), 
-        ("AB10AC", date(2023,1,1), "cssr2", "icb3", 2),
+        ("AB10AB", date(2023,1,1), "cssr2", "icb3", 3), 
+        ("AB10AC", date(2023,1,1), "cssr2", "icb3", 3), 
+        ("AB10AC", date(2023,1,1), "cssr2", "icb3", 3),
     ]
 
     sample_rows_with_la_and_hybrid_area_postcode_counts = [

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -451,7 +451,7 @@ class ONSData:
 
 @dataclass
 class PAFilledPostsByIcbAreaSchema:
-    sample_ons_contemporary_schema = StructType(
+    sample_ons_contemporary_with_duplicates_schema = StructType(
         [
             StructField(ONSClean.postcode, StringType(), True),
             StructField(ONSClean.contemporary_ons_import_date, DateType(), True),
@@ -459,6 +459,8 @@ class PAFilledPostsByIcbAreaSchema:
             StructField(ONSClean.contemporary_icb, StringType(), True),
         ]
     )
+
+    sample_ons_contemporary_schema = sample_ons_contemporary_with_duplicates_schema
 
     expected_postcode_count_per_la_schema = StructType(
         [

--- a/tests/unit/test_dpr_split_pa_filled_posts_into_icb_areas.py
+++ b/tests/unit/test_dpr_split_pa_filled_posts_into_icb_areas.py
@@ -55,6 +55,34 @@ class MainTests(SplitPAFilledPostsIntoIcbAreas):
         )
 
 
+class CheckForDuplicatePostcodes(SplitPAFilledPostsIntoIcbAreas):
+    def setUp(self) -> None:
+        super().setUp()
+
+    def test_check_for_duplicate_postcodes_raises_error_when_duplicates_found(
+        self,
+    ):
+        with self.assertRaises(ValueError) as context:
+            job.check_for_duplicate_postcodes(self.sample_ons_contemporary_df)
+
+        self.assertTrue(
+            "Postcode directory has 1 or more duplicates" in str(context.exception)
+        )
+
+    def test_check_for_duplicate_postcodes_does_not_raise_error_with_no_duplicates(
+        self,
+    ):
+        deduplicated_sample_ons_contemporary_rows = (
+            self.sample_ons_contemporary_df.distinct()
+        )
+
+        returned_int = job.check_for_duplicate_postcodes(
+            deduplicated_sample_ons_contemporary_rows
+        )
+
+        self.assertEqual(returned_int, 0)
+
+
 class CountPostcodesPerListOfColumns(SplitPAFilledPostsIntoIcbAreas):
     def setUp(self) -> None:
         super().setUp()

--- a/tests/unit/test_dpr_split_pa_filled_posts_into_icb_areas.py
+++ b/tests/unit/test_dpr_split_pa_filled_posts_into_icb_areas.py
@@ -59,11 +59,16 @@ class CheckForDuplicatePostcodes(SplitPAFilledPostsIntoIcbAreas):
     def setUp(self) -> None:
         super().setUp()
 
+        self.sample_df = self.spark.createDataFrame(
+            TestData.sample_ons_contemporary_with_duplicates_rows,
+            schema=TestSchema.sample_ons_contemporary_with_duplicates_schema,
+        )
+
     def test_check_for_duplicate_postcodes_raises_error_when_duplicates_found(
         self,
     ):
         with self.assertRaises(ValueError) as context:
-            job.check_for_duplicate_postcodes(self.sample_ons_contemporary_df)
+            job.check_for_duplicate_postcodes(self.sample_df)
 
         self.assertTrue(
             "Postcode directory has 1 or more duplicates" in str(context.exception)
@@ -72,12 +77,10 @@ class CheckForDuplicatePostcodes(SplitPAFilledPostsIntoIcbAreas):
     def test_check_for_duplicate_postcodes_does_not_raise_error_with_no_duplicates(
         self,
     ):
-        deduplicated_sample_ons_contemporary_rows = (
-            self.sample_ons_contemporary_df.distinct()
-        )
+        deduplicated_sample_ons_contemporary_df = self.sample_df.distinct()
 
         returned_int = job.check_for_duplicate_postcodes(
-            deduplicated_sample_ons_contemporary_rows
+            deduplicated_sample_ons_contemporary_df
         )
 
         self.assertEqual(returned_int, 0)


### PR DESCRIPTION
# Description
This function used to use approx_count_distinct to count postcodes per LA then per LA/ICB hybrid. Then make percentages.
Because it's approximate, the percentages often don't sum to 100%. Which means, when PA filled posts get broken down, their sum is not the same as the original overall value.

These need to be exactly the same.

Approx count distinct was used because there may be duplicates in the postcode file. But it's not expected to have duplicates in the postcode directory, and if there were then they would have the same la/icb area allocated to them, so it won't affect the proportions.

https://trello.com/c/7PmtU4dH/501-fix-issue-with-dpr-split-by-icb-count-over-window-is-not-accurate-enough

# How to test
Unit tests passing.
Successful run in Glue ( runtime: 2m14s):
https://eu-west-2.console.aws.amazon.com/gluestudio/home?region=eu-west-2#/editor/job/accurate-dpr-to-icb-job-split_pa_filled_posts_into_icb_areas_job/runs

# Developer checklist
- [x] Unit test
- [x] Linked to Trello ticket
- [ ] Documentation up to date
