### PR TITLE
Add logic to prevent values less than 1.0 being used as final estimates

### DIFF
--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -2171,6 +2171,8 @@ class IndCQCDataUtils:
         ("1-000002", None, 30.0, 50.0),
         ("1-000003", 20.0, 70.0, 60.0),
         ("1-000004", None, None, 40.0),
+        ("1-000005", None, 0.5, 40.0),
+        ("1-000006", -1.0, 10.0, 30.0),
     ]
 
     expected_rows_with_estimate_filled_posts_and_source = [
@@ -2178,6 +2180,8 @@ class IndCQCDataUtils:
         ("1-000002", None, 30.0, 50.0, 30.0, "model_name_2"),
         ("1-000003", 20.0, 70.0, 60.0, 20.0, "model_name_1"),
         ("1-000004", None, None, 40.0, 40.0, "model_name_3"),
+        ("1-000005", None, 0.5, 40.0, 40.0, "model_name_3"),
+        ("1-000006", -1.0, 10.0, 30.0, 10.0, "model_name_2"),
     ]
 
     source_missing_rows = [

--- a/utils/ind_cqc_filled_posts_utils/utils.py
+++ b/utils/ind_cqc_filled_posts_utils/utils.py
@@ -42,6 +42,7 @@ def populate_estimate_filled_posts_and_source_in_the_order_of_the_column_list(
                 (
                     F.col(IndCQC.estimate_filled_posts).isNull()
                     & (F.col(model_name).isNotNull())
+                    & (F.col(model_name) >= 1.0)
                 ),
                 F.col(model_name),
             ).otherwise(F.col(IndCQC.estimate_filled_posts)),


### PR DESCRIPTION
# Description
Previously the final estimate selection was choosing values that were lower than 1. It is reasonable to assume that if a location exists and is registered that it will have at least one filled post. This change makes sure that if a establishment has a model with a value less than 1, that estimate is not selected as the final estimate.

# How to test
Unit tests passing
Run successfully in branch: https://eu-west-2.console.aws.amazon.com/gluestudio/home?region=eu-west-2#/editor/job/add-lower-limit-to-final-estim-estimate_ind_cqc_filled_posts_job/runs

# Developer checklist
- [ ] Unit test
- [ ] Linked to Trello ticket
- [ ] Documentation up to date
