### PR TITLE
Update rolling average from 12 months to a year

### DIFF
--- a/jobs/estimate_ind_cqc_filled_posts.py
+++ b/jobs/estimate_ind_cqc_filled_posts.py
@@ -58,6 +58,9 @@ def main(
 ) -> DataFrame:
     print("Estimating independent CQC filled posts...")
 
+    spark = utils.get_spark()
+    spark.sql("set spark.sql.broadcastTimeout = 2000")
+
     cleaned_ind_cqc_df = utils.read_from_parquet(
         cleaned_ind_cqc_source, cleaned_ind_cqc_columns
     )

--- a/jobs/estimate_ind_cqc_filled_posts.py
+++ b/jobs/estimate_ind_cqc_filled_posts.py
@@ -46,7 +46,7 @@ cleaned_ind_cqc_columns = [
 
 PartitionKeys = [Keys.year, Keys.month, Keys.day, Keys.import_date]
 
-NUMBER_OF_DAYS_IN_ROLLING_AVERAGE = 88  # Note: using 88 as a proxy for 3 months
+NUMBER_OF_DAYS_IN_ROLLING_AVERAGE = 366  # Note: using 366 as a proxy for 12 months
 
 
 def main(


### PR DESCRIPTION
# Description
We previously used a 3 month rolling average, but this broke when we started using deduplicated ASCWDS data to feed the models because we only have annual ASCWDS files prior to 2021, but 6 monthly CQC files, so for half the files, there was no new data to calculate the rolling average from.

We chose to use the twelve moth rolling average across the whole dataset.

# How to test

- Unit tests passing
- Run in branch: https://eu-west-2.console.aws.amazon.com/gluestudio/home?region=eu-west-2#/editor/job/rolling-avg-size-estimate_ind_cqc_filled_posts_job/runs
- Rerun main pipeline after merging

# Developer checklist
- [x] Unit test
- [x] Linked to Trello ticket : https://trello.com/c/JAWJ1i1k/549-fix-problem-with-rolling-average-job
- [x] Documentation up to date : https://skillsforcare.atlassian.net/wiki/spaces/DE/pages/1116045314/Rolling+Average+Model
