### PR TITLE
Set validation to error

### DIFF
--- a/jobs/validate_ascwds_workplace_cleaned_data.py
+++ b/jobs/validate_ascwds_workplace_cleaned_data.py
@@ -31,10 +31,10 @@ def main(
 
     check_result_df = validate_dataset(cleaned_ascwds_workplace_df, rules)
 
+    utils.write_to_parquet(check_result_df, report_destination, mode="overwrite")
+
     if isinstance(check_result_df, DataFrame):
         raise_exception_if_any_checks_failed(check_result_df)
-
-    utils.write_to_parquet(check_result_df, report_destination, mode="overwrite")
 
 
 if __name__ == "__main__":

--- a/jobs/validate_ascwds_workplace_cleaned_data.py
+++ b/jobs/validate_ascwds_workplace_cleaned_data.py
@@ -3,6 +3,8 @@ import sys
 
 os.environ["SPARK_VERSION"] = "3.3"
 
+from pyspark.sql.dataframe import DataFrame
+
 from utils import utils
 from utils.column_names.ind_cqc_pipeline_columns import (
     PartitionKeys as Keys,
@@ -10,7 +12,10 @@ from utils.column_names.ind_cqc_pipeline_columns import (
 from utils.validation.validation_rules.ascwds_workplace_cleaned_validation_rules import (
     ASCWDSWorkplaceCleanedValidationRules as Rules,
 )
-from utils.validation.validation_utils import validate_dataset
+from utils.validation.validation_utils import (
+    validate_dataset,
+    raise_exception_if_any_checks_failed,
+)
 
 PartitionKeys = [Keys.year, Keys.month, Keys.day, Keys.import_date]
 
@@ -25,6 +30,9 @@ def main(
     rules = Rules.rules_to_check
 
     check_result_df = validate_dataset(cleaned_ascwds_workplace_df, rules)
+
+    if isinstance(check_result_df, DataFrame):
+        raise_exception_if_any_checks_failed(check_result_df)
 
     utils.write_to_parquet(check_result_df, report_destination, mode="overwrite")
 

--- a/jobs/validate_ascwds_workplace_raw_data.py
+++ b/jobs/validate_ascwds_workplace_raw_data.py
@@ -3,6 +3,8 @@ import sys
 
 os.environ["SPARK_VERSION"] = "3.3"
 
+from pyspark.sql.dataframe import DataFrame
+
 from utils import utils
 from utils.column_names.ind_cqc_pipeline_columns import (
     PartitionKeys as Keys,
@@ -10,7 +12,10 @@ from utils.column_names.ind_cqc_pipeline_columns import (
 from utils.validation.validation_rules.ascwds_workplace_raw_validation_rules import (
     ASCWDSWorkplaceRawValidationRules as Rules,
 )
-from utils.validation.validation_utils import validate_dataset
+from utils.validation.validation_utils import (
+    validate_dataset,
+    raise_exception_if_any_checks_failed,
+)
 
 PartitionKeys = [Keys.year, Keys.month, Keys.day, Keys.import_date]
 
@@ -27,6 +32,9 @@ def main(
     check_result_df = validate_dataset(raw_ascwds_workplace_df, rules)
 
     utils.write_to_parquet(check_result_df, report_destination, mode="overwrite")
+
+    if isinstance(check_result_df, DataFrame):
+        raise_exception_if_any_checks_failed(check_result_df)
 
 
 if __name__ == "__main__":

--- a/jobs/validate_care_home_ind_cqc_features_data.py
+++ b/jobs/validate_care_home_ind_cqc_features_data.py
@@ -18,7 +18,10 @@ from utils.column_values.categorical_column_values import (
 from utils.validation.validation_rules.care_home_ind_cqc_features_validation_rules import (
     CareHomeIndCqcFeaturesValidationRules as Rules,
 )
-from utils.validation.validation_utils import validate_dataset
+from utils.validation.validation_utils import (
+    validate_dataset,
+    raise_exception_if_any_checks_failed,
+)
 from utils.validation.validation_rule_names import RuleNames as RuleName
 
 PartitionKeys = [Keys.year, Keys.month, Keys.day, Keys.import_date]
@@ -44,15 +47,18 @@ def main(
     )
     rules = Rules.rules_to_check
 
-    rules[
-        RuleName.size_of_dataset
-    ] = calculate_expected_size_of_care_home_ind_cqc_features_dataset(
-        cleaned_ind_cqc_df
+    rules[RuleName.size_of_dataset] = (
+        calculate_expected_size_of_care_home_ind_cqc_features_dataset(
+            cleaned_ind_cqc_df
+        )
     )
 
     check_result_df = validate_dataset(care_home_ind_cqc_features_df, rules)
 
     utils.write_to_parquet(check_result_df, report_destination, mode="overwrite")
+
+    if isinstance(check_result_df, DataFrame):
+        raise_exception_if_any_checks_failed(check_result_df)
 
 
 def calculate_expected_size_of_care_home_ind_cqc_features_dataset(

--- a/jobs/validate_care_home_ind_cqc_features_data.py
+++ b/jobs/validate_care_home_ind_cqc_features_data.py
@@ -47,10 +47,10 @@ def main(
     )
     rules = Rules.rules_to_check
 
-    rules[RuleName.size_of_dataset] = (
-        calculate_expected_size_of_care_home_ind_cqc_features_dataset(
-            cleaned_ind_cqc_df
-        )
+    rules[
+        RuleName.size_of_dataset
+    ] = calculate_expected_size_of_care_home_ind_cqc_features_dataset(
+        cleaned_ind_cqc_df
     )
 
     check_result_df = validate_dataset(care_home_ind_cqc_features_df, rules)

--- a/jobs/validate_cleaned_ind_cqc_data.py
+++ b/jobs/validate_cleaned_ind_cqc_data.py
@@ -12,7 +12,10 @@ from utils.column_names.ind_cqc_pipeline_columns import (
 from utils.validation.validation_rules.cleaned_ind_cqc_validation_rules import (
     CleanedIndCqcValidationRules as Rules,
 )
-from utils.validation.validation_utils import validate_dataset
+from utils.validation.validation_utils import (
+    validate_dataset,
+    raise_exception_if_any_checks_failed,
+)
 from utils.validation.validation_rule_names import RuleNames as RuleName
 
 PartitionKeys = [Keys.year, Keys.month, Keys.day, Keys.import_date]
@@ -31,11 +34,14 @@ def main(
     )
     rules = Rules.rules_to_check
 
-    rules[
-        RuleName.size_of_dataset
-    ] = calculate_expected_size_of_cleaned_ind_cqc_dataset(merged_ind_cqc_df)
+    rules[RuleName.size_of_dataset] = (
+        calculate_expected_size_of_cleaned_ind_cqc_dataset(merged_ind_cqc_df)
+    )
 
     check_result_df = validate_dataset(cleaned_ind_cqc_df, rules)
+
+    if isinstance(check_result_df, DataFrame):
+        raise_exception_if_any_checks_failed(check_result_df)
 
     utils.write_to_parquet(check_result_df, report_destination, mode="overwrite")
 

--- a/jobs/validate_cleaned_ind_cqc_data.py
+++ b/jobs/validate_cleaned_ind_cqc_data.py
@@ -34,9 +34,9 @@ def main(
     )
     rules = Rules.rules_to_check
 
-    rules[RuleName.size_of_dataset] = (
-        calculate_expected_size_of_cleaned_ind_cqc_dataset(merged_ind_cqc_df)
-    )
+    rules[
+        RuleName.size_of_dataset
+    ] = calculate_expected_size_of_cleaned_ind_cqc_dataset(merged_ind_cqc_df)
 
     check_result_df = validate_dataset(cleaned_ind_cqc_df, rules)
 

--- a/jobs/validate_cleaned_ind_cqc_data.py
+++ b/jobs/validate_cleaned_ind_cqc_data.py
@@ -40,10 +40,10 @@ def main(
 
     check_result_df = validate_dataset(cleaned_ind_cqc_df, rules)
 
+    utils.write_to_parquet(check_result_df, report_destination, mode="overwrite")
+
     if isinstance(check_result_df, DataFrame):
         raise_exception_if_any_checks_failed(check_result_df)
-
-    utils.write_to_parquet(check_result_df, report_destination, mode="overwrite")
 
 
 def calculate_expected_size_of_cleaned_ind_cqc_dataset(

--- a/jobs/validate_estimated_ind_cqc_filled_posts_by_job_role_data.py
+++ b/jobs/validate_estimated_ind_cqc_filled_posts_by_job_role_data.py
@@ -34,10 +34,10 @@ def main(
     )
     rules = Rules.rules_to_check
 
-    rules[RuleName.size_of_dataset] = (
-        calculate_expected_size_of_estimated_ind_cqc_filled_posts_by_job_role_dataset(
-            cleaned_ind_cqc_df
-        )
+    rules[
+        RuleName.size_of_dataset
+    ] = calculate_expected_size_of_estimated_ind_cqc_filled_posts_by_job_role_dataset(
+        cleaned_ind_cqc_df
     )
 
     check_result_df = validate_dataset(

--- a/jobs/validate_estimated_ind_cqc_filled_posts_by_job_role_data.py
+++ b/jobs/validate_estimated_ind_cqc_filled_posts_by_job_role_data.py
@@ -44,10 +44,10 @@ def main(
         estimated_ind_cqc_filled_posts_by_job_role_df, rules
     )
 
+    utils.write_to_parquet(check_result_df, report_destination, mode="overwrite")
+
     if isinstance(check_result_df, DataFrame):
         raise_exception_if_any_checks_failed(check_result_df)
-
-    utils.write_to_parquet(check_result_df, report_destination, mode="overwrite")
 
 
 def calculate_expected_size_of_estimated_ind_cqc_filled_posts_by_job_role_dataset(

--- a/jobs/validate_estimated_ind_cqc_filled_posts_by_job_role_data.py
+++ b/jobs/validate_estimated_ind_cqc_filled_posts_by_job_role_data.py
@@ -12,7 +12,10 @@ from utils.column_names.ind_cqc_pipeline_columns import (
 from utils.validation.validation_rules.estimated_ind_cqc_filled_posts_by_job_role_validation_rules import (
     EstimatedIndCqcFilledPostsByJobRoleValidationRules as Rules,
 )
-from utils.validation.validation_utils import validate_dataset
+from utils.validation.validation_utils import (
+    validate_dataset,
+    raise_exception_if_any_checks_failed,
+)
 from utils.validation.validation_rule_names import RuleNames as RuleName
 
 PartitionKeys = [Keys.year, Keys.month, Keys.day, Keys.import_date]
@@ -31,15 +34,18 @@ def main(
     )
     rules = Rules.rules_to_check
 
-    rules[
-        RuleName.size_of_dataset
-    ] = calculate_expected_size_of_estimated_ind_cqc_filled_posts_by_job_role_dataset(
-        cleaned_ind_cqc_df
+    rules[RuleName.size_of_dataset] = (
+        calculate_expected_size_of_estimated_ind_cqc_filled_posts_by_job_role_dataset(
+            cleaned_ind_cqc_df
+        )
     )
 
     check_result_df = validate_dataset(
         estimated_ind_cqc_filled_posts_by_job_role_df, rules
     )
+
+    if isinstance(check_result_df, DataFrame):
+        raise_exception_if_any_checks_failed(check_result_df)
 
     utils.write_to_parquet(check_result_df, report_destination, mode="overwrite")
 

--- a/jobs/validate_estimated_ind_cqc_filled_posts_data.py
+++ b/jobs/validate_estimated_ind_cqc_filled_posts_data.py
@@ -34,10 +34,10 @@ def main(
     )
     rules = Rules.rules_to_check
 
-    rules[RuleName.size_of_dataset] = (
-        calculate_expected_size_of_estimated_ind_cqc_filled_posts_dataset(
-            cleaned_ind_cqc_df
-        )
+    rules[
+        RuleName.size_of_dataset
+    ] = calculate_expected_size_of_estimated_ind_cqc_filled_posts_dataset(
+        cleaned_ind_cqc_df
     )
 
     check_result_df = validate_dataset(estimated_ind_cqc_filled_posts_df, rules)

--- a/jobs/validate_estimated_ind_cqc_filled_posts_data.py
+++ b/jobs/validate_estimated_ind_cqc_filled_posts_data.py
@@ -12,7 +12,10 @@ from utils.column_names.ind_cqc_pipeline_columns import (
 from utils.validation.validation_rules.estimated_ind_cqc_filled_posts_validation_rules import (
     EstimatedIndCqcFilledPostsValidationRules as Rules,
 )
-from utils.validation.validation_utils import validate_dataset
+from utils.validation.validation_utils import (
+    validate_dataset,
+    raise_exception_if_any_checks_failed,
+)
 from utils.validation.validation_rule_names import RuleNames as RuleName
 
 PartitionKeys = [Keys.year, Keys.month, Keys.day, Keys.import_date]
@@ -31,15 +34,18 @@ def main(
     )
     rules = Rules.rules_to_check
 
-    rules[
-        RuleName.size_of_dataset
-    ] = calculate_expected_size_of_estimated_ind_cqc_filled_posts_dataset(
-        cleaned_ind_cqc_df
+    rules[RuleName.size_of_dataset] = (
+        calculate_expected_size_of_estimated_ind_cqc_filled_posts_dataset(
+            cleaned_ind_cqc_df
+        )
     )
 
     check_result_df = validate_dataset(estimated_ind_cqc_filled_posts_df, rules)
 
     utils.write_to_parquet(check_result_df, report_destination, mode="overwrite")
+
+    if isinstance(check_result_df, DataFrame):
+        raise_exception_if_any_checks_failed(check_result_df)
 
 
 def calculate_expected_size_of_estimated_ind_cqc_filled_posts_dataset(

--- a/jobs/validate_locations_api_cleaned_data.py
+++ b/jobs/validate_locations_api_cleaned_data.py
@@ -51,9 +51,9 @@ def main(
     )
     rules = Rules.rules_to_check
 
-    rules[
-        RuleName.size_of_dataset
-    ] = calculate_expected_size_of_cleaned_cqc_locations_dataset(raw_location_df)
+    rules[RuleName.size_of_dataset] = (
+        calculate_expected_size_of_cleaned_cqc_locations_dataset(raw_location_df)
+    )
 
     cleaned_cqc_locations_df = add_column_with_length_of_string(
         cleaned_cqc_locations_df, [CQCL.location_id, CQCL.provider_id]
@@ -61,10 +61,10 @@ def main(
 
     check_result_df = validate_dataset(cleaned_cqc_locations_df, rules)
 
+    utils.write_to_parquet(check_result_df, report_destination, mode="overwrite")
+
     if isinstance(check_result_df, DataFrame):
         raise_exception_if_any_checks_failed(check_result_df)
-
-    utils.write_to_parquet(check_result_df, report_destination, mode="overwrite")
 
 
 def calculate_expected_size_of_cleaned_cqc_locations_dataset(

--- a/jobs/validate_locations_api_cleaned_data.py
+++ b/jobs/validate_locations_api_cleaned_data.py
@@ -23,6 +23,7 @@ from utils.validation.validation_rules.locations_api_cleaned_validation_rules im
 from utils.validation.validation_utils import (
     validate_dataset,
     add_column_with_length_of_string,
+    raise_exception_if_any_checks_failed,
 )
 from utils.validation.validation_rule_names import RuleNames as RuleName
 
@@ -50,15 +51,18 @@ def main(
     )
     rules = Rules.rules_to_check
 
-    rules[
-        RuleName.size_of_dataset
-    ] = calculate_expected_size_of_cleaned_cqc_locations_dataset(raw_location_df)
+    rules[RuleName.size_of_dataset] = (
+        calculate_expected_size_of_cleaned_cqc_locations_dataset(raw_location_df)
+    )
 
     cleaned_cqc_locations_df = add_column_with_length_of_string(
         cleaned_cqc_locations_df, [CQCL.location_id, CQCL.provider_id]
     )
 
     check_result_df = validate_dataset(cleaned_cqc_locations_df, rules)
+
+    if isinstance(check_result_df, DataFrame):
+        raise_exception_if_any_checks_failed(check_result_df)
 
     utils.write_to_parquet(check_result_df, report_destination, mode="overwrite")
 

--- a/jobs/validate_locations_api_cleaned_data.py
+++ b/jobs/validate_locations_api_cleaned_data.py
@@ -51,9 +51,9 @@ def main(
     )
     rules = Rules.rules_to_check
 
-    rules[RuleName.size_of_dataset] = (
-        calculate_expected_size_of_cleaned_cqc_locations_dataset(raw_location_df)
-    )
+    rules[
+        RuleName.size_of_dataset
+    ] = calculate_expected_size_of_cleaned_cqc_locations_dataset(raw_location_df)
 
     cleaned_cqc_locations_df = add_column_with_length_of_string(
         cleaned_cqc_locations_df, [CQCL.location_id, CQCL.provider_id]

--- a/jobs/validate_locations_api_raw_data.py
+++ b/jobs/validate_locations_api_raw_data.py
@@ -3,12 +3,15 @@ import sys
 
 os.environ["SPARK_VERSION"] = "3.3"
 
+from pyspark.sql.dataframe import DataFrame
+
 from utils import utils
 from utils.validation.validation_rules.locations_api_raw_validation_rules import (
     LocationsAPIRawValidationRules as Rules,
 )
 from utils.validation.validation_utils import (
     validate_dataset,
+    raise_exception_if_any_checks_failed,
 )
 
 
@@ -24,6 +27,9 @@ def main(
     check_result_df = validate_dataset(raw_location_df, rules)
 
     utils.write_to_parquet(check_result_df, report_destination, mode="overwrite")
+
+    if isinstance(check_result_df, DataFrame):
+        raise_exception_if_any_checks_failed(check_result_df)
 
 
 if __name__ == "__main__":

--- a/jobs/validate_merged_ind_cqc_data.py
+++ b/jobs/validate_merged_ind_cqc_data.py
@@ -18,7 +18,10 @@ from utils.column_values.categorical_column_values import (
 from utils.validation.validation_rules.merged_ind_cqc_validation_rules import (
     MergedIndCqcValidationRules as Rules,
 )
-from utils.validation.validation_utils import validate_dataset
+from utils.validation.validation_utils import (
+    validate_dataset,
+    raise_exception_if_any_checks_failed,
+)
 from utils.validation.validation_rule_names import RuleNames as RuleName
 
 PartitionKeys = [Keys.year, Keys.month, Keys.day, Keys.import_date]
@@ -51,6 +54,9 @@ def main(
     check_result_df = validate_dataset(merged_ind_cqc_df, rules)
 
     utils.write_to_parquet(check_result_df, report_destination, mode="overwrite")
+
+    if isinstance(check_result_df, DataFrame):
+        raise_exception_if_any_checks_failed(check_result_df)
 
 
 def calculate_expected_size_of_merged_ind_cqc_dataset(

--- a/jobs/validate_non_res_ascwds_inc_dormancy_ind_cqc_features_data.py
+++ b/jobs/validate_non_res_ascwds_inc_dormancy_ind_cqc_features_data.py
@@ -18,7 +18,10 @@ from utils.column_values.categorical_column_values import (
 from utils.validation.validation_rules.non_res_ascwds_inc_dormancy_ind_cqc_features_validation_rules import (
     NonResASCWDSIncDormancyIndCqcFeaturesValidationRules as Rules,
 )
-from utils.validation.validation_utils import validate_dataset
+from utils.validation.validation_utils import (
+    validate_dataset,
+    raise_exception_if_any_checks_failed,
+)
 from utils.validation.validation_rule_names import RuleNames as RuleName
 
 PartitionKeys = [Keys.year, Keys.month, Keys.day, Keys.import_date]
@@ -45,10 +48,10 @@ def main(
     )
     rules = Rules.rules_to_check
 
-    rules[
-        RuleName.size_of_dataset
-    ] = calculate_expected_size_of_non_res_ascwds_inc_dormancy_ind_cqc_features_dataset(
-        cleaned_ind_cqc_df
+    rules[RuleName.size_of_dataset] = (
+        calculate_expected_size_of_non_res_ascwds_inc_dormancy_ind_cqc_features_dataset(
+            cleaned_ind_cqc_df
+        )
     )
 
     check_result_df = validate_dataset(
@@ -56,6 +59,9 @@ def main(
     )
 
     utils.write_to_parquet(check_result_df, report_destination, mode="overwrite")
+
+    if isinstance(check_result_df, DataFrame):
+        raise_exception_if_any_checks_failed(check_result_df)
 
 
 def calculate_expected_size_of_non_res_ascwds_inc_dormancy_ind_cqc_features_dataset(

--- a/jobs/validate_non_res_ascwds_inc_dormancy_ind_cqc_features_data.py
+++ b/jobs/validate_non_res_ascwds_inc_dormancy_ind_cqc_features_data.py
@@ -48,10 +48,10 @@ def main(
     )
     rules = Rules.rules_to_check
 
-    rules[RuleName.size_of_dataset] = (
-        calculate_expected_size_of_non_res_ascwds_inc_dormancy_ind_cqc_features_dataset(
-            cleaned_ind_cqc_df
-        )
+    rules[
+        RuleName.size_of_dataset
+    ] = calculate_expected_size_of_non_res_ascwds_inc_dormancy_ind_cqc_features_dataset(
+        cleaned_ind_cqc_df
     )
 
     check_result_df = validate_dataset(

--- a/jobs/validate_pir_cleaned_data.py
+++ b/jobs/validate_pir_cleaned_data.py
@@ -3,6 +3,7 @@ import sys
 
 os.environ["SPARK_VERSION"] = "3.3"
 
+from pyspark.sql.dataframe import DataFrame
 
 from utils import utils
 from utils.column_names.ind_cqc_pipeline_columns import (
@@ -11,7 +12,10 @@ from utils.column_names.ind_cqc_pipeline_columns import (
 from utils.validation.validation_rules.pir_cleaned_validation_rules import (
     PIRCleanedValidationRules as Rules,
 )
-from utils.validation.validation_utils import validate_dataset
+from utils.validation.validation_utils import (
+    validate_dataset,
+    raise_exception_if_any_checks_failed,
+)
 
 PartitionKeys = [Keys.year, Keys.month, Keys.day, Keys.import_date]
 
@@ -28,6 +32,9 @@ def main(
     check_result_df = validate_dataset(cleaned_cqc_pir_df, rules)
 
     utils.write_to_parquet(check_result_df, report_destination, mode="overwrite")
+
+    if isinstance(check_result_df, DataFrame):
+        raise_exception_if_any_checks_failed(check_result_df)
 
 
 if __name__ == "__main__":

--- a/jobs/validate_pir_raw_data.py
+++ b/jobs/validate_pir_raw_data.py
@@ -3,12 +3,16 @@ import sys
 
 os.environ["SPARK_VERSION"] = "3.3"
 
+from pyspark.sql.dataframe import DataFrame
 
 from utils import utils
 from utils.validation.validation_rules.pir_raw_validation_rules import (
     PIRRawValidationRules as Rules,
 )
-from utils.validation.validation_utils import validate_dataset
+from utils.validation.validation_utils import (
+    validate_dataset,
+    raise_exception_if_any_checks_failed,
+)
 
 
 def main(
@@ -23,6 +27,9 @@ def main(
     check_result_df = validate_dataset(raw_cqc_pir_df, rules)
 
     utils.write_to_parquet(check_result_df, report_destination, mode="overwrite")
+
+    if isinstance(check_result_df, DataFrame):
+        raise_exception_if_any_checks_failed(check_result_df)
 
 
 if __name__ == "__main__":

--- a/jobs/validate_postcode_directory_cleaned_data.py
+++ b/jobs/validate_postcode_directory_cleaned_data.py
@@ -15,7 +15,10 @@ from utils.column_names.ind_cqc_pipeline_columns import (
 from utils.validation.validation_rules.postcode_directory_cleaned_validation_rules import (
     PostcodeDirectoryCleanedValidationRules as Rules,
 )
-from utils.validation.validation_utils import validate_dataset
+from utils.validation.validation_utils import (
+    validate_dataset,
+    raise_exception_if_any_checks_failed,
+)
 from utils.validation.validation_rule_names import RuleNames as RuleName
 
 PartitionKeys = [Keys.year, Keys.month, Keys.day, Keys.import_date]
@@ -40,15 +43,18 @@ def main(
     )
     rules = Rules.rules_to_check
 
-    rules[
-        RuleName.size_of_dataset
-    ] = calculate_expected_size_of_cleaned_postcode_directory_dataset(
-        raw_postcode_directory_df
+    rules[RuleName.size_of_dataset] = (
+        calculate_expected_size_of_cleaned_postcode_directory_dataset(
+            raw_postcode_directory_df
+        )
     )
 
     check_result_df = validate_dataset(cleaned_postcode_directory_df, rules)
 
     utils.write_to_parquet(check_result_df, report_destination, mode="overwrite")
+
+    if isinstance(check_result_df, DataFrame):
+        raise_exception_if_any_checks_failed(check_result_df)
 
 
 def calculate_expected_size_of_cleaned_postcode_directory_dataset(

--- a/jobs/validate_postcode_directory_cleaned_data.py
+++ b/jobs/validate_postcode_directory_cleaned_data.py
@@ -43,10 +43,10 @@ def main(
     )
     rules = Rules.rules_to_check
 
-    rules[RuleName.size_of_dataset] = (
-        calculate_expected_size_of_cleaned_postcode_directory_dataset(
-            raw_postcode_directory_df
-        )
+    rules[
+        RuleName.size_of_dataset
+    ] = calculate_expected_size_of_cleaned_postcode_directory_dataset(
+        raw_postcode_directory_df
     )
 
     check_result_df = validate_dataset(cleaned_postcode_directory_df, rules)

--- a/jobs/validate_postcode_directory_raw_data.py
+++ b/jobs/validate_postcode_directory_raw_data.py
@@ -3,11 +3,16 @@ import sys
 
 os.environ["SPARK_VERSION"] = "3.3"
 
+from pyspark.sql.dataframe import DataFrame
+
 from utils import utils
 from utils.validation.validation_rules.postcode_directory_raw_validation_rules import (
     PostcodeDirectoryRawValidationRules as Rules,
 )
-from utils.validation.validation_utils import validate_dataset
+from utils.validation.validation_utils import (
+    validate_dataset,
+    raise_exception_if_any_checks_failed,
+)
 
 
 def main(
@@ -22,6 +27,9 @@ def main(
     check_result_df = validate_dataset(raw_postcode_directory_df, rules)
 
     utils.write_to_parquet(check_result_df, report_destination, mode="overwrite")
+
+    if isinstance(check_result_df, DataFrame):
+        raise_exception_if_any_checks_failed(check_result_df)
 
 
 if __name__ == "__main__":

--- a/jobs/validate_providers_api_cleaned_data.py
+++ b/jobs/validate_providers_api_cleaned_data.py
@@ -44,9 +44,9 @@ def main(
     )
     rules = Rules.rules_to_check
 
-    rules[RuleName.size_of_dataset] = (
-        calculate_expected_size_of_cleaned_cqc_providers_dataset(raw_provider_df)
-    )
+    rules[
+        RuleName.size_of_dataset
+    ] = calculate_expected_size_of_cleaned_cqc_providers_dataset(raw_provider_df)
     cleaned_cqc_providers_df = add_column_with_length_of_string(
         cleaned_cqc_providers_df, [CQCP.provider_id]
     )

--- a/jobs/validate_providers_api_cleaned_data.py
+++ b/jobs/validate_providers_api_cleaned_data.py
@@ -18,6 +18,7 @@ from utils.validation.validation_rules.providers_api_cleaned_validation_rules im
 from utils.validation.validation_utils import (
     validate_dataset,
     add_column_with_length_of_string,
+    raise_exception_if_any_checks_failed,
 )
 from utils.validation.validation_rule_names import RuleNames as RuleName
 
@@ -43,9 +44,9 @@ def main(
     )
     rules = Rules.rules_to_check
 
-    rules[
-        RuleName.size_of_dataset
-    ] = calculate_expected_size_of_cleaned_cqc_providers_dataset(raw_provider_df)
+    rules[RuleName.size_of_dataset] = (
+        calculate_expected_size_of_cleaned_cqc_providers_dataset(raw_provider_df)
+    )
     cleaned_cqc_providers_df = add_column_with_length_of_string(
         cleaned_cqc_providers_df, [CQCP.provider_id]
     )
@@ -53,6 +54,9 @@ def main(
     check_result_df = validate_dataset(cleaned_cqc_providers_df, rules)
 
     utils.write_to_parquet(check_result_df, report_destination, mode="overwrite")
+
+    if isinstance(check_result_df, DataFrame):
+        raise_exception_if_any_checks_failed(check_result_df)
 
 
 def calculate_expected_size_of_cleaned_cqc_providers_dataset(

--- a/jobs/validate_providers_api_raw_data.py
+++ b/jobs/validate_providers_api_raw_data.py
@@ -3,11 +3,16 @@ import sys
 
 os.environ["SPARK_VERSION"] = "3.3"
 
+from pyspark.sql.dataframe import DataFrame
+
 from utils import utils
 from utils.validation.validation_rules.providers_api_raw_validation_rules import (
     ProvidersAPIRawValidationRules as Rules,
 )
-from utils.validation.validation_utils import validate_dataset
+from utils.validation.validation_utils import (
+    validate_dataset,
+    raise_exception_if_any_checks_failed,
+)
 
 
 def main(
@@ -22,6 +27,9 @@ def main(
     check_result_df = validate_dataset(raw_provider_df, rules)
 
     utils.write_to_parquet(check_result_df, report_destination, mode="overwrite")
+
+    if isinstance(check_result_df, DataFrame):
+        raise_exception_if_any_checks_failed(check_result_df)
 
 
 if __name__ == "__main__":

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -4583,6 +4583,8 @@ class ValidationUtils:
         ("loc_1", 5),
     ]
 
+    check_rows = fewer_distinct_values_result_rows
+
 
 @dataclass
 class ValidateLocationsAPICleanedData:

--- a/tests/unit/test_validate_care_home_ind_cqc_features.py
+++ b/tests/unit/test_validate_care_home_ind_cqc_features.py
@@ -47,14 +47,15 @@ class MainTests(ValidateCareHomeIndCQCFeaturesDatasetTests):
             self.test_care_home_ind_cqc_features_df,
         ]
 
-        job.main(
-            self.TEST_CLEANED_IND_CQC_SOURCE,
-            self.TEST_CARE_HOME_IND_CQC_FEATURES_SOURCE,
-            self.TEST_DESTINATION,
-        )
+        with self.assertRaises(ValueError):
+            job.main(
+                self.TEST_CLEANED_IND_CQC_SOURCE,
+                self.TEST_CARE_HOME_IND_CQC_FEATURES_SOURCE,
+                self.TEST_DESTINATION,
+            )
 
-        self.assertEqual(read_from_parquet_patch.call_count, 2)
-        self.assertEqual(write_to_parquet_patch.call_count, 1)
+            self.assertEqual(read_from_parquet_patch.call_count, 2)
+            self.assertEqual(write_to_parquet_patch.call_count, 1)
 
 
 class CalculateExpectedSizeofDataset(ValidateCareHomeIndCQCFeaturesDatasetTests):

--- a/tests/unit/test_validate_cleaned_ind_cqc_data.py
+++ b/tests/unit/test_validate_cleaned_ind_cqc_data.py
@@ -46,14 +46,15 @@ class MainTests(ValidateCleanedIndCQCDatasetTests):
             self.test_cleaned_ind_cqc_df,
         ]
 
-        job.main(
-            self.TEST_MERGED_IND_CQC_SOURCE,
-            self.TEST_CLEANED_IND_CQC_SOURCE,
-            self.TEST_DESTINATION,
-        )
+        with self.assertRaises(ValueError):
+            job.main(
+                self.TEST_MERGED_IND_CQC_SOURCE,
+                self.TEST_CLEANED_IND_CQC_SOURCE,
+                self.TEST_DESTINATION,
+            )
 
-        self.assertEqual(read_from_parquet_patch.call_count, 2)
-        self.assertEqual(write_to_parquet_patch.call_count, 1)
+            self.assertEqual(read_from_parquet_patch.call_count, 2)
+            self.assertEqual(write_to_parquet_patch.call_count, 1)
 
 
 class CalculateExpectedSizeofDataset(ValidateCleanedIndCQCDatasetTests):

--- a/tests/unit/test_validate_estimated_ind_cqc_filled_posts_data.py
+++ b/tests/unit/test_validate_estimated_ind_cqc_filled_posts_data.py
@@ -47,14 +47,15 @@ class MainTests(ValidateEstimatedIndCqcFilledPostsDatasetTests):
             self.test_estimated_ind_cqc_filled_posts_df,
         ]
 
-        job.main(
-            self.TEST_CLEANED_IND_CQC_SOURCE,
-            self.TEST_ESTIMATED_IND_CQC_FILLED_POSTS_SOURCE,
-            self.TEST_DESTINATION,
-        )
+        with self.assertRaises(ValueError):
+            job.main(
+                self.TEST_CLEANED_IND_CQC_SOURCE,
+                self.TEST_ESTIMATED_IND_CQC_FILLED_POSTS_SOURCE,
+                self.TEST_DESTINATION,
+            )
 
-        self.assertEqual(read_from_parquet_patch.call_count, 2)
-        self.assertEqual(write_to_parquet_patch.call_count, 1)
+            self.assertEqual(read_from_parquet_patch.call_count, 2)
+            self.assertEqual(write_to_parquet_patch.call_count, 1)
 
 
 class CalculateExpectedSizeofDataset(ValidateEstimatedIndCqcFilledPostsDatasetTests):

--- a/tests/unit/test_validate_locations_api_cleaned_data.py
+++ b/tests/unit/test_validate_locations_api_cleaned_data.py
@@ -34,7 +34,6 @@ class MainTests(ValidateLocationsAPICleanedDatasetTests):
     def setUp(self) -> None:
         return super().setUp()
 
-    @unittest.skip("testing")
     @patch("utils.utils.write_to_parquet")
     @patch("utils.utils.read_from_parquet")
     def test_main_runs(
@@ -47,14 +46,15 @@ class MainTests(ValidateLocationsAPICleanedDatasetTests):
             self.test_cleaned_cqc_locations_df,
         ]
 
-        job.main(
-            self.TEST_RAW_CQC_LOCATION_SOURCE,
-            self.TEST_CQC_LOCATIONS_API_CLEANED_SOURCE,
-            self.TEST_DESTINATION,
-        )
+        with self.assertRaises(ValueError):
+            job.main(
+                self.TEST_RAW_CQC_LOCATION_SOURCE,
+                self.TEST_CQC_LOCATIONS_API_CLEANED_SOURCE,
+                self.TEST_DESTINATION,
+            )
 
-        self.assertEqual(read_from_parquet_patch.call_count, 2)
-        self.assertEqual(write_to_parquet_patch.call_count, 1)
+            self.assertEqual(read_from_parquet_patch.call_count, 2)
+            self.assertEqual(write_to_parquet_patch.call_count, 1)
 
 
 class CalculateExpectedSizeofDataset(ValidateLocationsAPICleanedDatasetTests):

--- a/tests/unit/test_validate_locations_api_cleaned_data.py
+++ b/tests/unit/test_validate_locations_api_cleaned_data.py
@@ -34,6 +34,7 @@ class MainTests(ValidateLocationsAPICleanedDatasetTests):
     def setUp(self) -> None:
         return super().setUp()
 
+    @unittest.skip("testing")
     @patch("utils.utils.write_to_parquet")
     @patch("utils.utils.read_from_parquet")
     def test_main_runs(

--- a/tests/unit/test_validate_locations_api_raw_data.py
+++ b/tests/unit/test_validate_locations_api_raw_data.py
@@ -39,13 +39,14 @@ class MainTests(ValidateLocationsAPIRawDatasetTests):
     ):
         read_from_parquet_patch.return_value = self.test_raw_cqc_location_df
 
-        job.main(
-            self.TEST_RAW_CQC_LOCATION_SOURCE,
-            self.TEST_DESTINATION,
-        )
+        with self.assertRaises(ValueError):
+            job.main(
+                self.TEST_RAW_CQC_LOCATION_SOURCE,
+                self.TEST_DESTINATION,
+            )
 
-        self.assertEqual(read_from_parquet_patch.call_count, 1)
-        self.assertEqual(write_to_parquet_patch.call_count, 1)
+            self.assertEqual(read_from_parquet_patch.call_count, 1)
+            self.assertEqual(write_to_parquet_patch.call_count, 1)
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_validate_merged_ind_cqc_data.py
+++ b/tests/unit/test_validate_merged_ind_cqc_data.py
@@ -46,14 +46,15 @@ class MainTests(ValidateMergedIndCQCDatasetTests):
             self.test_merged_ind_cqc_df,
         ]
 
-        job.main(
-            self.TEST_CQC_LOCATION_SOURCE,
-            self.TEST_MERGED_IND_CQC_SOURCE,
-            self.TEST_DESTINATION,
-        )
+        with self.assertRaises(ValueError):
+            job.main(
+                self.TEST_CQC_LOCATION_SOURCE,
+                self.TEST_MERGED_IND_CQC_SOURCE,
+                self.TEST_DESTINATION,
+            )
 
-        self.assertEqual(read_from_parquet_patch.call_count, 2)
-        self.assertEqual(write_to_parquet_patch.call_count, 1)
+            self.assertEqual(read_from_parquet_patch.call_count, 2)
+            self.assertEqual(write_to_parquet_patch.call_count, 1)
 
 
 class CalculateExpectedSizeofDataset(ValidateMergedIndCQCDatasetTests):

--- a/tests/unit/test_validate_pir_cleaned_data.py
+++ b/tests/unit/test_validate_pir_cleaned_data.py
@@ -40,13 +40,14 @@ class MainTests(ValidatePIRCleanedDatasetTests):
             self.test_cleaned_cqc_pir_df,
         ]
 
-        job.main(
-            self.TEST_CQC_PIR_CLEANED_SOURCE,
-            self.TEST_DESTINATION,
-        )
+        with self.assertRaises(ValueError):
+            job.main(
+                self.TEST_CQC_PIR_CLEANED_SOURCE,
+                self.TEST_DESTINATION,
+            )
 
-        self.assertEqual(read_from_parquet_patch.call_count, 1)
-        self.assertEqual(write_to_parquet_patch.call_count, 1)
+            self.assertEqual(read_from_parquet_patch.call_count, 1)
+            self.assertEqual(write_to_parquet_patch.call_count, 1)
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_validate_pir_raw_data.py
+++ b/tests/unit/test_validate_pir_raw_data.py
@@ -38,13 +38,14 @@ class MainTests(ValidatePIRRawDatasetTests):
     ):
         read_from_parquet_patch.return_value = self.test_raw_cqc_pir_df
 
-        job.main(
-            self.TEST_CQC_PIR_RAW_SOURCE,
-            self.TEST_DESTINATION,
-        )
+        with self.assertRaises(ValueError):
+            job.main(
+                self.TEST_CQC_PIR_RAW_SOURCE,
+                self.TEST_DESTINATION,
+            )
 
-        self.assertEqual(read_from_parquet_patch.call_count, 1)
-        self.assertEqual(write_to_parquet_patch.call_count, 1)
+            self.assertEqual(read_from_parquet_patch.call_count, 1)
+            self.assertEqual(write_to_parquet_patch.call_count, 1)
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_validate_postcode_directory_cleaned_data.py
+++ b/tests/unit/test_validate_postcode_directory_cleaned_data.py
@@ -47,14 +47,15 @@ class MainTests(ValidatePostcodeDirectoryCleanedDatasetTests):
             self.test_cleaned_postcode_directory_df,
         ]
 
-        job.main(
-            self.TEST_RAW_POSTCODE_DIRECTORY_SOURCE,
-            self.TEST_POSTCODE_DIRECTORY_CLEANED_SOURCE,
-            self.TEST_DESTINATION,
-        )
+        with self.assertRaises(ValueError):
+            job.main(
+                self.TEST_RAW_POSTCODE_DIRECTORY_SOURCE,
+                self.TEST_POSTCODE_DIRECTORY_CLEANED_SOURCE,
+                self.TEST_DESTINATION,
+            )
 
-        self.assertEqual(read_from_parquet_patch.call_count, 2)
-        self.assertEqual(write_to_parquet_patch.call_count, 1)
+            self.assertEqual(read_from_parquet_patch.call_count, 2)
+            self.assertEqual(write_to_parquet_patch.call_count, 1)
 
 
 class CalculateExpectedSizeofDataset(ValidatePostcodeDirectoryCleanedDatasetTests):

--- a/tests/unit/test_validate_postcode_directory_raw_data.py
+++ b/tests/unit/test_validate_postcode_directory_raw_data.py
@@ -39,13 +39,14 @@ class MainTests(ValidatePostcodeDirectoryRawDatasetTests):
     ):
         read_from_parquet_patch.return_value = self.test_raw_postcode_directory_df
 
-        job.main(
-            self.TEST_RAW_POSTCODE_DIRECTORY_SOURCE,
-            self.TEST_DESTINATION,
-        )
+        with self.assertRaises(ValueError):
+            job.main(
+                self.TEST_RAW_POSTCODE_DIRECTORY_SOURCE,
+                self.TEST_DESTINATION,
+            )
 
-        self.assertEqual(read_from_parquet_patch.call_count, 1)
-        self.assertEqual(write_to_parquet_patch.call_count, 1)
+            self.assertEqual(read_from_parquet_patch.call_count, 1)
+            self.assertEqual(write_to_parquet_patch.call_count, 1)
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_validate_providers_api_cleaned_data.py
+++ b/tests/unit/test_validate_providers_api_cleaned_data.py
@@ -46,14 +46,15 @@ class MainTests(ValidateProvidersAPICleanedDatasetTests):
             self.test_cleaned_cqc_providers_df,
         ]
 
-        job.main(
-            self.TEST_RAW_CQC_PROVIDER_SOURCE,
-            self.TEST_CQC_PROVIDERS_API_CLEANED_SOURCE,
-            self.TEST_DESTINATION,
-        )
+        with self.assertRaises(ValueError):
+            job.main(
+                self.TEST_RAW_CQC_PROVIDER_SOURCE,
+                self.TEST_CQC_PROVIDERS_API_CLEANED_SOURCE,
+                self.TEST_DESTINATION,
+            )
 
-        self.assertEqual(read_from_parquet_patch.call_count, 2)
-        self.assertEqual(write_to_parquet_patch.call_count, 1)
+            self.assertEqual(read_from_parquet_patch.call_count, 2)
+            self.assertEqual(write_to_parquet_patch.call_count, 1)
 
 
 class CalculateExpectedSizeofDataset(ValidateProvidersAPICleanedDatasetTests):

--- a/tests/unit/test_validation_utils.py
+++ b/tests/unit/test_validation_utils.py
@@ -197,7 +197,6 @@ class CheckOfMinValues(ValidateUtilsTests):
         self.min_values_rule = Data.min_values_rule
         self.min_values_multiple_columns_rule = Data.min_values_multiple_columns_rule
 
-    @unittest.skip("Testing behaviour in pipeline")
     def test_create_check_of_min_values_returns_success_when_values_are_above_minimum(
         self,
     ):
@@ -210,7 +209,6 @@ class CheckOfMinValues(ValidateUtilsTests):
         returned_df = job.validate_dataset(test_df, self.min_values_rule)
         self.assertEqual(returned_df.collect(), expected_df.collect())
 
-    @unittest.skip("Testing behaviour in pipeline")
     def test_create_check_of_min_values_returns_success_when_lowest_value_equals_minimum(
         self,
     ):
@@ -223,7 +221,6 @@ class CheckOfMinValues(ValidateUtilsTests):
         returned_df = job.validate_dataset(test_df, self.min_values_rule)
         self.assertEqual(returned_df.collect(), expected_df.collect())
 
-    @unittest.skip("Testing behaviour in pipeline")
     def test_create_check_of_min_values_returns_failure_when_lowest_value_is_below_minimum(
         self,
     ):
@@ -236,7 +233,6 @@ class CheckOfMinValues(ValidateUtilsTests):
         returned_df = job.validate_dataset(test_df, self.min_values_rule)
         self.assertEqual(returned_df.collect(), expected_df.collect())
 
-    @unittest.skip("Testing behaviour in pipeline")
     def test_create_check_of_min_values_returns_correct_results_when_multiple_columns_supplied(
         self,
     ):

--- a/tests/unit/test_validation_utils.py
+++ b/tests/unit/test_validation_utils.py
@@ -435,5 +435,17 @@ class AddColumnWithLengthOfString(ValidateUtilsTests):
         self.assertEqual(self.expected_df.collect(), self.returned_df.collect())
 
 
+class RaiseExceptionOnFailures(ValidateUtilsTests):
+    def setUp(self) -> None:
+        super().setUp()
+
+    def test_raise_exception_if_any_checks_failed_raises_exception(self):
+        test_df = self.spark.createDataFrame(Data.check_rows, Schemas.validation_schema)
+        with self.assertRaises(ValueError) as context:
+            job.raise_exception_if_any_checks_failed(test_df)
+
+        self.assertTrue("Data quaility failures detected." in str(context.exception))
+
+
 if __name__ == "__main__":
     unittest.main(warnings="ignore")

--- a/tests/unit/test_validation_utils.py
+++ b/tests/unit/test_validation_utils.py
@@ -197,6 +197,7 @@ class CheckOfMinValues(ValidateUtilsTests):
         self.min_values_rule = Data.min_values_rule
         self.min_values_multiple_columns_rule = Data.min_values_multiple_columns_rule
 
+    @unittest.skip("Testing behaviour in pipeline")
     def test_create_check_of_min_values_returns_success_when_values_are_above_minimum(
         self,
     ):
@@ -209,6 +210,7 @@ class CheckOfMinValues(ValidateUtilsTests):
         returned_df = job.validate_dataset(test_df, self.min_values_rule)
         self.assertEqual(returned_df.collect(), expected_df.collect())
 
+    @unittest.skip("Testing behaviour in pipeline")
     def test_create_check_of_min_values_returns_success_when_lowest_value_equals_minimum(
         self,
     ):
@@ -221,6 +223,7 @@ class CheckOfMinValues(ValidateUtilsTests):
         returned_df = job.validate_dataset(test_df, self.min_values_rule)
         self.assertEqual(returned_df.collect(), expected_df.collect())
 
+    @unittest.skip("Testing behaviour in pipeline")
     def test_create_check_of_min_values_returns_failure_when_lowest_value_is_below_minimum(
         self,
     ):
@@ -233,6 +236,7 @@ class CheckOfMinValues(ValidateUtilsTests):
         returned_df = job.validate_dataset(test_df, self.min_values_rule)
         self.assertEqual(returned_df.collect(), expected_df.collect())
 
+    @unittest.skip("Testing behaviour in pipeline")
     def test_create_check_of_min_values_returns_correct_results_when_multiple_columns_supplied(
         self,
     ):

--- a/utils/validation/validation_rules/locations_api_cleaned_validation_rules.py
+++ b/utils/validation/validation_rules/locations_api_cleaned_validation_rules.py
@@ -41,7 +41,7 @@ class LocationsAPICleanedValidationRules:
             CQCLClean.cqc_location_import_date,
         ],
         RuleName.min_values: {
-            CQCLClean.number_of_beds: 0,
+            CQCLClean.number_of_beds: 100,  # Change this back before merging PR
             Validation.location_id_length: 3,
             Validation.provider_id_length: 3,
         },

--- a/utils/validation/validation_rules/locations_api_cleaned_validation_rules.py
+++ b/utils/validation/validation_rules/locations_api_cleaned_validation_rules.py
@@ -41,7 +41,7 @@ class LocationsAPICleanedValidationRules:
             CQCLClean.cqc_location_import_date,
         ],
         RuleName.min_values: {
-            CQCLClean.number_of_beds: 100,  # Change this back before merging PR
+            CQCLClean.number_of_beds: 0,
             Validation.location_id_length: 3,
             Validation.provider_id_length: 3,
         },

--- a/utils/validation/validation_rules/locations_api_cleaned_validation_rules.py
+++ b/utils/validation/validation_rules/locations_api_cleaned_validation_rules.py
@@ -41,7 +41,7 @@ class LocationsAPICleanedValidationRules:
             CQCLClean.cqc_location_import_date,
         ],
         RuleName.min_values: {
-            CQCLClean.number_of_beds: 100,
+            CQCLClean.number_of_beds: 0,
             Validation.location_id_length: 3,
             Validation.provider_id_length: 3,
         },

--- a/utils/validation/validation_rules/locations_api_cleaned_validation_rules.py
+++ b/utils/validation/validation_rules/locations_api_cleaned_validation_rules.py
@@ -41,7 +41,7 @@ class LocationsAPICleanedValidationRules:
             CQCLClean.cqc_location_import_date,
         ],
         RuleName.min_values: {
-            CQCLClean.number_of_beds: 0,
+            CQCLClean.number_of_beds: 100,
             Validation.location_id_length: 3,
             Validation.provider_id_length: 3,
         },

--- a/utils/validation/validation_utils.py
+++ b/utils/validation/validation_utils.py
@@ -24,8 +24,6 @@ def validate_dataset(dataset: DataFrame, rules: dict) -> DataFrame:
     verification_run = add_checks_to_run(verification_run, rules)
     check_result = verification_run.run()
     check_result_df = VerificationResult.checkResultsAsDataFrame(spark, check_result)
-    if isinstance(check_result_df, DataFrame):
-        raise_exception_if_any_checks_failed(check_result_df)
     return check_result_df
 
 

--- a/utils/validation/validation_utils.py
+++ b/utils/validation/validation_utils.py
@@ -91,7 +91,7 @@ def create_check_of_size_of_dataset(expected_size: int) -> Check:
 
 def create_check_of_min_values(column_name: str, min_value: int) -> Check:
     spark = utils.get_spark()
-    check = Check(spark, CheckLevel.Warning, f"Min value in column")
+    check = Check(spark, CheckLevel.Error, f"Min value in column")
     check = check.hasMin(
         column_name,
         lambda x: x >= min_value,

--- a/utils/validation/validation_utils.py
+++ b/utils/validation/validation_utils.py
@@ -24,6 +24,8 @@ def validate_dataset(dataset: DataFrame, rules: dict) -> DataFrame:
     verification_run = add_checks_to_run(verification_run, rules)
     check_result = verification_run.run()
     check_result_df = VerificationResult.checkResultsAsDataFrame(spark, check_result)
+    if isinstance(check_result_df, DataFrame):
+        raise_exception_if_any_checks_failed(check_result_df)
     return check_result_df
 
 

--- a/utils/validation/validation_utils.py
+++ b/utils/validation/validation_utils.py
@@ -14,6 +14,7 @@ from pyspark.sql import (
 )
 
 from utils import utils
+from utils.column_names.validation_table_columns import Validation
 from utils.validation.validation_rule_names import RuleNames as RuleToCheck
 
 
@@ -149,3 +150,13 @@ def add_column_with_length_of_string(
         new_column_name = column_name + "_length"
         df = df.withColumn(new_column_name, F.length(column_name))
     return df
+
+
+def raise_exception_if_any_checks_failed(df: DataFrame):
+    df = df.where(df[Validation.constraint_status] == "Failure")
+
+    failures_count = df.count()
+    if failures_count == 0:
+        return
+
+    raise ValueError("Data quaility failures detected.")

--- a/utils/validation/validation_utils.py
+++ b/utils/validation/validation_utils.py
@@ -91,7 +91,7 @@ def create_check_of_size_of_dataset(expected_size: int) -> Check:
 
 def create_check_of_min_values(column_name: str, min_value: int) -> Check:
     spark = utils.get_spark()
-    check = Check(spark, CheckLevel.Error, f"Min value in column")
+    check = Check(spark, CheckLevel.Warning, f"Min value in column")
     check = check.hasMin(
         column_name,
         lambda x: x >= min_value,


### PR DESCRIPTION
# Description
Added function to raise a simple error if any data validation checks fail.
Tested new function.

# How to test
Unit tests passing
Run in branch with number of beds minimum value set to 100 (should error out) : https://eu-west-2.console.aws.amazon.com/gluestudio/home?region=eu-west-2#/editor/job/set-validation-to-error-validate_locations_api_cleaned_data_job/runs

# Developer checklist
- [x] Unit test
- [x] Linked to Trello ticket : https://trello.com/c/Ay9l7jsy/548-set-up-errors-for-validation
- [x] Documentation up to date
