### PR TITLE
Add latest cqc rating

### DIFF
--- a/jobs/merge_coverage_data.py
+++ b/jobs/merge_coverage_data.py
@@ -191,7 +191,7 @@ def add_flag_for_in_ascwds(
     return merged_coverage_df
 
 
-def filter_for_latest_cqc_ratings_only(
+def filter_for_latest_cqc_ratings(
     cqc_ratings_df: DataFrame,
 ) -> DataFrame:
     """
@@ -232,7 +232,7 @@ def join_latest_cqc_rating_into_coverage_df(
         DataFrame: The coverage dataframe with the latest overall CQC rating and the rating date added to it.
     """
 
-    latest_cqc_ratings_df = filter_for_latest_cqc_ratings_only(cqc_ratings_df)
+    latest_cqc_ratings_df = filter_for_latest_cqc_ratings(cqc_ratings_df)
 
     merged_coverage_with_latest_rating_df = merged_coverage_df.join(
         latest_cqc_ratings_df,

--- a/jobs/merge_coverage_data.py
+++ b/jobs/merge_coverage_data.py
@@ -20,7 +20,7 @@ from utils.column_names.coverage_columns import CoverageColumns
 from utils.column_names.cqc_ratings_columns import CQCRatingsColumns
 
 from utils.column_values.categorical_column_values import InAscwds
-from utils.column_values.categorical_column_values import CQCRatingsValues
+from utils.column_values.categorical_column_values import CQCLatestRating
 
 PartitionKeys = [Keys.year, Keys.month, Keys.day, Keys.import_date]
 
@@ -191,7 +191,7 @@ def add_flag_for_in_ascwds(
     return merged_coverage_df
 
 
-def keep_only_latest_cqc_ratings(
+def filter_for_latest_cqc_ratings_only(
     cqc_ratings_df: DataFrame,
 ) -> DataFrame:
     """
@@ -210,7 +210,7 @@ def keep_only_latest_cqc_ratings(
 
     return cqc_ratings_df.where(
         cqc_ratings_df[CQCRatingsColumns.latest_rating_flag]
-        == CQCRatingsValues.latest_rating
+        == CQCLatestRating.is_latest_rating
     )
 
 
@@ -219,7 +219,7 @@ def join_latest_cqc_rating_into_coverage_df(
     cqc_ratings_df: DataFrame,
 ) -> DataFrame:
     """
-     Join latest rating to coverage dataframe using locationid as key.
+    Join latest rating to coverage dataframe using locationid as key.
 
     Requirements that are not arguments: CQC locationid.
     All columns from the CQC ratings dataframe are joined to the coverage dataframe using locationid.
@@ -232,7 +232,7 @@ def join_latest_cqc_rating_into_coverage_df(
         DataFrame: The coverage dataframe with the latest overall CQC rating and the rating date added to it.
     """
 
-    latest_cqc_ratings_df = keep_only_latest_cqc_ratings(cqc_ratings_df)
+    latest_cqc_ratings_df = filter_for_latest_cqc_ratings_only(cqc_ratings_df)
 
     merged_coverage_with_latest_rating_df = merged_coverage_df.join(
         latest_cqc_ratings_df,

--- a/jobs/merge_coverage_data.py
+++ b/jobs/merge_coverage_data.py
@@ -187,7 +187,7 @@ def add_flag_for_in_ascwds(
     return merged_coverage_df
 
 
-def keep_only_latest_cqc_rating(
+def keep_only_latest_cqc_ratings(
     cqc_ratings_df: DataFrame,
 ) -> DataFrame:
     """
@@ -205,7 +205,8 @@ def keep_only_latest_cqc_rating(
     """
 
     return cqc_ratings_df.where(
-        CQCRatingsColumns.latest_rating_flag == CQCRatingsValues.latest_rating
+        cqc_ratings_df[CQCRatingsColumns.latest_rating_flag]
+        == CQCRatingsValues.latest_rating
     )
 
 

--- a/jobs/merge_coverage_data.py
+++ b/jobs/merge_coverage_data.py
@@ -105,6 +105,10 @@ def main(
 
     merged_coverage_df = add_flag_for_in_ascwds(merged_coverage_df)
 
+    merged_coverage_df = join_latest_cqc_rating_into_coverage_df(
+        merged_coverage_df, cqc_ratings_df
+    )
+
     utils.write_to_parquet(
         merged_coverage_df,
         merged_coverage_destination,
@@ -215,10 +219,10 @@ def join_latest_cqc_rating_into_coverage_df(
     cqc_ratings_df: DataFrame,
 ) -> DataFrame:
     """
-     Then join latest rating to coverage dataframe.
+     Join latest rating to coverage dataframe using locationid as key.
 
     Requirements that are not arguments: CQC locationid.
-    All columns from the CQC ratings dataframe are then joined to the coverage dataframe using locationid.
+    All columns from the CQC ratings dataframe are joined to the coverage dataframe using locationid.
 
     Args:
         cqc_ratings_df (DataFrame): A dataframe of cqc ratings.
@@ -227,6 +231,18 @@ def join_latest_cqc_rating_into_coverage_df(
     Returns:
         DataFrame: The coverage dataframe with the latest overall CQC rating and the rating date added to it.
     """
+
+    latest_cqc_ratings_df = keep_only_latest_cqc_ratings(cqc_ratings_df)
+
+    merged_coverage_with_latest_rating_df = merged_coverage_df.join(
+        latest_cqc_ratings_df,
+        CQCLClean.location_id,
+        how="left",
+    )
+
+    return merged_coverage_with_latest_rating_df.drop(
+        CQCRatingsColumns.latest_rating_flag
+    )
 
 
 if __name__ == "__main__":

--- a/jobs/merge_coverage_data.py
+++ b/jobs/merge_coverage_data.py
@@ -20,6 +20,7 @@ from utils.column_names.coverage_columns import CoverageColumns
 from utils.column_names.cqc_ratings_columns import CQCRatingsColumns
 
 from utils.column_values.categorical_column_values import InAscwds
+from utils.column_values.categorical_column_values import CQCRatingsValues
 
 PartitionKeys = [Keys.year, Keys.month, Keys.day, Keys.import_date]
 
@@ -184,6 +185,47 @@ def add_flag_for_in_ascwds(
     )
 
     return merged_coverage_df
+
+
+def keep_only_latest_cqc_rating(
+    cqc_ratings_df: DataFrame,
+) -> DataFrame:
+    """
+    Filter the CQC ratings dataframe to latest rating per location only.
+
+    Requirements that are not arguments: latest_rating_flag.
+    The CQC ratings dataset shows 1 for the latest rating in the latest_rating_flag column.
+    This function removes rows from the cqc ratings dataframe when latest_rating_flag = 0.
+
+    Args:
+        cqc_ratings_df (DataFrame): A dataframe of cqc ratings.
+
+    Returns:
+        DataFrame: The cqc ratings dataframe with only the latest rating per location.
+    """
+
+    return cqc_ratings_df.where(
+        CQCRatingsColumns.latest_rating_flag == CQCRatingsValues.latest_rating
+    )
+
+
+def join_latest_cqc_rating_into_coverage_df(
+    merged_coverage_df: DataFrame,
+    cqc_ratings_df: DataFrame,
+) -> DataFrame:
+    """
+     Then join latest rating to coverage dataframe.
+
+    Requirements that are not arguments: CQC locationid.
+    All columns from the CQC ratings dataframe are then joined to the coverage dataframe using locationid.
+
+    Args:
+        cqc_ratings_df (DataFrame): A dataframe of cqc ratings.
+        merged_coverage_df (DataFrame): A dataframe of CQC locations with ASC-WDS columns joined via locationid.
+
+    Returns:
+        DataFrame: The coverage dataframe with the latest overall CQC rating and the rating date added to it.
+    """
 
 
 if __name__ == "__main__":

--- a/jobs/merge_coverage_data.py
+++ b/jobs/merge_coverage_data.py
@@ -17,6 +17,7 @@ from utils.column_names.ind_cqc_pipeline_columns import (
     PartitionKeys as Keys,
 )
 from utils.column_names.coverage_columns import CoverageColumns
+from utils.column_names.cqc_ratings_columns import CQCRatingsColumns
 
 from utils.column_values.categorical_column_values import InAscwds
 
@@ -60,11 +61,18 @@ cleaned_ascwds_workplace_columns_to_import = [
     AWPClean.master_update_date_org,
     AWPClean.establishment_created_date,
 ]
+cqc_ratings_columns_to_import = [
+    AWPClean.location_id,
+    CQCRatingsColumns.date,
+    CQCRatingsColumns.overall_rating,
+    CQCRatingsColumns.latest_rating_flag,
+]
 
 
 def main(
     cleaned_cqc_location_source: str,
     workplace_for_reconciliation_source: str,
+    cqc_ratings_source: str,
     merged_coverage_destination: str,
 ):
     spark = utils.get_spark()
@@ -80,6 +88,11 @@ def main(
     ascwds_workplace_df = utils.read_from_parquet(
         workplace_for_reconciliation_source,
         selected_columns=cleaned_ascwds_workplace_columns_to_import,
+    )
+
+    cqc_ratings_df = utils.read_from_parquet(
+        cqc_ratings_source,
+        selected_columns=cqc_ratings_columns_to_import,
     )
 
     merged_coverage_df = join_ascwds_data_into_cqc_location_df(
@@ -180,6 +193,7 @@ if __name__ == "__main__":
     (
         cleaned_cqc_location_source,
         workplace_for_reconciliation_source,
+        cqc_ratings_source,
         merged_coverage_destination,
     ) = utils.collect_arguments(
         (
@@ -190,6 +204,7 @@ if __name__ == "__main__":
             "--workplace_for_reconciliation_source",
             "Source s3 directory for parquet ASCWDS workplace for reconciliation dataset",
         ),
+        ("--cqc_ratings_source", "Source s3 directory for parquet CQC ratings dataset"),
         (
             "--merged_coverage_destination",
             "Destination s3 directory for parquet",
@@ -198,6 +213,7 @@ if __name__ == "__main__":
     main(
         cleaned_cqc_location_source,
         workplace_for_reconciliation_source,
+        cqc_ratings_source,
         merged_coverage_destination,
     )
 

--- a/terraform/pipeline/glue.tf
+++ b/terraform/pipeline/glue.tf
@@ -393,6 +393,7 @@ module "merge_coverage_data_job" {
   job_parameters = {
     "--cleaned_cqc_location_source"         = "${module.datasets_bucket.bucket_uri}/domain=CQC/dataset=locations_api_cleaned/"
     "--workplace_for_reconciliation_source" = "${module.datasets_bucket.bucket_uri}/domain=SfC/dataset=workplace_for_reconciliation/"
+    "--cqc_ratings_source"                  = "${module.datasets_bucket.bucket_uri}/domain=SfC/dataset=cqc_ratings/"
     "--merged_coverage_destination"         = "${module.datasets_bucket.bucket_uri}/domain=SfC/dataset=merged_coverage_data/"
   }
 }

--- a/terraform/pipeline/step-functions/IndCqcFilledPostEstimatePipeline-StepFunction.json
+++ b/terraform/pipeline/step-functions/IndCqcFilledPostEstimatePipeline-StepFunction.json
@@ -322,7 +322,7 @@
                 "Arguments": {
                   "--cleaned_cqc_location_source": "${dataset_bucket_uri}/domain=CQC/dataset=locations_api_cleaned/",
                   "--workplace_for_reconciliation_source": "${dataset_bucket_uri}/domain=SfC/dataset=workplace_for_reconciliation/",
-                  "--cqc_ratings_source": "${datasets_bucket.bucket_uri}/domain=SfC/dataset=cqc_ratings/",
+                  "--cqc_ratings_source": "${dataset_bucket_uri}/domain=SfC/dataset=cqc_ratings/",
                   "--merged_coverage_destination": "${dataset_bucket_uri}/domain=SfC/dataset=merged_coverage_data/"
                 }
               },

--- a/terraform/pipeline/step-functions/IndCqcFilledPostEstimatePipeline-StepFunction.json
+++ b/terraform/pipeline/step-functions/IndCqcFilledPostEstimatePipeline-StepFunction.json
@@ -322,6 +322,7 @@
                 "Arguments": {
                   "--cleaned_cqc_location_source": "${dataset_bucket_uri}/domain=CQC/dataset=locations_api_cleaned/",
                   "--workplace_for_reconciliation_source": "${dataset_bucket_uri}/domain=SfC/dataset=workplace_for_reconciliation/",
+                  "--cqc_ratings_source": "${datasets_bucket.bucket_uri}/domain=SfC/dataset=cqc_ratings/",
                   "--merged_coverage_destination": "${dataset_bucket_uri}/domain=SfC/dataset=merged_coverage_data/"
                 }
               },

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -2247,6 +2247,12 @@ class MergeCoverageData:
         ("1", 1),
     ]
 
+    sample_cqc_ratings_for_merge_rows = [
+        ("1-000000001", "2024-01-01", "Good", 0),
+        ("1-000000001", "2024-01-02", "Good", 1),
+        ("1-000000002", "2024-01-01", None, 1),
+    ]
+
 
 @dataclass
 class IndCQCDataUtils:

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -2247,6 +2247,11 @@ class MergeCoverageData:
         ("1", 1),
     ]
 
+    sample_cqc_locations_rows = [
+        ("1-000000001",),
+        ("1-000000002",)
+    ]
+
     sample_cqc_ratings_for_merge_rows = [
         ("1-000000001", "2024-01-01", "Good", 0),
         ("1-000000001", "2024-01-02", "Good", 1),
@@ -2254,9 +2259,9 @@ class MergeCoverageData:
         ("1-000000002", "2024-01-01", None, 1),
     ]
 
-    expected_cqc_ratings_latest_rating_only_rows = [
-        ("1-000000001", "2024-01-02", "Good", 1),
-        ("1-000000002", "2024-01-01", None, 1),
+    expected_cqc_locations_and_latest_cqc_rating_rows = [
+        ("1-000000001", "2024-01-02", "Good",),
+        ("1-000000002", "2024-01-01", None,),
     ]
 
 

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -2247,10 +2247,7 @@ class MergeCoverageData:
         ("1", 1),
     ]
 
-    sample_cqc_locations_rows = [
-        ("1-000000001",),
-        ("1-000000002",)
-    ]
+    sample_cqc_locations_rows = [("1-000000001",), ("1-000000002",)]
 
     sample_cqc_ratings_for_merge_rows = [
         ("1-000000001", "2024-01-01", "Good", 0),
@@ -2259,10 +2256,12 @@ class MergeCoverageData:
         ("1-000000002", "2024-01-01", None, 1),
     ]
 
+    # fmt: off
     expected_cqc_locations_and_latest_cqc_rating_rows = [
         ("1-000000001", "2024-01-02", "Good",),
         ("1-000000002", "2024-01-01", None,),
     ]
+    # fmt: on
 
 
 @dataclass

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -2250,6 +2250,12 @@ class MergeCoverageData:
     sample_cqc_ratings_for_merge_rows = [
         ("1-000000001", "2024-01-01", "Good", 0),
         ("1-000000001", "2024-01-02", "Good", 1),
+        ("1-000000001", None, "Good", None),
+        ("1-000000002", "2024-01-01", None, 1),
+    ]
+
+    expected_cqc_ratings_latest_rating_only_rows = [
+        ("1-000000001", "2024-01-02", "Good", 1),
         ("1-000000002", "2024-01-01", None, 1),
     ]
 

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -1542,6 +1542,10 @@ class MergeCoverageData:
         ]
     )
 
+    sample_cqc_locations_schema = StructType(
+        [StructField(AWPClean.location_id, StringType(), True)]
+    )
+
     sample_cqc_ratings_for_merge_schema = StructType(
         [
             StructField(AWPClean.location_id, StringType(), True),
@@ -1551,7 +1555,13 @@ class MergeCoverageData:
         ]
     )
 
-    expected_cqc_ratings_latest_rating_only_schema = sample_cqc_ratings_for_merge_schema
+    expected_cqc_locations_and_latest_cqc_rating_schema = StructType(
+        [
+            *sample_cqc_locations_schema,
+            StructField(CQCRatingsColumns.date, StringType(), True),
+            StructField(CQCRatingsColumns.overall_rating, StringType(), True),
+        ]
+    )
 
 
 @dataclass

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -66,6 +66,7 @@ from utils.direct_payments_utils.direct_payments_column_names import (
 )
 
 from utils.column_names.coverage_columns import CoverageColumns
+from utils.column_names.cqc_ratings_columns import CQCRatingsColumns
 
 
 @dataclass
@@ -1538,6 +1539,15 @@ class MergeCoverageData:
         [
             *sample_in_ascwds_schema,
             StructField(CoverageColumns.in_ascwds, IntegerType(), True),
+        ]
+    )
+
+    sample_cqc_ratings_schema = StructType(
+        [
+            StructField(AWPClean.location_id, StringType(), True),
+            StructField(CQCRatingsColumns.date, StringType(), True),
+            StructField(CQCRatingsColumns.overall_rating, StringType(), True),
+            StructField(CQCRatingsColumns.latest_rating_flag, IntegerType(), True),
         ]
     )
 

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -1542,7 +1542,7 @@ class MergeCoverageData:
         ]
     )
 
-    sample_cqc_ratings_schema = StructType(
+    sample_cqc_ratings_for_merge_schema = StructType(
         [
             StructField(AWPClean.location_id, StringType(), True),
             StructField(CQCRatingsColumns.date, StringType(), True),
@@ -1550,6 +1550,8 @@ class MergeCoverageData:
             StructField(CQCRatingsColumns.latest_rating_flag, IntegerType(), True),
         ]
     )
+
+    expected_cqc_ratings_latest_rating_only_schema = sample_cqc_ratings_for_merge_schema
 
 
 @dataclass

--- a/tests/unit/test_merge_coverage_data.py
+++ b/tests/unit/test_merge_coverage_data.py
@@ -24,7 +24,7 @@ from utils.column_names.cqc_ratings_columns import CQCRatingsColumns
 from utils.column_values.categorical_column_values import CQCLatestRating
 
 
-class MergeCoverageDatasetTests(unittest.TestCase):
+class SetupForTests(unittest.TestCase):
     TEST_CQC_LOCATION_SOURCE = "some/directory"
     TEST_ASCWDS_WORKPLACE_SOURCE = "some/other/directory"
     TEST_CQC_RATINGS_SOURCE = "some/other/directory"
@@ -45,6 +45,11 @@ class MergeCoverageDatasetTests(unittest.TestCase):
             Data.sample_cqc_ratings_for_merge_rows,
             Schemas.sample_cqc_ratings_for_merge_schema,
         )
+
+
+class MainTests(SetupForTests):
+    def setUp(self) -> None:
+        super().setUp()
 
     @patch("jobs.merge_coverage_data.join_ascwds_data_into_cqc_location_df")
     @patch("utils.utils.write_to_parquet")
@@ -79,6 +84,11 @@ class MergeCoverageDatasetTests(unittest.TestCase):
             partitionKeys=self.partition_keys,
         )
 
+
+class JoinAscwdsIntoCqcLocationsTests(SetupForTests):
+    def setUp(self) -> None:
+        super().setUp()
+
     def test_join_ascwds_data_into_cqc_location_df(self):
         returned_df = job.join_ascwds_data_into_cqc_location_df(
             self.test_clean_cqc_location_df,
@@ -102,9 +112,9 @@ class MergeCoverageDatasetTests(unittest.TestCase):
         self.assertEqual(returned_data, expected_data)
 
 
-class AddFlagForInAscwdsTests(unittest.TestCase):
+class AddFlagForInAscwdsTests(SetupForTests):
     def setUp(self) -> None:
-        self.spark = utils.get_spark()
+        super().setUp()
 
         self.sample_in_ascwds_df = self.spark.createDataFrame(
             Data.sample_in_ascwds_rows, schema=Schemas.sample_in_ascwds_schema
@@ -133,7 +143,7 @@ class AddFlagForInAscwdsTests(unittest.TestCase):
         self.assertEqual(returned_rows, expected_rows)
 
 
-class KeepOnlyLatestCqcRatingTests(MergeCoverageDatasetTests):
+class FilterForLatestCqcRatings(SetupForTests):
     def setUp(self) -> None:
         super().setUp()
 
@@ -157,7 +167,7 @@ class KeepOnlyLatestCqcRatingTests(MergeCoverageDatasetTests):
         self.assertEqual(self.returned_in_ascwds_df.count(), 2)
 
 
-class JoinLatestCqcRatingsIntoCoverageTests(MergeCoverageDatasetTests):
+class JoinLatestCqcRatingsIntoCoverageTests(SetupForTests):
     def setUp(self) -> None:
         super().setUp()
 

--- a/tests/unit/test_merge_coverage_data.py
+++ b/tests/unit/test_merge_coverage_data.py
@@ -43,7 +43,7 @@ class MergeCoverageDatasetTests(unittest.TestCase):
         )
         self.test_cqc_ratings_df = self.spark.createDataFrame(
             Data.sample_cqc_ratings_for_merge_rows,
-            Schemas.sample_cqc_ratings_schema,
+            Schemas.sample_cqc_ratings_for_merge_schema,
         )
 
     @patch("jobs.merge_coverage_data.join_ascwds_data_into_cqc_location_df")

--- a/tests/unit/test_merge_coverage_data.py
+++ b/tests/unit/test_merge_coverage_data.py
@@ -23,6 +23,7 @@ from utils.column_names.coverage_columns import CoverageColumns
 class MergeCoverageDatasetTests(unittest.TestCase):
     TEST_CQC_LOCATION_SOURCE = "some/directory"
     TEST_ASCWDS_WORKPLACE_SOURCE = "some/other/directory"
+    TEST_CQC_RATINGS_SOURCE = "some/other/directory"
     TEST_DESTINATION = "some/other/directory"
     partition_keys = [Keys.year, Keys.month, Keys.day, Keys.import_date]
 
@@ -35,6 +36,10 @@ class MergeCoverageDatasetTests(unittest.TestCase):
         self.test_clean_ascwds_workplace_df = self.spark.createDataFrame(
             Data.clean_ascwds_workplace_for_merge_rows,
             Schemas.clean_ascwds_workplace_for_merge_schema,
+        )
+        self.test_cqc_ratings_df = self.spark.createDataFrame(
+            Data.sample_cqc_ratings_for_merge_rows,
+            Schemas.sample_cqc_ratings_schema,
         )
 
     @patch("jobs.merge_coverage_data.join_ascwds_data_into_cqc_location_df")
@@ -49,15 +54,17 @@ class MergeCoverageDatasetTests(unittest.TestCase):
         read_from_parquet_patch.side_effect = [
             self.test_clean_cqc_location_df,
             self.test_clean_ascwds_workplace_df,
+            self.test_cqc_ratings_df,
         ]
 
         job.main(
             self.TEST_CQC_LOCATION_SOURCE,
             self.TEST_ASCWDS_WORKPLACE_SOURCE,
+            self.TEST_CQC_RATINGS_SOURCE,
             self.TEST_DESTINATION,
         )
 
-        self.assertEqual(read_from_parquet_patch.call_count, 2)
+        self.assertEqual(read_from_parquet_patch.call_count, 3)
 
         join_ascwds_data_into_cqc_location_df.assert_called_once()
 

--- a/tests/unit/test_merge_coverage_data.py
+++ b/tests/unit/test_merge_coverage_data.py
@@ -147,11 +147,11 @@ class FilterForLatestCqcRatings(SetupForTests):
     def setUp(self) -> None:
         super().setUp()
 
-        self.returned_in_ascwds_df = job.filter_for_latest_cqc_ratings_only(
+        self.returned_in_ascwds_df = job.filter_for_latest_cqc_ratings(
             self.test_cqc_ratings_df
         )
 
-    def test_filter_for_latest_cqc_ratings_only_contains_latest_ratings(self):
+    def test_filter_for_latest_cqc_ratings_contains_latest_ratings(self):
         latest_rating_column_df = self.returned_in_ascwds_df.select(
             CQCRatingsColumns.latest_rating_flag
         )
@@ -163,7 +163,7 @@ class FilterForLatestCqcRatings(SetupForTests):
             distinct_latest_rating_rows[0][0], CQCLatestRating.is_latest_rating
         )
 
-    def test_filter_for_latest_cqc_ratings_only_has_expected_row_count(self):
+    def test_filter_for_latest_cqc_ratings_has_expected_row_count(self):
         self.assertEqual(self.returned_in_ascwds_df.count(), 2)
 
 

--- a/utils/column_names/cqc_ratings_columns.py
+++ b/utils/column_names/cqc_ratings_columns.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass
 
 @dataclass
 class CQCRatingsColumns:
-    date: str = "Date"
+    date: str = "rating_date"
     overall_rating: str = "Overall_rating"
     safe_rating: str = "Safe_rating"
     well_led_rating: str = "Well-led_rating"

--- a/utils/column_values/categorical_column_values.py
+++ b/utils/column_values/categorical_column_values.py
@@ -77,7 +77,9 @@ class Services(ColumnValues):
     hospice_services: str = "Hospice services"
     domiciliary_care_service: str = "Domiciliary care service"
     remote_clinical_advice_service: str = "Remote clinical advice service"
-    acute_services_without_overnight_beds: str = "Acute services without overnight beds / listed acute services with or without overnight beds"
+    acute_services_without_overnight_beds: str = (
+        "Acute services without overnight beds / listed acute services with or without overnight beds"
+    )
     specialist_college_service: str = "Specialist college service"
     ambulance_service: str = "Ambulance service"
     extra_care_housing_services: str = "Extra Care housing services"
@@ -107,7 +109,9 @@ class Services(ColumnValues):
     rehabilitation_services: str = "Rehabilitation services"
     doctors_treatment_service: str = "Doctors treatment service"
     hospice_services_at_home: str = "Hospice services at home"
-    hospital_services_for_people_with_mental_health_needs: str = "Hospital services for people with mental health needs, learning disabilities and problems with substance misuse"
+    hospital_services_for_people_with_mental_health_needs: str = (
+        "Hospital services for people with mental health needs, learning disabilities and problems with substance misuse"
+    )
 
 
 @dataclass
@@ -461,6 +465,8 @@ class CQCRatingsValues(ColumnValues):
     historic: str = "Historic"
     outstanding: str = "Outstanding"
     good: str = "Good"
+    latest_rating: int = 1
+    not_latest_rating: int = 0
 
 
 @dataclass

--- a/utils/column_values/categorical_column_values.py
+++ b/utils/column_values/categorical_column_values.py
@@ -77,7 +77,9 @@ class Services(ColumnValues):
     hospice_services: str = "Hospice services"
     domiciliary_care_service: str = "Domiciliary care service"
     remote_clinical_advice_service: str = "Remote clinical advice service"
-    acute_services_without_overnight_beds: str = "Acute services without overnight beds / listed acute services with or without overnight beds"
+    acute_services_without_overnight_beds: str = (
+        "Acute services without overnight beds / listed acute services with or without overnight beds"
+    )
     specialist_college_service: str = "Specialist college service"
     ambulance_service: str = "Ambulance service"
     extra_care_housing_services: str = "Extra Care housing services"
@@ -107,7 +109,9 @@ class Services(ColumnValues):
     rehabilitation_services: str = "Rehabilitation services"
     doctors_treatment_service: str = "Doctors treatment service"
     hospice_services_at_home: str = "Hospice services at home"
-    hospital_services_for_people_with_mental_health_needs: str = "Hospital services for people with mental health needs, learning disabilities and problems with substance misuse"
+    hospital_services_for_people_with_mental_health_needs: str = (
+        "Hospital services for people with mental health needs, learning disabilities and problems with substance misuse"
+    )
 
 
 @dataclass
@@ -461,7 +465,11 @@ class CQCRatingsValues(ColumnValues):
     historic: str = "Historic"
     outstanding: str = "Outstanding"
     good: str = "Good"
-    latest_rating: int = 1
+
+
+@dataclass
+class CQCLatestRating(ColumnValues):
+    is_latest_rating: int = 1
     not_latest_rating: int = 0
 
 

--- a/utils/column_values/categorical_column_values.py
+++ b/utils/column_values/categorical_column_values.py
@@ -77,9 +77,7 @@ class Services(ColumnValues):
     hospice_services: str = "Hospice services"
     domiciliary_care_service: str = "Domiciliary care service"
     remote_clinical_advice_service: str = "Remote clinical advice service"
-    acute_services_without_overnight_beds: str = (
-        "Acute services without overnight beds / listed acute services with or without overnight beds"
-    )
+    acute_services_without_overnight_beds: str = "Acute services without overnight beds / listed acute services with or without overnight beds"
     specialist_college_service: str = "Specialist college service"
     ambulance_service: str = "Ambulance service"
     extra_care_housing_services: str = "Extra Care housing services"
@@ -109,9 +107,7 @@ class Services(ColumnValues):
     rehabilitation_services: str = "Rehabilitation services"
     doctors_treatment_service: str = "Doctors treatment service"
     hospice_services_at_home: str = "Hospice services at home"
-    hospital_services_for_people_with_mental_health_needs: str = (
-        "Hospital services for people with mental health needs, learning disabilities and problems with substance misuse"
-    )
+    hospital_services_for_people_with_mental_health_needs: str = "Hospital services for people with mental health needs, learning disabilities and problems with substance misuse"
 
 
 @dataclass


### PR DESCRIPTION
# Description
Added two functions to merge_coverage_data job. One for filtering cqc ratings to latest only. One for applying the filter and then joining the ratings to coverage dataframe.
The join adds the latest overall rating and the rating date to the coverage dataframe.

Also changed the cqc ratings column name script so that date = "rating_date" instead of "date".

Link to Trello:  https://trello.com/c/uWWQi5a3

# How to test
Unit tests are passing.

Link to successful run in Glue: https://eu-west-2.console.aws.amazon.com/gluestudio/home?region=eu-west-2#/editor/job/add-latest-cqc-rating-merge_coverage_data_job/runs

Link to successful ind cqc filled posts step function: https://eu-west-2.console.aws.amazon.com/states/home?region=eu-west-2#/v2/executions/details/arn:aws:states:eu-west-2:344210435447:execution:add-latest-cqc-rating-Ind-CQC-Filled-Post-Estimates-Pipeline:5994db55-d866-4fbb-90c5-6f72e384a198

# Developer checklist
- [x] Unit test
- [x] Linked to Trello ticket
- [ ] Documentation up to date
