### PR TITLE
Fix invalid postcode in locations

### DIFF
--- a/jobs/clean_cqc_location_data.py
+++ b/jobs/clean_cqc_location_data.py
@@ -29,7 +29,10 @@ from utils.column_names.cleaned_data_files.ons_cleaned import (
     current_geography_columns,
 )
 from utils.cqc_location_dictionaries import InvalidPostcodes
-from utils.raw_data_adjustments import remove_records_from_locations_data
+from utils.raw_data_adjustments import (
+    remove_records_from_locations_data,
+    replace_incorrect_postcode_in_locations_data,
+)
 
 
 cqcPartitionKeys = [Keys.year, Keys.month, Keys.day, Keys.import_date]
@@ -92,6 +95,7 @@ def main(
 
     cqc_location_df = remove_non_social_care_locations(cqc_location_df)
     cqc_location_df = remove_records_from_locations_data(cqc_location_df)
+    cqc_location_df = replace_incorrect_postcode_in_locations_data(cqc_location_df)
     cqc_location_df = utils.format_date_fields(
         cqc_location_df,
         date_column_identifier=CQCLClean.registration_date,  # This will format both registration date and deregistration date

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -5134,34 +5134,106 @@ class RawDataAdjustments:
     expected_locations_data = locations_data_without_rows_to_remove
 
     replace_incorrect_postcodes_one_location_rows = [
-        ("1-19593903579", "C04 5EN",),
-        ("1-19593903579", "CO4 5EN",),
-        ("1-19593903579", "AB1 2CD",),
-        ("1-19593903579", None,),
+        (
+            "1-19593903579",
+            "C04 5EN",
+        ),
+        (
+            "1-19593903579",
+            "CO4 5EN",
+        ),
+        (
+            "1-19593903579",
+            "AB1 2CD",
+        ),
+        (
+            "1-19593903579",
+            None,
+        ),
     ]
     replace_incorrect_postcodes_multiple_locations_rows = [
-        ("1-19593903579", "C04 5EN",),
-        ("1-19593903579", "CO4 5EN",),
-        ("1-19593903579", "AB1 2CD",),
-        ("1-19593903579", None,),
-        ("other_location", "C04 5EN",),
-        ("other_location", "CO4 5EN",),
-        ("other_location", "AB1 2CD",),
-        ("other_location", None,),
+        (
+            "1-19593903579",
+            "C04 5EN",
+        ),
+        (
+            "1-19593903579",
+            "CO4 5EN",
+        ),
+        (
+            "1-19593903579",
+            "AB1 2CD",
+        ),
+        (
+            "1-19593903579",
+            None,
+        ),
+        (
+            "other_location",
+            "C04 5EN",
+        ),
+        (
+            "other_location",
+            "CO4 5EN",
+        ),
+        (
+            "other_location",
+            "AB1 2CD",
+        ),
+        (
+            "other_location",
+            None,
+        ),
     ]
     expected_replace_incorrect_postcodes_one_location_rows = [
-        ("1-19593903579", "CO4 5EN",),
-        ("1-19593903579", "CO4 5EN",),
-        ("1-19593903579", "AB1 2CD",),
-        ("1-19593903579", None,),
+        (
+            "1-19593903579",
+            "CO4 5EN",
+        ),
+        (
+            "1-19593903579",
+            "CO4 5EN",
+        ),
+        (
+            "1-19593903579",
+            "AB1 2CD",
+        ),
+        (
+            "1-19593903579",
+            None,
+        ),
     ]
     expected_replace_incorrect_postcodes_multiple_locations_rows = [
-        ("1-19593903579", "CO4 5EN",),
-        ("1-19593903579", "CO4 5EN",),
-        ("1-19593903579", "AB1 2CD",),
-        ("1-19593903579", None,),
-        ("other_location", "C04 5EN",),
-        ("other_location", "CO4 5EN",),
-        ("other_location", "AB1 2CD",),
-        ("other_location", None,),
+        (
+            "1-19593903579",
+            "CO4 5EN",
+        ),
+        (
+            "1-19593903579",
+            "CO4 5EN",
+        ),
+        (
+            "1-19593903579",
+            "AB1 2CD",
+        ),
+        (
+            "1-19593903579",
+            None,
+        ),
+        (
+            "other_location",
+            "C04 5EN",
+        ),
+        (
+            "other_location",
+            "CO4 5EN",
+        ),
+        (
+            "other_location",
+            "AB1 2CD",
+        ),
+        (
+            "other_location",
+            None,
+        ),
     ]

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -5132,3 +5132,36 @@ class RawDataAdjustments:
     ]
 
     expected_locations_data = locations_data_without_rows_to_remove
+
+    replace_incorrect_postcodes_one_location_rows = [
+        ("1-19593903579", "C04 5EN",),
+        ("1-19593903579", "CO4 5EN",),
+        ("1-19593903579", "AB1 2CD",),
+        ("1-19593903579", None,),
+    ]
+    replace_incorrect_postcodes_multiple_locations_rows = [
+        ("1-19593903579", "C04 5EN",),
+        ("1-19593903579", "CO4 5EN",),
+        ("1-19593903579", "AB1 2CD",),
+        ("1-19593903579", None,),
+        ("other_location", "C04 5EN",),
+        ("other_location", "CO4 5EN",),
+        ("other_location", "AB1 2CD",),
+        ("other_location", None,),
+    ]
+    expected_replace_incorrect_postcodes_one_location_rows = [
+        ("1-19593903579", "CO4 5EN",),
+        ("1-19593903579", "CO4 5EN",),
+        ("1-19593903579", "AB1 2CD",),
+        ("1-19593903579", None,),
+    ]
+    expected_replace_incorrect_postcodes_multiple_locations_rows = [
+        ("1-19593903579", "CO4 5EN",),
+        ("1-19593903579", "CO4 5EN",),
+        ("1-19593903579", "AB1 2CD",),
+        ("1-19593903579", None,),
+        ("other_location", "C04 5EN",),
+        ("other_location", "CO4 5EN",),
+        ("other_location", "AB1 2CD",),
+        ("other_location", None,),
+    ]

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -3572,3 +3572,10 @@ class RawDataAdjustments:
             StructField("other_column", StringType(), True),
         ]
     )
+
+    replace_incorrect_postcodes_schema = StructType(
+        [
+            StructField(CQCL.location_id, StringType(), True),
+            StructField(CQCL.postal_code, StringType(), True),
+        ]
+    )

--- a/tests/unit/test_raw_data_adjustments.py
+++ b/tests/unit/test_raw_data_adjustments.py
@@ -154,3 +154,68 @@ class RemoveRecordsFromLocationsDataTests(TestRawDataAdjustments):
 
         self.assertIsNotNone(returned_df)
         self.assertEqual(self.expected_df.collect(), returned_df.collect())
+
+
+class ReplaceIncorrectPostcodeinLocationdDataTests(TestRawDataAdjustments):
+    def setUp(self) -> None:
+        super().setUp()
+        self.test_one_location_df = self.spark.createDataFrame(
+            Data.replace_incorrect_postcodes_one_location_rows,
+            Schemas.replace_incorrect_postcodes_schema,
+        )
+        self.test_multiple_locations_df = self.spark.createDataFrame(
+            Data.replace_incorrect_postcodes_multiple_locations_rows,
+            Schemas.replace_incorrect_postcodes_schema,
+        )
+        self.returned_one_location_df = (
+            job.replace_incorrect_postcode_in_locations_data(self.test_one_location_df)
+        )
+        self.returned_multiple_locations_df = (
+            job.replace_incorrect_postcode_in_locations_data(
+                self.test_multiple_locations_df
+            )
+        )
+        self.expected_one_location_df = self.spark.createDataFrame(
+            Data.expected_replace_incorrect_postcodes_one_location_rows,
+            Schemas.replace_incorrect_postcodes_schema,
+        )
+        self.expected_multiple_locations_df = self.spark.createDataFrame(
+            Data.expected_replace_incorrect_postcodes_multiple_locations_rows,
+            Schemas.replace_incorrect_postcodes_schema,
+        )
+
+    def test_replace_incorrect_postcode_in_locations_data_changes_incorrect_postcode_for_relevant_location_id(
+        self,
+    ):
+        self.assertEqual(
+            self.returned_one_location_df.collect(),
+            self.expected_one_location_df.collect(),
+        )
+
+    def test_replace_incorrect_postcode_in_locations_data_does_not_change_only_incorrect_postcodes_for_other_location_ids(
+        self,
+    ):
+        self.assertEqual(
+            self.returned_multiple_locations_df.collect(),
+            self.expected_multiple_locations_df.collect(),
+        )
+
+    def test_replace_incorrect_postcode_in_locations_data_does_not_change_row_count(
+        self,
+    ):
+        self.assertEqual(
+            self.returned_one_location_df.count(), self.expected_one_location_df.count()
+        )
+        self.assertEqual(
+            self.returned_multiple_locations_df.count(),
+            self.expected_multiple_locations_df.count(),
+        )
+
+    def test_replace_incorrect_postcode_in_locations_data_does_not_change_columns(self):
+        self.assertEqual(
+            self.returned_one_location_df.columns, self.expected_one_location_df.columns
+        )
+        self.assertEqual(
+            self.returned_multiple_locations_df.columns,
+            self.expected_multiple_locations_df.columns,
+        )

--- a/utils/raw_data_adjustments.py
+++ b/utils/raw_data_adjustments.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 
-from pyspark.sql import DataFrame
+from pyspark.sql import DataFrame, functions as F
 
 from utils.column_names.cleaned_data_files.ascwds_worker_cleaned import (
     AscwdsWorkerCleanedColumns as AWKClean,
@@ -75,7 +75,14 @@ def replace_incorrect_postcode_in_locations_data(
     """
     This function replaces an inncorrect postcode where a 'O' has been recorded as a '0'.
     """
-
+    raw_locations_df = raw_locations_df.withColumn(
+        CQCL.postal_code,
+        F.when(
+            (raw_locations_df[CQCL.postal_code] == "C04 5EN")
+            & (raw_locations_df[CQCL.location_id] == "1-19593903579"),
+            F.lit("CO4 5EN"),
+        ).otherwise(raw_locations_df[CQCL.postal_code]),
+    )
     return raw_locations_df
 
 

--- a/utils/raw_data_adjustments.py
+++ b/utils/raw_data_adjustments.py
@@ -69,6 +69,16 @@ def remove_records_from_locations_data(
     return raw_locations_df
 
 
+def replace_incorrect_postcode_in_locations_data(
+    raw_locations_df: DataFrame,
+) -> DataFrame:
+    """
+    This function replaces an inncorrect postcode where a 'O' has been recorded as a '0'.
+    """
+
+    return raw_locations_df
+
+
 @dataclass
 class RecordsToRemoveInLocationsData:
     """


### PR DESCRIPTION
# Description
The latest date from the locations API included a new location with a mis-spelled post code. This PR includes a function and unit tests to fix this problem as part of the clean locations job.

# How to test
Unit tests passing
Run in branch here: https://eu-west-2.console.aws.amazon.com/gluestudio/home?region=eu-west-2#/editor/job/fix-invalid-postcode-in-locati-clean_cqc_location_data_job/runs

# Developer checklist
- [x] Unit test
- [x] Linked to Trello ticket: https://trello.com/c/nHE47FeF/675-epic-7-fix-invalid-postcode-in-locations-api
- [x] Documentation up to date
