### PR TITLE
Remove specialist colleges

### DIFF
--- a/jobs/clean_cqc_location_data.py
+++ b/jobs/clean_cqc_location_data.py
@@ -265,17 +265,17 @@ def allocate_primary_service_type(df: DataFrame):
 
 def remove_specialist_colleges(df: DataFrame):
     """
-    Removes rows where 'Specialist college service' is the first service listed
+    Removes rows where 'Specialist college service' is the only service listed
     in 'services_offered'.
 
-    We do not include locations which are primarily specialist colleges in our
+    We do not include locations which are only specialist colleges in our
     estimates. This function identifies and removes the ones listed in the locations dataset.
 
     Args:
         df (DataFrame): A cleaned locations dataframe with the services_offered column already created.
 
     Returns:
-        (DataFrame): A cleaned locations dataframe with locations which are primarily specialist colleges removed.
+        (DataFrame): A cleaned locations dataframe with locations which are only specialist colleges removed.
     """
     df = df.where(
         (df[CQCLClean.services_offered][0] != Services.specialist_college_service)

--- a/jobs/clean_cqc_location_data.py
+++ b/jobs/clean_cqc_location_data.py
@@ -279,7 +279,7 @@ def remove_specialist_colleges(df: DataFrame):
     """
     df = df.where(
         (df[CQCLClean.services_offered][0] != Services.specialist_college_service)
-        | (F.size(df[CQCLClean.services_offered]) == 0)
+        | (F.size(df[CQCLClean.services_offered]) != 1)
         | (df[CQCLClean.services_offered].isNull())
     )
     return df

--- a/jobs/clean_cqc_location_data.py
+++ b/jobs/clean_cqc_location_data.py
@@ -22,6 +22,7 @@ from utils.column_values.categorical_column_values import (
     LocationType,
     PrimaryServiceType,
     RegistrationStatus,
+    Services,
 )
 from utils.column_names.cleaned_data_files.ons_cleaned import (
     OnsCleanedColumns as ONSClean,
@@ -263,6 +264,24 @@ def allocate_primary_service_type(df: DataFrame):
 
 
 def remove_specialist_colleges(df: DataFrame):
+    """
+    Removes rows where 'Specialist college service' is the first service listed
+    in 'services_offered'.
+
+    We do not include locations which are primarily specialist colleges in our
+    estimates. This function identifies and removes the ones listed in the locations dataset.
+
+    Args:
+        df (DataFrame): A cleaned locations dataframe with the services_offered column already created.
+
+    Returns:
+        (DataFrame): A cleaned locations dataframe with locations which are primarily specialist colleges removed.
+    """
+    df = df.where(
+        (df[CQCLClean.services_offered][0] != Services.specialist_college_service)
+        | (F.size(df[CQCLClean.services_offered]) == 0)
+        | (df[CQCLClean.services_offered].isNull())
+    )
     return df
 
 

--- a/jobs/clean_cqc_location_data.py
+++ b/jobs/clean_cqc_location_data.py
@@ -104,6 +104,7 @@ def main(
     registered_locations_df = select_registered_locations_only(cqc_location_df)
 
     registered_locations_df = add_list_of_services_offered(registered_locations_df)
+    registered_locations_df = remove_specialist_colleges(registered_locations_df)
     registered_locations_df = allocate_primary_service_type(registered_locations_df)
 
     registered_locations_df = join_cqc_provider_data(
@@ -258,6 +259,10 @@ def allocate_primary_service_type(df: DataFrame):
         )
         .otherwise(PrimaryServiceType.non_residential),
     )
+    return df
+
+
+def remove_specialist_colleges(df: DataFrame):
     return df
 
 

--- a/jobs/validate_locations_api_cleaned_data.py
+++ b/jobs/validate_locations_api_cleaned_data.py
@@ -88,7 +88,7 @@ def calculate_expected_size_of_cleaned_cqc_locations_dataset(
                 raw_location_df[CQCL.gac_service_types][0][CQCL.description]
                 != Services.specialist_college_service
             )
-            | (F.size(raw_location_df[CQCL.gac_service_types]) != 0)
+            | (F.size(raw_location_df[CQCL.gac_service_types]) != 1)
             | (raw_location_df[CQCL.gac_service_types].isNull())
         )
     ).count()

--- a/jobs/validate_locations_api_cleaned_data.py
+++ b/jobs/validate_locations_api_cleaned_data.py
@@ -53,9 +53,9 @@ def main(
     )
     rules = Rules.rules_to_check
 
-    rules[RuleName.size_of_dataset] = (
-        calculate_expected_size_of_cleaned_cqc_locations_dataset(raw_location_df)
-    )
+    rules[
+        RuleName.size_of_dataset
+    ] = calculate_expected_size_of_cleaned_cqc_locations_dataset(raw_location_df)
 
     cleaned_cqc_locations_df = add_column_with_length_of_string(
         cleaned_cqc_locations_df, [CQCL.location_id, CQCL.provider_id]

--- a/jobs/validate_locations_api_cleaned_data.py
+++ b/jobs/validate_locations_api_cleaned_data.py
@@ -8,7 +8,6 @@ from pyspark.sql import DataFrame, functions as F
 from utils import utils
 from utils.column_names.cleaned_data_files.cqc_location_cleaned import (
     NewCqcLocationApiColumns as CQCL,
-    CqcLocationCleanedColumns as CQCLClean,
 )
 from utils.column_names.ind_cqc_pipeline_columns import (
     PartitionKeys as Keys,
@@ -36,6 +35,7 @@ raw_cqc_locations_columns_to_import = [
     CQCL.location_id,
     CQCL.type,
     CQCL.registration_status,
+    CQCL.gac_service_types,
 ]
 
 
@@ -85,11 +85,11 @@ def calculate_expected_size_of_cleaned_cqc_locations_dataset(
         )
         & (
             (
-                raw_location_df[CQCLClean.services_offered][0]
+                raw_location_df[CQCL.gac_service_types][0][CQCL.description]
                 != Services.specialist_college_service
             )
-            | (F.size(raw_location_df[CQCLClean.services_offered]) == 0)
-            | (raw_location_df[CQCLClean.services_offered].isNull())
+            | (F.size(raw_location_df[CQCL.gac_service_types]) == 0)
+            | (raw_location_df[CQCL.gac_service_types].isNull())
         )
     ).count()
     return expected_size

--- a/jobs/validate_locations_api_cleaned_data.py
+++ b/jobs/validate_locations_api_cleaned_data.py
@@ -53,9 +53,9 @@ def main(
     )
     rules = Rules.rules_to_check
 
-    rules[
-        RuleName.size_of_dataset
-    ] = calculate_expected_size_of_cleaned_cqc_locations_dataset(raw_location_df)
+    rules[RuleName.size_of_dataset] = (
+        calculate_expected_size_of_cleaned_cqc_locations_dataset(raw_location_df)
+    )
 
     cleaned_cqc_locations_df = add_column_with_length_of_string(
         cleaned_cqc_locations_df, [CQCL.location_id, CQCL.provider_id]
@@ -88,7 +88,7 @@ def calculate_expected_size_of_cleaned_cqc_locations_dataset(
                 raw_location_df[CQCL.gac_service_types][0][CQCL.description]
                 != Services.specialist_college_service
             )
-            | (F.size(raw_location_df[CQCL.gac_service_types]) == 0)
+            | (F.size(raw_location_df[CQCL.gac_service_types]) != 0)
             | (raw_location_df[CQCL.gac_service_types].isNull())
         )
     ).count()

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -4775,33 +4775,33 @@ class ValidationUtils:
 class ValidateLocationsAPICleanedData:
     # fmt: off
     raw_cqc_locations_rows = [
-        ("1-000000001", "20240101", LocationType.social_care_identifier, RegistrationStatus.registered),
-        ("1-000000002", "20240101", LocationType.social_care_identifier, RegistrationStatus.deregistered),
-        ("1-000000001", "20240201", LocationType.social_care_identifier, RegistrationStatus.registered),
-        ("1-000000002", "20240201", "not social care org", RegistrationStatus.deregistered),
+        ("1-000000001", "20240101", LocationType.social_care_identifier, RegistrationStatus.registered, [{CQCL.name: "name", CQCL.description: Services.care_home_service_with_nursing}]),
+        ("1-000000002", "20240101", LocationType.social_care_identifier, RegistrationStatus.deregistered, [{CQCL.name: "name", CQCL.description: Services.care_home_service_with_nursing}]),
+        ("1-000000001", "20240201", LocationType.social_care_identifier, RegistrationStatus.registered, [{CQCL.name: "name", CQCL.description: Services.care_home_service_with_nursing}]),
+        ("1-000000002", "20240201", "not social care org", RegistrationStatus.deregistered, [{CQCL.name: "name", CQCL.description: Services.care_home_service_with_nursing}]),
     ]
 
     cleaned_cqc_locations_rows = [
-        ("1-000000001", date(2024, 1, 1), date(2024, 1, 1), "Y", "name", "prov_1", "prov_name", Sector.independent, RegistrationStatus.registered, date(2024, 1, 1), "Y", 5, PrimaryServiceType.care_home_only, date(2024, 1, 1), "cssr", "region", date(2024, 1, 1), "cssr", "region", "RUI"),
-        ("1-000000002", date(2024, 1, 1), date(2024, 1, 1), "Y", "name", "prov_1", "prov_name", Sector.independent, RegistrationStatus.registered, date(2024, 1, 1), "Y", 5, PrimaryServiceType.care_home_only, date(2024, 1, 1), "cssr", "region", date(2024, 1, 1), "cssr", "region", "RUI"),
-        ("1-000000001", date(2024, 1, 9), date(2024, 1, 1), "Y", "name", "prov_1", "prov_name", Sector.independent, RegistrationStatus.registered, date(2024, 1, 1), "Y", 5, PrimaryServiceType.care_home_only, date(2024, 1, 1), "cssr", "region", date(2024, 1, 1), "cssr", "region", "RUI"),
-        ("1-000000002", date(2024, 1, 9), date(2024, 1, 1), "Y", "name", "prov_1", "prov_name", Sector.independent, RegistrationStatus.registered, date(2024, 1, 1), "Y", 5, PrimaryServiceType.care_home_only, date(2024, 1, 1), "cssr", "region", date(2024, 1, 1), "cssr", "region", "RUI"),
+        ("1-000000002", date(2024, 1, 1), date(2024, 1, 1), "Y", "name", "prov_1", "prov_name", Sector.independent, RegistrationStatus.registered, date(2024, 1, 1), "Y", 5, PrimaryServiceType.care_home_only, date(2024, 1, 1), "cssr", "region", date(2024, 1, 1), "cssr", "region", "RUI", None),
+        ("1-000000001", date(2024, 1, 9), date(2024, 1, 1), "Y", "name", "prov_1", "prov_name", Sector.independent, RegistrationStatus.registered, date(2024, 1, 1), "Y", 5, PrimaryServiceType.care_home_only, date(2024, 1, 1), "cssr", "region", date(2024, 1, 1), "cssr", "region", "RUI", None),
+        ("1-000000001", date(2024, 1, 1), date(2024, 1, 1), "Y", "name", "prov_1", "prov_name", Sector.independent, RegistrationStatus.registered, date(2024, 1, 1), "Y", 5, PrimaryServiceType.care_home_only, date(2024, 1, 1), "cssr", "region", date(2024, 1, 1), "cssr", "region", "RUI", None),
+        ("1-000000002", date(2024, 1, 9), date(2024, 1, 1), "Y", "name", "prov_1", "prov_name", Sector.independent, RegistrationStatus.registered, date(2024, 1, 1), "Y", 5, PrimaryServiceType.care_home_only, date(2024, 1, 1), "cssr", "region", date(2024, 1, 1), "cssr", "region", "RUI", None),
     ]
     
 
     calculate_expected_size_rows = [
-        ("loc_1", LocationType.social_care_identifier, RegistrationStatus.registered, [Services.care_home_service_with_nursing]),
-        ("loc_2", "non social care org", RegistrationStatus.registered, [Services.care_home_service_with_nursing]),
-        ("loc_3", None, RegistrationStatus.registered, [Services.care_home_service_with_nursing]),
-        ("loc_4", LocationType.social_care_identifier, RegistrationStatus.deregistered, [Services.care_home_service_with_nursing]),
-        ("loc_5", "non social care org", RegistrationStatus.deregistered, [Services.care_home_service_with_nursing]),
-        ("loc_6", None, RegistrationStatus.deregistered,  [Services.care_home_service_with_nursing]),
-        ("loc_7", LocationType.social_care_identifier, RegistrationStatus.registered, [Services.specialist_college_service]),
-        ("loc_8", "non social care org", RegistrationStatus.registered, [Services.specialist_college_service]),
-        ("loc_9", None, RegistrationStatus.registered, [Services.specialist_college_service]),
-        ("loc_10", LocationType.social_care_identifier, RegistrationStatus.deregistered, [Services.specialist_college_service]),
-        ("loc_11", "non social care org", RegistrationStatus.deregistered, [Services.specialist_college_service]),
-        ("loc_12", None, RegistrationStatus.deregistered,  [Services.specialist_college_service]),
+        ("loc_1", LocationType.social_care_identifier, RegistrationStatus.registered, [{CQCL.name: "name", CQCL.description: Services.care_home_service_with_nursing}]),
+        ("loc_2", "non social care org", RegistrationStatus.registered, [{CQCL.name: "name", CQCL.description: Services.care_home_service_with_nursing}]),
+        ("loc_3", None, RegistrationStatus.registered, [{CQCL.name: "name", CQCL.description: Services.care_home_service_with_nursing}]),
+        ("loc_4", LocationType.social_care_identifier, RegistrationStatus.deregistered, [{CQCL.name: "name", CQCL.description: Services.care_home_service_with_nursing}]),
+        ("loc_5", "non social care org", RegistrationStatus.deregistered, [{CQCL.name: "name", CQCL.description: Services.care_home_service_with_nursing}]),
+        ("loc_6", None, RegistrationStatus.deregistered,  [{CQCL.name: "name", CQCL.description: Services.care_home_service_with_nursing}]),
+        ("loc_7", LocationType.social_care_identifier, RegistrationStatus.registered, [{CQCL.name: "name", CQCL.description: Services.specialist_college_service}]),
+        ("loc_8", "non social care org", RegistrationStatus.registered, [{CQCL.name: "name", CQCL.description: Services.specialist_college_service}]),
+        ("loc_9", None, RegistrationStatus.registered, [{CQCL.name: "name", CQCL.description: Services.specialist_college_service}]),
+        ("loc_10", LocationType.social_care_identifier, RegistrationStatus.deregistered, [{CQCL.name: "name", CQCL.description: Services.specialist_college_service}]),
+        ("loc_11", "non social care org", RegistrationStatus.deregistered, [{CQCL.name: "name", CQCL.description: Services.specialist_college_service}]),
+        ("loc_12", None, RegistrationStatus.deregistered,  [{CQCL.name: "name", CQCL.description: Services.specialist_college_service}]),
         (RecordsToRemoveInLocationsData.dental_practice, LocationType.social_care_identifier, RegistrationStatus.registered, None),
         (RecordsToRemoveInLocationsData.temp_registration, LocationType.social_care_identifier, RegistrationStatus.registered, None),
     ]

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -4790,14 +4790,20 @@ class ValidateLocationsAPICleanedData:
     
 
     calculate_expected_size_rows = [
-        ("loc_1", LocationType.social_care_identifier, RegistrationStatus.registered),
-        ("loc_2", "non social care org", RegistrationStatus.registered),
-        ("loc_3", None, RegistrationStatus.registered),
-        ("loc_4", LocationType.social_care_identifier, RegistrationStatus.deregistered),
-        ("loc_5", "non social care org", RegistrationStatus.deregistered),
-        ("loc_6", None, RegistrationStatus.deregistered),
-        (RecordsToRemoveInLocationsData.dental_practice, LocationType.social_care_identifier, RegistrationStatus.registered),
-        (RecordsToRemoveInLocationsData.temp_registration, LocationType.social_care_identifier, RegistrationStatus.registered),
+        ("loc_1", LocationType.social_care_identifier, RegistrationStatus.registered, [Services.care_home_service_with_nursing]),
+        ("loc_2", "non social care org", RegistrationStatus.registered, [Services.care_home_service_with_nursing]),
+        ("loc_3", None, RegistrationStatus.registered, [Services.care_home_service_with_nursing]),
+        ("loc_4", LocationType.social_care_identifier, RegistrationStatus.deregistered, [Services.care_home_service_with_nursing]),
+        ("loc_5", "non social care org", RegistrationStatus.deregistered, [Services.care_home_service_with_nursing]),
+        ("loc_6", None, RegistrationStatus.deregistered,  [Services.care_home_service_with_nursing]),
+        ("loc_7", LocationType.social_care_identifier, RegistrationStatus.registered, [Services.specialist_college_service]),
+        ("loc_8", "non social care org", RegistrationStatus.registered, [Services.specialist_college_service]),
+        ("loc_9", None, RegistrationStatus.registered, [Services.specialist_college_service]),
+        ("loc_10", LocationType.social_care_identifier, RegistrationStatus.deregistered, [Services.specialist_college_service]),
+        ("loc_11", "non social care org", RegistrationStatus.deregistered, [Services.specialist_college_service]),
+        ("loc_12", None, RegistrationStatus.deregistered,  [Services.specialist_college_service]),
+        (RecordsToRemoveInLocationsData.dental_practice, LocationType.social_care_identifier, RegistrationStatus.registered, None),
+        (RecordsToRemoveInLocationsData.temp_registration, LocationType.social_care_identifier, RegistrationStatus.registered, None),
     ]
     # fmt: on
 

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -2235,10 +2235,15 @@ class CQCLocationsData:
             [Services.care_home_service_with_nursing],
         ),
     ]
-    expected_multiple_services_specialist_colleges_rows = test_multiple_services_specialist_colleges_rows
+    expected_multiple_services_specialist_colleges_rows = (
+        test_multiple_services_specialist_colleges_rows
+    )
     expected_without_specialist_colleges_rows = test_without_specialist_colleges_rows
-    expected_empty_array_specialist_colleges_rows = test_empty_array_specialist_colleges_rows
+    expected_empty_array_specialist_colleges_rows = (
+        test_empty_array_specialist_colleges_rows
+    )
     expected_null_row_specialist_colleges_rows = test_null_row_specialist_colleges_rows
+
 
 @dataclass
 class UtilsData:

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -1407,8 +1407,217 @@ class CQCLocationsData:
                 },
             ],
         ),
+        (
+            "location6",
+            "provider6",
+            [
+                {
+                    "name": "With nursing",
+                    "description": "Care home service with nursing",
+                },
+                {
+                    "name": "Homecare agencies",
+                    "description": "Domiciliary care service",
+                },
+            ],
+        ),
+        (
+            "location7",
+            "provider7",
+            [
+                {
+                    "name": "Without nursing",
+                    "description": "Care home service without nursing",
+                },
+                {
+                    "name": "With nursing",
+                    "description": "Care home service with nursing",
+                },
+            ],
+        ),
+        (
+            "location8",
+            "provider8",
+            [
+                {
+                    "name": "Without nursing",
+                    "description": "Care home service without nursing",
+                },
+                {
+                    "name": "Homecare agencies",
+                    "description": "Domiciliary care service",
+                },
+            ],
+        ),
+        (
+            "location9",
+            "provider9",
+            [
+                {
+                    "name": "Homecare agencies",
+                    "description": "Domiciliary care service",
+                },
+                {
+                    "name": "Without nursing",
+                    "description": "Care home service without nursing",
+                },
+            ],
+        ),
+        (
+            "location10",
+            "provider10",
+            [
+                {
+                    "name": "Homecare agencies",
+                    "description": "Domiciliary care service",
+                },
+                {
+                    "name": "With nursing",
+                    "description": "Care home service with nursing",
+                },
+            ],
+        ),
     ]
-
+    expected_primary_service_type_rows = [
+        (
+            "location1",
+            "provider1",
+            [
+                {
+                    "name": "Homecare agencies",
+                    "description": "Domiciliary care service",
+                }
+            ],
+            PrimaryServiceType.non_residential,
+        ),
+        (
+            "location2",
+            "provider2",
+            [
+                {
+                    "name": "With nursing",
+                    "description": "Care home service with nursing",
+                }
+            ],
+            PrimaryServiceType.care_home_with_nursing,
+        ),
+        (
+            "location3",
+            "provider3",
+            [
+                {
+                    "name": "Without nursing",
+                    "description": "Care home service without nursing",
+                }
+            ],
+            PrimaryServiceType.care_home_only,
+        ),
+        (
+            "location4",
+            "provider4",
+            [
+                {
+                    "name": "With nursing",
+                    "description": "Care home service with nursing",
+                },
+                {
+                    "name": "Without nursing",
+                    "description": "Care home service without nursing",
+                },
+            ],
+            PrimaryServiceType.care_home_with_nursing,
+        ),
+        (
+            "location5",
+            "provider5",
+            [
+                {
+                    "name": "Without nursing",
+                    "description": "Care home service without nursing",
+                },
+                {
+                    "name": "Fake",
+                    "description": "Fake service",
+                },
+            ],
+            PrimaryServiceType.care_home_only,
+        ),
+        (
+            "location6",
+            "provider6",
+            [
+                {
+                    "name": "With nursing",
+                    "description": "Care home service with nursing",
+                },
+                {
+                    "name": "Homecare agencies",
+                    "description": "Domiciliary care service",
+                },
+            ],
+            PrimaryServiceType.care_home_with_nursing,
+        ),
+        (
+            "location7",
+            "provider7",
+            [
+                {
+                    "name": "Without nursing",
+                    "description": "Care home service without nursing",
+                },
+                {
+                    "name": "With nursing",
+                    "description": "Care home service with nursing",
+                },
+            ],
+            PrimaryServiceType.care_home_with_nursing,
+        ),
+        (
+            "location8",
+            "provider8",
+            [
+                {
+                    "name": "Without nursing",
+                    "description": "Care home service without nursing",
+                },
+                {
+                    "name": "Homecare agencies",
+                    "description": "Domiciliary care service",
+                },
+            ],
+            PrimaryServiceType.care_home_only,
+        ),
+        (
+            "location9",
+            "provider9",
+            [
+                {
+                    "name": "Homecare agencies",
+                    "description": "Domiciliary care service",
+                },
+                {
+                    "name": "Without nursing",
+                    "description": "Care home service without nursing",
+                },
+            ],
+            PrimaryServiceType.care_home_only,
+        ),
+        (
+            "location10",
+            "provider10",
+            [
+                {
+                    "name": "Homecare agencies",
+                    "description": "Domiciliary care service",
+                },
+                {
+                    "name": "With nursing",
+                    "description": "Care home service with nursing",
+                },
+            ],
+            PrimaryServiceType.care_home_with_nursing,
+        ),
+    ]
     small_location_rows = [
         (
             "loc-1",

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -1348,6 +1348,67 @@ class CQCLocationsData:
         ),
     ]
 
+    list_of_services_rows = [
+        (
+            "location1",
+            "provider1",
+            [
+                {
+                    "name": "Homecare agencies",
+                    "description": "Domiciliary care service",
+                }
+            ],
+        ),
+        (
+            "location2",
+            "provider2",
+            [
+                {
+                    "name": "With nursing",
+                    "description": "Care home service with nursing",
+                }
+            ],
+        ),
+        (
+            "location3",
+            "provider3",
+            [
+                {
+                    "name": "Without nursing",
+                    "description": "Care home service without nursing",
+                }
+            ],
+        ),
+        (
+            "location4",
+            "provider4",
+            [
+                {
+                    "name": "With nursing",
+                    "description": "Care home service with nursing",
+                },
+                {
+                    "name": "Without nursing",
+                    "description": "Care home service without nursing",
+                },
+            ],
+        ),
+        (
+            "location5",
+            "provider5",
+            [
+                {
+                    "name": "Without nursing",
+                    "description": "Care home service without nursing",
+                },
+                {
+                    "name": "Fake",
+                    "description": "Fake service",
+                },
+            ],
+        ),
+    ]
+
     primary_service_type_rows = [
         (
             "location1",

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -1942,6 +1942,13 @@ class CQCLocationsData:
     ]
     expected_with_specialist_colleges_rows = [
         (
+            "loc 2",
+            [
+                Services.specialist_college_service,
+                Services.acute_services_with_overnight_beds,
+            ],
+        ),
+        (
             "loc 3",
             [Services.care_home_service_with_nursing],
         ),

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -1931,17 +1931,41 @@ class CQCLocationsData:
             "loc 3",
             [Services.care_home_service_with_nursing],
         ),
+        (
+            "loc 4",
+            [],
+        ),
+        (
+            "loc 5",
+            None,
+        ),
     ]
     expected_with_specialist_colleges_rows = [
         (
             "loc 3",
             [Services.care_home_service_with_nursing],
         ),
+        (
+            "loc 4",
+            [],
+        ),
+        (
+            "loc 5",
+            None,
+        ),
     ]
     test_without_specialist_colleges_rows = [
         (
             "loc 1",
             [Services.care_home_service_with_nursing],
+        ),
+        (
+            "loc 2",
+            [],
+        ),
+        (
+            "loc 3",
+            None,
         ),
     ]
     expected_without_specialist_colleges_rows = test_without_specialist_colleges_rows
@@ -1957,20 +1981,16 @@ class CQCLocationsData:
             "loc 2",
             [Services.care_home_service_with_nursing],
         ),
-    ]
-    expected_with_specialist_colleges_not_listed_first_rows = [
         (
-            "loc 1",
-            [
-                Services.acute_services_with_overnight_beds,
-                Services.specialist_college_service,
-            ],
+            "loc 3",
+            [],
         ),
         (
-            "loc 2",
-            [Services.care_home_service_with_nursing],
+            "loc 4",
+            None,
         ),
     ]
+    expected_with_specialist_colleges_not_listed_first_rows = test_with_specialist_colleges_not_listed_first_rows
 
 
 @dataclass

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -2185,32 +2185,17 @@ class CQCLocationsData:
             date(2024, 3, 1),
         ),
     ]
-    test_with_specialist_colleges_rows = [
+    test_only_service_specialist_colleges_rows = [
         (
             "loc 1",
             [Services.specialist_college_service],
         ),
         (
-            "loc 2",
-            [
-                Services.specialist_college_service,
-                Services.acute_services_with_overnight_beds,
-            ],
-        ),
-        (
-            "loc 3",
-            [Services.care_home_service_with_nursing],
-        ),
-        (
             "loc 4",
-            [],
-        ),
-        (
-            "loc 5",
-            None,
+            [Services.care_home_service_with_nursing],
         ),
     ]
-    expected_with_specialist_colleges_rows = [
+    test_multiple_services_specialist_colleges_rows = [
         (
             "loc 2",
             [
@@ -2220,57 +2205,40 @@ class CQCLocationsData:
         ),
         (
             "loc 3",
-            [Services.care_home_service_with_nursing],
-        ),
-        (
-            "loc 4",
-            [],
-        ),
-        (
-            "loc 5",
-            None,
+            [
+                Services.acute_services_with_overnight_beds,
+                Services.specialist_college_service,
+            ],
         ),
     ]
     test_without_specialist_colleges_rows = [
         (
-            "loc 1",
+            "loc 4",
             [Services.care_home_service_with_nursing],
         ),
+    ]
+    test_empty_array_specialist_colleges_rows = [
         (
-            "loc 2",
+            "loc 5",
             [],
         ),
+    ]
+    test_null_row_specialist_colleges_rows = [
         (
-            "loc 3",
+            "loc 6",
             None,
         ),
     ]
-    expected_without_specialist_colleges_rows = test_without_specialist_colleges_rows
-    test_with_specialist_colleges_not_listed_first_rows = [
-        (
-            "loc 1",
-            [
-                Services.acute_services_with_overnight_beds,
-                Services.specialist_college_service,
-            ],
-        ),
-        (
-            "loc 2",
-            [Services.care_home_service_with_nursing],
-        ),
-        (
-            "loc 3",
-            [],
-        ),
+    expected_only_service_specialist_colleges_rows = [
         (
             "loc 4",
-            None,
+            [Services.care_home_service_with_nursing],
         ),
     ]
-    expected_with_specialist_colleges_not_listed_first_rows = (
-        test_with_specialist_colleges_not_listed_first_rows
-    )
-
+    expected_multiple_services_specialist_colleges_rows = test_multiple_services_specialist_colleges_rows
+    expected_without_specialist_colleges_rows = test_without_specialist_colleges_rows
+    expected_empty_array_specialist_colleges_rows = test_empty_array_specialist_colleges_rows
+    expected_null_row_specialist_colleges_rows = test_null_row_specialist_colleges_rows
 
 @dataclass
 class UtilsData:

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -1990,7 +1990,9 @@ class CQCLocationsData:
             None,
         ),
     ]
-    expected_with_specialist_colleges_not_listed_first_rows = test_with_specialist_colleges_not_listed_first_rows
+    expected_with_specialist_colleges_not_listed_first_rows = (
+        test_with_specialist_colleges_not_listed_first_rows
+    )
 
 
 @dataclass

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -21,6 +21,7 @@ from utils.column_values.categorical_column_values import (
     ParentsOrSinglesAndSubs,
     IsParent,
     SingleSubDescription,
+    Services,
 )
 from utils.ind_cqc_filled_posts_utils.ascwds_filled_posts_calculator.calculate_ascwds_filled_posts_absolute_difference_within_range import (
     ascwds_filled_posts_absolute_difference_within_range_source_description,
@@ -1912,6 +1913,62 @@ class CQCLocationsData:
             "prov_1",
             Sector.independent,
             date(2024, 3, 1),
+        ),
+    ]
+    test_with_specialist_colleges_rows = [
+        (
+            "loc 1",
+            [Services.specialist_college_service],
+        ),
+        (
+            "loc 2",
+            [
+                Services.specialist_college_service,
+                Services.acute_services_with_overnight_beds,
+            ],
+        ),
+        (
+            "loc 3",
+            [Services.care_home_service_with_nursing],
+        ),
+    ]
+    expected_with_specialist_colleges_rows = [
+        (
+            "loc 3",
+            [Services.care_home_service_with_nursing],
+        ),
+    ]
+    test_without_specialist_colleges_rows = [
+        (
+            "loc 1",
+            [Services.care_home_service_with_nursing],
+        ),
+    ]
+    expected_without_specialist_colleges_rows = test_without_specialist_colleges_rows
+    test_with_specialist_colleges_not_listed_first_rows = [
+        (
+            "loc 1",
+            [
+                Services.acute_services_with_overnight_beds,
+                Services.specialist_college_service,
+            ],
+        ),
+        (
+            "loc 2",
+            [Services.care_home_service_with_nursing],
+        ),
+    ]
+    expected_with_specialist_colleges_not_listed_first_rows = [
+        (
+            "loc 1",
+            [
+                Services.acute_services_with_overnight_beds,
+                Services.specialist_college_service,
+            ],
+        ),
+        (
+            "loc 2",
+            [Services.care_home_service_with_nursing],
         ),
     ]
 

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -3210,6 +3210,17 @@ class ValidateLocationsAPICleanedData:
             StructField(Keys.import_date, StringType(), True),
             StructField(CQCL.type, StringType(), True),
             StructField(CQCL.registration_status, StringType(), True),
+            StructField(
+                CQCL.gac_service_types,
+                ArrayType(
+                    StructType(
+                        [
+                            StructField(CQCL.name, StringType(), True),
+                            StructField(CQCL.description, StringType(), True),
+                        ]
+                    )
+                ),
+            ),
         ]
     )
     cleaned_cqc_locations_schema = StructType(
@@ -3234,6 +3245,12 @@ class ValidateLocationsAPICleanedData:
             StructField(CQCLClean.current_cssr, StringType(), True),
             StructField(CQCLClean.current_region, StringType(), True),
             StructField(CQCLClean.current_rural_urban_ind_11, StringType(), True),
+            StructField(
+                CQCLClean.services_offered,
+                ArrayType(
+                    StringType(),
+                ),
+            ),
         ]
     )
     calculate_expected_size_schema = StructType(
@@ -3242,9 +3259,14 @@ class ValidateLocationsAPICleanedData:
             StructField(CQCL.type, StringType(), True),
             StructField(CQCL.registration_status, StringType(), True),
             StructField(
-                CQCLClean.services_offered,
+                CQCL.gac_service_types,
                 ArrayType(
-                    StringType(),
+                    StructType(
+                        [
+                            StructField(CQCL.name, StringType(), True),
+                            StructField(CQCL.description, StringType(), True),
+                        ]
+                    )
                 ),
             ),
         ]

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -1199,6 +1199,13 @@ class CQCLocationsSchema:
         ]
     )
 
+    remove_specialist_colleges_schema = StructType(
+        [
+            StructField(CQCL.location_id, StringType(), True),
+            StructField(CQCLClean.services_offered, StringType(), True),
+        ]
+    )
+
 
 @dataclass
 class UtilsSchema:

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -1202,7 +1202,12 @@ class CQCLocationsSchema:
     remove_specialist_colleges_schema = StructType(
         [
             StructField(CQCL.location_id, StringType(), True),
-            StructField(CQCLClean.services_offered, StringType(), True),
+            StructField(
+                CQCLClean.services_offered,
+                ArrayType(
+                    StringType(),
+                ),
+            ),
         ]
     )
 

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -3241,6 +3241,12 @@ class ValidateLocationsAPICleanedData:
             StructField(CQCL.location_id, StringType(), True),
             StructField(CQCL.type, StringType(), True),
             StructField(CQCL.registration_status, StringType(), True),
+            StructField(
+                CQCLClean.services_offered,
+                ArrayType(
+                    StringType(),
+                ),
+            ),
         ]
     )
 

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -1061,6 +1061,24 @@ class CQCLocationsSchema:
             ),
         ]
     )
+    expected_primary_service_type_schema = StructType(
+        [
+            StructField(CQCL.location_id, StringType(), True),
+            StructField(CQCL.provider_id, StringType(), True),
+            StructField(
+                CQCL.gac_service_types,
+                ArrayType(
+                    StructType(
+                        [
+                            StructField(CQCL.name, StringType(), True),
+                            StructField(CQCL.description, StringType(), True),
+                        ]
+                    )
+                ),
+            ),
+            StructField(CQCLClean.primary_service_type, StringType(), True),
+        ]
+    )
 
     small_location_schema = StructType(
         [

--- a/tests/unit/test_clean_cqc_location_data.py
+++ b/tests/unit/test_clean_cqc_location_data.py
@@ -222,7 +222,7 @@ class ListServicesOfferedTests(CleanCQCLocationDatasetTests):
     def setUp(self) -> None:
         super().setUp()
         self.test_services_offered_df = self.spark.createDataFrame(
-            Data.primary_service_type_rows,
+            Data.list_of_services_rows,
             schema=Schemas.primary_service_type_schema,
         )
         self.returned_df = job.add_list_of_services_offered(

--- a/tests/unit/test_clean_cqc_location_data.py
+++ b/tests/unit/test_clean_cqc_location_data.py
@@ -306,12 +306,12 @@ class RemoveSpecialistCollegesTests(CleanCQCLocationDatasetTests):
             self.returned_df.count(), self.test_with_specialist_colleges_df.count()
         )
 
-    def test_remove_specialist_colleges_drops_rows_where_specialist_college_is_the_first_service_listed(
+    def test_remove_specialist_colleges_does_not_drop_rows_where_specialist_college_is_the_first_service_listed(
         self,
     ):
         self.assertEqual(self.returned_df.collect(), self.expected_df.collect())
 
-    def test_remove_specialist_colleges_drops_rows_where_specialist_college_is_listed_but_not_the_first_service_listed(
+    def test_remove_specialist_colleges_has_the_same_number_of_rows_where_specialist_college_is_listed_but_not_the_first_service_listed(
         self,
     ):
         test_df = self.spark.createDataFrame(

--- a/tests/unit/test_clean_cqc_location_data.py
+++ b/tests/unit/test_clean_cqc_location_data.py
@@ -276,15 +276,7 @@ class AllocatePrimaryServiceTests(CleanCQCLocationDatasetTests):
         ).first()[0]
 
         self.assertEqual(len(primary_service_values), 10)
-        self.assertEqual(primary_service_values[0], PrimaryServiceType.non_residential)
-        self.assertEqual(
-            primary_service_values[1], PrimaryServiceType.care_home_with_nursing
-        )
-        self.assertEqual(primary_service_values[2], PrimaryServiceType.care_home_only)
-        self.assertEqual(
-            primary_service_values[3], PrimaryServiceType.care_home_with_nursing
-        )
-        self.assertEqual(primary_service_values[4], PrimaryServiceType.care_home_only)
+
         self.assertEqual(output_df.collect(), expected_df.collect())
 
 

--- a/tests/unit/test_clean_cqc_location_data.py
+++ b/tests/unit/test_clean_cqc_location_data.py
@@ -225,22 +225,21 @@ class ListServicesOfferedTests(CleanCQCLocationDatasetTests):
             Data.primary_service_type_rows,
             schema=Schemas.primary_service_type_schema,
         )
+        self.returned_df = job.add_list_of_services_offered(
+            self.test_services_offered_df
+        )
 
-    def test_allocate_primary_service_type_add_column(self):
-        returned_df = job.add_list_of_services_offered(self.test_services_offered_df)
+    def test_add_list_of_services_offered_adds_column(self):
+        self.assertTrue(CQCLCleaned.services_offered in self.returned_df.columns)
 
-        self.assertTrue(CQCLCleaned.services_offered in returned_df.columns)
-
-    def test_allocate_primary_service_type_returns_correct_data(self):
-        returned_df = job.add_list_of_services_offered(self.test_services_offered_df)
-
+    def test_add_list_of_services_offered_returns_correct_data(self):
         expected_df = self.spark.createDataFrame(
             Data.expected_services_offered_rows,
             Schemas.expected_services_offered_schema,
         )
 
         returned_data = (
-            returned_df.select(sorted(returned_df.columns))
+            self.returned_df.select(sorted(self.returned_df.columns))
             .sort(CQCLCleaned.location_id)
             .collect()
         )

--- a/tests/unit/test_clean_cqc_location_data.py
+++ b/tests/unit/test_clean_cqc_location_data.py
@@ -302,7 +302,9 @@ class RemoveSpecialistCollegesTests(CleanCQCLocationDatasetTests):
     def test_remove_specialist_colleges_has_fewer_rows_when_specialist_colleges_are_present(
         self,
     ):
-        self.assertLess(self.returned_df.count(), self.expected_df.count())
+        self.assertLess(
+            self.returned_df.count(), self.test_with_specialist_colleges_df.count()
+        )
 
     def test_remove_specialist_colleges_drops_rows_where_specialist_college_is_the_first_service_listed(
         self,

--- a/tests/unit/test_clean_cqc_location_data.py
+++ b/tests/unit/test_clean_cqc_location_data.py
@@ -306,7 +306,10 @@ class RemoveSpecialistCollegesTests(CleanCQCLocationDatasetTests):
     def test_remove_specialist_colleges_does_not_drop_rows_where_specialist_college_is_the_first_service_listed(
         self,
     ):
-        self.assertEqual(self.returned_df.collect(), self.expected_df.collect())
+        self.assertEqual(
+            self.returned_df.sort(CQCL.location_id).collect(),
+            self.expected_df.sort(CQCL.location_id).collect(),
+        )
 
     def test_remove_specialist_colleges_has_the_same_number_of_rows_where_specialist_college_is_listed_but_not_the_first_service_listed(
         self,
@@ -320,7 +323,10 @@ class RemoveSpecialistCollegesTests(CleanCQCLocationDatasetTests):
             Data.expected_with_specialist_colleges_not_listed_first_rows,
             Schemas.remove_specialist_colleges_schema,
         )
-        self.assertEqual(returned_df.collect(), expected_df.collect())
+        self.assertEqual(
+            returned_df.sort(CQCL.location_id).collect(),
+            expected_df.sort(CQCL.location_id).collect(),
+        )
 
     def test_remove_specialist_colleges_has_the_same_number_of_rows_when_specialist_colleges_are_not_present(
         self,

--- a/tests/unit/test_clean_cqc_location_data.py
+++ b/tests/unit/test_clean_cqc_location_data.py
@@ -262,6 +262,10 @@ class AllocatePrimaryServiceTests(CleanCQCLocationDatasetTests):
             Data.primary_service_type_rows,
             schema=Schemas.primary_service_type_schema,
         )
+        expected_df = self.spark.createDataFrame(
+            Data.expected_primary_service_type_rows,
+            schema=Schemas.expected_primary_service_type_schema,
+        )
 
         output_df = job.allocate_primary_service_type(test_primary_service_df)
 
@@ -271,7 +275,7 @@ class AllocatePrimaryServiceTests(CleanCQCLocationDatasetTests):
             F.collect_list(PRIMARY_SERVICE_TYPE_COLUMN_NAME)
         ).first()[0]
 
-        self.assertEqual(len(primary_service_values), 5)
+        self.assertEqual(len(primary_service_values), 10)
         self.assertEqual(primary_service_values[0], PrimaryServiceType.non_residential)
         self.assertEqual(
             primary_service_values[1], PrimaryServiceType.care_home_with_nursing
@@ -281,6 +285,7 @@ class AllocatePrimaryServiceTests(CleanCQCLocationDatasetTests):
             primary_service_values[3], PrimaryServiceType.care_home_with_nursing
         )
         self.assertEqual(primary_service_values[4], PrimaryServiceType.care_home_only)
+        self.assertEqual(output_df.collect(), expected_df.collect())
 
 
 class RemoveSpecialistCollegesTests(CleanCQCLocationDatasetTests):


### PR DESCRIPTION
# Description
This PR adds a function to the clean CQC locations job which removes rows where the primary service type is specialist college.
Unit tests added.
Updates made to validation row count.

# How to test
Unit tests passing
Run in branch here: https://eu-west-2.console.aws.amazon.com/states/home?region=eu-west-2#/v2/executions/details/arn:aws:states:eu-west-2:344210435447:execution:remove-specialist-colleges-Ind-CQC-Filled-Post-Estimates-Pipeline:e59f1b1f-70c2-4c86-af9e-4e013f2bf387

# Developer checklist
- [x] Unit test
- [x] Linked to Trello ticket: https://trello.com/c/BKn6NzwK/496-epic-7-remove-specialist-colleges-from-data-must
- [x] Documentation up to date
