### PR TITLE
Filter to known values

### DIFF
--- a/jobs/diagnostics_on_known_filled_posts.py
+++ b/jobs/diagnostics_on_known_filled_posts.py
@@ -39,6 +39,9 @@ def main(
     )
 
     # filter to where ascwds clean is not null
+    filled_posts_df = filter_to_known_values(
+        filled_posts_df, IndCQC.ascwds_filled_posts_clean
+    )
 
     # reshape df so that cols are: location id, cqc_location_import date, service, ascwds_filled-posts_clean, estimate_source, estimate_value
 
@@ -56,7 +59,7 @@ def main(
 
 
 def filter_to_known_values(df: DataFrame, column: str) -> DataFrame:
-    return df
+    return df.filter(df[column].isNotNull())
 
 
 def restructure_dataframe_to_column_wise(df: DataFrame) -> DataFrame:

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -5166,10 +5166,19 @@ class DiagnosticsOnKnownFilledPostsData:
     ]
 
     filter_to_known_values_rows = [
-        ("loc 1", 1.0,),
-        ("loc 2", None,),
+        (
+            "loc 1",
+            1.0,
+        ),
+        (
+            "loc 2",
+            None,
+        ),
     ]
 
     expected_filter_to_known_values_rows = [
-        ("loc 1", 1.0,),
+        (
+            "loc 1",
+            1.0,
+        ),
     ]

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -5164,5 +5164,12 @@ class DiagnosticsOnKnownFilledPostsData:
             10.0,
         ),
     ]
-    filter_to_known_values_rows = []
-    expected_filter_to_known_values_rows = []
+
+    filter_to_known_values_rows = [
+        ("loc 1", 1.0,),
+        ("loc 2", None,),
+    ]
+
+    expected_filter_to_known_values_rows = [
+        ("loc 1", 1.0,),
+    ]

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -3601,4 +3601,14 @@ class DiagnosticsOnKnownFilledPostsSchemas:
             StructField(IndCQC.estimate_filled_posts, FloatType(), True),
         ]
     )
-    filter_to_known_values_schema = []
+
+    filter_to_known_values_schema = StructType(
+        [
+            StructField(IndCQC.location_id, StringType(), False),
+            StructField(
+                IndCQC.ascwds_filled_posts_clean,
+                FloatType(),
+                True,
+            ),
+        ]
+    )

--- a/tests/unit/test_diagnostics_on_known_filled_posts.py
+++ b/tests/unit/test_diagnostics_on_known_filled_posts.py
@@ -66,6 +66,9 @@ class FilterToKnownValuesTests(DiagnosticsOnKnownFilledPostsTests):
     def test_filter_to_known_values_does_not_remove_any_columns(self):
         self.assertEqual(self.returned_df.columns, self.expected_df.columns)
 
+    def test_filter_to_known_values_has_expected_row_count(self):
+        self.assertEqual(self.returned_df.count(), self.expected_df.count())
+
 
 class RestructureDataframeToColumnWiseTests(DiagnosticsOnKnownFilledPostsTests):
     def setUp(self) -> None:

--- a/tests/unit/test_diagnostics_on_known_filled_posts.py
+++ b/tests/unit/test_diagnostics_on_known_filled_posts.py
@@ -60,9 +60,11 @@ class FilterToKnownValuesTests(DiagnosticsOnKnownFilledPostsTests):
         )
         self.returned_df = job.filter_to_known_values(self.test_df, self.test_column)
 
-    @unittest.skip("to do")
     def test_filter_to_known_values_removes_null_values_from_specified_column(self):
         self.assertEqual(self.returned_df.collect(), self.expected_df.collect())
+
+    def test_filter_to_known_values_does_not_remove_any_columns(self):
+        self.assertEqual(self.returned_df.columns, self.expected_df.columns)
 
 
 class RestructureDataframeToColumnWiseTests(DiagnosticsOnKnownFilledPostsTests):


### PR DESCRIPTION
# Description
Added function to diagnostics_on_known_filled_posts job that removes rows from a given dataframe where given column has null values.

Link to Trello: https://trello.com/c/buWnc72r

# How to test
Unit tests are passing.
Job is not setup in Glue yet so no Glue run.

# Developer checklist
- [x] Unit test
- [x] Linked to Trello ticket
- [ ] Documentation up to date
