### PR TITLE
Restructure dataframe columnwise

### DIFF
--- a/jobs/diagnostics_on_known_filled_posts.py
+++ b/jobs/diagnostics_on_known_filled_posts.py
@@ -60,6 +60,21 @@ def filter_to_known_values(df: DataFrame, column: str) -> DataFrame:
 
 
 def restructure_dataframe_to_column_wise(df: DataFrame) -> DataFrame:
+    """
+    Reshapes the dataframe so that all estimated values are in one column.
+
+    This function reshapes the dataframe to make it easier to calculate the aggregations
+    using a window function. Model values that were previously in separate columns for
+    each model are joined into a single column with a corresponding column describing which
+    model they are from. This means that the unique index of the dataframe with now be the
+    combination of location id, cqc location import date and estimate source.
+
+    Args:
+        df (DataFrame): A dataframe of estimates with each model's values in a different column.
+
+    Returns:
+        DataFrame: A dataframe of estimates with each model's values in a single column and a column of corresponding model names.
+    """
     return df
 
 

--- a/jobs/diagnostics_on_known_filled_posts.py
+++ b/jobs/diagnostics_on_known_filled_posts.py
@@ -46,7 +46,7 @@ def main(
     # filter to where ascwds clean is not null
 
     # reshape df so that cols are: location id, cqc_location_import date, service, ascwds_filled-posts_clean, estimate_source, estimate_value
-
+    filled_posts_df = restructure_dataframe_to_column_wise(filled_posts_df)
     # drop rows where estimate value is missing
 
     # create windows for model/ service splits

--- a/jobs/diagnostics_on_known_filled_posts.py
+++ b/jobs/diagnostics_on_known_filled_posts.py
@@ -110,7 +110,9 @@ def create_list_of_models():
     list_of_models = (
         CatValues.estimate_filled_posts_source_column_values.categorical_values
     )
+    print(list_of_models)
     list_of_models.append(IndCQC.estimate_filled_posts)
+    print(list_of_models)
     return list_of_models
 
 

--- a/jobs/diagnostics_on_known_filled_posts.py
+++ b/jobs/diagnostics_on_known_filled_posts.py
@@ -111,7 +111,7 @@ def create_list_of_models():
         CatValues.estimate_filled_posts_source_column_values.categorical_values
     )
     print(list_of_models)
-    list_of_models.append(IndCQC.estimate_filled_posts)
+    list_of_models = list_of_models + [IndCQC.estimate_filled_posts]
     print(list_of_models)
     return list_of_models
 

--- a/jobs/diagnostics_on_known_filled_posts.py
+++ b/jobs/diagnostics_on_known_filled_posts.py
@@ -82,7 +82,6 @@ def restructure_dataframe_to_column_wise(df: DataFrame) -> DataFrame:
     """
     reshaped_df = create_empty_reshaped_dataframe()
     list_of_models = create_list_of_models()
-    print(list_of_models)
     for model in list_of_models:
         model_df = df.select(
             IndCQC.location_id,
@@ -110,9 +109,7 @@ def create_list_of_models():
     list_of_models = (
         CatValues.estimate_filled_posts_source_column_values.categorical_values
     )
-    print(list_of_models)
     list_of_models = list_of_models + [IndCQC.estimate_filled_posts]
-    print(list_of_models)
     return list_of_models
 
 

--- a/jobs/diagnostics_on_known_filled_posts.py
+++ b/jobs/diagnostics_on_known_filled_posts.py
@@ -82,6 +82,7 @@ def restructure_dataframe_to_column_wise(df: DataFrame) -> DataFrame:
     """
     reshaped_df = create_empty_reshaped_dataframe()
     list_of_models = create_list_of_models()
+    print(list_of_models)
     for model in list_of_models:
         model_df = df.select(
             IndCQC.location_id,

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -5166,3 +5166,24 @@ class DiagnosticsOnKnownFilledPostsData:
     ]
     filter_to_known_values_rows = []
     expected_filter_to_known_values_rows = []
+    restructure_dataframe_rows = [
+        ("loc 1", date(2024, 1, 1), PrimaryServiceType.care_home_only, 10.0, 10.0, 8.0),
+    ]
+    expected_restructure_dataframe_rows = [
+        (
+            "loc 1",
+            date(2024, 1, 1),
+            PrimaryServiceType.care_home_only,
+            10.0,
+            IndCQC.ascwds_filled_posts_dedup_clean,
+            10.0,
+        ),
+        (
+            "loc 1",
+            date(2024, 1, 1),
+            PrimaryServiceType.care_home_only,
+            10.0,
+            IndCQC.rolling_average_model,
+            8.0,
+        ),
+    ]

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -5167,7 +5167,18 @@ class DiagnosticsOnKnownFilledPostsData:
     filter_to_known_values_rows = []
     expected_filter_to_known_values_rows = []
     restructure_dataframe_rows = [
-        ("loc 1", date(2024, 1, 1), PrimaryServiceType.care_home_only, 10.0, 10.0, 8.0),
+        (
+            "loc 1",
+            date(2024, 1, 1),
+            10.0,
+            10.0,
+            PrimaryServiceType.care_home_only,
+            11.0,
+            12.0,
+            9.0,
+            8.0,
+            10.0,
+        ),
     ]
     expected_restructure_dataframe_rows = [
         (
@@ -5184,6 +5195,38 @@ class DiagnosticsOnKnownFilledPostsData:
             PrimaryServiceType.care_home_only,
             10.0,
             IndCQC.rolling_average_model,
+            11.0,
+        ),
+        (
+            "loc 1",
+            date(2024, 1, 1),
+            PrimaryServiceType.care_home_only,
+            10.0,
+            IndCQC.care_home_model,
+            12.0,
+        ),
+        (
+            "loc 1",
+            date(2024, 1, 1),
+            PrimaryServiceType.care_home_only,
+            10.0,
+            IndCQC.extrapolation_care_home_model,
+            9.0,
+        ),
+        (
+            "loc 1",
+            date(2024, 1, 1),
+            PrimaryServiceType.care_home_only,
+            10.0,
+            IndCQC.interpolation_model,
             8.0,
+        ),
+        (
+            "loc 1",
+            date(2024, 1, 1),
+            PrimaryServiceType.care_home_only,
+            10.0,
+            IndCQC.estimate_filled_posts,
+            10.0,
         ),
     ]

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -3602,3 +3602,39 @@ class DiagnosticsOnKnownFilledPostsSchemas:
         ]
     )
     filter_to_known_values_schema = []
+    restructure_dataframe_schema = estimate_filled_posts_schema = StructType(
+        [
+            StructField(IndCQC.location_id, StringType(), False),
+            StructField(IndCQC.cqc_location_import_date, DateType(), False),
+            StructField(
+                IndCQC.ascwds_filled_posts_clean,
+                FloatType(),
+                True,
+            ),
+            StructField(IndCQC.ascwds_filled_posts_dedup_clean, FloatType(), True),
+            StructField(IndCQC.primary_service_type, StringType(), True),
+            StructField(IndCQC.rolling_average_model, FloatType(), True),
+            StructField(IndCQC.care_home_model, FloatType(), True),
+            StructField(IndCQC.extrapolation_care_home_model, FloatType(), True),
+            StructField(IndCQC.interpolation_model, FloatType(), True),
+            StructField(IndCQC.estimate_filled_posts, FloatType(), True),
+        ]
+    )
+    expected_restructure_dataframe_schema = estimate_filled_posts_schema = StructType(
+        [
+            StructField(IndCQC.location_id, StringType(), False),
+            StructField(IndCQC.cqc_location_import_date, DateType(), False),
+            StructField(
+                IndCQC.ascwds_filled_posts_clean,
+                FloatType(),
+                True,
+            ),
+            StructField(IndCQC.ascwds_filled_posts_dedup_clean, FloatType(), True),
+            StructField(IndCQC.primary_service_type, StringType(), True),
+            StructField(IndCQC.rolling_average_model, FloatType(), True),
+            StructField(IndCQC.care_home_model, FloatType(), True),
+            StructField(IndCQC.extrapolation_care_home_model, FloatType(), True),
+            StructField(IndCQC.interpolation_model, FloatType(), True),
+            StructField(IndCQC.estimate_filled_posts, FloatType(), True),
+        ]
+    )

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -3602,7 +3602,8 @@ class DiagnosticsOnKnownFilledPostsSchemas:
         ]
     )
     filter_to_known_values_schema = []
-    restructure_dataframe_schema = estimate_filled_posts_schema = StructType(
+    restructure_dataframe_schema = estimate_filled_posts_schema
+    expected_restructure_dataframe_schema = StructType(
         [
             StructField(IndCQC.location_id, StringType(), False),
             StructField(IndCQC.cqc_location_import_date, DateType(), False),
@@ -3612,21 +3613,7 @@ class DiagnosticsOnKnownFilledPostsSchemas:
                 FloatType(),
                 True,
             ),
-            StructField(IndCQC.ascwds_filled_posts_dedup_clean, FloatType(), True),
-            StructField(IndCQC.rolling_average_model, FloatType(), True),
-        ]
-    )
-    expected_restructure_dataframe_schema = estimate_filled_posts_schema = StructType(
-        [
-            StructField(IndCQC.location_id, StringType(), False),
-            StructField(IndCQC.cqc_location_import_date, DateType(), False),
-            StructField(IndCQC.primary_service_type, StringType(), True),
-            StructField(
-                IndCQC.ascwds_filled_posts_clean,
-                FloatType(),
-                True,
-            ),
-            StructField(IndCQC.estimate_source, FloatType(), True),
+            StructField(IndCQC.estimate_source, StringType(), True),
             StructField(IndCQC.estimate_value, FloatType(), True),
         ]
     )

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -3606,35 +3606,27 @@ class DiagnosticsOnKnownFilledPostsSchemas:
         [
             StructField(IndCQC.location_id, StringType(), False),
             StructField(IndCQC.cqc_location_import_date, DateType(), False),
+            StructField(IndCQC.primary_service_type, StringType(), True),
             StructField(
                 IndCQC.ascwds_filled_posts_clean,
                 FloatType(),
                 True,
             ),
             StructField(IndCQC.ascwds_filled_posts_dedup_clean, FloatType(), True),
-            StructField(IndCQC.primary_service_type, StringType(), True),
             StructField(IndCQC.rolling_average_model, FloatType(), True),
-            StructField(IndCQC.care_home_model, FloatType(), True),
-            StructField(IndCQC.extrapolation_care_home_model, FloatType(), True),
-            StructField(IndCQC.interpolation_model, FloatType(), True),
-            StructField(IndCQC.estimate_filled_posts, FloatType(), True),
         ]
     )
     expected_restructure_dataframe_schema = estimate_filled_posts_schema = StructType(
         [
             StructField(IndCQC.location_id, StringType(), False),
             StructField(IndCQC.cqc_location_import_date, DateType(), False),
+            StructField(IndCQC.primary_service_type, StringType(), True),
             StructField(
                 IndCQC.ascwds_filled_posts_clean,
                 FloatType(),
                 True,
             ),
-            StructField(IndCQC.ascwds_filled_posts_dedup_clean, FloatType(), True),
-            StructField(IndCQC.primary_service_type, StringType(), True),
-            StructField(IndCQC.rolling_average_model, FloatType(), True),
-            StructField(IndCQC.care_home_model, FloatType(), True),
-            StructField(IndCQC.extrapolation_care_home_model, FloatType(), True),
-            StructField(IndCQC.interpolation_model, FloatType(), True),
-            StructField(IndCQC.estimate_filled_posts, FloatType(), True),
+            StructField(IndCQC.estimate_source, FloatType(), True),
+            StructField(IndCQC.estimate_value, FloatType(), True),
         ]
     )

--- a/tests/unit/test_diagnostics_on_known_filled_posts.py
+++ b/tests/unit/test_diagnostics_on_known_filled_posts.py
@@ -68,23 +68,33 @@ class FilterToKnownValuesTests(DiagnosticsOnKnownFilledPostsTests):
 class RestructureDataframeToColumnWiseTests(DiagnosticsOnKnownFilledPostsTests):
     def setUp(self) -> None:
         super().setUp()
+        self.test_df = self.spark.createDataFrame(
+            Data.restructure_dataframe_rows, Schemas.restructure_dataframe_schema
+        )
+        self.expected_df = self.spark.createDataFrame(
+            Data.expected_restructure_dataframe_rows,
+            Schemas.restructure_dataframe_schema,
+        )
+        self.returned_df = job.restructure_dataframe_to_column_wise(self.test_df)
 
     @unittest.skip("to do")
     def test_restructure_dataframe_to_column_wise_has_correct_columns(self):
-        pass
+        self.assertEqual(self.returned_df.schema, self.expected_df.schema)
 
     @unittest.skip("to do")
     def test_restructure_dataframe_to_column_wise_has_correct_row_count(self):
-        pass
+        self.assertEqual(self.returned_df.count(), self.expected_df.count())
 
     @unittest.skip("to do")
     def test_restructure_dataframe_to_column_wise_has_correct_values(self):
-        pass
+        self.assertEqual(self.returned_df.collect(), self.expected_df.collect())
 
     @unittest.skip("to do")
     def test_restructure_dataframe_to_column_wise_has_no_duplicate_indices(self):
-        # indices are a combination of location id, cqc import date, and estimate source
-        pass
+        deduplicated_df = self.returned_df.select(
+            IndCQC.location_id, IndCQC.cqc_location_import_date, IndCQC.estimate_source
+        ).distinct()
+        self.assertEqual(self.returned_df.count(), deduplicated_df.count())
 
 
 class CreateWindowForModelAndServiceSplitsTests(DiagnosticsOnKnownFilledPostsTests):

--- a/tests/unit/test_diagnostics_on_known_filled_posts.py
+++ b/tests/unit/test_diagnostics_on_known_filled_posts.py
@@ -77,22 +77,10 @@ class RestructureDataframeToColumnWiseTests(DiagnosticsOnKnownFilledPostsTests):
         )
         self.returned_df = job.restructure_dataframe_to_column_wise(self.test_df)
 
-    def test_restructure_dataframe_to_column_wise_has_correct_columns(self):
-        self.assertEqual(self.returned_df.schema, self.expected_df.schema)
-
-    def test_restructure_dataframe_to_column_wise_has_correct_row_count(self):
-        self.assertEqual(self.returned_df.count(), self.expected_df.count())
-
     def test_restructure_dataframe_to_column_wise_has_correct_values(self):
         returned_data = self.returned_df.sort(IndCQC.estimate_source).collect()
         expected_data = self.expected_df.sort(IndCQC.estimate_source).collect()
         self.assertEqual(returned_data, expected_data)
-
-    def test_restructure_dataframe_to_column_wise_has_no_duplicate_indices(self):
-        deduplicated_df = self.returned_df.select(
-            IndCQC.location_id, IndCQC.cqc_location_import_date, IndCQC.estimate_source
-        ).distinct()
-        self.assertEqual(self.returned_df.count(), deduplicated_df.count())
 
 
 class CreateWindowForModelAndServiceSplitsTests(DiagnosticsOnKnownFilledPostsTests):

--- a/tests/unit/test_diagnostics_on_known_filled_posts.py
+++ b/tests/unit/test_diagnostics_on_known_filled_posts.py
@@ -73,23 +73,21 @@ class RestructureDataframeToColumnWiseTests(DiagnosticsOnKnownFilledPostsTests):
         )
         self.expected_df = self.spark.createDataFrame(
             Data.expected_restructure_dataframe_rows,
-            Schemas.restructure_dataframe_schema,
+            Schemas.expected_restructure_dataframe_schema,
         )
         self.returned_df = job.restructure_dataframe_to_column_wise(self.test_df)
 
-    @unittest.skip("to do")
     def test_restructure_dataframe_to_column_wise_has_correct_columns(self):
         self.assertEqual(self.returned_df.schema, self.expected_df.schema)
 
-    @unittest.skip("to do")
     def test_restructure_dataframe_to_column_wise_has_correct_row_count(self):
         self.assertEqual(self.returned_df.count(), self.expected_df.count())
 
-    @unittest.skip("to do")
     def test_restructure_dataframe_to_column_wise_has_correct_values(self):
-        self.assertEqual(self.returned_df.collect(), self.expected_df.collect())
+        returned_data = self.returned_df.sort(IndCQC.estimate_source).collect()
+        expected_data = self.expected_df.sort(IndCQC.estimate_source).collect()
+        self.assertEqual(returned_data, expected_data)
 
-    @unittest.skip("to do")
     def test_restructure_dataframe_to_column_wise_has_no_duplicate_indices(self):
         deduplicated_df = self.returned_df.select(
             IndCQC.location_id, IndCQC.cqc_location_import_date, IndCQC.estimate_source

--- a/tests/unit/test_diagnostics_on_known_filled_posts.py
+++ b/tests/unit/test_diagnostics_on_known_filled_posts.py
@@ -76,6 +76,8 @@ class RestructureDataframeToColumnWiseTests(DiagnosticsOnKnownFilledPostsTests):
             Schemas.expected_restructure_dataframe_schema,
         )
         self.returned_df = job.restructure_dataframe_to_column_wise(self.test_df)
+        self.returned_df.sort(IndCQC.estimate_source).show()
+        self.expected_df.sort(IndCQC.estimate_source).show()
 
     def test_restructure_dataframe_to_column_wise_has_correct_values(self):
         returned_data = self.returned_df.sort(IndCQC.estimate_source).collect()

--- a/tests/unit/test_diagnostics_on_known_filled_posts.py
+++ b/tests/unit/test_diagnostics_on_known_filled_posts.py
@@ -76,8 +76,6 @@ class RestructureDataframeToColumnWiseTests(DiagnosticsOnKnownFilledPostsTests):
             Schemas.expected_restructure_dataframe_schema,
         )
         self.returned_df = job.restructure_dataframe_to_column_wise(self.test_df)
-        self.returned_df.sort(IndCQC.estimate_source).show()
-        self.expected_df.sort(IndCQC.estimate_source).show()
 
     def test_restructure_dataframe_to_column_wise_has_correct_values(self):
         returned_data = self.returned_df.sort(IndCQC.estimate_source).collect()

--- a/tests/unit/test_diagnostics_on_known_filled_posts.py
+++ b/tests/unit/test_diagnostics_on_known_filled_posts.py
@@ -69,6 +69,23 @@ class RestructureDataframeToColumnWiseTests(DiagnosticsOnKnownFilledPostsTests):
     def setUp(self) -> None:
         super().setUp()
 
+    @unittest.skip("to do")
+    def test_restructure_dataframe_to_column_wise_has_correct_columns(self):
+        pass
+
+    @unittest.skip("to do")
+    def test_restructure_dataframe_to_column_wise_has_correct_row_count(self):
+        pass
+
+    @unittest.skip("to do")
+    def test_restructure_dataframe_to_column_wise_has_correct_values(self):
+        pass
+
+    @unittest.skip("to do")
+    def test_restructure_dataframe_to_column_wise_has_no_duplicate_indices(self):
+        # indices are a combination of location id, cqc import date, and estimate source
+        pass
+
 
 class CreateWindowForModelAndServiceSplitsTests(DiagnosticsOnKnownFilledPostsTests):
     def setUp(self) -> None:

--- a/utils/column_names/ind_cqc_pipeline_columns.py
+++ b/utils/column_names/ind_cqc_pipeline_columns.py
@@ -79,6 +79,8 @@ class IndCqcColumns:
     establishment_id: str = AWPClean.establishment_id
     estimate_filled_posts: str = "estimate_filled_posts"
     estimate_filled_posts_source: str = "estimate_filled_posts_source"
+    estimate_source: str = "estimate_source"
+    estimate_value: str = "estimate_value"
     extrapolation_care_home_model: str = "extrapolation_" + care_home_model
     extrapolation_ratio: str = "extrapolation_ratio"
     features: str = "features"

--- a/utils/column_values/categorical_columns_by_dataset.py
+++ b/utils/column_values/categorical_columns_by_dataset.py
@@ -180,3 +180,10 @@ class EstimatedIndCQCFilledPostsCategoricalValues:
     estimate_filled_posts_source_column_values = EstimateFilledPostsSource(
         IndCQC.estimate_filled_posts_source
     )
+
+
+@dataclass
+class DiagnosticOnKnownFilledPostsCategoricalValues:
+    estimate_filled_posts_source_column_values = EstimateFilledPostsSource(
+        IndCQC.estimate_filled_posts_source
+    )


### PR DESCRIPTION
# Description
This PR adds the second stage of the diagnostics job.

It restructures the dataframe so that all the estimates are in one column for easier processing.

# How to test
Unit tests passing

# Developer checklist
- [x] Unit test
- [x] Linked to Trello ticket:https://trello.com/c/0KeFXfzH/682-epic-4-set-up-ascwds-diagnostic-job-restructure-dataframe-to-columnwise-function
- [x] Documentation up to date
