### PR TITLE
Separate out current and historic values

### DIFF
--- a/jobs/flatten_cqc_ratings.py
+++ b/jobs/flatten_cqc_ratings.py
@@ -21,7 +21,7 @@ from utils.column_values.categorical_column_values import (
     LocationType,
     RegistrationStatus,
     CQCRatingsValues,
-    CQCCurretnOrHistoricValues,
+    CQCCurrentOrHistoricValues,
 )
 from utils.column_names.cqc_ratings_columns import (
     CQCRatingsColumns as CQCRatings,
@@ -117,7 +117,7 @@ def prepare_current_ratings(cqc_location_df: DataFrame) -> DataFrame:
     ratings_df = flatten_current_ratings(cqc_location_df)
     ratings_df = recode_unknown_codes_to_null(ratings_df)
     ratings_df = add_current_or_historic_column(
-        ratings_df, CQCCurretnOrHistoricValues.current
+        ratings_df, CQCCurrentOrHistoricValues.current
     )
     return ratings_df
 
@@ -126,7 +126,7 @@ def prepare_historic_ratings(cqc_location_df: DataFrame) -> DataFrame:
     ratings_df = flatten_historic_ratings(cqc_location_df)
     ratings_df = recode_unknown_codes_to_null(ratings_df)
     ratings_df = add_current_or_historic_column(
-        ratings_df, CQCCurretnOrHistoricValues.historic
+        ratings_df, CQCCurrentOrHistoricValues.historic
     )
     return ratings_df
 
@@ -338,7 +338,7 @@ def select_ratings_for_benchmarks(ratings_df: DataFrame) -> DataFrame:
         (ratings_df[CQCL.registration_status] == RegistrationStatus.registered)
         & (
             ratings_df[CQCRatings.current_or_historic]
-            == CQCCurretnOrHistoricValues.current
+            == CQCCurrentOrHistoricValues.current
         )
     )
     return benchmark_ratings_df

--- a/jobs/flatten_cqc_ratings.py
+++ b/jobs/flatten_cqc_ratings.py
@@ -21,6 +21,7 @@ from utils.column_values.categorical_column_values import (
     LocationType,
     RegistrationStatus,
     CQCRatingsValues,
+    CQCCurretnOrHistoricValues,
 )
 from utils.column_names.cqc_ratings_columns import (
     CQCRatingsColumns as CQCRatings,
@@ -115,14 +116,18 @@ def filter_to_first_import_of_most_recent_month(df: DataFrame) -> DataFrame:
 def prepare_current_ratings(cqc_location_df: DataFrame) -> DataFrame:
     ratings_df = flatten_current_ratings(cqc_location_df)
     ratings_df = recode_unknown_codes_to_null(ratings_df)
-    ratings_df = add_current_or_historic_column(ratings_df, CQCRatingsValues.current)
+    ratings_df = add_current_or_historic_column(
+        ratings_df, CQCCurretnOrHistoricValues.current
+    )
     return ratings_df
 
 
 def prepare_historic_ratings(cqc_location_df: DataFrame) -> DataFrame:
     ratings_df = flatten_historic_ratings(cqc_location_df)
     ratings_df = recode_unknown_codes_to_null(ratings_df)
-    ratings_df = add_current_or_historic_column(ratings_df, CQCRatingsValues.historic)
+    ratings_df = add_current_or_historic_column(
+        ratings_df, CQCCurretnOrHistoricValues.historic
+    )
     return ratings_df
 
 
@@ -331,7 +336,10 @@ def create_standard_ratings_dataset(ratings_df: DataFrame) -> DataFrame:
 def select_ratings_for_benchmarks(ratings_df: DataFrame) -> DataFrame:
     benchmark_ratings_df = ratings_df.where(
         (ratings_df[CQCL.registration_status] == RegistrationStatus.registered)
-        & (ratings_df[CQCRatings.current_or_historic] == CQCRatingsValues.current)
+        & (
+            ratings_df[CQCRatings.current_or_historic]
+            == CQCCurretnOrHistoricValues.current
+        )
     )
     return benchmark_ratings_df
 

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -18,6 +18,7 @@ from utils.column_values.categorical_column_values import (
     Sector,
     LocationType,
     CQCRatingsValues,
+    CQCCurretnOrHistoricValues,
     ParentsOrSinglesAndSubs,
     IsParent,
     SingleSubDescription,
@@ -4436,10 +4437,10 @@ class FlattenCQCRatings:
         ("loc_1",),
     ]
     expected_add_current_rows = [
-        ("loc_1", CQCRatingsValues.current),
+        ("loc_1", CQCCurretnOrHistoricValues.current),
     ]
     expected_add_historic_rows = [
-        ("loc_1", CQCRatingsValues.historic),
+        ("loc_1", CQCCurretnOrHistoricValues.historic),
     ]
 
     remove_blank_rows_rows = [
@@ -4777,13 +4778,13 @@ class FlattenCQCRatings:
         ),
     ]
     select_ratings_for_benchmarks_rows = [
-        ("loc_1", RegistrationStatus.registered, CQCRatingsValues.current),
-        ("loc_2", RegistrationStatus.registered, CQCRatingsValues.historic),
-        ("loc_3", RegistrationStatus.deregistered, CQCRatingsValues.current),
-        ("loc_4", RegistrationStatus.deregistered, CQCRatingsValues.historic),
+        ("loc_1", RegistrationStatus.registered, CQCCurretnOrHistoricValues.current),
+        ("loc_2", RegistrationStatus.registered, CQCCurretnOrHistoricValues.historic),
+        ("loc_3", RegistrationStatus.deregistered, CQCCurretnOrHistoricValues.current),
+        ("loc_4", RegistrationStatus.deregistered, CQCCurretnOrHistoricValues.historic),
     ]
     expected_select_ratings_for_benchmarks_rows = [
-        ("loc_1", RegistrationStatus.registered, CQCRatingsValues.current),
+        ("loc_1", RegistrationStatus.registered, CQCCurretnOrHistoricValues.current),
     ]
 
     add_good_or_outstanding_flag_rows = [

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -18,7 +18,7 @@ from utils.column_values.categorical_column_values import (
     Sector,
     LocationType,
     CQCRatingsValues,
-    CQCCurretnOrHistoricValues,
+    CQCCurrentOrHistoricValues,
     ParentsOrSinglesAndSubs,
     IsParent,
     SingleSubDescription,
@@ -4437,10 +4437,10 @@ class FlattenCQCRatings:
         ("loc_1",),
     ]
     expected_add_current_rows = [
-        ("loc_1", CQCCurretnOrHistoricValues.current),
+        ("loc_1", CQCCurrentOrHistoricValues.current),
     ]
     expected_add_historic_rows = [
-        ("loc_1", CQCCurretnOrHistoricValues.historic),
+        ("loc_1", CQCCurrentOrHistoricValues.historic),
     ]
 
     remove_blank_rows_rows = [
@@ -4778,13 +4778,13 @@ class FlattenCQCRatings:
         ),
     ]
     select_ratings_for_benchmarks_rows = [
-        ("loc_1", RegistrationStatus.registered, CQCCurretnOrHistoricValues.current),
-        ("loc_2", RegistrationStatus.registered, CQCCurretnOrHistoricValues.historic),
-        ("loc_3", RegistrationStatus.deregistered, CQCCurretnOrHistoricValues.current),
-        ("loc_4", RegistrationStatus.deregistered, CQCCurretnOrHistoricValues.historic),
+        ("loc_1", RegistrationStatus.registered, CQCCurrentOrHistoricValues.current),
+        ("loc_2", RegistrationStatus.registered, CQCCurrentOrHistoricValues.historic),
+        ("loc_3", RegistrationStatus.deregistered, CQCCurrentOrHistoricValues.current),
+        ("loc_4", RegistrationStatus.deregistered, CQCCurrentOrHistoricValues.historic),
     ]
     expected_select_ratings_for_benchmarks_rows = [
-        ("loc_1", RegistrationStatus.registered, CQCCurretnOrHistoricValues.current),
+        ("loc_1", RegistrationStatus.registered, CQCCurrentOrHistoricValues.current),
     ]
 
     add_good_or_outstanding_flag_rows = [

--- a/tests/unit/test_flatten_cqc_ratings.py
+++ b/tests/unit/test_flatten_cqc_ratings.py
@@ -16,7 +16,7 @@ from utils.column_names.raw_data_files.cqc_location_api_columns import (
     NewCqcLocationApiColumns as CQCL,
 )
 from utils.column_values.categorical_column_values import (
-    CQCCurretnOrHistoricValues,
+    CQCCurrentOrHistoricValues,
 )
 
 
@@ -216,10 +216,10 @@ class AddCurrentOrHistoricColumn(FlattenCQCRatingsTests):
             Schema.expected_add_current_or_historic_schema,
         )
         self.returned_current_df = job.add_current_or_historic_column(
-            self.test_ratings_df, CQCCurretnOrHistoricValues.current
+            self.test_ratings_df, CQCCurrentOrHistoricValues.current
         )
         self.returned_historic_df = job.add_current_or_historic_column(
-            self.test_ratings_df, CQCCurretnOrHistoricValues.historic
+            self.test_ratings_df, CQCCurrentOrHistoricValues.historic
         )
 
     def test_add_current_or_historic_column_returns_correct_values_when_passed_current(

--- a/tests/unit/test_flatten_cqc_ratings.py
+++ b/tests/unit/test_flatten_cqc_ratings.py
@@ -16,7 +16,7 @@ from utils.column_names.raw_data_files.cqc_location_api_columns import (
     NewCqcLocationApiColumns as CQCL,
 )
 from utils.column_values.categorical_column_values import (
-    CQCRatingsValues,
+    CQCCurretnOrHistoricValues,
 )
 
 
@@ -216,10 +216,10 @@ class AddCurrentOrHistoricColumn(FlattenCQCRatingsTests):
             Schema.expected_add_current_or_historic_schema,
         )
         self.returned_current_df = job.add_current_or_historic_column(
-            self.test_ratings_df, CQCRatingsValues.current
+            self.test_ratings_df, CQCCurretnOrHistoricValues.current
         )
         self.returned_historic_df = job.add_current_or_historic_column(
-            self.test_ratings_df, CQCRatingsValues.historic
+            self.test_ratings_df, CQCCurretnOrHistoricValues.historic
         )
 
     def test_add_current_or_historic_column_returns_correct_values_when_passed_current(

--- a/utils/column_values/categorical_column_values.py
+++ b/utils/column_values/categorical_column_values.py
@@ -77,7 +77,9 @@ class Services(ColumnValues):
     hospice_services: str = "Hospice services"
     domiciliary_care_service: str = "Domiciliary care service"
     remote_clinical_advice_service: str = "Remote clinical advice service"
-    acute_services_without_overnight_beds: str = "Acute services without overnight beds / listed acute services with or without overnight beds"
+    acute_services_without_overnight_beds: str = (
+        "Acute services without overnight beds / listed acute services with or without overnight beds"
+    )
     specialist_college_service: str = "Specialist college service"
     ambulance_service: str = "Ambulance service"
     extra_care_housing_services: str = "Extra Care housing services"
@@ -107,7 +109,9 @@ class Services(ColumnValues):
     rehabilitation_services: str = "Rehabilitation services"
     doctors_treatment_service: str = "Doctors treatment service"
     hospice_services_at_home: str = "Hospice services at home"
-    hospital_services_for_people_with_mental_health_needs: str = "Hospital services for people with mental health needs, learning disabilities and problems with substance misuse"
+    hospital_services_for_people_with_mental_health_needs: str = (
+        "Hospital services for people with mental health needs, learning disabilities and problems with substance misuse"
+    )
 
 
 @dataclass
@@ -466,7 +470,7 @@ class CQCRatingsValues(ColumnValues):
 
 
 @dataclass
-class CQCCurretnOrHistoricValues(ColumnValues):
+class CQCCurrentOrHistoricValues(ColumnValues):
     current: str = "Current"
     historic: str = "Historic"
 

--- a/utils/column_values/categorical_column_values.py
+++ b/utils/column_values/categorical_column_values.py
@@ -459,12 +459,16 @@ class EstimateFilledPostsSource(ColumnValues):
 
 @dataclass
 class CQCRatingsValues(ColumnValues):
-    current: str = "Current"
-    historic: str = "Historic"
     outstanding: str = "Outstanding"
     good: str = "Good"
     requires_improvement: str = "Requires improvement"
     inadequate: str = "Inadequate"
+
+
+@dataclass
+class CQCCurretnOrHistoricValues(ColumnValues):
+    current: str = "Current"
+    historic: str = "Historic"
 
 
 @dataclass

--- a/utils/column_values/categorical_column_values.py
+++ b/utils/column_values/categorical_column_values.py
@@ -77,9 +77,7 @@ class Services(ColumnValues):
     hospice_services: str = "Hospice services"
     domiciliary_care_service: str = "Domiciliary care service"
     remote_clinical_advice_service: str = "Remote clinical advice service"
-    acute_services_without_overnight_beds: str = (
-        "Acute services without overnight beds / listed acute services with or without overnight beds"
-    )
+    acute_services_without_overnight_beds: str = "Acute services without overnight beds / listed acute services with or without overnight beds"
     specialist_college_service: str = "Specialist college service"
     ambulance_service: str = "Ambulance service"
     extra_care_housing_services: str = "Extra Care housing services"
@@ -109,9 +107,7 @@ class Services(ColumnValues):
     rehabilitation_services: str = "Rehabilitation services"
     doctors_treatment_service: str = "Doctors treatment service"
     hospice_services_at_home: str = "Hospice services at home"
-    hospital_services_for_people_with_mental_health_needs: str = (
-        "Hospital services for people with mental health needs, learning disabilities and problems with substance misuse"
-    )
+    hospital_services_for_people_with_mental_health_needs: str = "Hospital services for people with mental health needs, learning disabilities and problems with substance misuse"
 
 
 @dataclass


### PR DESCRIPTION
# Description
Separate out CQC ratings column values so each class represents a column

# How to test
Unit tests passing
Run in branch: https://eu-west-2.console.aws.amazon.com/gluestudio/home?region=eu-west-2#/editor/job/split-cqc-ratings-column-value-flatten_cqc_ratings_job/runs

# Developer checklist
- [x] Unit test
- [x] Linked to Trello ticket: https://trello.com/c/4XydFLYl/673-split-column-values-in-cqc-ratings-column-values-class-into-values-from-different-columns
- [x] Documentation up to date
