### PR TITLE
Move interpolation to new estimates missing ascwds filled posts job

### DIFF
--- a/jobs/estimate_ind_cqc_filled_posts.py
+++ b/jobs/estimate_ind_cqc_filled_posts.py
@@ -11,7 +11,6 @@ from utils.estimate_filled_posts.models.primary_service_rolling_average import (
     model_primary_service_rolling_average,
 )
 from utils.estimate_filled_posts.models.extrapolation import model_extrapolation
-from utils.estimate_filled_posts.models.interpolation import model_interpolation
 from utils.estimate_filled_posts.models.care_homes import model_care_homes
 from utils.estimate_filled_posts.models.non_res_with_dormancy import (
     model_non_res_with_dormancy,
@@ -82,15 +81,6 @@ def main(
     non_res_without_dormancy_features_df = utils.read_from_parquet(
         non_res_without_dormancy_features_source
     )
-
-    cleaned_ind_cqc_df = utils.create_unix_timestamp_variable_from_date_column(
-        cleaned_ind_cqc_df,
-        date_col=IndCQC.cqc_location_import_date,
-        date_format="yyyy-MM-dd",
-        new_col_name=IndCQC.unix_time,
-    )
-
-    cleaned_ind_cqc_df = model_interpolation(cleaned_ind_cqc_df)
 
     cleaned_ind_cqc_df = model_care_homes(
         cleaned_ind_cqc_df,

--- a/jobs/estimate_ind_cqc_filled_posts.py
+++ b/jobs/estimate_ind_cqc_filled_posts.py
@@ -44,6 +44,8 @@ cleaned_ind_cqc_columns = [
     IndCQC.current_ons_import_date,
     IndCQC.current_cssr,
     IndCQC.current_region,
+    IndCQC.interpolation_model,
+    IndCQC.unix_time,
     Keys.year,
     Keys.month,
     Keys.day,

--- a/jobs/estimate_missing_ascwds_ind_cqc_filled_posts.py
+++ b/jobs/estimate_missing_ascwds_ind_cqc_filled_posts.py
@@ -4,8 +4,10 @@ from pyspark.sql import DataFrame
 
 from utils import utils
 from utils.column_names.ind_cqc_pipeline_columns import (
+    IndCqcColumns as IndCQC,
     PartitionKeys as Keys,
 )
+from utils.estimate_filled_posts.models.interpolation import model_interpolation
 
 
 PartitionKeys = [Keys.year, Keys.month, Keys.day, Keys.import_date]
@@ -18,6 +20,15 @@ def main(
     print("Estimating independent CQC filled posts...")
 
     cleaned_ind_cqc_df = utils.read_from_parquet(cleaned_ind_cqc_source)
+
+    cleaned_ind_cqc_df = utils.create_unix_timestamp_variable_from_date_column(
+        cleaned_ind_cqc_df,
+        date_col=IndCQC.cqc_location_import_date,
+        date_format="yyyy-MM-dd",
+        new_col_name=IndCQC.unix_time,
+    )
+
+    cleaned_ind_cqc_df = model_interpolation(cleaned_ind_cqc_df)
 
     print(f"Exporting as parquet to {estimated_missing_ascwds_ind_cqc_destination}")
 

--- a/terraform/pipeline/glue.tf
+++ b/terraform/pipeline/glue.tf
@@ -730,15 +730,15 @@ module "estimate_ind_cqc_filled_posts_job" {
   datasets_bucket   = module.datasets_bucket
 
   job_parameters = {
-    "--cleaned_ind_cqc_source"                   = "${module.datasets_bucket.bucket_uri}/domain=ind_cqc_filled_posts/dataset=cleaned_ind_cqc_data/"
-    "--care_home_features_source"                = "${module.datasets_bucket.bucket_uri}/domain=ind_cqc_filled_posts/dataset=care_home_ind_cqc_features/"
-    "--care_home_model_source"                   = "${module.pipeline_resources.bucket_uri}/models/care_home_filled_posts_prediction/3.2.0/"
-    "--non_res_with_dormancy_features_source"    = "${module.datasets_bucket.bucket_uri}/domain=ind_cqc_filled_posts/dataset=non_res_ascwds_inc_dormancy_ind_cqc_features/"
-    "--non_res_with_dormancy_model_source"       = "${module.pipeline_resources.bucket_uri}/models/non_residential_with_dormancy_prediction/1.0.0/"
-    "--non_res_without_dormancy_features_source" = "${module.datasets_bucket.bucket_uri}/domain=ind_cqc_filled_posts/dataset=non_res_ascwds_without_dormancy_ind_cqc_features/"
-    "--non_res_without_dormancy_model_source"    = "${module.pipeline_resources.bucket_uri}/models/non_residential_without_dormancy_prediction/1.0.0/"
-    "--estimated_ind_cqc_destination"            = "${module.datasets_bucket.bucket_uri}/domain=ind_cqc_filled_posts/dataset=estimated_ind_cqc_filled_posts/"
-    "--ml_model_metrics_destination"             = "${module.datasets_bucket.bucket_uri}/domain=ind_cqc_filled_posts/dataset=ml_model_metrics/"
+    "--estimate_missing_ascwds_filled_posts_data_source" = "${module.datasets_bucket.bucket_uri}/domain=ind_cqc_filled_posts/dataset=estimated_missing_ascwds_filled_posts/"
+    "--care_home_features_source"                        = "${module.datasets_bucket.bucket_uri}/domain=ind_cqc_filled_posts/dataset=care_home_ind_cqc_features/"
+    "--care_home_model_source"                           = "${module.pipeline_resources.bucket_uri}/models/care_home_filled_posts_prediction/3.2.0/"
+    "--non_res_with_dormancy_features_source"            = "${module.datasets_bucket.bucket_uri}/domain=ind_cqc_filled_posts/dataset=non_res_ascwds_inc_dormancy_ind_cqc_features/"
+    "--non_res_with_dormancy_model_source"               = "${module.pipeline_resources.bucket_uri}/models/non_residential_with_dormancy_prediction/1.0.0/"
+    "--non_res_without_dormancy_features_source"         = "${module.datasets_bucket.bucket_uri}/domain=ind_cqc_filled_posts/dataset=non_res_ascwds_without_dormancy_ind_cqc_features/"
+    "--non_res_without_dormancy_model_source"            = "${module.pipeline_resources.bucket_uri}/models/non_residential_without_dormancy_prediction/1.0.0/"
+    "--estimated_ind_cqc_destination"                    = "${module.datasets_bucket.bucket_uri}/domain=ind_cqc_filled_posts/dataset=estimated_ind_cqc_filled_posts/"
+    "--ml_model_metrics_destination"                     = "${module.datasets_bucket.bucket_uri}/domain=ind_cqc_filled_posts/dataset=ml_model_metrics/"
   }
 }
 

--- a/terraform/pipeline/step-functions/IndCqcFilledPostEstimatePipeline-StepFunction.json
+++ b/terraform/pipeline/step-functions/IndCqcFilledPostEstimatePipeline-StepFunction.json
@@ -248,7 +248,7 @@
               "Parameters": {
                 "JobName": "${estimate_ind_cqc_filled_posts_job_name}",
                 "Arguments": {
-                  "--cleaned_ind_cqc_source": "${dataset_bucket_uri}/domain=ind_cqc_filled_posts/dataset=cleaned_ind_cqc_data/",
+                  "--estimate_missing_ascwds_filled_posts_data_source": "${dataset_bucket_uri}/domain=ind_cqc_filled_posts/dataset=estimated_missing_ascwds_filled_posts/",
                   "--care_home_features_source": "${dataset_bucket_uri}/domain=ind_cqc_filled_posts/dataset=care_home_ind_cqc_features/",
                   "--care_home_model_source": "${pipeline_resources_bucket_uri}/models/care_home_filled_posts_prediction/3.2.0/",
                   "--non_res_with_dormancy_features_source": "${dataset_bucket_uri}/domain=ind_cqc_filled_posts/dataset=non_res_ascwds_inc_dormancy_ind_cqc_features/",

--- a/utils/validation/validation_rules/estimated_missing_ascwds_filled_posts_validation_rules.py
+++ b/utils/validation/validation_rules/estimated_missing_ascwds_filled_posts_validation_rules.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+import time
 
 from utils.column_names.ind_cqc_pipeline_columns import (
     IndCqcColumns,
@@ -31,6 +32,7 @@ class EstimatedIndCqcFilledPostsValidationRules:
             IndCqcColumns.current_region,
             IndCqcColumns.current_rural_urban_indicator_2011,
             IndCqcColumns.ascwds_filtering_rule,
+            IndCqcColumns.unix_time,
         ],
         RuleName.index_columns: [
             IndCqcColumns.location_id,
@@ -42,6 +44,8 @@ class EstimatedIndCqcFilledPostsValidationRules:
             IndCqcColumns.total_staff_bounded: 1,
             IndCqcColumns.worker_records_bounded: 1,
             IndCqcColumns.filled_posts_per_bed_ratio: 0.0,
+            IndCqcColumns.interpolation_model: 0.0,
+            IndCqcColumns.unix_time: 1262304000,  # 1st Jan 2010 in unix time
         },
         RuleName.max_values: {
             IndCqcColumns.number_of_beds: 500,
@@ -49,6 +53,8 @@ class EstimatedIndCqcFilledPostsValidationRules:
             IndCqcColumns.total_staff_bounded: 3000,
             IndCqcColumns.worker_records_bounded: 3000,
             IndCqcColumns.filled_posts_per_bed_ratio: 15.0,
+            IndCqcColumns.interpolation_model: 3000.0,
+            IndCqcColumns.unix_time: int(time.time()),  # current unix time
         },
         RuleName.categorical_values_in_columns: {
             IndCqcColumns.care_home: CatValues.care_home_column_values.categorical_values,


### PR DESCRIPTION
# Description
Move interpolation and the calculation of unix time to the new estimates missing ascwds filled posts job

# How to test
Unit tests passing
Run in branch: https://eu-west-2.console.aws.amazon.com/states/home?region=eu-west-2#/v2/executions/details/arn:aws:states:eu-west-2:344210435447:execution:move-interpolation-Ind-CQC-Filled-Post-Estimates-Pipeline:ab731535-4fdf-4831-b316-316811721496

# Developer checklist
- [x] Unit test
- [x] Linked to Trello ticket: https://trello.com/c/qxhmWTF6/709-refactor-move-interpolation-to-first-round-estimates-must
- [x] Documentation up to date
