### PR TITLE
Changed date formatting in raw_date_format to yyyyMMdd and removed argument from write to parquet call

### DIFF
--- a/jobs/spss_csv_to_parquet.py
+++ b/jobs/spss_csv_to_parquet.py
@@ -13,10 +13,10 @@ def main(source, destination):
     )
     df_with_formatted_date = utils.format_date_fields(
         df_with_formatted_date,
-        raw_date_format="yyyy/MM/dd",
+        raw_date_format="yyyyMMdd",
         date_column_identifier="snapshot_date_formatted",
     )
-    utils.write_to_parquet(df_with_formatted_date, destination, False)
+    utils.write_to_parquet(df_with_formatted_date, destination)
 
 
 def collect_arguments():


### PR DESCRIPTION
Changed date formatting in raw_date_format to yyyyMMdd
Removed mode argument from write to parquet call as its redundant.

# Description

# How to test
No unit test but ran sucessfully in branch and the date column created by the function is formatted like this 2020-04-01

# Developer checklist
- [ ] Unit test
- [ ] Linked to Trello ticket
- [ ] Documentation up to date
