### PR TITLE
Filter changing carehome status

### DIFF
--- a/jobs/estimate_missing_ascwds_ind_cqc_filled_posts.py
+++ b/jobs/estimate_missing_ascwds_ind_cqc_filled_posts.py
@@ -67,6 +67,10 @@ def main(
     )
     estimate_missing_ascwds_df = merge_imputed_columns(estimate_missing_ascwds_df)
 
+    estimate_missing_ascwds_df = null_changing_carehome_status_from_imputed_columns(
+        estimate_missing_ascwds_df
+    )
+
     print(f"Exporting as parquet to {estimated_missing_ascwds_ind_cqc_destination}")
 
     utils.write_to_parquet(
@@ -131,6 +135,19 @@ def merge_imputed_columns(df: DataFrame) -> DataFrame:
             F.col(IndCQC.extrapolation_rolling_average_model),
         ),
     )
+    return df
+
+
+def null_changing_carehome_status_from_imputed_columns(df: DataFrame) -> DataFrame:
+    """
+    Nulls imputed data for locations which change from care home to not care home, or vice-versa at some point in their history.
+
+    Args:
+        df (DataFrame): A dataframe contianing the columns location_id, carehome, and ascwds_filled_posts_imputed.
+
+    Returns:
+        DataFrame: A dataframe with locations changing care home status nulled.
+    """
     return df
 
 

--- a/jobs/estimate_missing_ascwds_ind_cqc_filled_posts.py
+++ b/jobs/estimate_missing_ascwds_ind_cqc_filled_posts.py
@@ -143,10 +143,23 @@ def null_changing_carehome_status_from_imputed_columns(df: DataFrame) -> DataFra
     Nulls imputed data for locations which change from care home to not care home, or vice-versa at some point in their history.
 
     Args:
-        df (DataFrame): A dataframe contianing the columns location_id, carehome, and ascwds_filled_posts_imputed.
+        df (DataFrame): A dataframe contianing the columns location_id, cqc_location_import_date, carehome, and ascwds_filled_posts_imputed.
 
     Returns:
         DataFrame: A dataframe with locations changing care home status nulled.
+    """
+    return df
+
+
+def create_list_of_locations_with_changing_care_home_status(df: DataFrame) -> list:
+    """
+    Creates a list of location ids for locations which change from care home to not care home, or vice-versa at some point in their history.
+
+    Args:
+        df (DataFrame): A dataframe contianing the columns location_id, cqc_location_import_date, carehome, and ascwds_filled_posts_imputed.
+
+    Returns:
+        list: A list of locations ids of locations with a changing care home status.
     """
     return df
 

--- a/jobs/estimate_missing_ascwds_ind_cqc_filled_posts.py
+++ b/jobs/estimate_missing_ascwds_ind_cqc_filled_posts.py
@@ -149,7 +149,13 @@ def null_changing_carehome_status_from_imputed_columns(df: DataFrame) -> DataFra
         DataFrame: A dataframe with locations changing care home status nulled.
     """
     list_of_locations = create_list_of_locations_with_changing_care_home_status(df)
-    df = df.where(~df[IndCQC.location_id].isin(list_of_locations))
+    df = df.withColumn(
+        IndCQC.ascwds_filled_posts_imputed,
+        F.when(
+            ~df[IndCQC.location_id].isin(list_of_locations),
+            F.col(IndCQC.ascwds_filled_posts_imputed),
+        ),
+    )
     return df
 
 

--- a/jobs/estimate_missing_ascwds_ind_cqc_filled_posts.py
+++ b/jobs/estimate_missing_ascwds_ind_cqc_filled_posts.py
@@ -148,6 +148,8 @@ def null_changing_carehome_status_from_imputed_columns(df: DataFrame) -> DataFra
     Returns:
         DataFrame: A dataframe with locations changing care home status nulled.
     """
+    list_of_locations = create_list_of_locations_with_changing_care_home_status(df)
+    df = df.where(~df[IndCQC.location_id].isin(list_of_locations))
     return df
 
 

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -3454,6 +3454,27 @@ class EstimateMissingAscwdsFilledPostsData:
         ),
     ]
 
+    null_changing_carehome_status_rows = [
+        ("loc 1", date(2024, 1, 1), CareHome.care_home, 20.0),
+        ("loc 1", date(2024, 2, 1), CareHome.care_home, 20.0),
+        ("loc 2", date(2024, 1, 1), CareHome.not_care_home, 20.0),
+        ("loc 2", date(2024, 2, 1), CareHome.not_care_home, 20.0),
+        ("loc 3", date(2024, 1, 1), CareHome.care_home, 20.0),
+        ("loc 3", date(2024, 2, 1), CareHome.not_care_home, 20.0),
+        ("loc 4", date(2024, 1, 1), CareHome.not_care_home, 20.0),
+        ("loc 4", date(2024, 2, 1), CareHome.care_home, 20.0),
+    ]
+    expected_null_changing_carehome_status_rows = [
+        ("loc 1", date(2024, 1, 1), CareHome.care_home, 20.0),
+        ("loc 1", date(2024, 2, 1), CareHome.care_home, 20.0),
+        ("loc 2", date(2024, 1, 1), CareHome.not_care_home, 20.0),
+        ("loc 2", date(2024, 2, 1), CareHome.not_care_home, 20.0),
+        ("loc 3", date(2024, 1, 1), CareHome.care_home, None),
+        ("loc 3", date(2024, 2, 1), CareHome.not_care_home, None),
+        ("loc 4", date(2024, 1, 1), CareHome.not_care_home, None),
+        ("loc 4", date(2024, 2, 1), CareHome.care_home, None),
+    ]
+
 
 @dataclass
 class ModelPrimaryServiceRollingAverage:

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -3474,6 +3474,7 @@ class EstimateMissingAscwdsFilledPostsData:
         ("loc 4", date(2024, 1, 1), CareHome.not_care_home, None),
         ("loc 4", date(2024, 2, 1), CareHome.care_home, None),
     ]
+    expected_list_of_changing_carehome_statuses = ["loc 3", "loc 4"]
 
 
 @dataclass

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -2081,6 +2081,23 @@ class EstimateMissingAscwdsFilledPostsSchemas:
         ]
     )
 
+    null_changing_carehome_status_schema = StructType(
+        [
+            StructField(IndCQC.location_id, StringType(), True),
+            StructField(
+                IndCQC.cqc_location_import_date,
+                DateType(),
+                True,
+            ),
+            StructField(IndCQC.care_home, StringType(), True),
+            StructField(
+                IndCQC.ascwds_filled_posts_imputed,
+                FloatType(),
+                True,
+            ),
+        ]
+    )
+
 
 @dataclass
 class ModelPrimaryServiceRollingAverage:

--- a/tests/unit/test_estimate_missing_ascwds_ind_cqc_filled_posts.py
+++ b/tests/unit/test_estimate_missing_ascwds_ind_cqc_filled_posts.py
@@ -116,5 +116,33 @@ class MergeImputedColumnsTests(EstimateMissingAscwdsFilledPostsTests):
             )
 
 
+class NullChangingCarehomeStatusFromImputedColumnsTests(
+    EstimateMissingAscwdsFilledPostsTests
+):
+    def setUp(self) -> None:
+        super().setUp()
+
+    def test_null_changing_carehome_status_from_imputed_columns_returns_correct_values(
+        self,
+    ):
+        test_df = self.spark.createDataFrame(
+            Data.null_changing_carehome_status_rows,
+            Schemas.null_changing_carehome_status_schema,
+        )
+        returned_df = job.null_changing_carehome_status_from_imputed_columns(test_df)
+        expected_df = self.spark.createDataFrame(
+            Data.expected_null_changing_carehome_status_rows,
+            Schemas.null_changing_carehome_status_schema,
+        )
+        returned_data = returned_df.sort(IndCQC.location_id).collect()
+        expected_data = expected_df.collect()
+        for i in range(len(returned_data)):
+            self.assertEqual(
+                returned_data[i][IndCQC.ascwds_filled_posts_imputed],
+                expected_data[i][IndCQC.ascwds_filled_posts_imputed],
+                f"Returned row {i} does not match expected",
+            )
+
+
 if __name__ == "__main__":
     unittest.main(warnings="ignore")

--- a/tests/unit/test_estimate_missing_ascwds_ind_cqc_filled_posts.py
+++ b/tests/unit/test_estimate_missing_ascwds_ind_cqc_filled_posts.py
@@ -121,27 +121,36 @@ class NullChangingCarehomeStatusFromImputedColumnsTests(
 ):
     def setUp(self) -> None:
         super().setUp()
+        self.test_df = self.spark.createDataFrame(
+            Data.null_changing_carehome_status_rows,
+            Schemas.null_changing_carehome_status_schema,
+        )
+        self.expected_df = self.spark.createDataFrame(
+            Data.expected_null_changing_carehome_status_rows,
+            Schemas.null_changing_carehome_status_schema,
+        )
+        self.returned_df = job.null_changing_carehome_status_from_imputed_columns(
+            self.test_df
+        )
+        self.returned_df.show()
+        self.expected_df.show()
 
     def test_null_changing_carehome_status_from_imputed_columns_returns_correct_values(
         self,
     ):
-        test_df = self.spark.createDataFrame(
-            Data.null_changing_carehome_status_rows,
-            Schemas.null_changing_carehome_status_schema,
-        )
-        returned_df = job.null_changing_carehome_status_from_imputed_columns(test_df)
-        expected_df = self.spark.createDataFrame(
-            Data.expected_null_changing_carehome_status_rows,
-            Schemas.null_changing_carehome_status_schema,
-        )
-        returned_data = returned_df.sort(IndCQC.location_id).collect()
-        expected_data = expected_df.collect()
+        returned_data = self.returned_df.sort(IndCQC.location_id).collect()
+        expected_data = self.expected_df.collect()
         for i in range(len(returned_data)):
             self.assertEqual(
                 returned_data[i][IndCQC.ascwds_filled_posts_imputed],
                 expected_data[i][IndCQC.ascwds_filled_posts_imputed],
                 f"Returned row {i} does not match expected",
             )
+
+    def test_null_changing_carehome_status_from_imputed_columns_returns_correct_row_count(
+        self,
+    ):
+        self.assertEqual(self.returned_df.count(), self.expected_df.count())
 
     def test_create_list_of_locations_with_changing_care_home_status_returns_correct_values(
         self,

--- a/tests/unit/test_estimate_missing_ascwds_ind_cqc_filled_posts.py
+++ b/tests/unit/test_estimate_missing_ascwds_ind_cqc_filled_posts.py
@@ -132,8 +132,6 @@ class NullChangingCarehomeStatusFromImputedColumnsTests(
         self.returned_df = job.null_changing_carehome_status_from_imputed_columns(
             self.test_df
         )
-        self.returned_df.show()
-        self.expected_df.show()
 
     def test_null_changing_carehome_status_from_imputed_columns_returns_correct_values(
         self,

--- a/tests/unit/test_estimate_missing_ascwds_ind_cqc_filled_posts.py
+++ b/tests/unit/test_estimate_missing_ascwds_ind_cqc_filled_posts.py
@@ -143,6 +143,20 @@ class NullChangingCarehomeStatusFromImputedColumnsTests(
                 f"Returned row {i} does not match expected",
             )
 
+    def test_create_list_of_locations_with_changing_care_home_status_returns_correct_values(
+        self,
+    ):
+        test_df = self.spark.createDataFrame(
+            Data.null_changing_carehome_status_rows,
+            Schemas.null_changing_carehome_status_schema,
+        )
+        returned_list = job.create_list_of_locations_with_changing_care_home_status(
+            test_df
+        )
+        expected_list = Data.expected_list_of_changing_carehome_statuses
+
+        self.assertEqual(returned_list, expected_list)
+
 
 if __name__ == "__main__":
     unittest.main(warnings="ignore")


### PR DESCRIPTION
# Description
Add a filter to imputed data to remove locations which change their status from care home to non-res or vice versa
Adds unit testing for functions

# How to test
Unit tests passing
Run in branch: https://eu-west-2.console.aws.amazon.com/states/home?region=eu-west-2#/v2/executions/details/arn:aws:states:eu-west-2:344210435447:execution:filter-changing-carehome-statu-Ind-CQC-Filled-Post-Estimates-Pipeline:2edb3f22-bca9-4271-8397-4ced6e5026da
Used in EMR - finding correct number of locations

# Developer checklist
- [x] Unit test
- [x] Linked to Trello ticket: https://trello.com/c/jXoKbEzv/746-filter-out-locations-which-change-care-home-status-at-some-point-in-time
- [x] Documentation up to date
