### PR TITLE
Retain dedup clean for switchers

### DIFF
--- a/jobs/estimate_missing_ascwds_ind_cqc_filled_posts.py
+++ b/jobs/estimate_missing_ascwds_ind_cqc_filled_posts.py
@@ -142,11 +142,13 @@ def null_changing_carehome_status_from_imputed_columns(df: DataFrame) -> DataFra
     """
     Nulls imputed data for locations which change from care home to not care home, or vice-versa at some point in their history.
 
+    This function nulls imputed data for locations which change from care home to not care home, or vice-versa at some point in their history. If those locations have a value for ascwds_filled_posts_dedup_clean, that value is used instead, otherwise the value is nulled.
+
     Args:
-        df (DataFrame): A dataframe contianing the columns location_id, cqc_location_import_date, carehome, and ascwds_filled_posts_imputed.
+        df (DataFrame): A dataframe contianing the columns location_id, cqc_location_import_date, carehome, ascwds_filled_posts_dedup_clean and ascwds_filled_posts_imputed.
 
     Returns:
-        DataFrame: A dataframe with locations changing care home status nulled.
+        DataFrame: A dataframe with locations changing care home status nulled, unless they have ascwds_filled_posts_dedup_clean data available.
     """
     list_of_locations = create_list_of_locations_with_changing_care_home_status(df)
     df = df.withColumn(

--- a/jobs/estimate_missing_ascwds_ind_cqc_filled_posts.py
+++ b/jobs/estimate_missing_ascwds_ind_cqc_filled_posts.py
@@ -154,6 +154,8 @@ def null_changing_carehome_status_from_imputed_columns(df: DataFrame) -> DataFra
         F.when(
             ~df[IndCQC.location_id].isin(list_of_locations),
             F.col(IndCQC.ascwds_filled_posts_imputed),
+        ).otherwise(
+            F.col(IndCQC.ascwds_filled_posts_dedup_clean),
         ),
     )
     return df

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -3459,9 +3459,9 @@ class EstimateMissingAscwdsFilledPostsData:
         ("loc 1", date(2024, 2, 1), CareHome.care_home, 20.0, 10.0),
         ("loc 2", date(2024, 1, 1), CareHome.not_care_home, 20.0, 10.0),
         ("loc 2", date(2024, 2, 1), CareHome.not_care_home, 20.0, 10.0),
-        ("loc 3", date(2024, 1, 1), CareHome.care_home, 20.0, 10.0),
-        ("loc 3", date(2024, 2, 1), CareHome.not_care_home, 20.0, 10.0),
-        ("loc 4", date(2024, 1, 1), CareHome.not_care_home, 20.0, 10.0),
+        ("loc 3", date(2024, 1, 1), CareHome.care_home, 20.0, None),
+        ("loc 3", date(2024, 2, 1), CareHome.not_care_home, 20.0, None),
+        ("loc 4", date(2024, 1, 1), CareHome.not_care_home, 20.0, None),
         ("loc 4", date(2024, 2, 1), CareHome.care_home, 20.0, 10.0),
     ]
     expected_null_changing_carehome_status_rows = [
@@ -3469,10 +3469,10 @@ class EstimateMissingAscwdsFilledPostsData:
         ("loc 1", date(2024, 2, 1), CareHome.care_home, 20.0, 10.0),
         ("loc 2", date(2024, 1, 1), CareHome.not_care_home, 20.0, 10.0),
         ("loc 2", date(2024, 2, 1), CareHome.not_care_home, 20.0, 10.0),
-        ("loc 3", date(2024, 1, 1), CareHome.care_home, None, 10.0),
-        ("loc 3", date(2024, 2, 1), CareHome.not_care_home, None, 10.0),
-        ("loc 4", date(2024, 1, 1), CareHome.not_care_home, None, 10.0),
-        ("loc 4", date(2024, 2, 1), CareHome.care_home, None, 10.0),
+        ("loc 3", date(2024, 1, 1), CareHome.care_home, None, None),
+        ("loc 3", date(2024, 2, 1), CareHome.not_care_home, None, None),
+        ("loc 4", date(2024, 1, 1), CareHome.not_care_home, None, None),
+        ("loc 4", date(2024, 2, 1), CareHome.care_home, 10.0, 10.0),
     ]
     expected_list_of_changing_carehome_statuses = ["loc 3", "loc 4"]
 

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -3455,25 +3455,35 @@ class EstimateMissingAscwdsFilledPostsData:
     ]
 
     null_changing_carehome_status_rows = [
-        ("loc 1", date(2024, 1, 1), CareHome.care_home, 20.0, 10.0),
-        ("loc 1", date(2024, 2, 1), CareHome.care_home, 20.0, 10.0),
-        ("loc 2", date(2024, 1, 1), CareHome.not_care_home, 20.0, 10.0),
-        ("loc 2", date(2024, 2, 1), CareHome.not_care_home, 20.0, 10.0),
+        ("loc 1", date(2024, 1, 1), CareHome.care_home, 20.0, None),
+        ("loc 1", date(2024, 2, 1), CareHome.care_home, 20.0, None),
+        ("loc 2", date(2024, 1, 1), CareHome.not_care_home, 20.0, None),
+        ("loc 2", date(2024, 2, 1), CareHome.not_care_home, 20.0, None),
         ("loc 3", date(2024, 1, 1), CareHome.care_home, 20.0, None),
         ("loc 3", date(2024, 2, 1), CareHome.not_care_home, 20.0, None),
         ("loc 4", date(2024, 1, 1), CareHome.not_care_home, 20.0, None),
-        ("loc 4", date(2024, 2, 1), CareHome.care_home, 20.0, 10.0),
+        ("loc 4", date(2024, 2, 1), CareHome.care_home, 20.0, None),
     ]
     expected_null_changing_carehome_status_rows = [
-        ("loc 1", date(2024, 1, 1), CareHome.care_home, 20.0, 10.0),
-        ("loc 1", date(2024, 2, 1), CareHome.care_home, 20.0, 10.0),
-        ("loc 2", date(2024, 1, 1), CareHome.not_care_home, 20.0, 10.0),
-        ("loc 2", date(2024, 2, 1), CareHome.not_care_home, 20.0, 10.0),
+        ("loc 1", date(2024, 1, 1), CareHome.care_home, 20.0, None),
+        ("loc 1", date(2024, 2, 1), CareHome.care_home, 20.0, None),
+        ("loc 2", date(2024, 1, 1), CareHome.not_care_home, 20.0, None),
+        ("loc 2", date(2024, 2, 1), CareHome.not_care_home, 20.0, None),
         ("loc 3", date(2024, 1, 1), CareHome.care_home, None, None),
         ("loc 3", date(2024, 2, 1), CareHome.not_care_home, None, None),
         ("loc 4", date(2024, 1, 1), CareHome.not_care_home, None, None),
-        ("loc 4", date(2024, 2, 1), CareHome.care_home, 10.0, 10.0),
+        ("loc 4", date(2024, 2, 1), CareHome.care_home, None, None),
     ]
+
+    retain_ascwds_filled_posts_dedup_clean_changing_carehome_status_rows = [
+        ("loc 1", date(2024, 1, 1), CareHome.not_care_home, 20.0, None),
+        ("loc 1", date(2024, 2, 1), CareHome.care_home, 20.0, 10.0),
+    ]
+    expected_retain_ascwds_filled_posts_dedup_clean_changing_carehome_status_rows = [
+        ("loc 1", date(2024, 1, 1), CareHome.not_care_home, None, None),
+        ("loc 1", date(2024, 2, 1), CareHome.care_home, 10.0, 10.0),
+    ]
+
     expected_list_of_changing_carehome_statuses = ["loc 3", "loc 4"]
 
 

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -3455,24 +3455,24 @@ class EstimateMissingAscwdsFilledPostsData:
     ]
 
     null_changing_carehome_status_rows = [
-        ("loc 1", date(2024, 1, 1), CareHome.care_home, 20.0),
-        ("loc 1", date(2024, 2, 1), CareHome.care_home, 20.0),
-        ("loc 2", date(2024, 1, 1), CareHome.not_care_home, 20.0),
-        ("loc 2", date(2024, 2, 1), CareHome.not_care_home, 20.0),
-        ("loc 3", date(2024, 1, 1), CareHome.care_home, 20.0),
-        ("loc 3", date(2024, 2, 1), CareHome.not_care_home, 20.0),
-        ("loc 4", date(2024, 1, 1), CareHome.not_care_home, 20.0),
-        ("loc 4", date(2024, 2, 1), CareHome.care_home, 20.0),
+        ("loc 1", date(2024, 1, 1), CareHome.care_home, 20.0, 10.0),
+        ("loc 1", date(2024, 2, 1), CareHome.care_home, 20.0, 10.0),
+        ("loc 2", date(2024, 1, 1), CareHome.not_care_home, 20.0, 10.0),
+        ("loc 2", date(2024, 2, 1), CareHome.not_care_home, 20.0, 10.0),
+        ("loc 3", date(2024, 1, 1), CareHome.care_home, 20.0, 10.0),
+        ("loc 3", date(2024, 2, 1), CareHome.not_care_home, 20.0, 10.0),
+        ("loc 4", date(2024, 1, 1), CareHome.not_care_home, 20.0, 10.0),
+        ("loc 4", date(2024, 2, 1), CareHome.care_home, 20.0, 10.0),
     ]
     expected_null_changing_carehome_status_rows = [
-        ("loc 1", date(2024, 1, 1), CareHome.care_home, 20.0),
-        ("loc 1", date(2024, 2, 1), CareHome.care_home, 20.0),
-        ("loc 2", date(2024, 1, 1), CareHome.not_care_home, 20.0),
-        ("loc 2", date(2024, 2, 1), CareHome.not_care_home, 20.0),
-        ("loc 3", date(2024, 1, 1), CareHome.care_home, None),
-        ("loc 3", date(2024, 2, 1), CareHome.not_care_home, None),
-        ("loc 4", date(2024, 1, 1), CareHome.not_care_home, None),
-        ("loc 4", date(2024, 2, 1), CareHome.care_home, None),
+        ("loc 1", date(2024, 1, 1), CareHome.care_home, 20.0, 10.0),
+        ("loc 1", date(2024, 2, 1), CareHome.care_home, 20.0, 10.0),
+        ("loc 2", date(2024, 1, 1), CareHome.not_care_home, 20.0, 10.0),
+        ("loc 2", date(2024, 2, 1), CareHome.not_care_home, 20.0, 10.0),
+        ("loc 3", date(2024, 1, 1), CareHome.care_home, None, 10.0),
+        ("loc 3", date(2024, 2, 1), CareHome.not_care_home, None, 10.0),
+        ("loc 4", date(2024, 1, 1), CareHome.not_care_home, None, 10.0),
+        ("loc 4", date(2024, 2, 1), CareHome.care_home, None, 10.0),
     ]
     expected_list_of_changing_carehome_statuses = ["loc 3", "loc 4"]
 

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -2102,6 +2102,7 @@ class EstimateMissingAscwdsFilledPostsSchemas:
             ),
         ]
     )
+    retain_ascwds_filled_posts_dedup_clean_changing_carehome_status_schema = null_changing_carehome_status_schema
 
 
 @dataclass

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -2102,7 +2102,9 @@ class EstimateMissingAscwdsFilledPostsSchemas:
             ),
         ]
     )
-    retain_ascwds_filled_posts_dedup_clean_changing_carehome_status_schema = null_changing_carehome_status_schema
+    retain_ascwds_filled_posts_dedup_clean_changing_carehome_status_schema = (
+        null_changing_carehome_status_schema
+    )
 
 
 @dataclass

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -2095,6 +2095,11 @@ class EstimateMissingAscwdsFilledPostsSchemas:
                 FloatType(),
                 True,
             ),
+            StructField(
+                IndCQC.ascwds_filled_posts_dedup_clean,
+                FloatType(),
+                True,
+            ),
         ]
     )
 

--- a/tests/unit/test_estimate_missing_ascwds_ind_cqc_filled_posts.py
+++ b/tests/unit/test_estimate_missing_ascwds_ind_cqc_filled_posts.py
@@ -133,11 +133,32 @@ class NullChangingCarehomeStatusFromImputedColumnsTests(
             self.test_df
         )
 
-    def test_null_changing_carehome_status_from_imputed_columns_returns_correct_values(
+    def test_null_changing_carehome_status_from_imputed_columns_returns_correct_values_when_no_ascwds_data_exists(
         self,
     ):
         returned_data = self.returned_df.sort(IndCQC.location_id).collect()
         expected_data = self.expected_df.collect()
+        for i in range(len(returned_data)):
+            self.assertEqual(
+                returned_data[i][IndCQC.ascwds_filled_posts_imputed],
+                expected_data[i][IndCQC.ascwds_filled_posts_imputed],
+                f"Returned row {i} does not match expected",
+            )
+
+    def test_null_changing_carehome_status_from_imputed_columns_returns_correct_values_when_ascwds_data_exists(
+        self,
+    ):
+        test_df = self.spark.createDataFrame(
+            Data.retain_ascwds_filled_posts_dedup_clean_changing_carehome_status_rows,
+            Schemas.retain_ascwds_filled_posts_dedup_clean_changing_carehome_status_schema,
+        )
+        expected_df = self.spark.createDataFrame(
+            Data.expected_retain_ascwds_filled_posts_dedup_clean_changing_carehome_status_rows,
+            Schemas.retain_ascwds_filled_posts_dedup_clean_changing_carehome_status_schema,
+        )
+        returned_df = job.null_changing_carehome_status_from_imputed_columns(test_df)
+        returned_data = returned_df.sort(IndCQC.location_id).collect()
+        expected_data = expected_df.collect()
         for i in range(len(returned_data)):
             self.assertEqual(
                 returned_data[i][IndCQC.ascwds_filled_posts_imputed],


### PR DESCRIPTION
# Description
Previously all data was removed from a location which changed between care home and non-res. This PR updates the logic so that ascwds_filled_posts_dedup_clean is used for these locations, if available.

# How to test
Unit tests passing
Run in branch: https://eu-west-2.console.aws.amazon.com/states/home?region=eu-west-2#/v2/executions/details/arn:aws:states:eu-west-2:344210435447:execution:retain-dedup-clean-for-switche-Ind-CQC-Filled-Post-Estimates-Pipeline:f29291a1-8100-441d-80f9-86414ea8a0a4

# Developer checklist
- [x] Unit test
- [x] Linked to Trello ticket: https://trello.com/c/z77bbABj/747-for-places-who-switch-between-nr-and-ch-copy-over-ascwdsfilled-postsdeduplicatedclean
- [x] Documentation up to date
