### PR TITLE
Clean capacity tracker care home data

### DIFF
--- a/jobs/clean_ascwds_workplace_data.py
+++ b/jobs/clean_ascwds_workplace_data.py
@@ -88,7 +88,7 @@ def main(
         ascwds_workplace_df
     )
 
-    ascwds_workplace_df = cast_to_int(ascwds_workplace_df, COLUMNS_TO_BOUND)
+    ascwds_workplace_df = cUtils.cast_to_int(ascwds_workplace_df, COLUMNS_TO_BOUND)
 
     ascwds_workplace_df = cUtils.set_column_bounds(
         ascwds_workplace_df,
@@ -125,12 +125,6 @@ def main(
         mode="overwrite",
         partitionKeys=partition_keys,
     )
-
-
-def cast_to_int(df: DataFrame, column_names: list) -> DataFrame:
-    for column in column_names:
-        df = df.withColumn(column, df[column].cast(IntegerType()))
-    return df
 
 
 def remove_workplaces_with_duplicate_location_ids(df: DataFrame) -> DataFrame:

--- a/jobs/clean_capacity_tracker_care_home_data.py
+++ b/jobs/clean_capacity_tracker_care_home_data.py
@@ -73,9 +73,9 @@ def main(
 
 def remove_rows_where_agency_and_non_agency_values_match(df: DataFrame) -> DataFrame:
     """
-    Remove rows where the number of employed for a non-agency job role matches the corresponding agency job role.
+    Remove rows where the number of employed for non-agency job roles matches the corresponding agency job roles.
 
-    Matching rows are removed as the likelihood of this number exactly matching is low and suggests that data quality may be poor.
+    Matching rows are removed as the likelihood of these numbers exactly matching is low and suggests that data quality may be poor.
 
     Args:
         df(DataFrame): A dataframe with capacity tracker care home data.
@@ -85,8 +85,8 @@ def remove_rows_where_agency_and_non_agency_values_match(df: DataFrame) -> DataF
     """
     df = df.where(
         (df[CTCH.nurses_employed] != df[CTCH.agency_nurses_employed])
-        & (df[CTCH.care_workers_employed] != df[CTCH.agency_care_workers_employed])
-        & (
+        | (df[CTCH.care_workers_employed] != df[CTCH.agency_care_workers_employed])
+        | (
             df[CTCH.non_care_workers_employed]
             != df[CTCH.agency_non_care_workers_employed]
         )

--- a/jobs/clean_capacity_tracker_care_home_data.py
+++ b/jobs/clean_capacity_tracker_care_home_data.py
@@ -40,25 +40,19 @@ def main(
         CTCH.agency_care_workers_employed,
         CTCH.agency_non_care_workers_employed,
     ]
-    # change numbers to ints
     capacity_tracker_care_home_df = cUtils.cast_to_int(
         capacity_tracker_care_home_df, columns_to_cast_to_integers
     )
-    # add import date column
     capacity_tracker_care_home_df = cUtils.column_to_date(
         capacity_tracker_care_home_df,
         Keys.import_date,
         CTCHClean.capacity_tracker_import_date,
     )
-    # Remove those with exactly same directly employed and non-directly employed
     capacity_tracker_care_home_df = (
         remove_rows_where_agency_and_non_agency_values_match(
             capacity_tracker_care_home_df
         )
     )
-    # add total agency column
-    # add total non-agency column
-    # add total agency and non agency column
     capacity_tracker_care_home_df = create_new_columns_with_totals(
         capacity_tracker_care_home_df
     )

--- a/jobs/clean_capacity_tracker_care_home_data.py
+++ b/jobs/clean_capacity_tracker_care_home_data.py
@@ -110,6 +110,22 @@ def create_new_columns_with_totals(df: DataFrame) -> DataFrame:
     Returns:
         DataFrame: A dataframe with three additional columns with totals for agency staff, non agency staff, and combined agency and non agency staff.
     """
+    df = df.withColumn(
+        CTCHClean.non_agency_total_employed,
+        df[CTCH.nurses_employed]
+        + df[CTCH.care_workers_employed]
+        + df[CTCH.non_care_workers_employed],
+    )
+    df = df.withColumn(
+        CTCHClean.agency_total_employed,
+        df[CTCH.agency_nurses_employed]
+        + df[CTCH.agency_care_workers_employed]
+        + df[CTCH.agency_non_care_workers_employed],
+    )
+    df = df.withColumn(
+        CTCHClean.agency_and_non_agency_total_employed,
+        df[CTCHClean.agency_total_employed] + df[CTCHClean.non_agency_total_employed],
+    )
     return df
 
 

--- a/jobs/clean_capacity_tracker_care_home_data.py
+++ b/jobs/clean_capacity_tracker_care_home_data.py
@@ -51,6 +51,11 @@ def main(
         CTCHClean.capacity_tracker_import_date,
     )
     # Remove those with exactly same directly employed and non-directly employed
+    capacity_tracker_care_home_df = (
+        remove_rows_where_agency_and_non_agency_values_match(
+            capacity_tracker_care_home_df
+        )
+    )
     # add total agency column
     # add total non-agency column
     # add total agency and non agency column
@@ -67,6 +72,21 @@ def main(
             Keys.import_date,
         ],
     )
+
+
+def remove_rows_where_agency_and_non_agency_values_match(df: DataFrame) -> DataFrame:
+    """
+    Remove rows where the number of employed for a non-agency job role matches the corresponding agency job role.
+
+    Matching rows are removed as the likelihood of this number exactly matching is low and suggests that data quality may be poor.
+
+    Args:
+        df(DataFrame): A dataframe with capacity tracker care home data.
+
+    Returns:
+        DataFrame: A dataframe with suspect rows removed.
+    """
+    return df
 
 
 if __name__ == "__main__":

--- a/jobs/clean_capacity_tracker_care_home_data.py
+++ b/jobs/clean_capacity_tracker_care_home_data.py
@@ -6,6 +6,7 @@ from utils import utils
 import utils.cleaning_utils as cUtils
 from utils.column_names.capacity_tracker_columns import (
     CapacityTrackerCareHomeColumns as CTCH,
+    CapacityTrackerCareHomeCleanColumns as CTCHClean,
 )
 from utils.column_names.ind_cqc_pipeline_columns import PartitionKeys as Keys
 
@@ -31,9 +32,24 @@ def main(
     capacity_tracker_care_home_df = utils.read_from_parquet(
         capacity_tracker_care_home_source, CAPACITY_TRACKER_CARE_HOME_COLUMNS
     )
-
+    columns_to_cast_to_integers = [
+        CTCH.nurses_employed,
+        CTCH.care_workers_employed,
+        CTCH.non_care_workers_employed,
+        CTCH.agency_nurses_employed,
+        CTCH.agency_care_workers_employed,
+        CTCH.agency_non_care_workers_employed,
+    ]
     # change numbers to ints
+    capacity_tracker_care_home_df = cUtils.cast_to_int(
+        capacity_tracker_care_home_df, columns_to_cast_to_integers
+    )
     # add import date column
+    capacity_tracker_care_home_df = cUtils.column_to_date(
+        capacity_tracker_care_home_df,
+        Keys.import_date,
+        CTCHClean.capacity_tracker_import_date,
+    )
     # Remove those with exactly same directly employed and non-directly employed
     # add total agency column
     # add total non-agency column

--- a/jobs/clean_capacity_tracker_care_home_data.py
+++ b/jobs/clean_capacity_tracker_care_home_data.py
@@ -59,6 +59,9 @@ def main(
     # add total agency column
     # add total non-agency column
     # add total agency and non agency column
+    capacity_tracker_care_home_df = create_new_columns_with_totals(
+        capacity_tracker_care_home_df
+    )
 
     print(f"Exporting as parquet to {cleaned_capacity_tracker_care_home_destination}")
     utils.write_to_parquet(
@@ -94,6 +97,19 @@ def remove_rows_where_agency_and_non_agency_values_match(df: DataFrame) -> DataF
             != df[CTCH.agency_non_care_workers_employed]
         )
     )
+    return df
+
+
+def create_new_columns_with_totals(df: DataFrame) -> DataFrame:
+    """
+    Adds new columns with totals for agency staff, non agency staff, and combined agency and non agency staff.
+
+    Args:
+        df(DataFrame): A dataframe with capacity tracker care home data.
+
+    Returns:
+        DataFrame: A dataframe with three additional columns with totals for agency staff, non agency staff, and combined agency and non agency staff.
+    """
     return df
 
 

--- a/jobs/clean_capacity_tracker_care_home_data.py
+++ b/jobs/clean_capacity_tracker_care_home_data.py
@@ -86,6 +86,14 @@ def remove_rows_where_agency_and_non_agency_values_match(df: DataFrame) -> DataF
     Returns:
         DataFrame: A dataframe with suspect rows removed.
     """
+    df = df.where(
+        (df[CTCH.nurses_employed] != df[CTCH.agency_nurses_employed])
+        & (df[CTCH.care_workers_employed] != df[CTCH.agency_care_workers_employed])
+        & (
+            df[CTCH.non_care_workers_employed]
+            != df[CTCH.agency_non_care_workers_employed]
+        )
+    )
     return df
 
 

--- a/jobs/clean_capacity_tracker_care_home_data.py
+++ b/jobs/clean_capacity_tracker_care_home_data.py
@@ -32,6 +32,13 @@ def main(
         capacity_tracker_care_home_source, CAPACITY_TRACKER_CARE_HOME_COLUMNS
     )
 
+    # change numbers to ints
+    # add import date column
+    # Remove those with exactly same directly employed and non-directly employed
+    # add total agency column
+    # add total non-agency column
+    # add total agency and non agency column
+
     print(f"Exporting as parquet to {cleaned_capacity_tracker_care_home_destination}")
     utils.write_to_parquet(
         capacity_tracker_care_home_df,

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -795,6 +795,20 @@ class CapacityTrackerCareHomeData:
         ),
     ]
 
+    remove_matching_agency_and_non_agency_rows = [
+        ("loc 1", "1", "2", "3", "4", "5", "6"),
+        ("loc 2", "1", "2", "3", "1", "5", "6"),
+        ("loc 3", "1", "2", "3", "4", "2", "6"),
+        ("loc 4", "1", "2", "3", "4", "5", "3"),
+        ("loc 5", "1", "2", "3", "1", "2", "6"),
+        ("loc 6", "1", "2", "3", "1", "5", "3"),
+        ("loc 7", "1", "2", "3", "4", "2", "3"),
+        ("loc 8", "1", "2", "3", "1", "2", "3"),
+    ]
+    expected_remove_matching_agency_and_non_agency_rows = [
+        ("loc 1", "1", "2", "3", "4", "5", "6"),
+    ]
+
 
 @dataclass
 class CapacityTrackerDomCareData:

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -807,6 +807,12 @@ class CapacityTrackerCareHomeData:
     ]
     expected_remove_matching_agency_and_non_agency_rows = [
         ("loc 1", "1", "2", "3", "4", "5", "6"),
+        ("loc 2", "1", "2", "3", "1", "5", "6"),
+        ("loc 3", "1", "2", "3", "4", "2", "6"),
+        ("loc 4", "1", "2", "3", "4", "5", "3"),
+        ("loc 5", "1", "2", "3", "1", "2", "6"),
+        ("loc 6", "1", "2", "3", "1", "5", "3"),
+        ("loc 7", "1", "2", "3", "4", "2", "3"),
     ]
 
     create_new_columns_with_totals_rows = [

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -248,68 +248,6 @@ class ASCWDSWorkplaceData:
         ),
     ]
 
-    cast_to_int_rows = [
-        (
-            "loc 1",
-            "20",
-            "18",
-        ),
-    ]
-
-    cast_to_int_errors_rows = [
-        (
-            "loc 1",
-            "20",
-            "18",
-        ),
-        (
-            "loc 2",
-            "ZO",
-            "18",
-        ),
-        (
-            "loc 3",
-            "20",
-            "IB",
-        ),
-        (
-            "loc 4",
-            "ZO",
-            "IB",
-        ),
-    ]
-
-    cast_to_int_expected_rows = [
-        (
-            "loc 1",
-            20,
-            18,
-        ),
-    ]
-
-    cast_to_int_errors_expected_rows = [
-        (
-            "loc 1",
-            20,
-            18,
-        ),
-        (
-            "loc 2",
-            None,
-            18,
-        ),
-        (
-            "loc 3",
-            20,
-            None,
-        ),
-        (
-            "loc 4",
-            None,
-            None,
-        ),
-    ]
-
     small_location_rows = [
         (
             "loc-1",
@@ -2357,6 +2295,68 @@ class CleaningUtilsData:
         ("loc 3", "20220205", "2022", "02", "05"),
         ("loc 5", "20220301", "2022", "03", "01"),
         ("loc 6", "20220402", "2022", "04", "02"),
+    ]
+
+    cast_to_int_rows = [
+        (
+            "loc 1",
+            "20",
+            "18",
+        ),
+    ]
+
+    cast_to_int_errors_rows = [
+        (
+            "loc 1",
+            "20",
+            "18",
+        ),
+        (
+            "loc 2",
+            "ZO",
+            "18",
+        ),
+        (
+            "loc 3",
+            "20",
+            "IB",
+        ),
+        (
+            "loc 4",
+            "ZO",
+            "IB",
+        ),
+    ]
+
+    cast_to_int_expected_rows = [
+        (
+            "loc 1",
+            20,
+            18,
+        ),
+    ]
+
+    cast_to_int_errors_expected_rows = [
+        (
+            "loc 1",
+            20,
+            18,
+        ),
+        (
+            "loc 2",
+            None,
+            18,
+        ),
+        (
+            "loc 3",
+            20,
+            None,
+        ),
+        (
+            "loc 4",
+            None,
+            None,
+        ),
     ]
 
 

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -810,10 +810,10 @@ class CapacityTrackerCareHomeData:
     ]
 
     create_new_columns_with_totals_rows = [
-        ("loc 1", 1, 2, 3, 4, 5, 6),
+        ("loc 1", 1, 2, 3, 40, 50, 60),
     ]
     expected_create_new_columns_with_totals_rows = [
-        ("loc 1", 1, 2, 3, 4, 5, 6, 6, 15, 21),
+        ("loc 1", 1, 2, 3, 40, 50, 60, 6, 150, 156),
     ]
 
 

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -809,6 +809,13 @@ class CapacityTrackerCareHomeData:
         ("loc 1", "1", "2", "3", "4", "5", "6"),
     ]
 
+    create_new_columns_with_totals_rows = [
+        ("loc 1", 1, 2, 3, 4, 5, 6),
+    ]
+    expected_create_new_columns_with_totals_rows = [
+        ("loc 1", 1, 2, 3, 4, 5, 6, 6, 15, 21),
+    ]
+
 
 @dataclass
 class CapacityTrackerDomCareData:

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -15,6 +15,7 @@ from pyspark.sql.types import (
 
 from utils.column_names.capacity_tracker_columns import (
     CapacityTrackerCareHomeColumns as CTCH,
+    CapacityTrackerCareHomeCleanColumns as CTCHClean,
 )
 from utils.column_names.cleaned_data_files.ascwds_worker_cleaned import (
     AscwdsWorkerCleanedColumns as AWKClean,
@@ -503,6 +504,27 @@ class CapacityTrackerCareHomeSchema:
             StructField(CTCH.agency_nurses_employed, StringType(), True),
             StructField(CTCH.agency_care_workers_employed, StringType(), True),
             StructField(CTCH.agency_non_care_workers_employed, StringType(), True),
+        ]
+    )
+    create_new_columns_with_totals_schema = StructType(
+        [
+            StructField(CTCH.cqc_id, StringType(), True),
+            StructField(CTCH.nurses_employed, IntegerType(), True),
+            StructField(CTCH.care_workers_employed, IntegerType(), True),
+            StructField(CTCH.non_care_workers_employed, IntegerType(), True),
+            StructField(CTCH.agency_nurses_employed, IntegerType(), True),
+            StructField(CTCH.agency_care_workers_employed, IntegerType(), True),
+            StructField(CTCH.agency_non_care_workers_employed, IntegerType(), True),
+        ]
+    )
+    expected_create_new_columns_with_totals_schema = StructType(
+        [
+            *create_new_columns_with_totals_schema,
+            StructField(CTCHClean.non_agency_total_employed, IntegerType(), True),
+            StructField(CTCHClean.agency_total_employed, IntegerType(), True),
+            StructField(
+                CTCHClean.agency_and_non_agency_total_employed, IntegerType(), True
+            ),
         ]
     )
 

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -494,6 +494,17 @@ class CapacityTrackerCareHomeSchema:
             StructField("other column", StringType(), True),
         ]
     )
+    remove_matching_agency_and_non_agency_schema = StructType(
+        [
+            StructField(CTCH.cqc_id, StringType(), True),
+            StructField(CTCH.nurses_employed, StringType(), True),
+            StructField(CTCH.care_workers_employed, StringType(), True),
+            StructField(CTCH.non_care_workers_employed, StringType(), True),
+            StructField(CTCH.agency_nurses_employed, StringType(), True),
+            StructField(CTCH.agency_care_workers_employed, StringType(), True),
+            StructField(CTCH.agency_non_care_workers_employed, StringType(), True),
+        ]
+    )
 
 
 @dataclass

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -134,22 +134,6 @@ class ASCWDSWorkplaceSchemas:
         ]
     )
 
-    cast_to_int_schema = StructType(
-        [
-            StructField(AWP.location_id, StringType(), True),
-            StructField(AWP.total_staff, StringType(), True),
-            StructField(AWP.worker_records, StringType(), True),
-        ]
-    )
-
-    cast_to_int_expected_schema = StructType(
-        [
-            StructField(AWP.location_id, StringType(), True),
-            StructField(AWP.total_staff, IntegerType(), True),
-            StructField(AWP.worker_records, IntegerType(), True),
-        ]
-    )
-
     location_schema = StructType(
         [
             StructField(AWP.location_id, StringType(), True),
@@ -1193,6 +1177,22 @@ class CleaningUtilsSchemas:
             StructField(Keys.year, StringType(), True),
             StructField(Keys.month, StringType(), True),
             StructField(Keys.day, StringType(), True),
+        ]
+    )
+
+    cast_to_int_schema = StructType(
+        [
+            StructField(AWP.location_id, StringType(), True),
+            StructField(AWP.total_staff, StringType(), True),
+            StructField(AWP.worker_records, StringType(), True),
+        ]
+    )
+
+    cast_to_int_expected_schema = StructType(
+        [
+            StructField(AWP.location_id, StringType(), True),
+            StructField(AWP.total_staff, IntegerType(), True),
+            StructField(AWP.worker_records, IntegerType(), True),
         ]
     )
 

--- a/tests/unit/test_clean_ascwds_workplace_data.py
+++ b/tests/unit/test_clean_ascwds_workplace_data.py
@@ -75,45 +75,6 @@ class MainTests(CleanASCWDSWorkplaceDatasetTests):
         self.assertEqual(write_to_parquet_mock.call_count, 2)
 
 
-class CastToIntTests(CleanASCWDSWorkplaceDatasetTests):
-    def setUp(self) -> None:
-        super().setUp()
-
-    def test_cast_to_int_returns_strings_formatted_as_ints_to_ints(self):
-        cast_to_int_df = self.spark.createDataFrame(
-            Data.cast_to_int_rows, Schemas.cast_to_int_schema
-        )
-        cast_to_int_expected_df = self.spark.createDataFrame(
-            Data.cast_to_int_expected_rows, Schemas.cast_to_int_expected_schema
-        )
-
-        returned_df = job.cast_to_int(cast_to_int_df, self.filled_posts_columns)
-
-        returned_data = returned_df.sort(AWP.location_id).collect()
-        expected_data = cast_to_int_expected_df.sort(AWP.location_id).collect()
-
-        self.assertEqual(expected_data, returned_data)
-
-    def test_cast_to_int_returns_strings_not_formatted_as_ints_as_none(self):
-        cast_to_int_with_errors_df = self.spark.createDataFrame(
-            Data.cast_to_int_errors_rows, Schemas.cast_to_int_schema
-        )
-        cast_to_int_with_errors_expected_df = self.spark.createDataFrame(
-            Data.cast_to_int_errors_expected_rows, Schemas.cast_to_int_expected_schema
-        )
-
-        returned_df = job.cast_to_int(
-            cast_to_int_with_errors_df, self.filled_posts_columns
-        )
-
-        returned_data = returned_df.sort(AWP.location_id).collect()
-        expected_data = cast_to_int_with_errors_expected_df.sort(
-            AWP.location_id
-        ).collect()
-
-        self.assertEqual(expected_data, returned_data)
-
-
 class CreatePurgedDfsForReconciliationAndDataTests(CleanASCWDSWorkplaceDatasetTests):
     def setUp(self):
         super().setUp()

--- a/tests/unit/test_clean_capacity_tracker_care_home_data.py
+++ b/tests/unit/test_clean_capacity_tracker_care_home_data.py
@@ -55,5 +55,28 @@ class MainTests(CapacityTrackerCareHomeTests):
         )
 
 
+class RemoveRowsWhereAgencyAndNonAgenyValuesMatchTests(CapacityTrackerCareHomeTests):
+    def setUp(self) -> None:
+        super().setUp()
+        self.test_df = self.spark.createDataFrame(
+            Data.remove_matching_agency_and_non_agency_rows,
+            Schemas.remove_matching_agency_and_non_agency_schema,
+        )
+        self.expected_df = self.spark.createDataFrame(
+            Data.expected_remove_matching_agency_and_non_agency_rows,
+            Schemas.remove_matching_agency_and_non_agency_schema,
+        )
+
+    def test_remove_rows_where_agency_and_non_agency_values_match_returns_correct_data(
+        self,
+    ):
+        returned_df = job.remove_rows_where_agency_and_non_agency_values_match(
+            self.test_df
+        )
+        self.assertEqual(
+            returned_df.sort(CTCH.cqc_id).collect(), self.expected_df.collect()
+        )
+
+
 if __name__ == "__main__":
     unittest.main(warnings="ignore")

--- a/tests/unit/test_clean_capacity_tracker_care_home_data.py
+++ b/tests/unit/test_clean_capacity_tracker_care_home_data.py
@@ -78,5 +78,26 @@ class RemoveRowsWhereAgencyAndNonAgenyValuesMatchTests(CapacityTrackerCareHomeTe
         )
 
 
+class CreateNewColumnsWithTotalsTests(CapacityTrackerCareHomeTests):
+    def setUp(self) -> None:
+        super().setUp()
+        self.test_df = self.spark.createDataFrame(
+            Data.create_new_columns_with_totals_rows,
+            Schemas.create_new_columns_with_totals_schema,
+        )
+        self.expected_df = self.spark.createDataFrame(
+            Data.expected_create_new_columns_with_totals_rows,
+            Schemas.expected_create_new_columns_with_totals_schema,
+        )
+
+    def test_create_new_columns_with_totals_returns_correct_data(
+        self,
+    ):
+        returned_df = job.create_new_columns_with_totals(self.test_df)
+        self.assertEqual(
+            returned_df.sort(CTCH.cqc_id).collect(), self.expected_df.collect()
+        )
+
+
 if __name__ == "__main__":
     unittest.main(warnings="ignore")

--- a/utils/cleaning_utils.py
+++ b/utils/cleaning_utils.py
@@ -1,9 +1,9 @@
 from pyspark.sql import (
     DataFrame,
     Window,
+    functions as F,
 )
-
-import pyspark.sql.functions as F
+from pyspark.sql.types import IntegerType
 
 from utils.column_names.ind_cqc_pipeline_columns import PartitionKeys as Keys
 
@@ -194,4 +194,10 @@ def reduce_dataset_to_earliest_file_per_month(df: DataFrame) -> DataFrame:
     w = Window.partitionBy(Keys.year, Keys.month).orderBy(Keys.day)
     df = df.withColumn(earliest_day_in_month, F.first(Keys.day).over(w))
     df = df.where(df[earliest_day_in_month] == df[Keys.day]).drop(earliest_day_in_month)
+    return df
+
+
+def cast_to_int(df: DataFrame, column_names: list) -> DataFrame:
+    for column in column_names:
+        df = df.withColumn(column, df[column].cast(IntegerType()))
     return df

--- a/utils/column_names/capacity_tracker_columns.py
+++ b/utils/column_names/capacity_tracker_columns.py
@@ -43,3 +43,8 @@ class CapacityTrackerCareHomeColumns:
     sub_icb: str = "subicb"
     used_beds: str = "usedbeds"
     workforce_status: str = "workforcestatus"
+
+
+@dataclass
+class CapacityTrackerCareHomeCleanColumns:
+    capacity_tracker_import_date: str = "capacity_tracker_import_date"

--- a/utils/column_names/capacity_tracker_columns.py
+++ b/utils/column_names/capacity_tracker_columns.py
@@ -48,3 +48,6 @@ class CapacityTrackerCareHomeColumns:
 @dataclass
 class CapacityTrackerCareHomeCleanColumns:
     capacity_tracker_import_date: str = "capacity_tracker_import_date"
+    agency_total_employed: str = "agency_total_employed"
+    non_agency_total_employed: str = "non_agency_total_employed"
+    agency_and_non_agency_total_employed: str = "agency_and_non_agency_total_employed"


### PR DESCRIPTION
# Description
Adds cleaning steps for capacity tracker care home data

# How to test
Unit tests passing
Run in branch: https://eu-west-2.console.aws.amazon.com/states/home?region=eu-west-2#/statemachines/view/arn%3Aaws%3Astates%3Aeu-west-2%3A344210435447%3AstateMachine%3Aclean-ct-data-IngestAndCleanCapacityTrackerDataPipeline?type=standard

# Developer checklist
- [x] Unit test
- [x] Linked to Trello ticket: https://trello.com/c/L6xpKtp1/759-clean-capacity-tracker-data
- [x] Documentation up to date
