### PR TITLE
Generalise calculate beds ratio 

### DIFF
--- a/jobs/clean_ind_cqc_filled_posts.py
+++ b/jobs/clean_ind_cqc_filled_posts.py
@@ -2,7 +2,12 @@ import sys
 from pyspark.sql import DataFrame, Window, functions as F
 
 from utils import utils
-from utils.cleaning_utils import reduce_dataset_to_earliest_file_per_month
+import utils.cleaning_utils as cUtils
+from utils.column_names.ind_cqc_pipeline_columns import (
+    PartitionKeys as Keys,
+    IndCqcColumns as IndCQC,
+)
+from utils.column_values.categorical_column_values import CareHome
 from utils.ind_cqc_filled_posts_utils.ascwds_filled_posts_calculator.ascwds_filled_posts_calculator import (
     calculate_ascwds_filled_posts,
 )
@@ -10,11 +15,6 @@ from utils.ind_cqc_filled_posts_utils.clean_ascwds_filled_post_outliers.clean_as
     clean_ascwds_filled_post_outliers,
 )
 
-from utils.column_names.ind_cqc_pipeline_columns import (
-    PartitionKeys as Keys,
-    IndCqcColumns as IndCQC,
-)
-from utils.column_values.categorical_column_values import CareHome
 
 PartitionKeys = [Keys.year, Keys.month, Keys.day, Keys.import_date]
 average_number_of_beds: str = "avg_beds"
@@ -28,7 +28,7 @@ def main(
 
     locations_df = utils.read_from_parquet(merged_ind_cqc_source)
 
-    locations_df = reduce_dataset_to_earliest_file_per_month(locations_df)
+    locations_df = cUtils.reduce_dataset_to_earliest_file_per_month(locations_df)
 
     locations_df = replace_zero_beds_with_null(locations_df)
     locations_df = populate_missing_care_home_number_of_beds(locations_df)
@@ -47,13 +47,13 @@ def main(
         IndCQC.ascwds_filled_posts_dedup,
     )
 
-    locations_df = calculate_filled_posts_per_bed_ratio(
+    locations_df = cUtils.calculate_filled_posts_per_bed_ratio(
         locations_df, IndCQC.ascwds_filled_posts_dedup
     )
 
     locations_df = clean_ascwds_filled_post_outliers(locations_df)
 
-    locations_df = calculate_filled_posts_per_bed_ratio(
+    locations_df = cUtils.calculate_filled_posts_per_bed_ratio(
         locations_df, IndCQC.ascwds_filled_posts_dedup_clean
     )
 

--- a/jobs/clean_ind_cqc_filled_posts.py
+++ b/jobs/clean_ind_cqc_filled_posts.py
@@ -161,29 +161,6 @@ def create_column_with_repeated_values_removed(
     return df_without_repeated_values
 
 
-def calculate_filled_posts_per_bed_ratio(
-    input_df: DataFrame, filled_posts_column: str
-) -> DataFrame:
-    """
-    Add a column with the filled post per bed ratio for care homes.
-
-    Args:
-        input_df (DataFrame): A dataframe containing the given column, care_home and numberofbeds.
-        filled_posts_column (str): The name of the column to use for calculating the ratio.
-
-    Returns (DataFrame): The same dataframe with an additional column contianing the filled posts per bed ratio for care homes.
-    """
-    input_df = input_df.withColumn(
-        IndCQC.filled_posts_per_bed_ratio,
-        F.when(
-            F.col(IndCQC.care_home) == CareHome.care_home,
-            F.col(filled_posts_column) / F.col(IndCQC.number_of_beds),
-        ),
-    )
-
-    return input_df
-
-
 if __name__ == "__main__":
     print("Spark job 'clean_ind_cqc_filled_posts' starting...")
     print(f"Job parameters: {sys.argv}")

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -2385,6 +2385,33 @@ class CleaningUtilsData:
             None,
         ),
     ]
+    
+    filled_posts_per_bed_ratio_rows = [
+        ("1-000000001", 5.0, 100, CareHome.care_home),
+        ("1-000000002", 2.0, 1, CareHome.care_home),
+        ("1-000000003", None, 100, CareHome.care_home),
+        ("1-000000004", 0.0, 1, CareHome.care_home),
+        ("1-000000005", 5.0, None, CareHome.care_home),
+        ("1-000000006", 2.0, 0, CareHome.care_home),
+        ("1-000000007", None, 0, CareHome.care_home),
+        ("1-000000008", 0.0, None, CareHome.care_home),
+        ("1-000000009", None, None, CareHome.care_home),
+        ("1-000000010", 0.0, 0, CareHome.care_home),
+        ("1-000000011", 4.0, 10, CareHome.not_care_home),
+    ]
+    expected_filled_posts_per_bed_ratio_rows = [
+        ("1-000000001", 5.0, 100, CareHome.care_home, 0.05),
+        ("1-000000002", 2.0, 1, CareHome.care_home, 2.0),
+        ("1-000000003", None, 100, CareHome.care_home, None),
+        ("1-000000004", 0.0, 1, CareHome.care_home, 0.0),
+        ("1-000000005", 5.0, None, CareHome.care_home, None),
+        ("1-000000006", 2.0, 0, CareHome.care_home, None),
+        ("1-000000007", None, 0, CareHome.care_home, None),
+        ("1-000000008", 0.0, None, CareHome.care_home, None),
+        ("1-000000009", None, None, CareHome.care_home, None),
+        ("1-000000010", 0.0, 0, CareHome.care_home, None),
+        ("1-000000011", 4.0, 10, CareHome.not_care_home, None),
+    ]
 
 
 @dataclass
@@ -2645,32 +2672,6 @@ class CleanIndCQCData:
         ("2", 3, date(2024, 2, 1), None),
     ]
 
-    filled_posts_per_bed_ratio_rows = [
-        ("1-000000001", 5.0, 100, CareHome.care_home),
-        ("1-000000002", 2.0, 1, CareHome.care_home),
-        ("1-000000003", None, 100, CareHome.care_home),
-        ("1-000000004", 0.0, 1, CareHome.care_home),
-        ("1-000000005", 5.0, None, CareHome.care_home),
-        ("1-000000006", 2.0, 0, CareHome.care_home),
-        ("1-000000007", None, 0, CareHome.care_home),
-        ("1-000000008", 0.0, None, CareHome.care_home),
-        ("1-000000009", None, None, CareHome.care_home),
-        ("1-000000010", 0.0, 0, CareHome.care_home),
-        ("1-000000011", 4.0, 10, CareHome.not_care_home),
-    ]
-    expected_filled_posts_per_bed_ratio_rows = [
-        ("1-000000001", 5.0, 100, CareHome.care_home, 0.05),
-        ("1-000000002", 2.0, 1, CareHome.care_home, 2.0),
-        ("1-000000003", None, 100, CareHome.care_home, None),
-        ("1-000000004", 0.0, 1, CareHome.care_home, 0.0),
-        ("1-000000005", 5.0, None, CareHome.care_home, None),
-        ("1-000000006", 2.0, 0, CareHome.care_home, None),
-        ("1-000000007", None, 0, CareHome.care_home, None),
-        ("1-000000008", 0.0, None, CareHome.care_home, None),
-        ("1-000000009", None, None, CareHome.care_home, None),
-        ("1-000000010", 0.0, 0, CareHome.care_home, None),
-        ("1-000000011", 4.0, 10, CareHome.not_care_home, None),
-    ]
 
 
 @dataclass

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -3176,14 +3176,14 @@ class WinsorizeCareHomeFilledPostsPerBedRatioOutliersData:
     ]
 
     winsorize_outliers_rows = [
-        ("1", 9.0, 15, 0.6, 1.0, 5.0),
-        ("2", 30.0, 15, 2.0, 1.0, 5.0),
-        ("3", 90.0, 15, 6.0, 1.0, 5.0),
+        ("1", CareHome.care_home, 9.0, 15, 0.6, 1.0, 5.0),
+        ("2", CareHome.care_home, 30.0, 15, 2.0, 1.0, 5.0),
+        ("3", CareHome.care_home, 90.0, 15, 6.0, 1.0, 5.0),
     ]
     expected_winsorize_outliers_rows = [
-        ("1", 15.0, 15, 1.0, 1.0, 5.0),
-        ("2", 30.0, 15, 2.0, 1.0, 5.0),
-        ("3", 75.0, 15, 5.0, 1.0, 5.0),
+        ("1", CareHome.care_home, 15.0, 15, 1.0, 1.0, 5.0),
+        ("2", CareHome.care_home, 30.0, 15, 2.0, 1.0, 5.0),
+        ("3", CareHome.care_home, 75.0, 15, 5.0, 1.0, 5.0),
     ]
 
     set_minimum_permitted_ratio_rows = [

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -2385,7 +2385,7 @@ class CleaningUtilsData:
             None,
         ),
     ]
-    
+
     filled_posts_per_bed_ratio_rows = [
         ("1-000000001", 5.0, 100, CareHome.care_home),
         ("1-000000002", 2.0, 1, CareHome.care_home),
@@ -2671,7 +2671,6 @@ class CleanIndCQCData:
         ("2", 3, date(2024, 1, 1), 3),
         ("2", 3, date(2024, 2, 1), None),
     ]
-
 
 
 @dataclass

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -1230,6 +1230,21 @@ class CleaningUtilsSchemas:
         ]
     )
 
+    filled_posts_per_bed_ratio_schema = StructType(
+        [
+            StructField(IndCQC.location_id, StringType(), True),
+            StructField(IndCQC.ascwds_filled_posts_dedup, DoubleType(), True),
+            StructField(IndCQC.number_of_beds, IntegerType(), True),
+            StructField(IndCQC.care_home, StringType(), True),
+        ]
+    )
+    expected_filled_posts_per_bed_ratio_schema = StructType(
+        [
+            *filled_posts_per_bed_ratio_schema,
+            StructField(IndCQC.filled_posts_per_bed_ratio, DoubleType(), True),
+        ]
+    )
+
 
 @dataclass
 class CQCProviderSchema:
@@ -1566,21 +1581,6 @@ class CleanIndCQCData:
             StructField("integer_column", IntegerType(), True),
             StructField(IndCQC.cqc_location_import_date, DateType(), True),
             StructField("integer_column_deduplicated", IntegerType(), True),
-        ]
-    )
-
-    filled_posts_per_bed_ratio_schema = StructType(
-        [
-            StructField(IndCQC.location_id, StringType(), True),
-            StructField(IndCQC.ascwds_filled_posts_dedup, DoubleType(), True),
-            StructField(IndCQC.number_of_beds, IntegerType(), True),
-            StructField(IndCQC.care_home, StringType(), True),
-        ]
-    )
-    expected_filled_posts_per_bed_ratio_schema = StructType(
-        [
-            *filled_posts_per_bed_ratio_schema,
-            StructField(IndCQC.filled_posts_per_bed_ratio, DoubleType(), True),
         ]
     )
 

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -2003,6 +2003,7 @@ class WinsorizeCareHomeFilledPostsPerBedRatioOutliersSchema:
     winsorize_outliers_schema = StructType(
         [
             StructField(IndCQC.location_id, StringType(), True),
+            StructField(IndCQC.care_home, StringType(), True),
             StructField(IndCQC.ascwds_filled_posts_dedup_clean, FloatType(), True),
             StructField(IndCQC.number_of_beds, IntegerType(), True),
             StructField(IndCQC.filled_posts_per_bed_ratio, FloatType(), True),

--- a/tests/unit/test_clean_ind_cqc_filled_posts.py
+++ b/tests/unit/test_clean_ind_cqc_filled_posts.py
@@ -286,26 +286,5 @@ class AddColumnWithRepeatedValuesRemovedTests(CleanIndFilledPostsTests):
         self.assertEqual(self.returned_df.count(), self.test_purge_outdated_df.count())
 
 
-class CalculateFilledPostsPerBedRatioTests(CleanIndFilledPostsTests):
-    def setUp(self) -> None:
-        super().setUp()
-
-    def test_calculate_filled_posts_per_bed_ratio(self):
-        test_df = self.spark.createDataFrame(
-            Data.filled_posts_per_bed_ratio_rows,
-            Schemas.filled_posts_per_bed_ratio_schema,
-        )
-        returned_df = job.calculate_filled_posts_per_bed_ratio(
-            test_df, IndCQC.ascwds_filled_posts_dedup
-        )
-        expected_df = self.spark.createDataFrame(
-            Data.expected_filled_posts_per_bed_ratio_rows,
-            Schemas.expected_filled_posts_per_bed_ratio_schema,
-        )
-        self.assertEqual(
-            returned_df.sort(IndCQC.location_id).collect(), expected_df.collect()
-        )
-
-
 if __name__ == "__main__":
     unittest.main(warnings="ignore")

--- a/tests/unit/test_cleaning_utils.py
+++ b/tests/unit/test_cleaning_utils.py
@@ -641,9 +641,9 @@ class CastToIntTests(unittest.TestCase):
         self.assertEqual(expected_data, returned_data)
 
 
-class CalculateFilledPostsPerBedRatioTests(CleanIndFilledPostsTests):
+class CalculateFilledPostsPerBedRatioTests(unittest.TestCase):
     def setUp(self) -> None:
-        super().setUp()
+        self.spark = utils.get_spark()
 
     def test_calculate_filled_posts_per_bed_ratio(self):
         test_df = self.spark.createDataFrame(

--- a/tests/unit/test_cleaning_utils.py
+++ b/tests/unit/test_cleaning_utils.py
@@ -639,3 +639,24 @@ class CastToIntTests(unittest.TestCase):
         ).collect()
 
         self.assertEqual(expected_data, returned_data)
+
+
+class CalculateFilledPostsPerBedRatioTests(CleanIndFilledPostsTests):
+    def setUp(self) -> None:
+        super().setUp()
+
+    def test_calculate_filled_posts_per_bed_ratio(self):
+        test_df = self.spark.createDataFrame(
+            Data.filled_posts_per_bed_ratio_rows,
+            Schemas.filled_posts_per_bed_ratio_schema,
+        )
+        returned_df = job.calculate_filled_posts_per_bed_ratio(
+            test_df, IndCQC.ascwds_filled_posts_dedup
+        )
+        expected_df = self.spark.createDataFrame(
+            Data.expected_filled_posts_per_bed_ratio_rows,
+            Schemas.expected_filled_posts_per_bed_ratio_schema,
+        )
+        self.assertEqual(
+            returned_df.sort(IndCQC.location_id).collect(), expected_df.collect()
+        )

--- a/utils/cleaning_utils.py
+++ b/utils/cleaning_utils.py
@@ -5,7 +5,11 @@ from pyspark.sql import (
 )
 from pyspark.sql.types import IntegerType
 
-from utils.column_names.ind_cqc_pipeline_columns import PartitionKeys as Keys
+from utils.column_names.ind_cqc_pipeline_columns import (
+    PartitionKeys as Keys,
+    IndCqcColumns as IndCQC,
+)
+from utils.column_values.categorical_column_values import CareHome
 
 key: str = "key"
 value: str = "value"

--- a/utils/cleaning_utils.py
+++ b/utils/cleaning_utils.py
@@ -201,3 +201,26 @@ def cast_to_int(df: DataFrame, column_names: list) -> DataFrame:
     for column in column_names:
         df = df.withColumn(column, df[column].cast(IntegerType()))
     return df
+
+
+def calculate_filled_posts_per_bed_ratio(
+    input_df: DataFrame, filled_posts_column: str
+) -> DataFrame:
+    """
+    Add a column with the filled post per bed ratio for care homes.
+
+    Args:
+        input_df (DataFrame): A dataframe containing the given column, care_home and numberofbeds.
+        filled_posts_column (str): The name of the column to use for calculating the ratio.
+
+    Returns (DataFrame): The same dataframe with an additional column contianing the filled posts per bed ratio for care homes.
+    """
+    input_df = input_df.withColumn(
+        IndCQC.filled_posts_per_bed_ratio,
+        F.when(
+            F.col(IndCQC.care_home) == CareHome.care_home,
+            F.col(filled_posts_column) / F.col(IndCQC.number_of_beds),
+        ),
+    )
+
+    return input_df

--- a/utils/ind_cqc_filled_posts_utils/clean_ascwds_filled_post_outliers/null_grouped_providers.py
+++ b/utils/ind_cqc_filled_posts_utils/clean_ascwds_filled_post_outliers/null_grouped_providers.py
@@ -2,6 +2,7 @@ from dataclasses import dataclass
 
 from pyspark.sql import DataFrame, functions as F, Window
 
+import utils.cleaning_utils as cUtils
 from utils.column_names.ind_cqc_pipeline_columns import (
     IndCqcColumns as IndCQC,
 )
@@ -164,10 +165,8 @@ def null_care_home_grouped_providers(df: DataFrame) -> DataFrame:
         ).otherwise(F.col(IndCQC.ascwds_filled_posts_dedup_clean)),
     )
 
-    # TODO create a generic function to recalculate the ratio following filled post amendments (we recalculate the ratio several times during the filtering process)
-    df = df.withColumn(
-        IndCQC.filled_posts_per_bed_ratio,
-        F.col(IndCQC.ascwds_filled_posts_dedup_clean) / F.col(IndCQC.number_of_beds),
+    df = cUtils.calculate_filled_posts_per_bed_ratio(
+        df, IndCQC.ascwds_filled_posts_dedup_clean
     )
 
     df = update_filtering_rule(

--- a/utils/ind_cqc_filled_posts_utils/clean_ascwds_filled_post_outliers/winsorize_care_home_filled_posts_per_bed_ratio_outliers.py
+++ b/utils/ind_cqc_filled_posts_utils/clean_ascwds_filled_post_outliers/winsorize_care_home_filled_posts_per_bed_ratio_outliers.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass
 from pyspark.sql import DataFrame, functions as F
 from pyspark.ml.feature import Bucketizer
 
+import utils.cleaning_utils as cUtils
 from utils.column_names.ind_cqc_pipeline_columns import (
     IndCqcColumns as IndCQC,
 )
@@ -431,9 +432,8 @@ def winsorize_outliers(
         .otherwise(F.col(IndCQC.ascwds_filled_posts_dedup_clean)),
     )
 
-    winsorized_df = winsorized_df.withColumn(
-        IndCQC.filled_posts_per_bed_ratio,
-        F.col(IndCQC.ascwds_filled_posts_dedup_clean) / F.col(IndCQC.number_of_beds),
+    winsorized_df = cUtils.calculate_filled_posts_per_bed_ratio(
+        winsorized_df, IndCQC.ascwds_filled_posts_dedup_clean
     )
 
     return winsorized_df


### PR DESCRIPTION
# Description
Move function to calculate beds ratio into cleaning utils
Apply function throughout filtering scripts

# How to test
Unit tests passing
Run in branch: https://eu-west-2.console.aws.amazon.com/states/home?region=eu-west-2#/v2/executions/details/arn:aws:states:eu-west-2:344210435447:execution:generalise-calculate-beds-rati-Ind-CQC-Filled-Post-Estimates-Pipeline:b23ce126-cbcf-4b08-8eba-926e89db0f01

# Developer checklist
- [x] Unit test
- [x] Linked to Trello ticket: https://trello.com/c/t7clsYSf/770-write-generic-function-to-recalculate-ratio-based-on-a-filter-nulling-winsorizing-filled-posts
- [x] Documentation up to date
