### PR TITLE
Remove original pir col from estimates job

### DIFF
--- a/utils/validation/validation_rules/estimated_ind_cqc_filled_posts_validation_rules.py
+++ b/utils/validation/validation_rules/estimated_ind_cqc_filled_posts_validation_rules.py
@@ -32,29 +32,27 @@ class EstimatedIndCqcFilledPostsValidationRules:
             IndCqcColumns.cqc_location_import_date,
         ],
         RuleName.min_values: {
-            IndCqcColumns.number_of_beds: 1,
-            IndCqcColumns.people_directly_employed: 1,
-            IndCqcColumns.unix_time: 1262304000,  # 1st Jan 2010 in unix time
-            IndCqcColumns.estimate_filled_posts: 1.0,
-            IndCqcColumns.people_directly_employed_dedup: 1,
             IndCqcColumns.ascwds_filled_posts: 1.0,
             IndCqcColumns.ascwds_filled_posts_dedup_clean: 1.0,
+            IndCqcColumns.estimate_filled_posts: 1.0,
             IndCqcColumns.interpolation_model: 0.0,
+            IndCqcColumns.number_of_beds: 1,
+            IndCqcColumns.people_directly_employed_dedup: 1,
+            IndCqcColumns.unix_time: 1262304000,  # 1st Jan 2010 in unix time
         },
         RuleName.max_values: {
-            IndCqcColumns.number_of_beds: 500,
-            IndCqcColumns.people_directly_employed: 10000,
-            IndCqcColumns.unix_time: int(time.time()),  # current unix time
-            # IndCqcColumns.estimate_filled_posts: 3000.0, # temporarily removed until non res models are fixed
-            IndCqcColumns.people_directly_employed_dedup: 10000,
             IndCqcColumns.ascwds_filled_posts: 3000.0,
             IndCqcColumns.ascwds_filled_posts_dedup_clean: 3000.0,
-            IndCqcColumns.extrapolation_care_home_model: 3000.0,
-            IndCqcColumns.interpolation_model: 3000.0,
             IndCqcColumns.care_home_model: 3000.0,
+            # IndCqcColumns.estimate_filled_posts: 3000.0, # temporarily removed until non res models are fixed
+            IndCqcColumns.extrapolation_care_home_model: 3000.0,
+            # IndCqcColumns.extrapolation_non_res_with_dormancy_model: 3000.0, # temporarily removed until non res models are fixed
+            IndCqcColumns.interpolation_model: 3000.0,
             IndCqcColumns.non_res_with_dormancy_model: 3000.0,
             IndCqcColumns.non_res_without_dormancy_model: 3000.0,
-            # IndCqcColumns.extrapolation_non_res_with_dormancy_model: 3000.0, # temporarily removed until non res models are fixed
+            IndCqcColumns.number_of_beds: 500,
+            IndCqcColumns.people_directly_employed_dedup: 10000,
+            IndCqcColumns.unix_time: int(time.time()),  # current unix time
         },
         RuleName.categorical_values_in_columns: {
             IndCqcColumns.care_home: CatValues.care_home_column_values.categorical_values,


### PR DESCRIPTION
# Description
Removed the validation in the estimates job for people_directly_employed as that column is no longer in the dataset (we still validate for people_directly_employed_dedup)

Also alphabetised list, just find it easier!
