### PR TITLE
Amend non res feature validation size check to match the job filtering

### DIFF
--- a/jobs/validate_non_res_ascwds_inc_dormancy_ind_cqc_features_data.py
+++ b/jobs/validate_non_res_ascwds_inc_dormancy_ind_cqc_features_data.py
@@ -26,6 +26,7 @@ cleaned_ind_cqc_columns_to_import = [
     IndCQC.location_id,
     IndCQC.care_home,
     IndCQC.dormancy,
+    IndCQC.imputed_gac_service_types,
 ]
 
 
@@ -76,6 +77,7 @@ def calculate_expected_size_of_non_res_ascwds_inc_dormancy_ind_cqc_features_data
     expected_size = cleaned_ind_cqc_df.where(
         (cleaned_ind_cqc_df[IndCQC.care_home] == CareHome.not_care_home)
         & (cleaned_ind_cqc_df[IndCQC.dormancy].isNotNull())
+        & (cleaned_ind_cqc_df[IndCQC.imputed_gac_service_types].isNotNull())
     ).count()
     return expected_size
 

--- a/jobs/validate_non_res_ascwds_inc_dormancy_ind_cqc_features_data.py
+++ b/jobs/validate_non_res_ascwds_inc_dormancy_ind_cqc_features_data.py
@@ -1,8 +1,6 @@
 import os
 import sys
 
-os.environ["SPARK_VERSION"] = "3.3"
-
 from pyspark.sql.dataframe import DataFrame
 
 from utils import utils
@@ -10,9 +8,7 @@ from utils.column_names.ind_cqc_pipeline_columns import (
     IndCqcColumns as IndCQC,
     PartitionKeys as Keys,
 )
-from utils.column_values.categorical_column_values import (
-    CareHome,
-)
+from utils.column_values.categorical_column_values import CareHome
 from utils.validation.validation_rules.non_res_ascwds_inc_dormancy_ind_cqc_features_validation_rules import (
     NonResASCWDSIncDormancyIndCqcFeaturesValidationRules as Rules,
 )
@@ -22,6 +18,7 @@ from utils.validation.validation_utils import (
 )
 from utils.validation.validation_rule_names import RuleNames as RuleName
 
+os.environ["SPARK_VERSION"] = "3.3"
 PartitionKeys = [Keys.year, Keys.month, Keys.day, Keys.import_date]
 
 cleaned_ind_cqc_columns_to_import = [

--- a/jobs/validate_non_res_ascwds_without_dormancy_ind_cqc_features_data.py
+++ b/jobs/validate_non_res_ascwds_without_dormancy_ind_cqc_features_data.py
@@ -1,8 +1,6 @@
 import os
 import sys
 
-os.environ["SPARK_VERSION"] = "3.3"
-
 from pyspark.sql.dataframe import DataFrame
 
 from utils import utils
@@ -10,9 +8,7 @@ from utils.column_names.ind_cqc_pipeline_columns import (
     IndCqcColumns as IndCQC,
     PartitionKeys as Keys,
 )
-from utils.column_values.categorical_column_values import (
-    CareHome,
-)
+from utils.column_values.categorical_column_values import CareHome
 from utils.validation.validation_rules.non_res_ascwds_without_dormancy_ind_cqc_features_validation_rules import (
     NonResASCWDSWithoutDormancyIndCqcFeaturesValidationRules as Rules,
 )
@@ -22,6 +18,7 @@ from utils.validation.validation_utils import (
 )
 from utils.validation.validation_rule_names import RuleNames as RuleName
 
+os.environ["SPARK_VERSION"] = "3.3"
 PartitionKeys = [Keys.year, Keys.month, Keys.day, Keys.import_date]
 
 cleaned_ind_cqc_columns_to_import = [

--- a/jobs/validate_non_res_ascwds_without_dormancy_ind_cqc_features_data.py
+++ b/jobs/validate_non_res_ascwds_without_dormancy_ind_cqc_features_data.py
@@ -26,6 +26,7 @@ cleaned_ind_cqc_columns_to_import = [
     IndCQC.location_id,
     IndCQC.care_home,
     IndCQC.dormancy,
+    IndCQC.imputed_gac_service_types,
 ]
 
 
@@ -75,6 +76,7 @@ def calculate_expected_size_of_non_res_ascwds_without_dormancy_ind_cqc_features_
     """
     expected_size = cleaned_ind_cqc_df.where(
         (cleaned_ind_cqc_df[IndCQC.care_home] == CareHome.not_care_home)
+        & (cleaned_ind_cqc_df[IndCQC.imputed_gac_service_types].isNotNull())
     ).count()
     return expected_size
 

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -5899,10 +5899,10 @@ class ValidateCareHomeIndCqcFeaturesData:
 class ValidateNonResASCWDSIncDormancyIndCqcFeaturesData:
     # fmt: off
     cleaned_ind_cqc_rows = [
-        ("1-000000001", date(2024, 1, 1), CareHome.not_care_home, "Y"),
-        ("1-000000002", date(2024, 1, 1), CareHome.not_care_home, "Y"),
-        ("1-000000001", date(2024, 1, 9), CareHome.not_care_home, "Y"),
-        ("1-000000002", date(2024, 1, 9), CareHome.not_care_home, "Y"),
+        ("1-000000001", date(2024, 1, 1), CareHome.not_care_home, "Y", [{"name": "Name", "description": "Desc"}]),
+        ("1-000000002", date(2024, 1, 1), CareHome.not_care_home, "N", [{"name": "Name", "description": "Desc"}]),
+        ("1-000000001", date(2024, 1, 9), CareHome.not_care_home, "Y", [{"name": "Name", "description": "Desc"}]),
+        ("1-000000002", date(2024, 1, 9), CareHome.not_care_home, "N", [{"name": "Name", "description": "Desc"}]),
     ]
 
     non_res_ascwds_inc_dormancy_ind_cqc_features_rows = [
@@ -5913,18 +5913,18 @@ class ValidateNonResASCWDSIncDormancyIndCqcFeaturesData:
     ]
 
     calculate_expected_size_rows = [
-        ("1-000000001", date(2024, 1, 1), CareHome.care_home, "Y"),
-        ("1-000000002", date(2024, 1, 1), CareHome.care_home, "Y"),
-        ("1-000000001", date(2024, 1, 9), CareHome.not_care_home, "Y"),
-        ("1-000000002", date(2024, 1, 9), None, "Y"),
-        ("1-000000003", date(2024, 1, 1), CareHome.care_home, "N"),
-        ("1-000000004", date(2024, 1, 1), CareHome.care_home, "N"),
-        ("1-000000003", date(2024, 1, 9), CareHome.not_care_home, "N"),
-        ("1-000000004", date(2024, 1, 9), None, "N"),
-        ("1-000000005", date(2024, 1, 1), CareHome.care_home, None),
-        ("1-000000006", date(2024, 1, 1), CareHome.care_home, None),
-        ("1-000000005", date(2024, 1, 9), CareHome.not_care_home, None),
-        ("1-000000006", date(2024, 1, 9), None, None),
+        ("1-000000001", date(2024, 1, 1), CareHome.care_home, "Y", [{"name": "Name", "description": "Desc"}]),
+        ("1-000000002", date(2024, 1, 1), CareHome.care_home, None, [{"name": "Name", "description": "Desc"}]),
+        ("1-000000003", date(2024, 1, 1), CareHome.care_home, "Y", None),
+        ("1-000000004", date(2024, 1, 1), CareHome.care_home, None, None),
+        ("1-000000005", date(2024, 1, 1), CareHome.not_care_home, "Y", [{"name": "Name", "description": "Desc"}]),
+        ("1-000000006", date(2024, 1, 1), CareHome.not_care_home, None, [{"name": "Name", "description": "Desc"}]),
+        ("1-000000007", date(2024, 1, 1), CareHome.not_care_home, "Y", None),
+        ("1-000000008", date(2024, 1, 1), CareHome.not_care_home, None, None),
+        ("1-000000009", date(2024, 1, 1), None, "Y", [{"name": "Name", "description": "Desc"}]),
+        ("1-000000010", date(2024, 1, 1), None, None, [{"name": "Name", "description": "Desc"}]),
+        ("1-000000011", date(2024, 1, 1), None, "Y", None),
+        ("1-000000012", date(2024, 1, 1), None, None, None),
     ]
     # fmt: on
 
@@ -5933,10 +5933,10 @@ class ValidateNonResASCWDSIncDormancyIndCqcFeaturesData:
 class ValidateNonResASCWDSWithoutDormancyIndCqcFeaturesData:
     # fmt: off
     cleaned_ind_cqc_rows = [
-        ("1-000000001", date(2024, 1, 1), CareHome.not_care_home, None),
-        ("1-000000002", date(2024, 1, 1), CareHome.not_care_home, None),
-        ("1-000000001", date(2024, 1, 9), CareHome.not_care_home, None),
-        ("1-000000002", date(2024, 1, 9), CareHome.not_care_home, None),
+        ("1-000000001", date(2024, 1, 1), CareHome.not_care_home, "Y", [{"name": "Name", "description": "Desc"}]),
+        ("1-000000002", date(2024, 1, 1), CareHome.not_care_home, "Y", [{"name": "Name", "description": "Desc"}]),
+        ("1-000000001", date(2024, 1, 9), CareHome.not_care_home, None, [{"name": "Name", "description": "Desc"}]),
+        ("1-000000002", date(2024, 1, 9), CareHome.not_care_home, None, [{"name": "Name", "description": "Desc"}]),
     ]
 
     non_res_ascwds_without_dormancy_ind_cqc_features_rows = [
@@ -5947,18 +5947,18 @@ class ValidateNonResASCWDSWithoutDormancyIndCqcFeaturesData:
     ]
 
     calculate_expected_size_rows = [
-        ("1-000000001", date(2024, 1, 1), CareHome.care_home, "Y"),
-        ("1-000000002", date(2024, 1, 1), CareHome.care_home, "Y"),
-        ("1-000000001", date(2024, 1, 9), CareHome.not_care_home, "Y"),
-        ("1-000000002", date(2024, 1, 9), None, "Y"),
-        ("1-000000003", date(2024, 1, 1), CareHome.care_home, "N"),
-        ("1-000000004", date(2024, 1, 1), CareHome.care_home, "N"),
-        ("1-000000003", date(2024, 1, 9), CareHome.not_care_home, "N"),
-        ("1-000000004", date(2024, 1, 9), None, "N"),
-        ("1-000000005", date(2024, 1, 1), CareHome.care_home, None),
-        ("1-000000006", date(2024, 1, 1), CareHome.care_home, None),
-        ("1-000000005", date(2024, 1, 9), CareHome.not_care_home, None),
-        ("1-000000006", date(2024, 1, 9), None, None),
+        ("1-000000001", date(2024, 1, 1), CareHome.care_home, "Y", [{"name": "Name", "description": "Desc"}]),
+        ("1-000000002", date(2024, 1, 1), CareHome.care_home, None, [{"name": "Name", "description": "Desc"}]),
+        ("1-000000003", date(2024, 1, 1), CareHome.care_home, "Y", None),
+        ("1-000000004", date(2024, 1, 1), CareHome.care_home, None, None),
+        ("1-000000005", date(2024, 1, 1), CareHome.not_care_home, "Y", [{"name": "Name", "description": "Desc"}]),
+        ("1-000000006", date(2024, 1, 1), CareHome.not_care_home, None, [{"name": "Name", "description": "Desc"}]),
+        ("1-000000007", date(2024, 1, 1), CareHome.not_care_home, "Y", None),
+        ("1-000000008", date(2024, 1, 1), CareHome.not_care_home, None, None),
+        ("1-000000009", date(2024, 1, 1), None, "Y", [{"name": "Name", "description": "Desc"}]),
+        ("1-000000010", date(2024, 1, 1), None, None, [{"name": "Name", "description": "Desc"}]),
+        ("1-000000011", date(2024, 1, 1), None, "Y", None),
+        ("1-000000012", date(2024, 1, 1), None, None, None),
     ]
     # fmt: on
 

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -3870,6 +3870,17 @@ class ValidateNonResASCWDSIndCqcFeaturesSchema:
             StructField(IndCQC.cqc_location_import_date, DateType(), True),
             StructField(IndCQC.care_home, StringType(), True),
             StructField(IndCQC.dormancy, StringType(), True),
+            StructField(
+                IndCQC.imputed_gac_service_types,
+                ArrayType(
+                    StructType(
+                        [
+                            StructField(CQCL.name, StringType(), True),
+                            StructField(CQCL.description, StringType(), True),
+                        ]
+                    )
+                ),
+            ),
         ]
     )
     non_res_ascwds_ind_cqc_features_schema = StructType(

--- a/tests/unit/test_validate_non_res_ascwds_inc_dormancy_ind_cqc_features.py
+++ b/tests/unit/test_validate_non_res_ascwds_inc_dormancy_ind_cqc_features.py
@@ -76,7 +76,7 @@ class CalculateExpectedSizeofDataset(
         test_df = self.spark.createDataFrame(
             Data.calculate_expected_size_rows, Schemas.calculate_expected_size_schema
         )
-        expected_row_count = 2
+        expected_row_count = 1
         returned_row_count = job.calculate_expected_size_of_non_res_ascwds_inc_dormancy_ind_cqc_features_dataset(
             test_df
         )

--- a/tests/unit/test_validate_non_res_ascwds_without_dormancy_ind_cqc_features.py
+++ b/tests/unit/test_validate_non_res_ascwds_without_dormancy_ind_cqc_features.py
@@ -76,7 +76,7 @@ class CalculateExpectedSizeofDataset(
         test_df = self.spark.createDataFrame(
             Data.calculate_expected_size_rows, Schemas.calculate_expected_size_schema
         )
-        expected_row_count = 3
+        expected_row_count = 2
         returned_row_count = job.calculate_expected_size_of_non_res_ascwds_without_dormancy_ind_cqc_features_dataset(
             test_df
         )

--- a/utils/column_names/ind_cqc_pipeline_columns.py
+++ b/utils/column_names/ind_cqc_pipeline_columns.py
@@ -111,6 +111,7 @@ class IndCqcColumns:
     first_submission_time: str = "first_submission_time"
     gac_service_types: str = CQCLClean.gac_service_types
     import_month_index: str = "import_month_index"
+    imputed_gac_service_types: str = CQCLClean.imputed_gac_service_types
     imputed_registration_date: str = CQCLClean.imputed_registration_date
     interpolation_model: str = "interpolation_model"
     interpolation_model_ascwds_filled_posts_dedup_clean: str = (


### PR DESCRIPTION
# Description
Branch data currently failing validations as services which have never been known are all nulled, and the features script removes null rows from the data. This additional non-null filter ensure that the size will match the expected size

Branch now completing validations

# How to test
[branch run](https://eu-west-2.console.aws.amazon.com/states/home?region=eu-west-2#/v2/executions/details/arn:aws:states:eu-west-2:344210435447:execution:amend-non-res-validation-size-Ind-CQC-Filled-Post-Estimates-Pipeline:d43f3c00-7814-4ec0-b676-b130f2bc50f1)

[trello ticket](https://trello.com/c/vxXoP7fa/778-filter-null-services-from-non-res-validation-size-check)

# Developer checklist
- [X] Unit test
- [X] Linked to Trello ticket
- [X] Documentation up to date
