### PR TITLE
Set column bounds for non res ct data

### DIFF
--- a/jobs/clean_capacity_tracker_non_res_data.py
+++ b/jobs/clean_capacity_tracker_non_res_data.py
@@ -17,6 +17,7 @@ CAPACITY_TRACKER_NON_RES_COLUMNS = [
     Keys.day,
     Keys.import_date,
 ]
+OUTLIER_CUTOFF = 5000
 
 
 def main(
@@ -36,6 +37,13 @@ def main(
         capacity_tracker_non_res_df,
         Keys.import_date,
         CTNRClean.capacity_tracker_import_date,
+    )
+    columns_to_bound = [CTNR.cqc_care_workers_employed, CTNR.service_user_count]
+    capacity_tracker_non_res_df = cUtils.set_bounds_for_columns(
+        capacity_tracker_non_res_df,
+        columns_to_bound,
+        columns_to_bound,
+        upper_limit=OUTLIER_CUTOFF,
     )
 
     print(f"Exporting as parquet to {cleaned_capacity_tracker_non_res_destination}")


### PR DESCRIPTION
# Description
Cap capacity tracker data in columns used for diagnostics.

# How to test
Unit tests passing
Run in branch: https://eu-west-2.console.aws.amazon.com/states/home?region=eu-west-2#/v2/executions/details/arn:aws:states:eu-west-2:344210435447:execution:ct-non-res-cleaning-IngestAndCleanCapacityTrackerDataPipeline:e488beb9-6598-4cd7-aa29-1dd63bc95419
Max values in cleaned columns in athena are below capped values

# Developer checklist
- [x] Unit test
- [x] Linked to Trello ticket: https://trello.com/c/wwhvyeZb/798-bound-non-res-capacity-tracker-data
- [x] Documentation up to date
