### PR TITLE
Renamed 'last' to 'final'

### DIFF
--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -2538,18 +2538,18 @@ class ModelExtrapolationNew:
         ]
     )
 
-    first_and_last_submission_dates_schema = StructType(
+    first_and_final_submission_dates_schema = StructType(
         [
             StructField(IndCQC.location_id, StringType(), False),
             StructField(IndCQC.unix_time, IntegerType(), False),
             StructField(IndCQC.ascwds_filled_posts_dedup_clean, DoubleType(), True),
         ]
     )
-    expected_first_and_last_submission_dates_schema = StructType(
+    expected_first_and_final_submission_dates_schema = StructType(
         [
-            *first_and_last_submission_dates_schema,
+            *first_and_final_submission_dates_schema,
             StructField(IndCQC.first_submission_time, IntegerType(), True),
-            StructField(IndCQC.last_submission_time, IntegerType(), True),
+            StructField(IndCQC.final_submission_time, IntegerType(), True),
         ]
     )
 
@@ -2581,7 +2581,7 @@ class ModelExtrapolationNew:
             StructField(IndCQC.unix_time, IntegerType(), False),
             StructField(IndCQC.ascwds_filled_posts_dedup_clean, FloatType(), True),
             StructField(IndCQC.first_submission_time, IntegerType(), True),
-            StructField(IndCQC.last_submission_time, IntegerType(), True),
+            StructField(IndCQC.final_submission_time, IntegerType(), True),
             StructField(IndCQC.rolling_average_model, FloatType(), False),
         ]
     )
@@ -2605,7 +2605,7 @@ class ModelExtrapolationNew:
             StructField(IndCQC.unix_time, IntegerType(), False),
             StructField(IndCQC.ascwds_filled_posts_dedup_clean, FloatType(), True),
             StructField(IndCQC.first_submission_time, IntegerType(), True),
-            StructField(IndCQC.last_submission_time, IntegerType(), True),
+            StructField(IndCQC.final_submission_time, IntegerType(), True),
             StructField(IndCQC.extrapolation_forwards, FloatType(), True),
             StructField(IndCQC.extrapolation_backwards, FloatType(), True),
         ]
@@ -2666,11 +2666,11 @@ class ModelExtrapolation:
         [
             StructField(IndCQC.location_id, StringType(), False),
             StructField(IndCQC.cqc_location_import_date, StringType(), False),
-            StructField(IndCQC.unix_time, LongType(), False),
+            StructField(IndCQC.unix_time, IntegerType(), False),
             StructField(IndCQC.ascwds_filled_posts_dedup_clean, DoubleType(), True),
             StructField(IndCQC.rolling_average_model, DoubleType(), True),
-            StructField(IndCQC.first_submission_time, LongType(), False),
-            StructField(IndCQC.last_submission_time, LongType(), False),
+            StructField(IndCQC.first_submission_time, IntegerType(), False),
+            StructField(IndCQC.final_submission_time, IntegerType(), False),
             StructField(IndCQC.first_filled_posts, DoubleType(), True),
             StructField(IndCQC.first_rolling_average, DoubleType(), True),
             StructField(IndCQC.last_filled_posts, DoubleType(), True),
@@ -2681,16 +2681,16 @@ class ModelExtrapolation:
         [
             StructField(IndCQC.location_id, StringType(), False),
             StructField(IndCQC.cqc_location_import_date, StringType(), False),
-            StructField(IndCQC.unix_time, LongType(), False),
+            StructField(IndCQC.unix_time, IntegerType(), False),
         ]
     )
     extrapolated_ratios_schema = StructType(
         [
             StructField(IndCQC.location_id, StringType(), False),
-            StructField(IndCQC.unix_time, LongType(), False),
+            StructField(IndCQC.unix_time, IntegerType(), False),
             StructField(IndCQC.rolling_average_model, DoubleType(), True),
-            StructField(IndCQC.first_submission_time, LongType(), False),
-            StructField(IndCQC.last_submission_time, LongType(), False),
+            StructField(IndCQC.first_submission_time, IntegerType(), False),
+            StructField(IndCQC.final_submission_time, IntegerType(), False),
             StructField(IndCQC.first_rolling_average, DoubleType(), True),
             StructField(IndCQC.last_rolling_average, DoubleType(), True),
         ]
@@ -2699,10 +2699,10 @@ class ModelExtrapolation:
         [
             StructField(IndCQC.location_id, StringType(), False),
             StructField(IndCQC.cqc_location_import_date, StringType(), False),
-            StructField(IndCQC.unix_time, LongType(), False),
+            StructField(IndCQC.unix_time, IntegerType(), False),
             StructField(IndCQC.rolling_average_model, DoubleType(), True),
-            StructField(IndCQC.first_submission_time, LongType(), False),
-            StructField(IndCQC.last_submission_time, LongType(), False),
+            StructField(IndCQC.first_submission_time, IntegerType(), False),
+            StructField(IndCQC.final_submission_time, IntegerType(), False),
             StructField(IndCQC.first_filled_posts, DoubleType(), True),
             StructField(IndCQC.last_filled_posts, DoubleType(), True),
             StructField(IndCQC.extrapolation_ratio, DoubleType(), True),
@@ -2901,8 +2901,8 @@ class ModelInterpolation:
     creating_timeseries_schema = StructType(
         [
             StructField(IndCQC.location_id, StringType(), True),
-            StructField(IndCQC.first_submission_time, LongType(), False),
-            StructField(IndCQC.last_submission_time, LongType(), True),
+            StructField(IndCQC.first_submission_time, IntegerType(), False),
+            StructField(IndCQC.final_submission_time, IntegerType(), True),
         ]
     )
     merging_exploded_data_schema = StructType(

--- a/tests/unit/test_extrapolation.py
+++ b/tests/unit/test_extrapolation.py
@@ -131,13 +131,13 @@ class TestModelExtrapolation(unittest.TestCase):
 
         output_df = output_df.sort(IndCqc.location_id, IndCqc.unix_time).collect()
         self.assertEqual(output_df[0][IndCqc.first_submission_time], 1675209600)
-        self.assertEqual(output_df[0][IndCqc.last_submission_time], 1675209600)
+        self.assertEqual(output_df[0][IndCqc.final_submission_time], 1675209600)
         self.assertEqual(output_df[2][IndCqc.first_submission_time], 1675209600)
-        self.assertEqual(output_df[2][IndCqc.last_submission_time], 1675209600)
+        self.assertEqual(output_df[2][IndCqc.final_submission_time], 1675209600)
         self.assertEqual(output_df[3][IndCqc.first_submission_time], 1672531200)
-        self.assertEqual(output_df[3][IndCqc.last_submission_time], 1675209600)
+        self.assertEqual(output_df[3][IndCqc.final_submission_time], 1675209600)
         self.assertEqual(output_df[5][IndCqc.first_submission_time], 1672531200)
-        self.assertEqual(output_df[5][IndCqc.last_submission_time], 1675209600)
+        self.assertEqual(output_df[5][IndCqc.final_submission_time], 1675209600)
 
     def test_add_filled_posts_and_model_value_for_first_and_last_submission(
         self,

--- a/tests/unit/test_interpolation.py
+++ b/tests/unit/test_interpolation.py
@@ -112,15 +112,15 @@ class TestModelInterpolation(unittest.TestCase):
             [
                 IndCqc.location_id,
                 IndCqc.first_submission_time,
-                IndCqc.last_submission_time,
+                IndCqc.final_submission_time,
             ],
         )
 
         output_df = output_df.sort(IndCqc.location_id).collect()
         self.assertEqual(output_df[0][IndCqc.first_submission_time], 1672617600)
-        self.assertEqual(output_df[0][IndCqc.last_submission_time], 1672617600)
+        self.assertEqual(output_df[0][IndCqc.final_submission_time], 1672617600)
         self.assertEqual(output_df[1][IndCqc.first_submission_time], 1672704000)
-        self.assertEqual(output_df[1][IndCqc.last_submission_time], 1673222400)
+        self.assertEqual(output_df[1][IndCqc.final_submission_time], 1673222400)
 
     def test_convert_first_and_last_known_years_into_exploded_df(self):
         df = job.convert_first_and_last_known_years_into_exploded_df(

--- a/utils/column_names/ind_cqc_pipeline_columns.py
+++ b/utils/column_names/ind_cqc_pipeline_columns.py
@@ -108,6 +108,7 @@ class IndCqcColumns:
     filled_posts_per_bed_ratio_within_std_resids: str = (
         "filled_posts_per_bed_ratio_within_std_resids"
     )
+    final_submission_time: str = "final_submission_time"
     first_filled_posts: str = "first_filled_posts"
     first_model_value: str = "first_model_value"
     first_non_null_value: str = "first_non_null_value"
@@ -126,7 +127,6 @@ class IndCqcColumns:
     )
     last_filled_posts: str = "last_filled_posts"
     last_rolling_average: str = "last_rolling_average"
-    last_submission_time: str = "last_submission_time"
     location_id: str = CQCLClean.location_id
     locations_at_provider_count: str = "locations_at_provider_count"
     locations_in_ascwds_at_provider_count: str = "locations_in_ascwds_at_provider_count"

--- a/utils/estimate_filled_posts/models/extrapolation.py
+++ b/utils/estimate_filled_posts/models/extrapolation.py
@@ -62,7 +62,7 @@ def add_filled_posts_and_model_value_for_first_and_last_submission(
 
     df = add_filled_posts_and_modelled_value_for_specific_time_period(
         df,
-        IndCqc.last_submission_time,
+        IndCqc.final_submission_time,
         IndCqc.last_filled_posts,
         model_column_name,
         last_model_column_name,
@@ -87,7 +87,7 @@ def add_first_and_last_submission_date_cols(df: DataFrame) -> DataFrame:
         IndCqc.location_id
     ).agg(
         F.min(IndCqc.unix_time).cast("integer").alias(IndCqc.first_submission_time),
-        F.max(IndCqc.unix_time).cast("integer").alias(IndCqc.last_submission_time),
+        F.max(IndCqc.unix_time).cast("integer").alias(IndCqc.final_submission_time),
     )
 
     return left_join_on_locationid(df, first_and_last_submission_date_df)
@@ -119,7 +119,7 @@ def add_extrapolated_values(
 ) -> DataFrame:
     df_with_extrapolation_models = extrapolation_df.where(
         (F.col(IndCqc.unix_time) < F.col(IndCqc.first_submission_time))
-        | (F.col(IndCqc.unix_time) > F.col(IndCqc.last_submission_time))
+        | (F.col(IndCqc.unix_time) > F.col(IndCqc.final_submission_time))
     )
 
     df_with_extrapolation_models = create_extrapolation_ratio_column(
@@ -155,7 +155,7 @@ def create_extrapolation_ratio_column(
                 / F.col(first_model_column_name)
             ),
         ).when(
-            (F.col(IndCqc.unix_time) > F.col(IndCqc.last_submission_time)),
+            (F.col(IndCqc.unix_time) > F.col(IndCqc.final_submission_time)),
             (
                 1
                 + (F.col(model_column_name) - F.col(last_model_column_name))
@@ -176,7 +176,7 @@ def create_extrapolation_model_column(
             (F.col(IndCqc.unix_time) < F.col(IndCqc.first_submission_time)),
             (F.col(IndCqc.first_filled_posts) * F.col(IndCqc.extrapolation_ratio)),
         ).when(
-            (F.col(IndCqc.unix_time) > F.col(IndCqc.last_submission_time)),
+            (F.col(IndCqc.unix_time) > F.col(IndCqc.final_submission_time)),
             (F.col(IndCqc.last_filled_posts) * F.col(IndCqc.extrapolation_ratio)),
         ),
     )

--- a/utils/estimate_filled_posts/models/extrapolation_new.py
+++ b/utils/estimate_filled_posts/models/extrapolation_new.py
@@ -15,7 +15,7 @@ def model_extrapolation(
     """
     Perform extrapolation on a column with null values using specified models.
 
-    This function calculates the first and last submission dates, performs forward and backward extrapolation,
+    This function calculates the first and final submission dates, performs forward and backward extrapolation,
     and combines the extrapolated results into a new column.
 
     Args:
@@ -29,7 +29,7 @@ def model_extrapolation(
     """
     window_spec_all_rows, window_spec_lagged = define_window_specs()
 
-    df = calculate_first_and_last_submission_dates(
+    df = calculate_first_and_final_submission_dates(
         df, column_with_null_values, window_spec_all_rows
     )
     df = extrapolation_forwards(
@@ -65,14 +65,14 @@ def define_window_specs() -> Tuple[Window, Window]:
     return window_spec_all_rows, window_spec_lagged
 
 
-def calculate_first_and_last_submission_dates(
+def calculate_first_and_final_submission_dates(
     df: DataFrame, column_with_null_values: str, window_spec: Window
 ) -> DataFrame:
     """
-    Calculates the first and last submission dates based on the '<column_with_null_values>' column.
+    Calculates the first and final submission dates based on the '<column_with_null_values>' column.
 
-    Calculates the first and last submission dates based on the '<column_with_null_values>' column
-    and adds them as new columns 'first_submission_time' and 'last_submission_time'.
+    Calculates the first and final submission dates based on the '<column_with_null_values>' column
+    and adds them as new columns 'first_submission_time' and 'final_submission_time'.
 
     Args:
         df (DataFrame): The input DataFrame.
@@ -80,7 +80,7 @@ def calculate_first_and_last_submission_dates(
         window_spec (Window): The window specification to use for the calculation.
 
     Returns:
-        DataFrame: The DataFrame with the added 'first_submission_time' and 'last_submission_time' columns.
+        DataFrame: The DataFrame with the added 'first_submission_time' and 'final_submission_time' columns.
     """
     df = get_selected_value(
         df,
@@ -95,7 +95,7 @@ def calculate_first_and_last_submission_dates(
         window_spec,
         column_with_null_values,
         IndCqc.unix_time,
-        IndCqc.last_submission_time,
+        IndCqc.final_submission_time,
         "last",
     )
     return df
@@ -108,9 +108,9 @@ def extrapolation_forwards(
     window_spec: Window,
 ) -> DataFrame:
     """
-    Calculates the backward extrapolation and adds it as a new column 'extrapolation_forwards'.
+    Calculates the forward extrapolation and adds it as a new column 'extrapolation_forwards'.
 
-    Calculates the backward extrapolation based on the last known non-null value and the rate of change of the selected model value, and adds it as a new column 'extrapolation_forwards'.
+    Calculates the forward extrapolation based on the last known non-null value and the rate of change of the selected model value, and adds it as a new column 'extrapolation_forwards'.
 
     Args:
         df (DataFrame): A dataframe with a column to extrapolate forwards.
@@ -206,11 +206,11 @@ def combine_extrapolation(df: DataFrame, extrapolated_column_name: str) -> DataF
     Combines forward and backward extrapolation values into a single column based on the specified model.
 
     This function creates a new column named '<extrapolated_column_name>' which contains:
-    - Forward extrapolation values if 'unix_time' is greater than the 'last_submission_time'.
+    - Forward extrapolation values if 'unix_time' is greater than the 'final_submission_time'.
     - Backward extrapolation values if 'unix_time' is less than the 'first_submission_time'.
 
     Args:
-        df (DataFrame): The input DataFrame containing the columns 'unix_time', 'first_submission_time', 'last_submission_time', 'extrapolation_forwards', and 'extrapolation_backwards'.
+        df (DataFrame): The input DataFrame containing the columns 'unix_time', 'first_submission_time', 'final_submission_time', 'extrapolation_forwards', and 'extrapolation_backwards'.
         model_to_extrapolate_from (str): The name of the model column used for extrapolation.
 
     Returns:
@@ -219,7 +219,7 @@ def combine_extrapolation(df: DataFrame, extrapolated_column_name: str) -> DataF
     df = df.withColumn(
         extrapolated_column_name,
         F.when(
-            F.col(IndCqc.unix_time) > F.col(IndCqc.last_submission_time),
+            F.col(IndCqc.unix_time) > F.col(IndCqc.final_submission_time),
             F.col(IndCqc.extrapolation_forwards),
         ).when(
             F.col(IndCqc.unix_time) < F.col(IndCqc.first_submission_time),

--- a/utils/estimate_filled_posts/models/interpolation.py
+++ b/utils/estimate_filled_posts/models/interpolation.py
@@ -82,7 +82,7 @@ def calculate_first_and_last_submission_date_per_location(df: DataFrame) -> Data
     """
     df = df.groupBy(IndCqc.location_id).agg(
         F.min(IndCqc.unix_time).cast("integer").alias(IndCqc.first_submission_time),
-        F.max(IndCqc.unix_time).cast("integer").alias(IndCqc.last_submission_time),
+        F.max(IndCqc.unix_time).cast("integer").alias(IndCqc.final_submission_time),
     )
     return df
 
@@ -94,7 +94,7 @@ def convert_first_and_last_known_years_into_exploded_df(df: DataFrame) -> DataFr
     This function creates a dataframe with rows in between the first and last submission date for each location id.
 
     Args:
-        df (DataFrame): A dataframe with the columns location_id and unix_time, first_submission_time, and last_submission_time.
+        df (DataFrame): A dataframe with the columns location_id and unix_time, first_submission_time, and final_submission_time.
 
     Retuns:
         DataFrame: A dataframe with rows in between the first and last submission date for each location id.
@@ -104,9 +104,9 @@ def convert_first_and_last_known_years_into_exploded_df(df: DataFrame) -> DataFr
     df = df.withColumn(
         IndCqc.unix_time,
         F.explode(
-            date_range_udf(IndCqc.first_submission_time, IndCqc.last_submission_time)
+            date_range_udf(IndCqc.first_submission_time, IndCqc.final_submission_time)
         ),
-    ).drop(IndCqc.first_submission_time, IndCqc.last_submission_time)
+    ).drop(IndCqc.first_submission_time, IndCqc.final_submission_time)
 
     return df
 


### PR DESCRIPTION
# Description
Potential confusion with needing the last (final) submission and the last (previous) submission, so renamed to 'final' in advance

# How to test
[Branch run successful](https://eu-west-2.console.aws.amazon.com/states/home?region=eu-west-2#/v2/executions/details/arn:aws:states:eu-west-2:344210435447:execution:rename-last-to-final-submissio-Ind-CQC-Filled-Post-Estimates-Pipeline:7b888b47-b9c8-4a70-9983-3de23ee1de09)

# Developer checklist
- [X] Unit test
- [X] Documentation up to date
