### PR TITLE
Create one imputation model column instead of separate extrapolation and interpolation

### DIFF
--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -4879,7 +4879,7 @@ class ModelPrimaryServiceRollingAverage:
 
 
 @dataclass
-class ModelImputationData:
+class ModelImputationWithExtrapolationAndInterpolationData:
     imputation_with_extrapolation_and_interpolation_rows = [
         ("1-001", date(2023, 1, 1), 1672531200, 10.0, 15.0),
         ("1-001", date(2023, 2, 1), 1675209600, None, 15.1),

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -4879,8 +4879,8 @@ class ModelPrimaryServiceRollingAverage:
 
 
 @dataclass
-class ModelExtrapolationAndInterpolation:
-    extrapolation_and_interpolation_rows = [
+class ModelImputationData:
+    imputation_with_extrapolation_and_interpolation_rows = [
         ("1-001", date(2023, 1, 1), 1672531200, 10.0, 15.0),
         ("1-001", date(2023, 2, 1), 1675209600, None, 15.1),
         ("1-001", date(2023, 3, 1), 1677628800, 30.0, 15.2),
@@ -4894,8 +4894,31 @@ class ModelExtrapolationAndInterpolation:
         ("1-004", date(2023, 3, 1), 1677628800, None, 50.7),
     ]
 
-    extrapolation_model_column_name = "extrapolation_null_values_column_trend_model"
-    interpolation_model_column_name = "interpolation_null_values_column_trend_model"
+    column_with_null_values_name: str = "null_values"
+    model_column_name: str = "trend_model"
+    imputation_model_column_name: str = "imputation_null_values_trend_model"
+    expected_column_name = imputation_model_column_name
+
+    imputation_model_rows = [
+        ("1-001", None, None, None),
+        ("1-002", None, None, 30.0),
+        ("1-003", None, 20.0, None),
+        ("1-004", None, 20.0, 30.0),
+        ("1-005", 10.0, None, None),
+        ("1-006", 10.0, None, 30.0),
+        ("1-007", 10.0, 20.0, None),
+        ("1-008", 10.0, 20.0, 30.0),
+    ]
+    expected_imputation_model_rows = [
+        ("1-001", None, None, None, None),
+        ("1-002", None, None, 30.0, 30.0),
+        ("1-003", None, 20.0, None, 20.0),
+        ("1-004", None, 20.0, 30.0, 20.0),
+        ("1-005", 10.0, None, None, 10.0),
+        ("1-006", 10.0, None, 30.0, 10.0),
+        ("1-007", 10.0, 20.0, None, 10.0),
+        ("1-008", 10.0, 20.0, 30.0, 10.0),
+    ]
 
 
 @dataclass

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -2642,7 +2642,7 @@ class ModelExtrapolationNew:
     expected_combine_extrapolation_schema = StructType(
         [
             *combine_extrapolation_schema,
-            StructField("extrapolation_model_name", FloatType(), True),
+            StructField(IndCQC.extrapolation_model, FloatType(), True),
         ]
     )
 

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -2528,14 +2528,29 @@ class ModelPrimaryServiceRollingAverage:
 
 
 @dataclass
-class ModelExtrapolationAndInterpolation:
-    extrapolation_and_interpolation_schema = StructType(
+class ModelImputationSchemas:
+    imputation_with_extrapolation_and_interpolation_schema = StructType(
         [
             StructField(IndCQC.location_id, StringType(), False),
             StructField(IndCQC.cqc_location_import_date, DateType(), False),
             StructField(IndCQC.unix_time, IntegerType(), False),
-            StructField("null_values_column", DoubleType(), True),
+            StructField("null_values", DoubleType(), True),
             StructField("trend_model", DoubleType(), True),
+        ]
+    )
+
+    imputation_model_schema = StructType(
+        [
+            StructField(IndCQC.location_id, StringType(), False),
+            StructField("null_values", DoubleType(), True),
+            StructField(IndCQC.extrapolation_model, DoubleType(), True),
+            StructField(IndCQC.interpolation_model, DoubleType(), True),
+        ]
+    )
+    expected_imputation_model_schema = StructType(
+        [
+            *imputation_model_schema,
+            StructField("imputation_model", DoubleType(), True),
         ]
     )
 

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -2528,7 +2528,7 @@ class ModelPrimaryServiceRollingAverage:
 
 
 @dataclass
-class ModelImputationSchemas:
+class ModelImputationWithExtrapolationAndInterpolationSchemas:
     imputation_with_extrapolation_and_interpolation_schema = StructType(
         [
             StructField(IndCQC.location_id, StringType(), False),

--- a/tests/unit/test_extrapolation_and_interpolation.py
+++ b/tests/unit/test_extrapolation_and_interpolation.py
@@ -2,13 +2,14 @@ import unittest
 from unittest.mock import Mock, patch
 import warnings
 
+from utils.column_names.ind_cqc_pipeline_columns import IndCqcColumns as IndCqc
 import utils.estimate_filled_posts.models.extrapolation_and_interpolation as job
 from utils import utils
-from tests.test_file_data import ModelExtrapolationAndInterpolation as Data
-from tests.test_file_schemas import ModelExtrapolationAndInterpolation as Schemas
+from tests.test_file_data import ModelImputationData as Data
+from tests.test_file_schemas import ModelImputationSchemas as Schemas
 
 
-class ModelExtrapolationAndInterpolationTests(unittest.TestCase):
+class ModelImputationWithExtrapolationAndInterpolationTests(unittest.TestCase):
     def setUp(self):
         self.spark = utils.get_spark()
 
@@ -16,21 +17,20 @@ class ModelExtrapolationAndInterpolationTests(unittest.TestCase):
         warnings.filterwarnings("ignore", category=DeprecationWarning)
 
 
-class MainTests(ModelExtrapolationAndInterpolationTests):
+class MainTests(ModelImputationWithExtrapolationAndInterpolationTests):
     def setUp(self) -> None:
         super().setUp()
 
-        self.extrapolation_and_interpolation_df = self.spark.createDataFrame(
-            Data.extrapolation_and_interpolation_rows,
-            Schemas.extrapolation_and_interpolation_schema,
+        self.imputation_with_extrapolation_and_interpolation_df = (
+            self.spark.createDataFrame(
+                Data.imputation_with_extrapolation_and_interpolation_rows,
+                Schemas.imputation_with_extrapolation_and_interpolation_schema,
+            )
         )
-        self.column_with_null_values: str = "null_values_column"
-        self.model_column_name: str = "trend_model"
-
         self.returned_df = job.model_imputation_with_extrapolation_and_interpolation(
-            self.extrapolation_and_interpolation_df,
-            self.column_with_null_values,
-            self.model_column_name,
+            self.imputation_with_extrapolation_and_interpolation_df,
+            Data.column_with_null_values_name,
+            Data.model_column_name,
         )
 
     @patch(
@@ -45,9 +45,9 @@ class MainTests(ModelExtrapolationAndInterpolationTests):
         model_interpolation_mock: Mock,
     ):
         job.model_imputation_with_extrapolation_and_interpolation(
-            self.extrapolation_and_interpolation_df,
-            self.column_with_null_values,
-            self.model_column_name,
+            self.imputation_with_extrapolation_and_interpolation_df,
+            Data.column_with_null_values_name,
+            Data.model_column_name,
         )
 
         model_extrapolation_mock.assert_called_once()
@@ -57,29 +57,51 @@ class MainTests(ModelExtrapolationAndInterpolationTests):
         self,
     ):
         self.assertEqual(
-            self.extrapolation_and_interpolation_df.count(), self.returned_df.count()
+            self.imputation_with_extrapolation_and_interpolation_df.count(),
+            self.returned_df.count(),
         )
 
-    def test_model_imputation_with_extrapolation_and_interpolation_returns_new_columns(
+    def test_model_imputation_with_extrapolation_and_interpolation_returns_new_column(
         self,
     ):
-        self.assertIn(Data.extrapolation_model_column_name, self.returned_df.columns)
-        self.assertIn(Data.interpolation_model_column_name, self.returned_df.columns)
+        self.assertIn(Data.imputation_model_column_name, self.returned_df.columns)
 
 
-class CreateNewColumnNamesTests(ModelExtrapolationAndInterpolationTests):
+class CreateImputationModelNameTests(
+    ModelImputationWithExtrapolationAndInterpolationTests
+):
     def setUp(self) -> None:
         super().setUp()
 
-    def test_create_new_column_names_returns_expected_strings(self):
-        null_column_name: str = "filled_posts"
-        model_column_name: str = "trend_model"
-        expected_column_names = (
-            "extrapolation_filled_posts_trend_model",
-            "interpolation_filled_posts_trend_model",
+    def test_create_imputation_model_name_returns_expected_column_name(self):
+        self.assertEqual(
+            job.create_imputation_model_name(
+                Data.column_with_null_values_name, Data.model_column_name
+            ),
+            Data.expected_column_name,
         )
 
-        self.assertEqual(
-            job.create_new_column_names(null_column_name, model_column_name),
-            expected_column_names,
+
+class ModelImputationTests(ModelImputationWithExtrapolationAndInterpolationTests):
+    def setUp(self) -> None:
+        super().setUp()
+
+    def test_imputation_model_returns_correct_values(self):
+        null_value_column: str = "null_values"
+        imputation_model: str = "imputation_model"
+        test_df = self.spark.createDataFrame(
+            Data.imputation_model_rows, Schemas.imputation_model_schema
         )
+        returned_df = job.model_imputation(test_df, null_value_column, imputation_model)
+        expected_df = self.spark.createDataFrame(
+            Data.expected_imputation_model_rows,
+            Schemas.expected_imputation_model_schema,
+        )
+        returned_data = returned_df.sort(IndCqc.location_id).collect()
+        expected_data = expected_df.collect()
+        for i in range(len(returned_data)):
+            self.assertEqual(
+                returned_data[i][imputation_model],
+                expected_data[i][imputation_model],
+                f"Returned row {i} does not match expected",
+            )

--- a/tests/unit/test_extrapolation_and_interpolation.py
+++ b/tests/unit/test_extrapolation_and_interpolation.py
@@ -5,8 +5,12 @@ import warnings
 from utils.column_names.ind_cqc_pipeline_columns import IndCqcColumns as IndCqc
 import utils.estimate_filled_posts.models.extrapolation_and_interpolation as job
 from utils import utils
-from tests.test_file_data import ModelImputationData as Data
-from tests.test_file_schemas import ModelImputationSchemas as Schemas
+from tests.test_file_data import (
+    ModelImputationWithExtrapolationAndInterpolationData as Data,
+)
+from tests.test_file_schemas import (
+    ModelImputationWithExtrapolationAndInterpolationSchemas as Schemas,
+)
 
 
 class ModelImputationWithExtrapolationAndInterpolationTests(unittest.TestCase):

--- a/tests/unit/test_extrapolation_and_interpolation.py
+++ b/tests/unit/test_extrapolation_and_interpolation.py
@@ -27,7 +27,7 @@ class MainTests(ModelExtrapolationAndInterpolationTests):
         self.column_with_null_values: str = "null_values_column"
         self.model_column_name: str = "trend_model"
 
-        self.returned_df = job.model_extrapolation_and_interpolation(
+        self.returned_df = job.model_imputation_with_extrapolation_and_interpolation(
             self.extrapolation_and_interpolation_df,
             self.column_with_null_values,
             self.model_column_name,
@@ -39,12 +39,12 @@ class MainTests(ModelExtrapolationAndInterpolationTests):
     @patch(
         "utils.estimate_filled_posts.models.extrapolation_and_interpolation.model_extrapolation"
     )
-    def test_model_extrapolation_and_interpolation_runs(
+    def test_model_imputation_with_extrapolation_and_interpolation_runs(
         self,
         model_extrapolation_mock: Mock,
         model_interpolation_mock: Mock,
     ):
-        job.model_extrapolation_and_interpolation(
+        job.model_imputation_with_extrapolation_and_interpolation(
             self.extrapolation_and_interpolation_df,
             self.column_with_null_values,
             self.model_column_name,
@@ -53,12 +53,16 @@ class MainTests(ModelExtrapolationAndInterpolationTests):
         model_extrapolation_mock.assert_called_once()
         model_interpolation_mock.assert_called_once()
 
-    def test_model_extrapolation_and_interpolation_returns_same_number_of_rows(self):
+    def test_model_imputation_with_extrapolation_and_interpolation_returns_same_number_of_rows(
+        self,
+    ):
         self.assertEqual(
             self.extrapolation_and_interpolation_df.count(), self.returned_df.count()
         )
 
-    def test_model_extrapolation_and_interpolation_returns_new_columns(self):
+    def test_model_imputation_with_extrapolation_and_interpolation_returns_new_columns(
+        self,
+    ):
         self.assertIn(Data.extrapolation_model_column_name, self.returned_df.columns)
         self.assertIn(Data.interpolation_model_column_name, self.returned_df.columns)
 

--- a/tests/unit/test_extrapolation_new.py
+++ b/tests/unit/test_extrapolation_new.py
@@ -41,7 +41,9 @@ class MainTests(ModelExtrapolationTests):
     def test_model_extrapolation_row_count_unchanged(self):
         self.assertEqual(self.returned_df.count(), self.extrapolation_df.count())
 
-    def test_model_extrapolation_and_interpolation_returns_new_columns(self):
+    def test_model_imputation_with_extrapolation_and_interpolation_returns_new_columns(
+        self,
+    ):
         self.assertIn(self.extrapolation_model_column_name, self.returned_df.columns)
 
 

--- a/tests/unit/test_extrapolation_new.py
+++ b/tests/unit/test_extrapolation_new.py
@@ -295,14 +295,11 @@ class CombineExtrapolationTests(ModelExtrapolationTests):
     def setUp(self):
         super().setUp()
 
-        self.extrapolation_model_name = "extrapolation_model_name"
         test_combine_extrapolation_df = self.spark.createDataFrame(
             Data.combine_extrapolation_rows,
             Schemas.combine_extrapolation_schema,
         )
-        self.returned_df = job.combine_extrapolation(
-            test_combine_extrapolation_df, self.extrapolation_model_name
-        )
+        self.returned_df = job.combine_extrapolation(test_combine_extrapolation_df)
         self.expected_df = self.spark.createDataFrame(
             Data.expected_combine_extrapolation_rows,
             Schemas.expected_combine_extrapolation_schema,
@@ -318,7 +315,7 @@ class CombineExtrapolationTests(ModelExtrapolationTests):
     def test_combine_extrapolation_returns_expected_values(self):
         for i in range(len(self.returned_data)):
             self.assertEqual(
-                self.returned_data[i][self.extrapolation_model_name],
-                self.expected_data[i][self.extrapolation_model_name],
+                self.returned_data[i][IndCqc.extrapolation_model],
+                self.expected_data[i][IndCqc.extrapolation_model],
                 f"Returned value in row {i} does not match expected",
             )

--- a/tests/unit/test_extrapolation_new.py
+++ b/tests/unit/test_extrapolation_new.py
@@ -41,7 +41,7 @@ class MainTests(ModelExtrapolationTests):
     def test_model_extrapolation_row_count_unchanged(self):
         self.assertEqual(self.returned_df.count(), self.extrapolation_df.count())
 
-    def test_model_imputation_with_extrapolation_and_interpolation_returns_new_columns(
+    def test_model_extrapolation_returns_new_column(
         self,
     ):
         self.assertIn(self.extrapolation_model_column_name, self.returned_df.columns)

--- a/tests/unit/test_extrapolation_new.py
+++ b/tests/unit/test_extrapolation_new.py
@@ -39,9 +39,7 @@ class MainTests(ModelExtrapolationTests):
     def test_model_extrapolation_row_count_unchanged(self):
         self.assertEqual(self.returned_df.count(), self.extrapolation_df.count())
 
-    def test_model_extrapolation_returns_new_column(
-        self,
-    ):
+    def test_model_extrapolation_returns_new_column(self):
         self.assertIn(IndCqc.extrapolation_model, self.returned_df.columns)
 
 

--- a/tests/unit/test_extrapolation_new.py
+++ b/tests/unit/test_extrapolation_new.py
@@ -20,7 +20,6 @@ class ModelExtrapolationTests(unittest.TestCase):
         self.extrapolation_df = self.spark.createDataFrame(
             Data.extrapolation_rows, Schemas.extrapolation_schema
         )
-        self.extrapolation_model_column_name = "extrapolation_rolling_average_model"
         self.model_column_name = IndCqc.rolling_average_model
 
         warnings.filterwarnings("ignore", category=ResourceWarning)
@@ -35,7 +34,6 @@ class MainTests(ModelExtrapolationTests):
             self.extrapolation_df,
             IndCqc.ascwds_filled_posts_dedup_clean,
             self.model_column_name,
-            self.extrapolation_model_column_name,
         )
 
     def test_model_extrapolation_row_count_unchanged(self):
@@ -44,7 +42,7 @@ class MainTests(ModelExtrapolationTests):
     def test_model_extrapolation_returns_new_column(
         self,
     ):
-        self.assertIn(self.extrapolation_model_column_name, self.returned_df.columns)
+        self.assertIn(IndCqc.extrapolation_model, self.returned_df.columns)
 
 
 class DefineWindowSpecsTests(ModelExtrapolationTests):

--- a/tests/unit/test_interpolation_new.py
+++ b/tests/unit/test_interpolation_new.py
@@ -20,9 +20,6 @@ class ModelInterpolationTests(unittest.TestCase):
         self.interpolation_df = self.spark.createDataFrame(
             Data.interpolation_rows, Schemas.interpolation_schema
         )
-        self.interpolation_model_column_name = (
-            "interpolation_filled_posts_rolling_average_model"
-        )
 
         warnings.filterwarnings("ignore", category=ResourceWarning)
         warnings.filterwarnings("ignore", category=DeprecationWarning)
@@ -35,14 +32,13 @@ class MainTests(ModelInterpolationTests):
         self.returned_df = job.model_interpolation(
             self.interpolation_df,
             IndCqc.ascwds_filled_posts_dedup_clean,
-            self.interpolation_model_column_name,
         )
 
     def test_model_interpolation_row_count_unchanged(self):
         self.assertEqual(self.returned_df.count(), self.interpolation_df.count())
 
     def test_model_interpolation_returns_new_column(self):
-        self.assertIn(self.interpolation_model_column_name, self.returned_df.columns)
+        self.assertIn(IndCqc.interpolation_model, self.returned_df.columns)
 
 
 class DefineWindowSpecsTests(ModelInterpolationTests):

--- a/utils/column_names/ind_cqc_pipeline_columns.py
+++ b/utils/column_names/ind_cqc_pipeline_columns.py
@@ -98,6 +98,7 @@ class IndCqcColumns:
     extrapolation_backwards: str = "extrapolation_backwards"
     extrapolation_care_home_model: str = "extrapolation_" + care_home_model
     extrapolation_forwards: str = "extrapolation_forwards"
+    extrapolation_model: str = "extrapolation_model"
     extrapolation_non_res_with_dormancy_model: str = (
         "extrapolation_non_res_with_dormancy_model"
     )

--- a/utils/estimate_filled_posts/models/extrapolation.py
+++ b/utils/estimate_filled_posts/models/extrapolation.py
@@ -47,7 +47,7 @@ def add_filled_posts_and_model_value_for_first_and_last_submission(
     df: DataFrame,
     model_column_name: str,
 ) -> DataFrame:
-    first_model_column_name, last_model_column_name = create_new_column_names(
+    first_model_column_name, last_model_column_name = create_imputation_model_names(
         model_column_name
     )
     df = add_first_and_last_submission_date_cols(df)
@@ -71,7 +71,7 @@ def add_filled_posts_and_model_value_for_first_and_last_submission(
     return df
 
 
-def create_new_column_names(model_column_name: str) -> tuple:
+def create_imputation_model_names(model_column_name: str) -> tuple:
     model_name = model_column_name[:-6]
     first_model_column_name = "first_" + model_name
     last_model_column_name = "last_" + model_name
@@ -142,7 +142,7 @@ def add_extrapolated_values(
 def create_extrapolation_ratio_column(
     df: DataFrame, model_column_name: str
 ) -> DataFrame:
-    first_model_column_name, last_model_column_name = create_new_column_names(
+    first_model_column_name, last_model_column_name = create_imputation_model_names(
         model_column_name
     )
     df_with_extrapolation_ratio_column = df.withColumn(

--- a/utils/estimate_filled_posts/models/extrapolation.py
+++ b/utils/estimate_filled_posts/models/extrapolation.py
@@ -47,7 +47,7 @@ def add_filled_posts_and_model_value_for_first_and_last_submission(
     df: DataFrame,
     model_column_name: str,
 ) -> DataFrame:
-    first_model_column_name, last_model_column_name = create_imputation_model_names(
+    first_model_column_name, last_model_column_name = create_new_column_names(
         model_column_name
     )
     df = add_first_and_last_submission_date_cols(df)
@@ -71,7 +71,7 @@ def add_filled_posts_and_model_value_for_first_and_last_submission(
     return df
 
 
-def create_imputation_model_names(model_column_name: str) -> tuple:
+def create_new_column_names(model_column_name: str) -> tuple:
     model_name = model_column_name[:-6]
     first_model_column_name = "first_" + model_name
     last_model_column_name = "last_" + model_name
@@ -142,7 +142,7 @@ def add_extrapolated_values(
 def create_extrapolation_ratio_column(
     df: DataFrame, model_column_name: str
 ) -> DataFrame:
-    first_model_column_name, last_model_column_name = create_imputation_model_names(
+    first_model_column_name, last_model_column_name = create_new_column_names(
         model_column_name
     )
     df_with_extrapolation_ratio_column = df.withColumn(

--- a/utils/estimate_filled_posts/models/extrapolation_and_interpolation.py
+++ b/utils/estimate_filled_posts/models/extrapolation_and_interpolation.py
@@ -1,22 +1,24 @@
-from pyspark.sql import DataFrame
-from typing import Tuple
+from pyspark.sql import DataFrame, functions as F
 
 from utils.column_names.ind_cqc_pipeline_columns import IndCqcColumns as IndCqc
 from utils.estimate_filled_posts.models.extrapolation_new import model_extrapolation
 from utils.estimate_filled_posts.models.interpolation_new import model_interpolation
 
 
-def model_extrapolation_and_interpolation(
+def model_imputation_with_extrapolation_and_interpolation(
     df: DataFrame,
     column_with_null_values: str,
     model_column_name: str,
 ) -> DataFrame:
     """
-    Extrapolates and interpolates non-null values in 'column_with_null_values' based on the rate of change of values in 'model_column_name' and adds them as new columns.
+    Create a new column of imputed values based on known values and null values being extrapolated and interpolated.
 
-    Calculates currently null values in a specified column by using the rate of change in a specified model column to
-    extrapolate and interpolate values. This process creates two additional columns: one with extrapolated
-    values and one with interpolated values.
+    This function creates a new column of data which takes non-null values from a column containing null values, and populates
+    the null values based on the rate of change of values in '<model_column_name>'. Values before the first known submission and
+    after the last known submission are extrapolated based on the rate of change of the '<model_column_name>'. Values in between
+    non-null values are interpolated using the rate of change of the '<model_column_name>' but the trend is adapted so that the
+    end point matches the next non-null value. A new column is added which includes the name of the '<column_with_null_values>'
+    and the '<model_column_name>'.
 
     Args:
         df (DataFrame): The input DataFrame containing the columns to be extrapolated and interpolated.
@@ -24,46 +26,46 @@ def model_extrapolation_and_interpolation(
         model_column_name (str): The name of the column containing the model values used for extrapolation and interpolation.
 
     Returns:
-        DataFrame: The DataFrame with the added columns for extrapolated and interpolated values.
+        DataFrame: The DataFrame with the added column for imputed values.
     """
-    (
-        extrapolation_model_column_name,
-        interpolation_model_column_name,
-    ) = create_new_column_names(column_with_null_values, model_column_name)
+    imputation_model_column_name = create_imputation_model_name(
+        column_with_null_values, model_column_name
+    )
 
     df = model_extrapolation(
         df,
         column_with_null_values,
         model_column_name,
-        extrapolation_model_column_name,
     )
     df = model_interpolation(
         df,
         column_with_null_values,
-        interpolation_model_column_name,
     )
+    df = model_imputation(df, column_with_null_values, imputation_model_column_name)
     df = df.drop(
         IndCqc.extrapolation_backwards,
         IndCqc.extrapolation_forwards,
         IndCqc.extrapolation_residual,
         IndCqc.proportion_of_time_between_submissions,
+        IndCqc.extrapolation_model,
+        IndCqc.interpolation_model,
     )
 
     return df
 
 
-def create_new_column_names(
+def create_imputation_model_name(
     column_with_null_values: str, model_column_name: str
-) -> Tuple[str, str]:
+) -> str:
     """
-    Generate new column names for extrapolation and interpolation outputs.
+    Generate a new column name imputation model output.
 
-    Generates new column names for extrapolation and interpolation outputs which includes the name of the column with
+    Generate a new column names for imputation model outputs which includes the name of the column with
     null values and the model name which trend line the process is following. For example:
         - 'filled_posts' using the 'rolling_average_model' trend would become
-          'extrapolation_filled_posts_rolling_average_model".
+          'imputatation_filled_posts_rolling_average_model".
         - 'filled_posts_per_bed_ratio' using the 'care_home_model' trend would become
-          'extrapolation_filled_posts_per_bed_ratio_care_home_model".
+          'imputatation_filled_posts_per_bed_ratio_care_home_model".
 
 
     Args:
@@ -71,12 +73,37 @@ def create_new_column_names(
         model_column_name (str): The name of the model column to use.
 
     Returns:
-        Tuple[str, str]: A tuple containing the extrapolation model column name and the interpolation model column name.
+        str: A string with the imputation model column name.
     """
-    extrapolation_model_column_name = (
-        "extrapolation_" + column_with_null_values + "_" + model_column_name
+    imputation_model_column_name = (
+        "imputation_" + column_with_null_values + "_" + model_column_name
     )
-    interpolation_model_column_name = (
-        "interpolation_" + column_with_null_values + "_" + model_column_name
+    return imputation_model_column_name
+
+
+def model_imputation(
+    df: DataFrame, column_with_null_values: str, imputation_model_column_name: str
+) -> DataFrame:
+    """
+    Merges the original '<column_with_null_values>' with extrapolated and interpolated columns to create a new column.
+
+    This function merges the original '<column_with_null_values>' with extrapolated and interpolated columns to create
+    a new column called '<imputation_model_column_name>'.
+
+    Args:
+        df (DataFrame): A dataframe with the columns extrapolation_model and interpolation_model.
+        column_with_null_values (str): The name of the column containing null values to be extrapolated and interpolated.
+        imputation_model_column_name (str): The name of the new column.
+
+    Returns:
+        Dataframe: A dataframe with a new merged column called '<imputation_model_column_name>'.
+    """
+    df = df.withColumn(
+        imputation_model_column_name,
+        F.coalesce(
+            F.col(column_with_null_values),
+            F.col(IndCqc.extrapolation_model),
+            F.col(IndCqc.interpolation_model),
+        ),
     )
-    return extrapolation_model_column_name, interpolation_model_column_name
+    return df

--- a/utils/estimate_filled_posts/models/extrapolation_new.py
+++ b/utils/estimate_filled_posts/models/extrapolation_new.py
@@ -11,7 +11,6 @@ def model_extrapolation(
     df: DataFrame,
     column_with_null_values: str,
     model_to_extrapolate_from: str,
-    extrapolated_column_name: str,
 ) -> DataFrame:
     """
     Perform extrapolation on a column with null values using specified models.
@@ -26,7 +25,7 @@ def model_extrapolation(
         extrapolated_column_name (str): The name of the new column to store extrapolated values.
 
     Returns:
-        DataFrame: The DataFrame with the extrapolated values in the specified column.
+        DataFrame: The DataFrame with the extrapolated values in the 'extrapolation_model' column.
     """
     window_spec_all_rows, window_spec_lagged = define_window_specs()
 
@@ -39,7 +38,7 @@ def model_extrapolation(
     df = extrapolation_backwards(
         df, column_with_null_values, model_to_extrapolate_from, window_spec_all_rows
     )
-    df = combine_extrapolation(df, extrapolated_column_name)
+    df = combine_extrapolation(df)
     df = df.drop(IndCqc.first_submission_time, IndCqc.final_submission_time)
 
     return df
@@ -202,23 +201,23 @@ def extrapolation_backwards(
     return df
 
 
-def combine_extrapolation(df: DataFrame, extrapolated_column_name: str) -> DataFrame:
+def combine_extrapolation(df: DataFrame) -> DataFrame:
     """
     Combines forward and backward extrapolation values into a single column based on the specified model.
 
-    This function creates a new column named '<extrapolated_column_name>' which contains:
+    This function creates a new column named 'extrapolation_model' which contains:
     - Forward extrapolation values if 'unix_time' is greater than the 'final_submission_time'.
     - Backward extrapolation values if 'unix_time' is less than the 'first_submission_time'.
 
     Args:
-        df (DataFrame): The input DataFrame containing the columns 'unix_time', 'first_submission_time', 'final_submission_time', 'extrapolation_forwards', and 'extrapolation_backwards'.
-        model_to_extrapolate_from (str): The name of the model column used for extrapolation.
+        df (DataFrame): The input DataFrame containing the columns 'unix_time', 'first_submission_time',
+            'final_submission_time', 'extrapolation_forwards', and 'extrapolation_backwards'.
 
     Returns:
         DataFrame: The DataFrame with the added combined extrapolation column.
     """
     df = df.withColumn(
-        extrapolated_column_name,
+        IndCqc.extrapolation_model,
         F.when(
             F.col(IndCqc.unix_time) > F.col(IndCqc.final_submission_time),
             F.col(IndCqc.extrapolation_forwards),

--- a/utils/estimate_filled_posts/models/interpolation_new.py
+++ b/utils/estimate_filled_posts/models/interpolation_new.py
@@ -10,21 +10,19 @@ from utils.ind_cqc_filled_posts_utils.utils import get_selected_value
 def model_interpolation(
     df: DataFrame,
     column_with_null_values: str,
-    interpolated_column_name: str,
 ) -> DataFrame:
     """
-    Perform interpolation on a column with null values and adds as a new column.
+    Perform interpolation on a column with null values and adds as a new column called 'interpolation_model'.
 
     This function uses the extrapolation_forwards values as a trend line to guide interpolated predictions
-    between two non-null values and inputs the interpolated results into a new column.
+    between two non-null values and inputs the interpolated results into a new column called 'interpolation_model'.
 
     Args:
         df (DataFrame): The input DataFrame containing the data.
         column_with_null_values (str): The name of the column that contains null values to be interpolated.
-        interpolated_column_name (str): The name of the new column to store interpolated values.
 
     Returns:
-        DataFrame: The DataFrame with the interpolated values in the specified column.
+        DataFrame: The DataFrame with the interpolated values in the 'interpolation_model' column.
     """
     window_spec_backwards, window_spec_forwards = define_window_specs()
 
@@ -35,7 +33,7 @@ def model_interpolation(
     )
 
     df = df.withColumn(
-        interpolated_column_name,
+        IndCqc.interpolation_model,
         F.col(IndCqc.extrapolation_forwards)
         + F.col(IndCqc.extrapolation_residual)
         * F.col(IndCqc.proportion_of_time_between_submissions),


### PR DESCRIPTION
# Description
Creates one imputation column which contains the name of the column with nulls and the model used to imputate from

Extrapolation and interpolation are dropped, so instead of having unique names they can just be generic 'interpolation_model' and 'extrapolation_model'.

![image](https://github.com/user-attachments/assets/74dab246-bd6c-4628-b30a-7fd2e2d0b35f)

# How to test
Tests passing, not in pipeline yet

# Developer checklist
- [X] Unit test
- [X] Documentation up to date
