### PR TITLE
Manually provide imputed col name

### DIFF
--- a/jobs/estimate_missing_ascwds_ind_cqc_filled_posts.py
+++ b/jobs/estimate_missing_ascwds_ind_cqc_filled_posts.py
@@ -55,6 +55,7 @@ def main(
         IndCQC.ascwds_filled_posts_dedup_clean,
         IndCQC.rolling_average_model,
         False,
+        IndCQC.imputed_posts_rolling_avg_model,
     )
 
     estimate_missing_ascwds_df = model_imputation_with_extrapolation_and_interpolation(
@@ -62,6 +63,7 @@ def main(
         IndCQC.filled_posts_per_bed_ratio,
         IndCQC.rolling_average_model_filled_posts_per_bed_ratio,
         True,
+        IndCQC.imputed_ratio_rolling_avg_model,
     )
 
     estimate_missing_ascwds_df = model_extrapolation(

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -4943,7 +4943,6 @@ class ModelImputationWithExtrapolationAndInterpolationData:
     column_with_null_values_name: str = "null_values"
     model_column_name: str = "trend_model"
     imputation_model_column_name: str = "imputation_null_values_trend_model"
-    expected_column_name = imputation_model_column_name
 
     imputation_model_rows = [
         ("1-001", None, None, None),

--- a/tests/unit/test_imputation_with_extrapolation_and_interpolation.py
+++ b/tests/unit/test_imputation_with_extrapolation_and_interpolation.py
@@ -37,7 +37,8 @@ class MainTests(ModelImputationWithExtrapolationAndInterpolationTests):
             self.imputation_with_extrapolation_and_interpolation_df,
             Data.column_with_null_values_name,
             Data.model_column_name,
-            care_home=False,
+            False,
+            Data.imputation_model_column_name,
         )
 
     @patch(
@@ -55,7 +56,8 @@ class MainTests(ModelImputationWithExtrapolationAndInterpolationTests):
             self.imputation_with_extrapolation_and_interpolation_df,
             Data.column_with_null_values_name,
             Data.model_column_name,
-            care_home=False,
+            False,
+            Data.imputation_model_column_name,
         )
 
         model_extrapolation_mock.assert_called_once()
@@ -73,21 +75,6 @@ class MainTests(ModelImputationWithExtrapolationAndInterpolationTests):
         self,
     ):
         self.assertIn(Data.imputation_model_column_name, self.returned_df.columns)
-
-
-class CreateImputationModelNameTests(
-    ModelImputationWithExtrapolationAndInterpolationTests
-):
-    def setUp(self) -> None:
-        super().setUp()
-
-    def test_create_imputation_model_name_returns_expected_column_name(self):
-        self.assertEqual(
-            job.create_imputation_model_name(
-                Data.column_with_null_values_name, Data.model_column_name
-            ),
-            Data.expected_column_name,
-        )
 
 
 class SplitDatasetForImputationTests(

--- a/utils/column_names/ind_cqc_pipeline_columns.py
+++ b/utils/column_names/ind_cqc_pipeline_columns.py
@@ -119,17 +119,9 @@ class IndCqcColumns:
     gac_service_types: str = CQCLClean.gac_service_types
     has_non_null_value: str = "has_non_null_value"
     import_month_index: str = "import_month_index"
-    imputation_filled_posts_rolling_average_model: str = (
-        "imputation_" + ascwds_filled_posts_dedup_clean + "_rolling_average_model"
-    )
-    imputation_posts_per_bed_ratio_rolling_average_model_filled_posts_per_bed_ratio: (
-        str
-    ) = (
-        "imputation_"
-        + filled_posts_per_bed_ratio
-        + "_rolling_average_model_filled_posts_per_bed_ratio"
-    )
     imputed_gac_service_types: str = CQCLClean.imputed_gac_service_types
+    imputed_posts_rolling_avg_model: str = "imputed_posts_rolling_avg_model"
+    imputed_ratio_rolling_avg_model: str = "imputed_ratio_rolling_avg_model"
     imputed_registration_date: str = CQCLClean.imputed_registration_date
     interpolation_model: str = "interpolation_model"
     interpolation_model_ascwds_filled_posts_dedup_clean: str = (

--- a/utils/validation/validation_rules/estimated_missing_ascwds_filled_posts_validation_rules.py
+++ b/utils/validation/validation_rules/estimated_missing_ascwds_filled_posts_validation_rules.py
@@ -50,8 +50,8 @@ class EstimatedIndCqcFilledPostsValidationRules:
             IndCqcColumns.interpolation_model: 0.0,
             IndCqcColumns.rolling_average_model: 0.0,
             IndCqcColumns.extrapolation_rolling_average_model: 0.0,
-            IndCqcColumns.imputation_filled_posts_rolling_average_model: 0.0,
-            IndCqcColumns.imputation_posts_per_bed_ratio_rolling_average_model_filled_posts_per_bed_ratio: 0.0,
+            IndCqcColumns.imputed_posts_rolling_avg_model: 0.0,
+            IndCqcColumns.imputed_ratio_rolling_avg_model: 0.0,
             IndCqcColumns.unix_time: 1262304000,  # 1st Jan 2010 in unix time
         },
         RuleName.max_values: {
@@ -65,8 +65,8 @@ class EstimatedIndCqcFilledPostsValidationRules:
             IndCqcColumns.interpolation_model: 3000.0,
             IndCqcColumns.rolling_average_model: 3000.0,
             IndCqcColumns.extrapolation_rolling_average_model: 3000.0,
-            IndCqcColumns.imputation_filled_posts_rolling_average_model: 3000.0,
-            IndCqcColumns.imputation_posts_per_bed_ratio_rolling_average_model_filled_posts_per_bed_ratio: 3000.0,
+            IndCqcColumns.imputed_posts_rolling_avg_model: 3000.0,
+            IndCqcColumns.imputed_ratio_rolling_avg_model: 3000.0,
             IndCqcColumns.unix_time: int(time.time()),  # current unix time
         },
         RuleName.categorical_values_in_columns: {


### PR DESCRIPTION
# Description
Automatically assigning the column name doesn't give the clearest names so switching to manually providing the name

# How to test
[Successful branch run](https://eu-west-2.console.aws.amazon.com/states/home?region=eu-west-2#/v2/executions/details/arn:aws:states:eu-west-2:344210435447:execution:manually-name-imputated-col-Ind-CQC-Filled-Post-Estimates-Pipeline:aa1a75b2-dada-48c7-a79e-47708d5e67be)

# Developer checklist
- [X] Unit test
- [X] Documentation up to date
