### PR TITLE
Remove merge_imputed_columns function

### DIFF
--- a/jobs/estimate_missing_ascwds_ind_cqc_filled_posts.py
+++ b/jobs/estimate_missing_ascwds_ind_cqc_filled_posts.py
@@ -88,10 +88,6 @@ def main(
         )
     )  # TODO function no longer required
 
-    estimate_missing_ascwds_df = merge_imputed_columns(
-        estimate_missing_ascwds_df
-    )  # TODO function no longer required
-
     print(f"Exporting as parquet to {estimated_missing_ascwds_ind_cqc_destination}")
 
     utils.write_to_parquet(
@@ -129,31 +125,6 @@ def merge_interpolated_values_into_interpolated_filled_posts(
             ),
             F.col(IndCQC.interpolation_model_filled_posts_per_bed_ratio)
             * F.col(IndCQC.number_of_beds),
-        ),
-    )
-    return df
-
-
-def merge_imputed_columns(df: DataFrame) -> DataFrame:
-    """
-    Merges the extrapolation and interpolation columns to create a new column.
-
-    This function merges the extrapolation and interpolation columns to create a new column called ascwds_filled_posts_imputed.
-
-    Args:
-        df (DataFrame): A dataframe with the columns extrapolation_rolling_average and interpolation_model_ascwds_filled_posts_dedup_clean.
-
-    Returns:
-        Dataframe: A dataframe with a new merged column called ascwds_filled_posts_imputed.
-    """
-    df = df.withColumn(
-        IndCQC.ascwds_filled_posts_imputed,
-        F.when(
-            df[IndCQC.interpolation_model].isNotNull(),
-            F.col(IndCQC.interpolation_model),
-        ).when(
-            df[IndCQC.extrapolation_rolling_average_model].isNotNull(),
-            F.col(IndCQC.extrapolation_rolling_average_model),
         ),
     )
     return df

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -4683,40 +4683,6 @@ class EstimateMissingAscwdsFilledPostsData:
         ("1-108967195", date(2022, 4, 22), 0, PrimaryServiceType.non_residential, None, None, "N", "rule_3", None),
     ]
     # fmt: on
-    merge_imputed_columns_rows = [
-        ("loc 1", 10.0, None),
-        ("loc 2", None, 11.0),
-        ("loc 3", 12.0, 12.0),
-        (
-            "loc 4",
-            13.0,
-            14.0,
-        ),  # This case should not appear in the data - illustrative only
-        (
-            "loc 5",
-            16.0,
-            15.0,
-        ),  # This case should not appear in the data - illustrative only
-        ("loc 6", None, None),
-    ]
-    expected_merge_imputed_columns_rows = [
-        ("loc 1", 10.0, None, 10.0),
-        ("loc 2", None, 11.0, 11.0),
-        ("loc 3", 12.0, 12.0, 12.0),
-        (
-            "loc 4",
-            13.0,
-            14.0,
-            14.0,
-        ),  # This case should not appear in the data - illustrative only
-        (
-            "loc 5",
-            16.0,
-            15.0,
-            15.0,
-        ),  # This case should not appear in the data - illustrative only
-        ("loc 6", None, None, None),
-    ]
 
     merge_interpolated_values_rows = [
         (

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -2431,25 +2431,6 @@ class EstimateMissingAscwdsFilledPostsSchemas:
         ]
     )
 
-    merge_imputed_columns_schema = StructType(
-        [
-            StructField(IndCQC.location_id, StringType(), True),
-            StructField(IndCQC.extrapolation_rolling_average_model, FloatType(), True),
-            StructField(
-                IndCQC.interpolation_model,
-                FloatType(),
-                True,
-            ),
-        ]
-    )
-
-    expected_merge_imputed_columns_schema = StructType(
-        [
-            *merge_imputed_columns_schema,
-            StructField(IndCQC.ascwds_filled_posts_imputed, FloatType(), True),
-        ]
-    )
-
     merge_interpolated_values_schema = StructType(
         [
             StructField(IndCQC.location_id, StringType(), True),

--- a/tests/unit/test_estimate_missing_ascwds_ind_cqc_filled_posts.py
+++ b/tests/unit/test_estimate_missing_ascwds_ind_cqc_filled_posts.py
@@ -93,28 +93,5 @@ class MergeInterpolatedValuesTests(EstimateMissingAscwdsFilledPostsTests):
             )
 
 
-class MergeImputedColumnsTests(EstimateMissingAscwdsFilledPostsTests):
-    def setUp(self) -> None:
-        super().setUp()
-
-    def test_merge_imputed_columns_returns_correct_values(self):
-        test_df = self.spark.createDataFrame(
-            Data.merge_imputed_columns_rows, Schemas.merge_imputed_columns_schema
-        )
-        returned_df = job.merge_imputed_columns(test_df)
-        expected_df = self.spark.createDataFrame(
-            Data.expected_merge_imputed_columns_rows,
-            Schemas.expected_merge_imputed_columns_schema,
-        )
-        returned_data = returned_df.sort(IndCQC.location_id).collect()
-        expected_data = expected_df.collect()
-        for i in range(len(returned_data)):
-            self.assertEqual(
-                returned_data[i][IndCQC.ascwds_filled_posts_imputed],
-                expected_data[i][IndCQC.ascwds_filled_posts_imputed],
-                f"Returned row {i} does not match expected",
-            )
-
-
 if __name__ == "__main__":
     unittest.main(warnings="ignore")

--- a/utils/column_names/ind_cqc_pipeline_columns.py
+++ b/utils/column_names/ind_cqc_pipeline_columns.py
@@ -29,7 +29,6 @@ class IndCqcColumns:
     ascwds_filled_posts: str = "ascwds_filled_posts"
     ascwds_filled_posts_dedup: str = ascwds_filled_posts + "_deduplicated"
     ascwds_filled_posts_dedup_clean: str = ascwds_filled_posts_dedup + "_clean"
-    ascwds_filled_posts_imputed: str = ascwds_filled_posts + "_imputed"
     ascwds_filled_posts_source: str = ascwds_filled_posts + "_source"
     ascwds_filtering_rule: str = "ascwds_filtering_rule"
     ascwds_workplace_import_date: str = AWPClean.ascwds_workplace_import_date


### PR DESCRIPTION
# Description
Function no longer required now imputation code in script

Removed function, tests and test data/schemas

[Branch ran successfully](https://eu-west-2.console.aws.amazon.com/states/home?region=eu-west-2#/v2/executions/details/arn:aws:states:eu-west-2:344210435447:execution:remove-merge-imputed-columns-Ind-CQC-Filled-Post-Estimates-Pipeline:41b3662d-9423-45a9-94a5-2754adfe5541)
