### PR TITLE
Update NR with dormancy model to v2.0.1 - retrained after only excluding ascwds totalstaff only

### DIFF
--- a/terraform/pipeline/glue.tf
+++ b/terraform/pipeline/glue.tf
@@ -760,7 +760,7 @@ module "estimate_ind_cqc_filled_posts_job" {
   job_parameters = {
     "--estimate_missing_ascwds_filled_posts_data_source" = "${module.datasets_bucket.bucket_uri}/domain=ind_cqc_filled_posts/dataset=estimated_missing_ascwds_filled_posts/"
     "--care_home_features_source"                        = "${module.datasets_bucket.bucket_uri}/domain=ind_cqc_filled_posts/dataset=care_home_ind_cqc_features/"
-    "--care_home_model_source"                           = "${module.pipeline_resources.bucket_uri}/models/care_home_filled_posts_prediction/4.0.1/"
+    "--care_home_model_source"                           = "${module.pipeline_resources.bucket_uri}/models/care_home_filled_posts_prediction/4.0.2/"
     "--non_res_with_dormancy_features_source"            = "${module.datasets_bucket.bucket_uri}/domain=ind_cqc_filled_posts/dataset=non_res_ascwds_inc_dormancy_ind_cqc_features/"
     "--non_res_with_dormancy_model_source"               = "${module.pipeline_resources.bucket_uri}/models/non_residential_with_dormancy_prediction/2.0.0/"
     "--non_res_without_dormancy_features_source"         = "${module.datasets_bucket.bucket_uri}/domain=ind_cqc_filled_posts/dataset=non_res_ascwds_without_dormancy_ind_cqc_features/"

--- a/terraform/pipeline/glue.tf
+++ b/terraform/pipeline/glue.tf
@@ -760,9 +760,9 @@ module "estimate_ind_cqc_filled_posts_job" {
   job_parameters = {
     "--estimate_missing_ascwds_filled_posts_data_source" = "${module.datasets_bucket.bucket_uri}/domain=ind_cqc_filled_posts/dataset=estimated_missing_ascwds_filled_posts/"
     "--care_home_features_source"                        = "${module.datasets_bucket.bucket_uri}/domain=ind_cqc_filled_posts/dataset=care_home_ind_cqc_features/"
-    "--care_home_model_source"                           = "${module.pipeline_resources.bucket_uri}/models/care_home_filled_posts_prediction/4.0.2/"
+    "--care_home_model_source"                           = "${module.pipeline_resources.bucket_uri}/models/care_home_filled_posts_prediction/4.0.1/"
     "--non_res_with_dormancy_features_source"            = "${module.datasets_bucket.bucket_uri}/domain=ind_cqc_filled_posts/dataset=non_res_ascwds_inc_dormancy_ind_cqc_features/"
-    "--non_res_with_dormancy_model_source"               = "${module.pipeline_resources.bucket_uri}/models/non_residential_with_dormancy_prediction/2.0.0/"
+    "--non_res_with_dormancy_model_source"               = "${module.pipeline_resources.bucket_uri}/models/non_residential_with_dormancy_prediction/2.0.1/"
     "--non_res_without_dormancy_features_source"         = "${module.datasets_bucket.bucket_uri}/domain=ind_cqc_filled_posts/dataset=non_res_ascwds_without_dormancy_ind_cqc_features/"
     "--non_res_without_dormancy_model_source"            = "${module.pipeline_resources.bucket_uri}/models/non_residential_without_dormancy_prediction/1.0.0/"
     "--estimated_ind_cqc_destination"                    = "${module.datasets_bucket.bucket_uri}/domain=ind_cqc_filled_posts/dataset=estimated_ind_cqc_filled_posts/"

--- a/terraform/pipeline/step-functions/IndCqcFilledPostEstimatePipeline-StepFunction.json
+++ b/terraform/pipeline/step-functions/IndCqcFilledPostEstimatePipeline-StepFunction.json
@@ -250,9 +250,9 @@
                 "Arguments": {
                   "--estimate_missing_ascwds_filled_posts_data_source": "${dataset_bucket_uri}/domain=ind_cqc_filled_posts/dataset=estimated_missing_ascwds_filled_posts/",
                   "--care_home_features_source": "${dataset_bucket_uri}/domain=ind_cqc_filled_posts/dataset=care_home_ind_cqc_features/",
-                  "--care_home_model_source": "${pipeline_resources_bucket_uri}/models/care_home_filled_posts_prediction/4.0.2/",
+                  "--care_home_model_source": "${pipeline_resources_bucket_uri}/models/care_home_filled_posts_prediction/4.0.1/",
                   "--non_res_with_dormancy_features_source": "${dataset_bucket_uri}/domain=ind_cqc_filled_posts/dataset=non_res_ascwds_inc_dormancy_ind_cqc_features/",
-                  "--non_res_with_dormancy_model_source": "${pipeline_resources_bucket_uri}/models/non_residential_with_dormancy_prediction/2.0.0/",
+                  "--non_res_with_dormancy_model_source": "${pipeline_resources_bucket_uri}/models/non_residential_with_dormancy_prediction/2.0.1/",
                   "--non_res_without_dormancy_features_source": "${dataset_bucket_uri}/domain=ind_cqc_filled_posts/dataset=non_res_ascwds_without_dormancy_ind_cqc_features/",
                   "--non_res_without_dormancy_model_source": "${pipeline_resources_bucket_uri}/models/non_residential_without_dormancy_prediction/1.0.0/",
                   "--estimated_ind_cqc_destination": "${dataset_bucket_uri}/domain=ind_cqc_filled_posts/dataset=estimated_ind_cqc_filled_posts/",

--- a/terraform/pipeline/step-functions/IndCqcFilledPostEstimatePipeline-StepFunction.json
+++ b/terraform/pipeline/step-functions/IndCqcFilledPostEstimatePipeline-StepFunction.json
@@ -250,7 +250,7 @@
                 "Arguments": {
                   "--estimate_missing_ascwds_filled_posts_data_source": "${dataset_bucket_uri}/domain=ind_cqc_filled_posts/dataset=estimated_missing_ascwds_filled_posts/",
                   "--care_home_features_source": "${dataset_bucket_uri}/domain=ind_cqc_filled_posts/dataset=care_home_ind_cqc_features/",
-                  "--care_home_model_source": "${pipeline_resources_bucket_uri}/models/care_home_filled_posts_prediction/4.0.1/",
+                  "--care_home_model_source": "${pipeline_resources_bucket_uri}/models/care_home_filled_posts_prediction/4.0.2/",
                   "--non_res_with_dormancy_features_source": "${dataset_bucket_uri}/domain=ind_cqc_filled_posts/dataset=non_res_ascwds_inc_dormancy_ind_cqc_features/",
                   "--non_res_with_dormancy_model_source": "${pipeline_resources_bucket_uri}/models/non_residential_with_dormancy_prediction/2.0.0/",
                   "--non_res_without_dormancy_features_source": "${dataset_bucket_uri}/domain=ind_cqc_filled_posts/dataset=non_res_ascwds_without_dormancy_ind_cqc_features/",


### PR DESCRIPTION
# Description
Update NR model following change to only include ASCWDS where totalstaff and worker records are similar (exclude where only one provided)

Model saved in location
https://eu-west-2.console.aws.amazon.com/s3/buckets/sfc-main-pipeline-resources?region=eu-west-2&bucketType=general&prefix=models/non_residential_with_dormancy_prediction/2.0.1/&showversions=false