### PR TITLE
Create reduced coverage dataset

### DIFF
--- a/jobs/merge_coverage_data.py
+++ b/jobs/merge_coverage_data.py
@@ -73,6 +73,7 @@ def main(
     workplace_for_reconciliation_source: str,
     cqc_ratings_source: str,
     merged_coverage_destination: str,
+    reduced_coverage_destination: str,
 ):
     spark = utils.get_spark()
     spark.sql(
@@ -110,6 +111,20 @@ def main(
     utils.write_to_parquet(
         merged_coverage_df,
         merged_coverage_destination,
+        mode="overwrite",
+        partitionKeys=PartitionKeys,
+    )
+
+    reduced_coverage_df = cUtils.reduce_dataset_to_earliest_file_per_month(
+        merged_coverage_df
+    )
+    reduced_coverage_df = utils.filter_df_to_maximum_value_in_column(
+        reduced_coverage_df, CQCLClean.cqc_location_import_date
+    )
+
+    utils.write_to_parquet(
+        reduced_coverage_df,
+        reduced_coverage_destination,
         mode="overwrite",
         partitionKeys=PartitionKeys,
     )
@@ -252,6 +267,7 @@ if __name__ == "__main__":
         workplace_for_reconciliation_source,
         cqc_ratings_source,
         merged_coverage_destination,
+        reduced_coverage_destination,
     ) = utils.collect_arguments(
         (
             "--cleaned_cqc_location_source",
@@ -264,7 +280,11 @@ if __name__ == "__main__":
         ("--cqc_ratings_source", "Source s3 directory for parquet CQC ratings dataset"),
         (
             "--merged_coverage_destination",
-            "Destination s3 directory for parquet",
+            "Destination s3 directory for full parquet",
+        ),
+        (
+            "--reduced_coverage_destination",
+            "Destination s3 directory for single month parquet",
         ),
     )
     main(
@@ -272,6 +292,7 @@ if __name__ == "__main__":
         workplace_for_reconciliation_source,
         cqc_ratings_source,
         merged_coverage_destination,
+        reduced_coverage_destination,
     )
 
     print("Spark job 'merge_coverage_data' complete")

--- a/terraform/pipeline/glue.tf
+++ b/terraform/pipeline/glue.tf
@@ -423,6 +423,7 @@ module "merge_coverage_data_job" {
     "--workplace_for_reconciliation_source" = "${module.datasets_bucket.bucket_uri}/domain=SfC/dataset=workplace_for_reconciliation/"
     "--cqc_ratings_source"                  = "${module.datasets_bucket.bucket_uri}/domain=SfC/dataset=cqc_ratings/"
     "--merged_coverage_destination"         = "${module.datasets_bucket.bucket_uri}/domain=SfC/dataset=merged_coverage_data/"
+    "--reduced_coverage_destination"        = "${module.datasets_bucket.bucket_uri}/domain=SfC/dataset=monthly_coverage_data/"
   }
 }
 

--- a/terraform/pipeline/step-functions/IndCqcFilledPostEstimatePipeline-StepFunction.json
+++ b/terraform/pipeline/step-functions/IndCqcFilledPostEstimatePipeline-StepFunction.json
@@ -353,7 +353,8 @@
                   "--cleaned_cqc_location_source": "${dataset_bucket_uri}/domain=CQC/dataset=locations_api_cleaned/",
                   "--workplace_for_reconciliation_source": "${dataset_bucket_uri}/domain=SfC/dataset=workplace_for_reconciliation/",
                   "--cqc_ratings_source": "${dataset_bucket_uri}/domain=SfC/dataset=cqc_ratings/",
-                  "--merged_coverage_destination": "${dataset_bucket_uri}/domain=SfC/dataset=merged_coverage_data/"
+                  "--merged_coverage_destination": "${dataset_bucket_uri}/domain=SfC/dataset=merged_coverage_data/",
+                  "--reduced_coverage_destination": "${dataset_bucket_uri}/domain=SfC/dataset=monthly_coverage_data/"
                 }
               },
               "Next": "Run sfc crawler"


### PR DESCRIPTION
# Description
Saves the most recent month's earliest dataset as a separate parquet for monthly coverage access.
Update main tests to account for change

# How to test
Unit tests passing
Run in branch: https://eu-west-2.console.aws.amazon.com/states/home?region=eu-west-2#/v2/executions/details/arn:aws:states:eu-west-2:344210435447:execution:create-reduced-coverage-datase-Ind-CQC-Filled-Post-Estimates-Pipeline:cc064f97-195d-4628-b63c-e11d66173f7f

# Developer checklist
- [x] Unit test
- [x] Linked to Trello ticket: https://trello.com/c/3uSxEUhE/824-create-reduced-dataset-for-monthly-coverage
- [x] Documentation up to date
