### PR TITLE
Rename feature jobs to prepare_features_...

### DIFF
--- a/jobs/prepare_features_care_home_ind_cqc.py
+++ b/jobs/prepare_features_care_home_ind_cqc.py
@@ -118,7 +118,7 @@ def filter_df_to_care_home_only(df: DataFrame) -> DataFrame:
 
 
 if __name__ == "__main__":
-    print("Spark job 'prepare_care_home_ind_cqc_features' starting...")
+    print("Spark job 'prepare_features_care_home_ind_cqc' starting...")
     print(f"Job parameters: {sys.argv}")
 
     (
@@ -140,4 +140,4 @@ if __name__ == "__main__":
         care_home_ind_cqc_features_destination,
     )
 
-    print("Spark job 'prepare_care_home_ind_cqc_features' complete")
+    print("Spark job 'prepare_features_care_home_ind_cqc' complete")

--- a/jobs/prepare_features_non_res_ascwds_ind_cqc.py
+++ b/jobs/prepare_features_non_res_ascwds_ind_cqc.py
@@ -240,7 +240,7 @@ def filter_df_to_non_null_dormancy(df: DataFrame) -> DataFrame:
 
 
 if __name__ == "__main__":
-    print("Spark job 'prepare_non_res_ascwds_ind_cqc_features' starting...")
+    print("Spark job 'prepare_features_non_res_ascwds_ind_cqc' starting...")
     print(f"Job parameters: {sys.argv}")
 
     (
@@ -268,4 +268,4 @@ if __name__ == "__main__":
         non_res_ascwds_without_dormancy_ind_cqc_features_destination,
     )
 
-    print("Spark job 'prepare_non_res_ascwds_ind_cqc_features' complete")
+    print("Spark job 'prepare_features_non_res_ascwds_ind_cqc' complete")

--- a/terraform/pipeline/glue.tf
+++ b/terraform/pipeline/glue.tf
@@ -180,9 +180,9 @@ module "clean_ons_data_job" {
 }
 
 
-module "prepare_non_res_ascwds_ind_cqc_features_job" {
+module "prepare_features_non_res_ascwds_ind_cqc_job" {
   source          = "../modules/glue-job"
-  script_name     = "prepare_non_res_ascwds_ind_cqc_features.py"
+  script_name     = "prepare_features_non_res_ascwds_ind_cqc.py"
   glue_role       = aws_iam_role.sfc_glue_service_iam_role
   resource_bucket = module.pipeline_resources
   datasets_bucket = module.datasets_bucket
@@ -721,9 +721,9 @@ module "validate_postcode_directory_raw_data_job" {
   }
 }
 
-module "prepare_care_home_ind_cqc_features_job" {
+module "prepare_features_care_home_ind_cqc_job" {
   source          = "../modules/glue-job"
-  script_name     = "prepare_care_home_ind_cqc_features.py"
+  script_name     = "prepare_features_care_home_ind_cqc.py"
   glue_role       = aws_iam_role.sfc_glue_service_iam_role
   resource_bucket = module.pipeline_resources
   datasets_bucket = module.datasets_bucket

--- a/terraform/pipeline/step-function.tf
+++ b/terraform/pipeline/step-function.tf
@@ -17,8 +17,8 @@ resource "aws_sfn_state_machine" "ind_cqc_filled_post_estimates_pipeline_state_m
     merge_coverage_data_job_name                          = module.merge_coverage_data_job.job_name
     clean_ind_cqc_filled_posts_job_name                   = module.clean_ind_cqc_filled_posts_job.job_name
     estimate_missing_ascwds_ind_cqc_filled_posts_job_name = module.estimate_missing_ascwds_ind_cqc_filled_posts_job.job_name
-    prepare_care_home_ind_cqc_features_job_name           = module.prepare_care_home_ind_cqc_features_job.job_name
-    prepare_non_res_ascwds_ind_cqc_features_job_name      = module.prepare_non_res_ascwds_ind_cqc_features_job.job_name
+    prepare_features_care_home_ind_cqc_job_name           = module.prepare_features_care_home_ind_cqc_job.job_name
+    prepare_features_non_res_ascwds_ind_cqc_job_name      = module.prepare_features_non_res_ascwds_ind_cqc_job.job_name
     estimate_ind_cqc_filled_posts_job_name                = module.estimate_ind_cqc_filled_posts_job.job_name
     estimate_ind_cqc_filled_posts_by_job_role_job_name    = module.estimate_ind_cqc_filled_posts_by_job_role_job.job_name
     diagnostics_on_known_filled_posts_job_name            = module.diagnostics_on_known_filled_posts_job.job_name

--- a/terraform/pipeline/step-functions/IndCqcFilledPostEstimatePipeline-StepFunction.json
+++ b/terraform/pipeline/step-functions/IndCqcFilledPostEstimatePipeline-StepFunction.json
@@ -211,7 +211,7 @@
                       "Type": "Task",
                       "Resource": "arn:aws:states:::glue:startJobRun.sync",
                       "Parameters": {
-                        "JobName": "${prepare_care_home_ind_cqc_features_job_name}",
+                        "JobName": "${prepare_features_care_home_ind_cqc_job_name}",
                         "Arguments": {
                           "--ind_cqc_filled_posts_cleaned_source": "${dataset_bucket_uri}/domain=ind_cqc_filled_posts/dataset=estimated_missing_ascwds_filled_posts/",
                           "--care_home_ind_cqc_features_destination": "${dataset_bucket_uri}/domain=ind_cqc_filled_posts/dataset=care_home_ind_cqc_features/"
@@ -228,7 +228,7 @@
                       "Type": "Task",
                       "Resource": "arn:aws:states:::glue:startJobRun.sync",
                       "Parameters": {
-                        "JobName": "${prepare_non_res_ascwds_ind_cqc_features_job_name}",
+                        "JobName": "${prepare_features_non_res_ascwds_ind_cqc_job_name}",
                         "Arguments": {
                           "--ind_cqc_filled_posts_cleaned_source": "${dataset_bucket_uri}/domain=ind_cqc_filled_posts/dataset=estimated_missing_ascwds_filled_posts/",
                           "--non_res_ascwds_inc_dormancy_ind_cqc_features_destination": "${dataset_bucket_uri}/domain=ind_cqc_filled_posts/dataset=non_res_ascwds_inc_dormancy_ind_cqc_features/",

--- a/tests/unit/test_prepare_features_care_home_ind_cqc.py
+++ b/tests/unit/test_prepare_features_care_home_ind_cqc.py
@@ -5,7 +5,7 @@ from unittest.mock import ANY, Mock, patch
 from pyspark.sql import functions as F
 from pyspark.ml.linalg import SparseVector
 
-import jobs.prepare_care_home_ind_cqc_features as job
+import jobs.prepare_features_care_home_ind_cqc as job
 from utils import utils
 
 from utils.column_names.ind_cqc_pipeline_columns import (
@@ -30,13 +30,13 @@ class CareHomeFeaturesIndCqcFilledPosts(unittest.TestCase):
         warnings.simplefilter("ignore", ResourceWarning)
 
     @patch("utils.utils.write_to_parquet")
-    @patch("jobs.prepare_care_home_ind_cqc_features.vectorise_dataframe")
-    @patch("jobs.prepare_care_home_ind_cqc_features.add_import_month_index_into_df")
+    @patch("jobs.prepare_features_care_home_ind_cqc.vectorise_dataframe")
+    @patch("jobs.prepare_features_care_home_ind_cqc.add_import_month_index_into_df")
     @patch(
-        "jobs.prepare_care_home_ind_cqc_features.convert_categorical_variable_to_binary_variables_based_on_a_dictionary"
+        "jobs.prepare_features_care_home_ind_cqc.convert_categorical_variable_to_binary_variables_based_on_a_dictionary"
     )
-    @patch("jobs.prepare_care_home_ind_cqc_features.column_expansion_with_dict")
-    @patch("jobs.prepare_care_home_ind_cqc_features.add_array_column_count_to_data")
+    @patch("jobs.prepare_features_care_home_ind_cqc.column_expansion_with_dict")
+    @patch("jobs.prepare_features_care_home_ind_cqc.add_array_column_count_to_data")
     @patch("utils.utils.read_from_parquet")
     def test_main(
         self,

--- a/tests/unit/test_prepare_features_non_res_ascwds_ind_cqc.py
+++ b/tests/unit/test_prepare_features_non_res_ascwds_ind_cqc.py
@@ -2,7 +2,7 @@ import unittest
 import warnings
 from unittest.mock import ANY, Mock, patch, call
 
-import jobs.prepare_non_res_ascwds_ind_cqc_features as job
+import jobs.prepare_features_non_res_ascwds_ind_cqc as job
 from utils import utils
 
 from utils.column_names.ind_cqc_pipeline_columns import (
@@ -25,14 +25,14 @@ class NonResLocationsFeatureEngineeringTests(unittest.TestCase):
         warnings.simplefilter("ignore", ResourceWarning)
 
     @patch("utils.utils.write_to_parquet")
-    @patch("jobs.prepare_non_res_ascwds_ind_cqc_features.vectorise_dataframe")
-    @patch("jobs.prepare_non_res_ascwds_ind_cqc_features.add_date_diff_into_df")
+    @patch("jobs.prepare_features_non_res_ascwds_ind_cqc.vectorise_dataframe")
+    @patch("jobs.prepare_features_non_res_ascwds_ind_cqc.add_date_diff_into_df")
     @patch(
-        "jobs.prepare_non_res_ascwds_ind_cqc_features.convert_categorical_variable_to_binary_variables_based_on_a_dictionary"
+        "jobs.prepare_features_non_res_ascwds_ind_cqc.convert_categorical_variable_to_binary_variables_based_on_a_dictionary"
     )
-    @patch("jobs.prepare_non_res_ascwds_ind_cqc_features.column_expansion_with_dict")
+    @patch("jobs.prepare_features_non_res_ascwds_ind_cqc.column_expansion_with_dict")
     @patch(
-        "jobs.prepare_non_res_ascwds_ind_cqc_features.add_array_column_count_to_data"
+        "jobs.prepare_features_non_res_ascwds_ind_cqc.add_array_column_count_to_data"
     )
     @patch("utils.utils.read_from_parquet")
     def test_main(


### PR DESCRIPTION
# Description
Renaming features jobs so they start with `prepare_features_....`

# How to test
[Branch run](https://eu-west-2.console.aws.amazon.com/states/home?region=eu-west-2#/v2/executions/details/arn:aws:states:eu-west-2:344210435447:execution:rename-feature-jobs-Ind-CQC-Filled-Post-Estimates-Pipeline:7a1f2c22-b395-4d9f-9872-7dfd0b181547)

# Developer checklist
- [X] Unit test
- [X] Documentation up to date
