### PR TITLE
Add rolling average to non residential capacity tracker data

### DIFF
--- a/jobs/clean_capacity_tracker_non_res_data.py
+++ b/jobs/clean_capacity_tracker_non_res_data.py
@@ -1,5 +1,7 @@
 import sys
 
+from pyspark.sql import DataFrame, functions as F, Window
+
 from utils import utils
 import utils.cleaning_utils as cUtils
 from utils.column_names.capacity_tracker_columns import (
@@ -7,9 +9,6 @@ from utils.column_names.capacity_tracker_columns import (
     CapacityTrackerNonResCleanColumns as CTNRClean,
 )
 from utils.column_names.ind_cqc_pipeline_columns import PartitionKeys as Keys
-from utils.estimate_filled_posts.models.primary_service_rolling_average import (
-    model_primary_service_rolling_average,
-)
 
 CAPACITY_TRACKER_NON_RES_COLUMNS = [
     CTNR.cqc_id,
@@ -49,12 +48,8 @@ def main(
         columns_to_bound,
         upper_limit=OUTLIER_CUTOFF,
     )
-    capacity_tracker_non_res_df = model_primary_service_rolling_average(
+    capacity_tracker_non_res_df = calculate_capacity_tracker_rolling_average(
         capacity_tracker_non_res_df,
-        care_home_column_to_average=CTNRClean.service_user_count,
-        non_res_column_to_average=CTNRClean.cqc_care_workers_employed,
-        number_of_days=NUMBER_OF_DAYS_IN_ROLLING_AVERAGE,
-        model_column_name=CTNRClean.capacity_tracker_rolling_average,
     )
 
     print(f"Exporting as parquet to {cleaned_capacity_tracker_non_res_destination}")
@@ -69,6 +64,10 @@ def main(
             Keys.import_date,
         ],
     )
+
+
+def calculate_capacity_tracker_rolling_average(df: DataFrame) -> DataFrame:
+    return df
 
 
 if __name__ == "__main__":

--- a/jobs/clean_capacity_tracker_non_res_data.py
+++ b/jobs/clean_capacity_tracker_non_res_data.py
@@ -67,6 +67,17 @@ def main(
 
 
 def calculate_capacity_tracker_rolling_average(df: DataFrame) -> DataFrame:
+    """
+    Calculates the rolling average of cqc_care_workers_employed as a new column in the dataset.
+
+    Args:
+        df(DataFrame): Non residential capacity tracker dataframe, including columns: cqc_id,
+        capacity_tracker_import_date, cqc_care_workers_employed.
+
+    Returns:
+        DataFrame: Non residential capactity tracker dataframe with an additional column containing
+        the rolling average of cqc_care_workers_employed.
+    """
     df = utils.create_unix_timestamp_variable_from_date_column(
         df,
         date_col=CTNRClean.capacity_tracker_import_date,

--- a/jobs/clean_capacity_tracker_non_res_data.py
+++ b/jobs/clean_capacity_tracker_non_res_data.py
@@ -67,6 +67,24 @@ def main(
 
 
 def calculate_capacity_tracker_rolling_average(df: DataFrame) -> DataFrame:
+    df = utils.create_unix_timestamp_variable_from_date_column(
+        df,
+        date_col=CTNRClean.capacity_tracker_import_date,
+        date_format="yyyy-MM-dd",
+        new_col_name=CTNRClean.unix_timestamp,
+    )
+    window = (
+        Window.partitionBy(F.col(CTNR.cqc_id))
+        .orderBy(F.col(CTNRClean.unix_timestamp))
+        .rangeBetween(
+            -utils.convert_days_to_unix_time(NUMBER_OF_DAYS_IN_ROLLING_AVERAGE), 0
+        )
+    )
+    df = df.withColumn(
+        CTNRClean.cqc_care_workers_employed_rolling_avg,
+        F.avg(CTNRClean.cqc_care_workers_employed).over(window),
+    )
+    df = df.drop(CTNRClean.unix_timestamp)
     return df
 
 

--- a/jobs/clean_capacity_tracker_non_res_data.py
+++ b/jobs/clean_capacity_tracker_non_res_data.py
@@ -7,6 +7,9 @@ from utils.column_names.capacity_tracker_columns import (
     CapacityTrackerNonResCleanColumns as CTNRClean,
 )
 from utils.column_names.ind_cqc_pipeline_columns import PartitionKeys as Keys
+from utils.estimate_filled_posts.models.primary_service_rolling_average import (
+    model_primary_service_rolling_average,
+)
 
 CAPACITY_TRACKER_NON_RES_COLUMNS = [
     CTNR.cqc_id,
@@ -18,6 +21,7 @@ CAPACITY_TRACKER_NON_RES_COLUMNS = [
     Keys.import_date,
 ]
 OUTLIER_CUTOFF = 5000
+NUMBER_OF_DAYS_IN_ROLLING_AVERAGE = 185  # Note: using 185 as a proxy for 6 months
 
 
 def main(
@@ -44,6 +48,13 @@ def main(
         columns_to_bound,
         columns_to_bound,
         upper_limit=OUTLIER_CUTOFF,
+    )
+    capacity_tracker_non_res_df = model_primary_service_rolling_average(
+        capacity_tracker_non_res_df,
+        care_home_column_to_average=CTNRClean.service_user_count,
+        non_res_column_to_average=CTNRClean.cqc_care_workers_employed,
+        number_of_days=NUMBER_OF_DAYS_IN_ROLLING_AVERAGE,
+        model_column_name=CTNRClean.capacity_tracker_rolling_average,
     )
 
     print(f"Exporting as parquet to {cleaned_capacity_tracker_non_res_destination}")

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -935,6 +935,23 @@ class CapacityTrackerNonResData:
         ("loc 1", "12", "300", "2024", "01", "01", "20240101", "other data"),
     ]
 
+    capacity_tracker_non_res_rolling_average_rows = [
+        ("loc 1", date(2024, 1, 1), 10),
+        ("loc 1", date(2024, 2, 1), 15),
+        ("loc 1", date(2024, 3, 1), 20),
+        ("loc 1", date(2024, 4, 1), None),
+        ("loc 2", date(2024, 1, 1), 10),
+        ("loc 2", date(2024, 2, 1), 15),
+    ]
+    expected_capacity_tracker_non_res_rolling_average_rows =[
+        ("loc 1", date(2024, 1, 1), 10, 10.0),
+        ("loc 1", date(2024, 3, 1), 15, 12.5),
+        ("loc 1", date(2024, 5, 1), 20, 15.0),
+        ("loc 1", date(2024, 7, 1), None, 17.5),
+        ("loc 2", date(2024, 1, 1), 10, 10.0),
+        ("loc 2", date(2024, 2, 1), 15, 12.5),
+    ]
+
     remove_invalid_characters_from_column_names_rows = [
         ("loc 1", "some data", "other data", "another data", "more data"),
     ]

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -937,17 +937,17 @@ class CapacityTrackerNonResData:
 
     capacity_tracker_non_res_rolling_average_rows = [
         ("loc 1", date(2024, 1, 1), 10),
-        ("loc 1", date(2024, 2, 1), 15),
-        ("loc 1", date(2024, 3, 1), 20),
-        ("loc 1", date(2024, 4, 1), None),
+        ("loc 1", date(2024, 3, 1), 15),
+        ("loc 1", date(2024, 5, 1), 20),
+        ("loc 1", date(2024, 8, 1), None),
         ("loc 2", date(2024, 1, 1), 10),
         ("loc 2", date(2024, 2, 1), 15),
     ]
-    expected_capacity_tracker_non_res_rolling_average_rows =[
+    expected_capacity_tracker_non_res_rolling_average_rows = [
         ("loc 1", date(2024, 1, 1), 10, 10.0),
         ("loc 1", date(2024, 3, 1), 15, 12.5),
         ("loc 1", date(2024, 5, 1), 20, 15.0),
-        ("loc 1", date(2024, 7, 1), None, 17.5),
+        ("loc 1", date(2024, 8, 1), None, 17.5),
         ("loc 2", date(2024, 1, 1), 10, 10.0),
         ("loc 2", date(2024, 2, 1), 15, 12.5),
     ]

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -938,18 +938,34 @@ class CapacityTrackerNonResData:
     capacity_tracker_non_res_rolling_average_rows = [
         ("loc 1", date(2024, 1, 1), 10),
         ("loc 1", date(2024, 3, 1), 15),
-        ("loc 1", date(2024, 5, 1), 20),
-        ("loc 1", date(2024, 8, 1), None),
-        ("loc 2", date(2024, 1, 1), 10),
-        ("loc 2", date(2024, 2, 1), 15),
     ]
     expected_capacity_tracker_non_res_rolling_average_rows = [
         ("loc 1", date(2024, 1, 1), 10, 10.0),
         ("loc 1", date(2024, 3, 1), 15, 12.5),
-        ("loc 1", date(2024, 5, 1), 20, 15.0),
-        ("loc 1", date(2024, 8, 1), None, 17.5),
-        ("loc 2", date(2024, 1, 1), 10, 10.0),
-        ("loc 2", date(2024, 2, 1), 15, 12.5),
+    ]
+
+    capacity_tracker_non_res_rolling_average_over_six_months_rows = [
+        ("loc 1", date(2024, 1, 1), 10),
+        ("loc 1", date(2024, 2, 1), 15),
+        ("loc 1", date(2024, 8, 1), None),
+    ]
+    expected_capacity_tracker_non_res_rolling_average_over_six_months_rows = [
+        ("loc 1", date(2024, 1, 1), 10, 10.0),
+        ("loc 1", date(2024, 2, 1), 15, 12.5),
+        ("loc 1", date(2024, 8, 1), None, 15.0),
+    ]
+
+    capacity_tracker_non_res_rolling_average_by_location_rows = [
+        ("loc 1", date(2024, 1, 1), 10),
+        ("loc 1", date(2024, 3, 1), 15),
+        ("loc 2", date(2024, 1, 1), 20),
+        ("loc 2", date(2024, 2, 1), 25),
+    ]
+    expected_capacity_tracker_non_res_rolling_average_by_location_rows = [
+        ("loc 1", date(2024, 1, 1), 10, 10.0),
+        ("loc 1", date(2024, 3, 1), 15, 12.5),
+        ("loc 2", date(2024, 1, 1), 20, 20.0),
+        ("loc 2", date(2024, 2, 1), 25, 22.5),
     ]
 
     remove_invalid_characters_from_column_names_rows = [

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -587,7 +587,6 @@ class CapacityTrackerNonResSchema:
             StructField(CTNR.cqc_id, StringType(), True),
             StructField(CTNRClean.capacity_tracker_import_date, DateType(), True),
             StructField(CTNR.cqc_care_workers_employed, IntegerType(), True),
-            
         ]
     )
     expected_capacity_tracker_non_res_rolling_average_schema = StructType(

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -552,7 +552,7 @@ class CapacityTrackerNonResSchema:
             StructField(CTNR.legacy_covid_confirmed, StringType(), True),
             StructField(CTNR.legacy_covid_suspected, StringType(), True),
             StructField(CTNR.cqc_care_workers_employed, StringType(), True),
-            StructField(CTNR.cqc_car_eworkers_absent, StringType(), True),
+            StructField(CTNR.cqc_care_workers_absent, StringType(), True),
             StructField(CTNR.can_provider_more_hours, StringType(), True),
             StructField(CTNR.extra_hours_count, StringType(), True),
             StructField(CTNR.covid_vaccination_full_course, StringType(), True),

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -582,6 +582,23 @@ class CapacityTrackerNonResSchema:
         ]
     )
 
+    capacity_tracker_non_res_rolling_average_schema = StructType(
+        [
+            StructField(CTNR.cqc_id, StringType(), True),
+            StructField(CTNRClean.capacity_tracker_import_date, DateType(), True),
+            StructField(CTNR.cqc_care_workers_employed, IntegerType(), True),
+            
+        ]
+    )
+    expected_capacity_tracker_non_res_rolling_average_schema = StructType(
+        [
+            *capacity_tracker_non_res_rolling_average_schema,
+            StructField(
+                CTNRClean.cqc_care_workers_employed_rolling_avg, FloatType(), True
+            ),
+        ]
+    )
+
     remove_invalid_characters_from_column_names_schema = StructType(
         [
             StructField(CTNR.cqc_id, StringType(), True),

--- a/tests/unit/test_clean_capacity_tracker_non_res_data.py
+++ b/tests/unit/test_clean_capacity_tracker_non_res_data.py
@@ -68,6 +68,8 @@ class CalculateCapacityTrackerRollingAverageTests(CapacityTrackerNonResTests):
 
     def test_calcaulte_capacity_tracker_rolling_average(self):
         returned_df = job.calculate_capacity_tracker_rolling_average(self.test_df)
+        returned_df.show()
+        self.expected_df.show()
         self.assertEqual(
             returned_df.sort(
                 CTNR.cqc_id, CTNRClean.capacity_tracker_import_date

--- a/tests/unit/test_clean_capacity_tracker_non_res_data.py
+++ b/tests/unit/test_clean_capacity_tracker_non_res_data.py
@@ -57,24 +57,24 @@ class MainTests(CapacityTrackerNonResTests):
 class CalculateCapacityTrackerRollingAverageTests(CapacityTrackerNonResTests):
     def setUp(self) -> None:
         super().setUp()
-        self.test_df = self.spark.createDataFrame(
+
+    def test_calculate_capacity_tracker_rolling_average(self):
+        test_df = self.spark.createDataFrame(
             Data.capacity_tracker_non_res_rolling_average_rows,
             Schemas.capacity_tracker_non_res_rolling_average_schema,
         )
-        self.expected_df = self.spark.createDataFrame(
+        expected_df = self.spark.createDataFrame(
             Data.expected_capacity_tracker_non_res_rolling_average_rows,
             Schemas.expected_capacity_tracker_non_res_rolling_average_schema,
         )
-
-    def test_calcaulte_capacity_tracker_rolling_average(self):
-        returned_df = job.calculate_capacity_tracker_rolling_average(self.test_df)
+        returned_df = job.calculate_capacity_tracker_rolling_average(test_df)
         returned_df.show()
-        self.expected_df.show()
+        expected_df.show()
         self.assertEqual(
             returned_df.sort(
                 CTNR.cqc_id, CTNRClean.capacity_tracker_import_date
             ).collect(),
-            self.expected_df.collect(),
+            expected_df.collect(),
         )
 
 

--- a/tests/unit/test_clean_capacity_tracker_non_res_data.py
+++ b/tests/unit/test_clean_capacity_tracker_non_res_data.py
@@ -58,13 +58,55 @@ class CalculateCapacityTrackerRollingAverageTests(CapacityTrackerNonResTests):
     def setUp(self) -> None:
         super().setUp()
 
-    def test_calculate_capacity_tracker_rolling_average(self):
+    def test_calculate_capacity_tracker_rolling_average_calculates_a_rolling_average(
+        self,
+    ):
         test_df = self.spark.createDataFrame(
             Data.capacity_tracker_non_res_rolling_average_rows,
             Schemas.capacity_tracker_non_res_rolling_average_schema,
         )
         expected_df = self.spark.createDataFrame(
             Data.expected_capacity_tracker_non_res_rolling_average_rows,
+            Schemas.expected_capacity_tracker_non_res_rolling_average_schema,
+        )
+        returned_df = job.calculate_capacity_tracker_rolling_average(test_df)
+        self.assertEqual(
+            returned_df.sort(
+                CTNR.cqc_id, CTNRClean.capacity_tracker_import_date
+            ).collect(),
+            expected_df.collect(),
+        )
+
+    def test_calculate_capacity_tracker_rolling_average_calculates_rolling_average_correctly_when_date_spans_over_185_days(
+        self,
+    ):
+        test_df = self.spark.createDataFrame(
+            Data.capacity_tracker_non_res_rolling_average_over_six_months_rows,
+            Schemas.capacity_tracker_non_res_rolling_average_schema,
+        )
+        expected_df = self.spark.createDataFrame(
+            Data.expected_capacity_tracker_non_res_rolling_average_over_six_months_rows,
+            Schemas.expected_capacity_tracker_non_res_rolling_average_schema,
+        )
+        returned_df = job.calculate_capacity_tracker_rolling_average(test_df)
+        returned_df.show()
+        expected_df.show()
+        self.assertEqual(
+            returned_df.sort(
+                CTNR.cqc_id, CTNRClean.capacity_tracker_import_date
+            ).collect(),
+            expected_df.collect(),
+        )
+
+    def test_calculate_capacity_tracker_rolling_average_calculates_rolling_average_separately_for_each_location(
+        self,
+    ):
+        test_df = self.spark.createDataFrame(
+            Data.capacity_tracker_non_res_rolling_average_by_location_rows,
+            Schemas.capacity_tracker_non_res_rolling_average_schema,
+        )
+        expected_df = self.spark.createDataFrame(
+            Data.expected_capacity_tracker_non_res_rolling_average_by_location_rows,
             Schemas.expected_capacity_tracker_non_res_rolling_average_schema,
         )
         returned_df = job.calculate_capacity_tracker_rolling_average(test_df)

--- a/tests/unit/test_clean_capacity_tracker_non_res_data.py
+++ b/tests/unit/test_clean_capacity_tracker_non_res_data.py
@@ -89,8 +89,6 @@ class CalculateCapacityTrackerRollingAverageTests(CapacityTrackerNonResTests):
             Schemas.expected_capacity_tracker_non_res_rolling_average_schema,
         )
         returned_df = job.calculate_capacity_tracker_rolling_average(test_df)
-        returned_df.show()
-        expected_df.show()
         self.assertEqual(
             returned_df.sort(
                 CTNR.cqc_id, CTNRClean.capacity_tracker_import_date
@@ -110,8 +108,6 @@ class CalculateCapacityTrackerRollingAverageTests(CapacityTrackerNonResTests):
             Schemas.expected_capacity_tracker_non_res_rolling_average_schema,
         )
         returned_df = job.calculate_capacity_tracker_rolling_average(test_df)
-        returned_df.show()
-        expected_df.show()
         self.assertEqual(
             returned_df.sort(
                 CTNR.cqc_id, CTNRClean.capacity_tracker_import_date

--- a/tests/unit/test_clean_capacity_tracker_non_res_data.py
+++ b/tests/unit/test_clean_capacity_tracker_non_res_data.py
@@ -5,6 +5,10 @@ import jobs.clean_capacity_tracker_non_res_data as job
 from tests.test_file_data import CapacityTrackerNonResData as Data
 from tests.test_file_schemas import CapacityTrackerNonResSchema as Schemas
 from utils import utils
+from utils.column_names.capacity_tracker_columns import (
+    CapacityTrackerNonResColumns as CTNR,
+    CapacityTrackerNonResCleanColumns as CTNRClean,
+)
 from utils.column_names.ind_cqc_pipeline_columns import PartitionKeys as Keys
 
 
@@ -47,6 +51,28 @@ class MainTests(CapacityTrackerNonResTests):
             self.TEST_CAPACITY_TRACKER_DESTINATION,
             mode="overwrite",
             partitionKeys=self.partition_keys,
+        )
+
+
+class CalculateCapacityTrackerRollingAverageTests(CapacityTrackerNonResTests):
+    def setUp(self) -> None:
+        super().setUp()
+        self.test_df = self.spark.createDataFrame(
+            Data.capacity_tracker_non_res_rolling_average_rows,
+            Schemas.capacity_tracker_non_res_rolling_average_schema,
+        )
+        self.expected_df = self.spark.createDataFrame(
+            Data.expected_capacity_tracker_non_res_rolling_average_rows,
+            Schemas.expected_capacity_tracker_non_res_rolling_average_schema,
+        )
+
+    def test_calcaulte_capacity_tracker_rolling_average(self):
+        returned_df = job.calculate_capacity_tracker_rolling_average(self.test_df)
+        self.assertEqual(
+            returned_df.sort(
+                CTNR.cqc_id, CTNRClean.capacity_tracker_import_date
+            ).collect(),
+            self.expected_df.collect(),
         )
 
 

--- a/utils/column_names/capacity_tracker_columns.py
+++ b/utils/column_names/capacity_tracker_columns.py
@@ -63,7 +63,7 @@ class CapacityTrackerNonResColumns:
     covid19_suspected_count: str = "covid19suspectedcount"
     covid_confirmed_and_suspected: str = "covidconfirmedandsuspected"
     covid_notes: str = "covidnotes"
-    cqc_car_eworkers_absent: str = "cqccareworkersabsent"
+    cqc_care_workers_absent: str = "cqccareworkersabsent"
     cqc_care_workers_employed: str = "cqccareworkersemployed"
     cqc_id: str = "cqcid"
     cqc_survey_last_updated_bst: str = "cqcsurveylastupdatedbst"
@@ -107,3 +107,4 @@ class CapacityTrackerNonResCleanColumns(CapacityTrackerNonResColumns):
     capacity_tracker_import_date: str = (
         CapacityTrackerCareHomeCleanColumns.capacity_tracker_import_date
     )
+    capacity_tracker_rolling_average: str = "capacity_tracker_rolling_average"

--- a/utils/column_names/capacity_tracker_columns.py
+++ b/utils/column_names/capacity_tracker_columns.py
@@ -110,3 +110,4 @@ class CapacityTrackerNonResCleanColumns(CapacityTrackerNonResColumns):
     cqc_care_workers_employed_rolling_avg: str = (
         CapacityTrackerNonResColumns.cqc_care_workers_employed + "_rolling_avg"
     )
+    unix_timestamp: str = "unix_timestamp"

--- a/utils/column_names/capacity_tracker_columns.py
+++ b/utils/column_names/capacity_tracker_columns.py
@@ -107,4 +107,6 @@ class CapacityTrackerNonResCleanColumns(CapacityTrackerNonResColumns):
     capacity_tracker_import_date: str = (
         CapacityTrackerCareHomeCleanColumns.capacity_tracker_import_date
     )
-    capacity_tracker_rolling_average: str = "capacity_tracker_rolling_average"
+    cqc_care_workers_employed_rolling_avg: str = (
+        CapacityTrackerNonResColumns.cqc_care_workers_employed + "_rolling_avg"
+    )


### PR DESCRIPTION
# Description
Add rolling average column to non residential capacity tracker data

# How to test
Unit tests passing
Run in branch: https://eu-west-2.console.aws.amazon.com/states/home?region=eu-west-2#/statemachines/view/arn%3Aaws%3Astates%3Aeu-west-2%3A344210435447%3AstateMachine%3Act-rolling-average-IngestAndCleanCapacityTrackerDataPipeline?type=standard

# Developer checklist
- [x] Unit test
- [x] Linked to Trello ticket: https://trello.com/c/MFfh6Vlr/828-add-column-for-rolling-average-of-ct-data
- [x] Documentation up to date
