### PR TITLE
Replace filters in features jobs with utils filter functions

### DIFF
--- a/jobs/prepare_features_care_home_ind_cqc.py
+++ b/jobs/prepare_features_care_home_ind_cqc.py
@@ -1,7 +1,7 @@
 import sys
 from typing import List
 
-from pyspark.sql import DataFrame, functions as F
+from pyspark.sql import DataFrame
 
 
 from utils import utils

--- a/jobs/prepare_features_care_home_ind_cqc.py
+++ b/jobs/prepare_features_care_home_ind_cqc.py
@@ -36,7 +36,9 @@ def main(
 
     locations_df = utils.read_from_parquet(ind_cqc_filled_posts_cleaned_source)
 
-    filtered_loc_data = filter_df_to_care_home_only(locations_df)
+    filtered_loc_data = utils.select_rows_with_value(
+        locations_df, IndCQC.care_home, CareHome.care_home
+    )
 
     features_df = add_array_column_count_to_data(
         df=filtered_loc_data,
@@ -111,10 +113,6 @@ def main(
         mode="overwrite",
         partitionKeys=[Keys.year, Keys.month, Keys.day, Keys.import_date],
     )
-
-
-def filter_df_to_care_home_only(df: DataFrame) -> DataFrame:
-    return df.filter(F.col(IndCQC.care_home) == CareHome.care_home)
 
 
 if __name__ == "__main__":

--- a/jobs/prepare_features_non_res_ascwds_ind_cqc.py
+++ b/jobs/prepare_features_non_res_ascwds_ind_cqc.py
@@ -1,8 +1,7 @@
 import sys
 from typing import List
 
-import pyspark.sql.functions as F
-from pyspark.sql.dataframe import DataFrame
+from pyspark.sql import DataFrame
 
 from utils import utils
 from utils.column_names.ind_cqc_pipeline_columns import (
@@ -105,7 +104,9 @@ def main(
         df=features_df,
     )
 
-    features_with_dormancy_df = filter_df_to_non_null_dormancy(features_df)
+    features_with_dormancy_df = utils.select_rows_with_non_null_value(
+        features_df, IndCQC.dormancy
+    )
 
     list_for_vectorisation_with_dormancy: List[str] = sorted(
         [
@@ -209,21 +210,6 @@ def main(
         mode="overwrite",
         partitionKeys=[Keys.year, Keys.month, Keys.day, Keys.import_date],
     )
-
-
-def filter_df_to_non_null_dormancy(df: DataFrame) -> DataFrame:
-    """
-    Removes rows where dormancy is null.
-
-    The function filters the dataframe to rows where dormancy has a non-null value.
-
-    Args:
-        df (DataFrame): A dataframe containing non-residential features data.
-
-    Returns:
-        DataFrame: A dataframe containing non-residential features data where dormancy has a non-null value.
-    """
-    return df.filter(F.col(IndCQC.dormancy).isNotNull())
 
 
 if __name__ == "__main__":

--- a/jobs/prepare_features_non_res_ascwds_ind_cqc.py
+++ b/jobs/prepare_features_non_res_ascwds_ind_cqc.py
@@ -41,7 +41,9 @@ def main(
 
     locations_df = utils.read_from_parquet(ind_cqc_filled_posts_cleaned_source)
 
-    non_res_locations_df = filter_df_to_non_res_only(locations_df)
+    non_res_locations_df = utils.select_rows_with_value(
+        locations_df, IndCQC.care_home, CareHome.not_care_home
+    )
 
     features_df = add_array_column_count_to_data(
         df=non_res_locations_df,
@@ -207,21 +209,6 @@ def main(
         mode="overwrite",
         partitionKeys=[Keys.year, Keys.month, Keys.day, Keys.import_date],
     )
-
-
-def filter_df_to_non_res_only(df: DataFrame) -> DataFrame:
-    """
-    Removes rows where primary service type is not non-residential.
-
-    The function filters the dataframe to rows where primary service type is non-residential.
-
-    Args:
-        df (DataFrame): A dataframe containing features data.
-
-    Returns:
-        DataFrame: A dataframe containing non-residential features data.
-    """
-    return df.filter(F.col(IndCQC.care_home) == CareHome.not_care_home)
 
 
 def filter_df_to_non_null_dormancy(df: DataFrame) -> DataFrame:

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -4544,17 +4544,6 @@ class NonResAscwdsWithDormancyFeaturesData(object):
     ]
     # fmt: on
 
-    filter_to_dormancy_rows = [
-        ("1-00001", "Y"),
-        ("1-00002", None),
-        ("1-00003", "N"),
-    ]
-
-    expected_filtered_to_dormancy_rows = [
-        ("1-00001", "Y"),
-        ("1-00003", "N"),
-    ]
-
 
 @dataclass
 class CareHomeFeaturesData:

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -4719,15 +4719,6 @@ class CareHomeFeaturesData:
     ]
     # fmt: on
 
-    filter_to_care_home_rows = rows = [
-        ("Y", Sector.independent),
-        ("N", Sector.independent),
-    ]
-
-    expected_filtered_to_care_home_rows = rows = [
-        ("Y", Sector.independent),
-    ]
-
 
 @dataclass
 class EstimateIndCQCFilledPostsData:

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -4544,15 +4544,6 @@ class NonResAscwdsWithDormancyFeaturesData(object):
     ]
     # fmt: on
 
-    filter_to_non_care_home_rows = [
-        ("Y", Sector.independent),
-        ("N", Sector.independent),
-    ]
-
-    expected_filtered_to_non_care_home_rows = [
-        ("N", Sector.independent),
-    ]
-
     filter_to_dormancy_rows = [
         ("1-00001", "Y"),
         ("1-00002", None),

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -2411,13 +2411,6 @@ class CareHomeFeaturesSchema:
         ]
     )
 
-    filter_to_care_home_schema = StructType(
-        [
-            StructField(IndCQC.care_home, StringType(), True),
-            StructField(IndCQC.cqc_sector, StringType(), True),
-        ]
-    )
-
 
 @dataclass
 class EstimateIndCQCFilledPostsSchemas:

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -2363,13 +2363,6 @@ class NonResAscwdsWithDormancyFeaturesSchema(object):
         ]
     )
 
-    filter_to_dormancy_schema = StructType(
-        [
-            StructField(IndCQC.location_id, StringType(), True),
-            StructField(IndCQC.dormancy, StringType(), True),
-        ]
-    )
-
 
 @dataclass
 class CareHomeFeaturesSchema:

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -2363,13 +2363,6 @@ class NonResAscwdsWithDormancyFeaturesSchema(object):
         ]
     )
 
-    filter_to_non_care_home_schema = StructType(
-        [
-            StructField(IndCQC.care_home, StringType(), True),
-            StructField(IndCQC.cqc_sector, StringType(), True),
-        ]
-    )
-
     filter_to_dormancy_schema = StructType(
         [
             StructField(IndCQC.location_id, StringType(), True),

--- a/tests/unit/test_prepare_features_care_home_ind_cqc.py
+++ b/tests/unit/test_prepare_features_care_home_ind_cqc.py
@@ -2,7 +2,7 @@ import unittest
 import warnings
 from unittest.mock import ANY, Mock, patch
 
-from pyspark.sql import functions as F
+from pyspark.sql import DataFrame, functions as F
 from pyspark.ml.linalg import SparseVector
 
 import jobs.prepare_features_care_home_ind_cqc as job
@@ -83,7 +83,7 @@ class CareHomeFeaturesIndCqcFilledPosts(unittest.TestCase):
 
         job.main(self.IND_FILLED_POSTS_CLEANED_DIR, self.CARE_HOME_FEATURES_DIR)
 
-        result = write_to_parquet_mock.call_args[0][0].orderBy(
+        result: DataFrame = write_to_parquet_mock.call_args[0][0].orderBy(
             F.col(IndCQC.location_id)
         )
 
@@ -106,7 +106,7 @@ class CareHomeFeaturesIndCqcFilledPosts(unittest.TestCase):
 
         job.main(self.IND_FILLED_POSTS_CLEANED_DIR, self.CARE_HOME_FEATURES_DIR)
 
-        result = write_to_parquet_mock.call_args[0][0]
+        result: DataFrame = write_to_parquet_mock.call_args[0][0]
 
         self.assertEqual(result.count(), 1)
 

--- a/tests/unit/test_prepare_features_non_res_ascwds_ind_cqc.py
+++ b/tests/unit/test_prepare_features_non_res_ascwds_ind_cqc.py
@@ -59,7 +59,7 @@ class NonResLocationsFeatureEngineeringTests(unittest.TestCase):
             self.WITHOUT_DORMANCY_DESTINATION,
         )
 
-        self.assertEqual(select_rows_with_value_mock, 1)
+        self.assertEqual(select_rows_with_value_mock.call_count, 1)
         self.assertEqual(add_array_column_count_to_data_mock.call_count, 3)
         self.assertEqual(column_expansion_with_dict_mock.call_count, 1)
         self.assertEqual(

--- a/tests/unit/test_prepare_features_non_res_ascwds_ind_cqc.py
+++ b/tests/unit/test_prepare_features_non_res_ascwds_ind_cqc.py
@@ -34,10 +34,12 @@ class NonResLocationsFeatureEngineeringTests(unittest.TestCase):
     @patch(
         "jobs.prepare_features_non_res_ascwds_ind_cqc.add_array_column_count_to_data"
     )
+    @patch("utils.utils.select_rows_with_value")
     @patch("utils.utils.read_from_parquet")
     def test_main(
         self,
         read_from_parquet_mock: Mock,
+        select_rows_with_value_mock: Mock,
         add_array_column_count_to_data_mock: Mock,
         column_expansion_with_dict_mock: Mock,
         convert_categorical_variable_to_binary_variables_based_on_a_dictionary_mock: Mock,
@@ -53,6 +55,7 @@ class NonResLocationsFeatureEngineeringTests(unittest.TestCase):
             self.WITHOUT_DORMANCY_DESTINATION,
         )
 
+        self.assertEqual(select_rows_with_value_mock, 1)
         self.assertEqual(add_array_column_count_to_data_mock.call_count, 3)
         self.assertEqual(column_expansion_with_dict_mock.call_count, 1)
         self.assertEqual(
@@ -98,19 +101,6 @@ class NonResLocationsFeatureEngineeringTests(unittest.TestCase):
         self.assertEqual(self.test_df.count(), 10)
         self.assertEqual(result_with_dormancy.count(), 6)
         self.assertEqual(result_without_dormancy.count(), 7)
-
-    def test_filter_df_for_non_res_care_home_data(self):
-        ind_cqc_df = self.spark.createDataFrame(
-            Data.filter_to_non_care_home_rows, Schemas.filter_to_non_care_home_schema
-        )
-        returned_df = job.filter_df_to_non_res_only(ind_cqc_df)
-        expected_df = self.spark.createDataFrame(
-            Data.expected_filtered_to_non_care_home_rows,
-            Schemas.filter_to_non_care_home_schema,
-        )
-        returned_data = returned_df.collect()
-        expected_data = expected_df.collect()
-        self.assertEqual(returned_data, expected_data)
 
     def test_filter_df_non_null_dormancy_data(self):
         ind_cqc_df = self.spark.createDataFrame(


### PR DESCRIPTION
# Description
Replaced the filter functions created in the jobs with the generic utils filtering functions.
Remove tests and test data

# How to test
[Branch run - still running at this point](https://eu-west-2.console.aws.amazon.com/states/home?region=eu-west-2#/v2/executions/details/arn:aws:states:eu-west-2:344210435447:execution:replace-filters-with-utils-fun-Ind-CQC-Filled-Post-Estimates-Pipeline:31c0c3c9-7a6b-4f0b-85e3-40f58155c8ec)

# Developer checklist
- [X] Unit test
- [X] Documentation up to date
