### PR TITLE
Run crawler when any gold validation jobs fail

### DIFF
--- a/terraform/pipeline/step-functions/GoldValidationPipeline-StepFunction.json
+++ b/terraform/pipeline/step-functions/GoldValidationPipeline-StepFunction.json
@@ -170,7 +170,7 @@
             }
           }
         ],
-        "Next": "StartCrawler",
+        "Next": "Start crawler when success",
         "Comment": "A state machine for validating Gold layer data",
         "Catch": [
           {
@@ -182,22 +182,13 @@
           }
         ]
       },
-      "StartCrawler": {
+      "Start crawler when success": {
         "Type": "Task",
         "Parameters": {
           "Name": "${data_validation_reports_crawler_name}"
         },
         "Resource": "arn:aws:states:::aws-sdk:glue:startCrawler",
-        "Next": "Success",
-        "Catch": [
-          {
-            "ErrorEquals": [
-              "States.ALL"
-            ],
-            "Next": "Publish error notification",
-            "ResultPath": "$.error"
-          }
-        ]
+        "Next": "Success"
       },
       "Publish error notification": {
         "Type": "Task",
@@ -213,6 +204,14 @@
             "CallbackToken.$": "$$.Task.Token"
           }
         },
+        "Next": "Start crawler when failed"
+      },
+      "Start crawler when failed": {
+        "Type": "Task",
+        "Parameters": {
+          "Name": "${data_validation_reports_crawler_name}"
+        },
+        "Resource": "arn:aws:states:::aws-sdk:glue:startCrawler",
         "Next": "Fail"
       },
       "Fail": {


### PR DESCRIPTION
# Description
Crawler now runs whether passes or fails

# How to test
[Branch run when fails](https://eu-west-2.console.aws.amazon.com/states/home?region=eu-west-2#/v2/executions/details/arn:aws:states:eu-west-2:344210435447:execution:add-crawler-if-gold-fails-Gold-Validation-Pipeline:ff382a08-9848-4707-8dd8-339674408132)

[Branch run when successful](https://eu-west-2.console.aws.amazon.com/states/home?region=eu-west-2#/v2/executions/details/arn:aws:states:eu-west-2:344210435447:execution:add-crawler-if-gold-fails-Gold-Validation-Pipeline:22fafc6f-989c-4cd9-9243-0c996dc1d0ad)
