### PR TITLE
Remove duplicate locations in ascwds and cqc for coverage data

### DIFF
--- a/jobs/merge_coverage_data.py
+++ b/jobs/merge_coverage_data.py
@@ -96,7 +96,12 @@ def main(
         selected_columns=cqc_ratings_columns_to_import,
     )
 
-    ascwds_workplace_df = remove_duplicate_locationids(ascwds_workplace_df)
+    ascwds_workplace_df = remove_duplicates(
+        ascwds_workplace_df,
+        AWPClean.ascwds_workplace_import_date,
+        AWPClean.location_id,
+        AWPClean.master_update_date,
+    )
 
     merged_coverage_df = join_ascwds_data_into_cqc_location_df(
         cqc_location_df,
@@ -106,6 +111,13 @@ def main(
     )
 
     merged_coverage_df = add_flag_for_in_ascwds(merged_coverage_df)
+
+    merged_coverage_df = remove_duplicates(
+        merged_coverage_df,
+        CQCLClean.cqc_location_import_date,
+        CQCLClean.location_id,
+        CoverageColumns.in_ascwds,
+    )
 
     merged_coverage_df = join_latest_cqc_rating_into_coverage_df(
         merged_coverage_df, cqc_ratings_df
@@ -133,26 +145,34 @@ def main(
     )
 
 
-def remove_duplicate_locationids(df: DataFrame) -> DataFrame:
+def remove_duplicates(
+    df: DataFrame,
+    import_date_column_name: str,
+    location_id_column_name: str,
+    column_to_sort_on: str,
+) -> DataFrame:
     """
-    Remove duplicate locationid rows.
+    Remove duplicate rows in the file based on a combination of import_date and ID columns, keeping the highest value in column_to_sort_on.
 
-    The ASCWDS dataframe used in this job is also used for reconciliation process which contains duplicate locationids.
-    This function removes duplicates from a DataFrame based on 'location_id' and 'ascwds_workplace_import_date' columns, keeping the row with the most recent 'master_update_date'.
+    Remove duplicate rows in the file based on a combination of import_date and ID columns.
+    The keeping the highest value in column_to_sort_on (this could be the most recent date, or keeping 1 instead of 0).
 
     Args:
         df (DataFrame): The input ASCWDS workplace DataFrame.
+        import_date_column_name (str): The name of the import_date column.
+        location_id_column (str): The name of the location ID column.
+        column_to_sort_on (str): The name of the column to sort on (sorted in descending order)
 
     Returns:
         DataFrame: A DataFrame with duplicate location_ids in the same import date removed.
     """
     sorted_df = df.orderBy(
-        F.col(AWPClean.ascwds_workplace_import_date),
-        F.col(AWPClean.location_id),
-        F.col(AWPClean.master_update_date).desc(),
+        F.col(import_date_column_name),
+        F.col(location_id_column_name),
+        F.col(column_to_sort_on).desc(),
     )
     deduped_df = sorted_df.dropDuplicates(
-        [AWPClean.ascwds_workplace_import_date, AWPClean.location_id]
+        [import_date_column_name, location_id_column_name]
     )
     return deduped_df
 

--- a/jobs/merge_coverage_data.py
+++ b/jobs/merge_coverage_data.py
@@ -1,4 +1,5 @@
 import sys
+from typing import List
 
 from pyspark.sql import DataFrame, functions as F
 
@@ -96,7 +97,11 @@ def main(
         selected_columns=cqc_ratings_columns_to_import,
     )
 
-    ascwds_workplace_df = remove_duplicate_locationids(ascwds_workplace_df)
+    ascwds_workplace_df = remove_duplicates_based_on_column_order(
+        ascwds_workplace_df,
+        [AWPClean.ascwds_workplace_import_date, AWPClean.location_id],
+        AWPClean.master_update_date,
+    )
 
     merged_coverage_df = join_ascwds_data_into_cqc_location_df(
         cqc_location_df,
@@ -106,6 +111,12 @@ def main(
     )
 
     merged_coverage_df = add_flag_for_in_ascwds(merged_coverage_df)
+
+    merged_coverage_df = remove_duplicates_based_on_column_order(
+        merged_coverage_df,
+        [CQCLClean.cqc_location_import_date, CQCLClean.name, CQCLClean.postcode],
+        CoverageColumns.in_ascwds,
+    )
 
     merged_coverage_df = join_latest_cqc_rating_into_coverage_df(
         merged_coverage_df, cqc_ratings_df
@@ -133,7 +144,11 @@ def main(
     )
 
 
-def remove_duplicate_locationids(df: DataFrame) -> DataFrame:
+def remove_duplicates_based_on_column_order(
+    df: DataFrame,
+    columns_to_identify_duplicates: List[str],
+    column_to_sort_on: str,
+) -> DataFrame:
     """
     Remove duplicate locationid rows.
 
@@ -142,18 +157,16 @@ def remove_duplicate_locationids(df: DataFrame) -> DataFrame:
 
     Args:
         df (DataFrame): The input ASCWDS workplace DataFrame.
+        columns_to_identify_duplicates (List[str]): List of column names used to highlight duplicates.
+        column_to_sort_on (str): The name of the column to sort on (sorted in descending order).
 
     Returns:
         DataFrame: A DataFrame with duplicate location_ids in the same import date removed.
     """
     sorted_df = df.orderBy(
-        F.col(AWPClean.ascwds_workplace_import_date),
-        F.col(AWPClean.location_id),
-        F.col(AWPClean.master_update_date).desc(),
+        columns_to_identify_duplicates + [F.col(column_to_sort_on).desc()],
     )
-    deduped_df = sorted_df.dropDuplicates(
-        [AWPClean.ascwds_workplace_import_date, AWPClean.location_id]
-    )
+    deduped_df = sorted_df.dropDuplicates([columns_to_identify_duplicates])
     return deduped_df
 
 

--- a/jobs/merge_coverage_data.py
+++ b/jobs/merge_coverage_data.py
@@ -27,6 +27,7 @@ cleaned_cqc_locations_columns_to_import = [
     CQCLClean.cqc_location_import_date,
     CQCLClean.location_id,
     CQCLClean.name,
+    CQCLClean.postal_code,
     CQCLClean.provider_id,
     CQCLClean.provider_name,
     CQCLClean.cqc_sector,
@@ -117,7 +118,7 @@ def main(
         [
             CQCLClean.cqc_location_import_date,
             CQCLClean.name,
-            CQCLClean.postcode,
+            CQCLClean.postal_code,
             CQCLClean.care_home,
         ],
         CoverageColumns.in_ascwds,
@@ -171,7 +172,7 @@ def remove_duplicates_based_on_column_order(
     sorted_df = df.orderBy(
         columns_to_identify_duplicates + [F.col(column_to_sort_on).desc()],
     )
-    deduped_df = sorted_df.dropDuplicates([columns_to_identify_duplicates])
+    deduped_df = sorted_df.dropDuplicates(columns_to_identify_duplicates)
     return deduped_df
 
 

--- a/jobs/merge_coverage_data.py
+++ b/jobs/merge_coverage_data.py
@@ -114,7 +114,12 @@ def main(
 
     merged_coverage_df = remove_duplicates_based_on_column_order(
         merged_coverage_df,
-        [CQCLClean.cqc_location_import_date, CQCLClean.name, CQCLClean.postcode],
+        [
+            CQCLClean.cqc_location_import_date,
+            CQCLClean.name,
+            CQCLClean.postcode,
+            CQCLClean.care_home,
+        ],
         CoverageColumns.in_ascwds,
     )
 

--- a/jobs/merge_coverage_data.py
+++ b/jobs/merge_coverage_data.py
@@ -149,7 +149,7 @@ def remove_duplicate_locationids(df: DataFrame) -> DataFrame:
     sorted_df = df.orderBy(
         F.col(AWPClean.ascwds_workplace_import_date),
         F.col(AWPClean.location_id),
-        F.col(AWPClean.master_update_date),
+        F.col(AWPClean.master_update_date).desc(),
     )
     deduped_df = sorted_df.dropDuplicates(
         [AWPClean.ascwds_workplace_import_date, AWPClean.location_id]

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -3698,6 +3698,19 @@ class MergeCoverageData:
     ]
     # fmt: on
 
+    remove_duplicate_locationids_rows = [
+        (date(2024, 1, 1), "1-001", date(2023, 1, 1)),
+        (date(2024, 1, 1), "1-001", date(2023, 2, 1)),
+        (date(2024, 2, 1), "1-001", date(2023, 2, 1)),
+        (date(2024, 2, 1), "1-002", date(2023, 2, 1)),
+        (date(2024, 2, 1), "1-002", date(2023, 2, 1)),
+    ]
+    expected_remove_duplicate_locationids_rows = [
+        (date(2024, 1, 1), "1-001", date(2023, 2, 1)),
+        (date(2024, 2, 1), "1-001", date(2023, 2, 1)),
+        (date(2024, 2, 1), "1-002", date(2023, 2, 1)),
+    ]
+
     # fmt: off
     expected_cqc_and_ascwds_merged_rows = [
         ("1-000000001", date(2024, 1, 1), date(2024, 1, 1), "Independent", "Y", 10, "1", 1,),

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -3694,6 +3694,20 @@ class MergeCoverageData:
         (date(2024, 3, 1), "1-000000003", date(2024, 1, 1), "4", 6),
     ]
 
+    # fmt: off
+    expected_cqc_and_ascwds_merged_rows = [
+        ("1-000000001", date(2024, 1, 1), date(2024, 1, 1), "Independent", "Y", 10, date(2024, 1, 1), "1", 1),
+        ("1-000000002", date(2024, 1, 1), date(2024, 1, 1), "Independent", "N", None, None, None, None),
+        ("1-000000003", date(2024, 1, 1), date(2024, 1, 1), "Independent", "N", None, date(2024, 1, 1), "3", 2),
+        ("1-000000001", date(2024, 1, 9), date(2024, 2, 1), "Independent", "Y", 10, date(2024, 1, 1), "1", 4),
+        ("1-000000002", date(2024, 1, 9), date(2024, 2, 1), "Independent", "N", None, None, None, None),
+        ("1-000000003", date(2024, 1, 9), date(2024, 2, 1), "Independent", "N", None, date(2024, 1, 1), "3", 5),
+        ("1-000000001", date(2024, 3, 1), date(2024, 3, 1), "Independent", "Y", 10, None, None, None),
+        ("1-000000002", date(2024, 3, 1), date(2024, 3, 1), "Independent", "N", None, None, None, None),
+        ("1-000000003", date(2024, 3, 1), date(2024, 3, 1), "Independent", "N", None, date(2024, 1, 1), "4", 6),
+    ]
+    # fmt: on
+
     remove_duplicate_locationids_rows = [
         (date(2024, 1, 1), "1-001", date(2023, 1, 1)),
         (date(2024, 1, 1), "1-001", date(2023, 2, 1)),
@@ -3706,20 +3720,6 @@ class MergeCoverageData:
         (date(2024, 2, 1), "1-001", date(2023, 2, 1)),
         (date(2024, 2, 1), "1-002", date(2023, 2, 1)),
     ]
-
-    # fmt: off
-    expected_cqc_and_ascwds_merged_rows = [
-        ("1-000000001", date(2024, 1, 1), date(2024, 1, 1), "Independent", "Y", 10, "1", 1,),
-        ("1-000000002", date(2024, 1, 1), date(2024, 1, 1), "Independent", "N", None, None, None,),
-        ("1-000000003", date(2024, 1, 1), date(2024, 1, 1), "Independent", "N", None, "3", 2,),
-        ("1-000000001", date(2024, 1, 9), date(2024, 2, 1), "Independent", "Y", 10, "1", 4,),
-        ("1-000000002", date(2024, 1, 9), date(2024, 2, 1), "Independent", "N", None, None, None,),
-        ("1-000000003", date(2024, 1, 9), date(2024, 2, 1), "Independent", "N", None, "3", 5,),
-        ("1-000000001", date(2024, 3, 1), date(2024, 3, 1), "Independent", "Y", 10, None, None,),
-        ("1-000000002", date(2024, 3, 1), date(2024, 3, 1), "Independent", "N", None, None, None,),
-        ("1-000000003", date(2024, 3, 1), date(2024, 3, 1), "Independent", "N", None, "4", 6,),
-    ]
-    # fmt: on
 
     sample_in_ascwds_rows = [
         (None,),

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -3673,30 +3673,26 @@ class MergeIndCQCData:
 
 @dataclass
 class MergeCoverageData:
-    # fmt: off
     clean_cqc_location_for_merge_rows = [
-        (date(2024, 1, 1), "1-000000001", "Independent", "Y", 10,),
-        (date(2024, 1, 1), "1-000000002", "Independent", "N", None,),
-        (date(2024, 1, 1), "1-000000003", "Independent", "N", None,),
-        (date(2024, 2, 1), "1-000000001", "Independent", "Y", 10,),
-        (date(2024, 2, 1), "1-000000002", "Independent", "N", None,),
-        (date(2024, 2, 1), "1-000000003", "Independent", "N", None,),
-        (date(2024, 3, 1), "1-000000001", "Independent", "Y", 10,),
-        (date(2024, 3, 1), "1-000000002", "Independent", "N", None,),
-        (date(2024, 3, 1), "1-000000003", "Independent", "N", None,),
+        (date(2024, 1, 1), "1-000000001", "Independent", "Y", 10),
+        (date(2024, 1, 1), "1-000000002", "Independent", "N", None),
+        (date(2024, 1, 1), "1-000000003", "Independent", "N", None),
+        (date(2024, 2, 1), "1-000000001", "Independent", "Y", 10),
+        (date(2024, 2, 1), "1-000000002", "Independent", "N", None),
+        (date(2024, 2, 1), "1-000000003", "Independent", "N", None),
+        (date(2024, 3, 1), "1-000000001", "Independent", "Y", 10),
+        (date(2024, 3, 1), "1-000000002", "Independent", "N", None),
+        (date(2024, 3, 1), "1-000000003", "Independent", "N", None),
     ]
-    # fmt: on
 
-    # fmt: off
     clean_ascwds_workplace_for_merge_rows = [
-        (date(2024, 1, 1), "1-000000001", "1", 1,),
-        (date(2024, 1, 1), "1-000000003", "3", 2,),
-        (date(2024, 1, 5), "1-000000001", "1", 3,),
-        (date(2024, 1, 9), "1-000000001", "1", 4,),
-        (date(2024, 1, 9), "1-000000003", "3", 5,),
-        (date(2024, 3, 1), "1-000000003", "4", 6,),
+        (date(2024, 1, 1), "1-000000001", date(2024, 1, 1), "1", 1),
+        (date(2024, 1, 1), "1-000000003", date(2024, 1, 1), "3", 2),
+        (date(2024, 1, 5), "1-000000001", date(2024, 1, 1), "1", 3),
+        (date(2024, 1, 9), "1-000000001", date(2024, 1, 1), "1", 4),
+        (date(2024, 1, 9), "1-000000003", date(2024, 1, 1), "3", 5),
+        (date(2024, 3, 1), "1-000000003", date(2024, 1, 1), "4", 6),
     ]
-    # fmt: on
 
     remove_duplicate_locationids_rows = [
         (date(2024, 1, 1), "1-001", date(2023, 1, 1)),

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -3673,17 +3673,19 @@ class MergeIndCQCData:
 
 @dataclass
 class MergeCoverageData:
+    # fmt: off
     clean_cqc_location_for_merge_rows = [
-        (date(2024, 1, 1), "1-000000001", "Independent", "Y", 10),
-        (date(2024, 1, 1), "1-000000002", "Independent", "N", None),
-        (date(2024, 1, 1), "1-000000003", "Independent", "N", None),
-        (date(2024, 2, 1), "1-000000001", "Independent", "Y", 10),
-        (date(2024, 2, 1), "1-000000002", "Independent", "N", None),
-        (date(2024, 2, 1), "1-000000003", "Independent", "N", None),
-        (date(2024, 3, 1), "1-000000001", "Independent", "Y", 10),
-        (date(2024, 3, 1), "1-000000002", "Independent", "N", None),
-        (date(2024, 3, 1), "1-000000003", "Independent", "N", None),
+        (date(2024, 1, 1), "1-000000001", "Name 1", "AB1 2CD", "Independent", "Y", 10),
+        (date(2024, 1, 1), "1-000000002", "Name 2", "EF3 4GH", "Independent", "N", None),
+        (date(2024, 1, 1), "1-000000003", "Name 3", "IJ5 6KL", "Independent", "N", None),
+        (date(2024, 2, 1), "1-000000001", "Name 1", "AB1 2CD", "Independent", "Y", 10),
+        (date(2024, 2, 1), "1-000000002", "Name 2", "EF3 4GH", "Independent", "N", None),
+        (date(2024, 2, 1), "1-000000003", "Name 3", "IJ5 6KL", "Independent", "N", None),
+        (date(2024, 3, 1), "1-000000001", "Name 1", "AB1 2CD", "Independent", "Y", 10),
+        (date(2024, 3, 1), "1-000000002", "Name 2", "EF3 4GH", "Independent", "N", None),
+        (date(2024, 3, 1), "1-000000003", "Name 3", "IJ5 6KL", "Independent", "N", None),
     ]
+    # fmt: on
 
     clean_ascwds_workplace_for_merge_rows = [
         (date(2024, 1, 1), "1-000000001", date(2024, 1, 1), "1", 1),
@@ -3696,15 +3698,15 @@ class MergeCoverageData:
 
     # fmt: off
     expected_cqc_and_ascwds_merged_rows = [
-        ("1-000000001", date(2024, 1, 1), date(2024, 1, 1), "Independent", "Y", 10, date(2024, 1, 1), "1", 1),
-        ("1-000000002", date(2024, 1, 1), date(2024, 1, 1), "Independent", "N", None, None, None, None),
-        ("1-000000003", date(2024, 1, 1), date(2024, 1, 1), "Independent", "N", None, date(2024, 1, 1), "3", 2),
-        ("1-000000001", date(2024, 1, 9), date(2024, 2, 1), "Independent", "Y", 10, date(2024, 1, 1), "1", 4),
-        ("1-000000002", date(2024, 1, 9), date(2024, 2, 1), "Independent", "N", None, None, None, None),
-        ("1-000000003", date(2024, 1, 9), date(2024, 2, 1), "Independent", "N", None, date(2024, 1, 1), "3", 5),
-        ("1-000000001", date(2024, 3, 1), date(2024, 3, 1), "Independent", "Y", 10, None, None, None),
-        ("1-000000002", date(2024, 3, 1), date(2024, 3, 1), "Independent", "N", None, None, None, None),
-        ("1-000000003", date(2024, 3, 1), date(2024, 3, 1), "Independent", "N", None, date(2024, 1, 1), "4", 6),
+        ("1-000000001", date(2024, 1, 1), date(2024, 1, 1), "Name 1", "AB1 2CD", "Independent", "Y", 10, date(2024, 1, 1), "1", 1),
+        ("1-000000002", date(2024, 1, 1), date(2024, 1, 1), "Name 2", "EF3 4GH", "Independent", "N", None, None, None, None),
+        ("1-000000003", date(2024, 1, 1), date(2024, 1, 1), "Name 3", "IJ5 6KL", "Independent", "N", None, date(2024, 1, 1), "3", 2),
+        ("1-000000001", date(2024, 1, 9), date(2024, 2, 1), "Name 1", "AB1 2CD", "Independent", "Y", 10, date(2024, 1, 1), "1", 4),
+        ("1-000000002", date(2024, 1, 9), date(2024, 2, 1), "Name 2", "EF3 4GH", "Independent", "N", None, None, None, None),
+        ("1-000000003", date(2024, 1, 9), date(2024, 2, 1), "Name 3", "IJ5 6KL", "Independent", "N", None, date(2024, 1, 1), "3", 5),
+        ("1-000000001", date(2024, 3, 1), date(2024, 3, 1), "Name 1", "AB1 2CD", "Independent", "Y", 10, None, None, None),
+        ("1-000000002", date(2024, 3, 1), date(2024, 3, 1), "Name 2", "EF3 4GH", "Independent", "N", None, None, None, None),
+        ("1-000000003", date(2024, 3, 1), date(2024, 3, 1), "Name 3", "IJ5 6KL", "Independent", "N", None, date(2024, 1, 1), "4", 6),
     ]
     # fmt: on
 

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -1692,6 +1692,14 @@ class MergeCoverageData:
         ]
     )
 
+    remove_duplicate_locationids_schema = StructType(
+        [
+            StructField(AWPClean.ascwds_workplace_import_date, DateType(), True),
+            StructField(AWPClean.location_id, StringType(), True),
+            StructField(AWPClean.master_update_date, DateType(), True),
+        ]
+    )
+
     expected_cqc_and_ascwds_merged_schema = StructType(
         [
             StructField(CQCLClean.location_id, StringType(), True),

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -1687,6 +1687,7 @@ class MergeCoverageData:
         [
             StructField(AWPClean.ascwds_workplace_import_date, DateType(), True),
             StructField(AWPClean.location_id, StringType(), True),
+            StructField(AWPClean.master_update_date, DateType(), True),
             StructField(AWPClean.establishment_id, StringType(), True),
             StructField(AWPClean.total_staff, IntegerType(), True),
         ]

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -1677,6 +1677,8 @@ class MergeCoverageData:
         [
             StructField(CQCLClean.cqc_location_import_date, DateType(), True),
             StructField(CQCLClean.location_id, StringType(), True),
+            StructField(CQCLClean.name, StringType(), True),
+            StructField(CQCLClean.postal_code, StringType(), True),
             StructField(CQCLClean.cqc_sector, StringType(), True),
             StructField(CQCLClean.care_home, StringType(), True),
             StructField(CQCLClean.number_of_beds, IntegerType(), True),
@@ -1698,6 +1700,8 @@ class MergeCoverageData:
             StructField(CQCLClean.location_id, StringType(), True),
             StructField(AWPClean.ascwds_workplace_import_date, DateType(), True),
             StructField(CQCLClean.cqc_location_import_date, DateType(), True),
+            StructField(CQCLClean.name, StringType(), True),
+            StructField(CQCLClean.postal_code, StringType(), True),
             StructField(CQCLClean.cqc_sector, StringType(), True),
             StructField(CQCLClean.care_home, StringType(), True),
             StructField(CQCLClean.number_of_beds, IntegerType(), True),

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -1693,14 +1693,6 @@ class MergeCoverageData:
         ]
     )
 
-    remove_duplicate_locationids_schema = StructType(
-        [
-            StructField(AWPClean.ascwds_workplace_import_date, DateType(), True),
-            StructField(AWPClean.location_id, StringType(), True),
-            StructField(AWPClean.master_update_date, DateType(), True),
-        ]
-    )
-
     expected_cqc_and_ascwds_merged_schema = StructType(
         [
             StructField(CQCLClean.location_id, StringType(), True),
@@ -1709,8 +1701,17 @@ class MergeCoverageData:
             StructField(CQCLClean.cqc_sector, StringType(), True),
             StructField(CQCLClean.care_home, StringType(), True),
             StructField(CQCLClean.number_of_beds, IntegerType(), True),
+            StructField(AWPClean.master_update_date, DateType(), True),
             StructField(AWPClean.establishment_id, StringType(), True),
             StructField(AWPClean.total_staff, IntegerType(), True),
+        ]
+    )
+
+    remove_duplicate_locationids_schema = StructType(
+        [
+            StructField(AWPClean.ascwds_workplace_import_date, DateType(), True),
+            StructField(AWPClean.location_id, StringType(), True),
+            StructField(AWPClean.master_update_date, DateType(), True),
         ]
     )
 

--- a/tests/unit/test_merge_coverage_data.py
+++ b/tests/unit/test_merge_coverage_data.py
@@ -97,6 +97,30 @@ class MainTests(SetupForTests):
         )
 
 
+class RemoveDuplicateLocationidsTests(SetupForTests):
+    def setUp(self) -> None:
+        super().setUp()
+
+    def test_remove_duplicate_locationids_returns_expected_rows(self):
+        test_df = self.spark.createDataFrame(
+            Data.remove_duplicate_locationids_rows,
+            Schemas.remove_duplicate_locationids_schema,
+        )
+        returned_df = job.remove_duplicate_locationids(test_df)
+
+        expected_df = self.spark.createDataFrame(
+            Data.expected_remove_duplicate_locationids_rows,
+            Schemas.remove_duplicate_locationids_schema,
+        )
+
+        returned_data = returned_df.sort(
+            AWPClean.ascwds_workplace_import_date, AWPClean.location_id
+        ).collect()
+        expected_data = expected_df.collect()
+
+        self.assertEqual(returned_data, expected_data)
+
+
 class JoinAscwdsIntoCqcLocationsTests(SetupForTests):
     def setUp(self) -> None:
         super().setUp()

--- a/tests/unit/test_merge_coverage_data.py
+++ b/tests/unit/test_merge_coverage_data.py
@@ -97,7 +97,7 @@ class MainTests(SetupForTests):
         )
 
 
-class RemoveDuplicateLocationIdsTests(SetupForTests):
+class RemoveDuplicatesBasedOnColumnOrderTests(SetupForTests):
     def setUp(self) -> None:
         super().setUp()
 
@@ -106,7 +106,11 @@ class RemoveDuplicateLocationIdsTests(SetupForTests):
             Data.remove_duplicate_locationids_rows,
             Schemas.remove_duplicate_locationids_schema,
         )
-        returned_df = job.remove_duplicate_locationids(test_df)
+        returned_df = job.remove_duplicates_based_on_column_order(
+            test_df,
+            [AWPClean.ascwds_workplace_import_date, AWPClean.location_id],
+            AWPClean.master_update_date,
+        )
 
         expected_df = self.spark.createDataFrame(
             Data.expected_remove_duplicate_locationids_rows,

--- a/tests/unit/test_merge_coverage_data.py
+++ b/tests/unit/test_merge_coverage_data.py
@@ -97,7 +97,7 @@ class MainTests(SetupForTests):
         )
 
 
-class RemoveDuplicatesTests(SetupForTests):
+class RemoveDuplicateLocationIdsTests(SetupForTests):
     def setUp(self) -> None:
         super().setUp()
 
@@ -106,12 +106,7 @@ class RemoveDuplicatesTests(SetupForTests):
             Data.remove_duplicate_locationids_rows,
             Schemas.remove_duplicate_locationids_schema,
         )
-        returned_df = job.remove_duplicates(
-            test_df,
-            AWPClean.ascwds_workplace_import_date,
-            AWPClean.location_id,
-            AWPClean.master_update_date,
-        )
+        returned_df = job.remove_duplicate_locationids(test_df)
 
         expected_df = self.spark.createDataFrame(
             Data.expected_remove_duplicate_locationids_rows,

--- a/tests/unit/test_merge_coverage_data.py
+++ b/tests/unit/test_merge_coverage_data.py
@@ -97,7 +97,7 @@ class MainTests(SetupForTests):
         )
 
 
-class RemoveDuplicateLocationidsTests(SetupForTests):
+class RemoveDuplicatesTests(SetupForTests):
     def setUp(self) -> None:
         super().setUp()
 
@@ -106,7 +106,12 @@ class RemoveDuplicateLocationidsTests(SetupForTests):
             Data.remove_duplicate_locationids_rows,
             Schemas.remove_duplicate_locationids_schema,
         )
-        returned_df = job.remove_duplicate_locationids(test_df)
+        returned_df = job.remove_duplicates(
+            test_df,
+            AWPClean.ascwds_workplace_import_date,
+            AWPClean.location_id,
+            AWPClean.master_update_date,
+        )
 
         expected_df = self.spark.createDataFrame(
             Data.expected_remove_duplicate_locationids_rows,


### PR DESCRIPTION
# Description
Creates a generic removes duplicates function which takes a list of columns used to highlight duplicates, plus sorts on another column in descending order (keeps the first value it finds).

In terms of ASCWDS data, this will keeps the most recently updated one (based on highest mupddate date)
In terms of CQC data, this will keep the one which is 'in ascwds' (in ASCWDS=1, not in ASCWDS =0).

If either of them are completely the same (same mupddate or both in/not in ASCWDS, then it doesn't matter which we keep)

# How to test
None of the problematic locationids identified from another branch appear as duplicates anymore

[Branch run](https://eu-west-2.console.aws.amazon.com/states/home?region=eu-west-2#/v2/executions/details/arn:aws:states:eu-west-2:344210435447:execution:remove-dupes-from-coverage-Ind-CQC-Filled-Post-Estimates-Pipeline:ae1d8854-9cc8-4145-8130-532bd7bf993e)

[Trello care](https://trello.com/c/tV8foJBH/851-remove-ascwds-locationid-duplicates)

# Developer checklist
- [X] Unit test
- [X] Linked to Trello ticket
- [X] Documentation up to date
