### PR TITLE
Update function to remove locations consistantly

### DIFF
--- a/jobs/merge_coverage_data.py
+++ b/jobs/merge_coverage_data.py
@@ -166,9 +166,6 @@ def remove_duplicates_based_on_column_order(
     """
     Remove duplicate locationid rows.
 
-    The ASCWDS dataframe used in this job is also used for reconciliation process which contains duplicate locationids.
-    This function removes duplicates from a DataFrame based on 'location_id' and 'ascwds_workplace_import_date' columns, keeping the row with the most recent 'master_update_date'.
-
     Args:
         df (DataFrame): The input ASCWDS workplace DataFrame.
         columns_to_identify_duplicates (List[str]): List of column names used to highlight duplicates.

--- a/jobs/merge_coverage_data.py
+++ b/jobs/merge_coverage_data.py
@@ -107,6 +107,7 @@ def main(
         ascwds_workplace_df,
         [AWPClean.ascwds_workplace_import_date, AWPClean.location_id],
         AWPClean.master_update_date,
+        sort_ascending=False,
     )
 
     merged_coverage_df = join_ascwds_data_into_cqc_location_df(
@@ -127,6 +128,7 @@ def main(
             CQCLClean.care_home,
         ],
         CoverageColumns.in_ascwds,
+        sort_ascending=False,
     )
 
     merged_coverage_df = join_latest_cqc_rating_into_coverage_df(
@@ -159,7 +161,7 @@ def remove_duplicates_based_on_column_order(
     df: DataFrame,
     columns_to_identify_duplicates: List[str],
     column_to_sort_on: str,
-    sort_descending: bool = False,
+    sort_ascending: bool = True,
 ) -> DataFrame:
     """
     Remove duplicate locationid rows.
@@ -171,13 +173,13 @@ def remove_duplicates_based_on_column_order(
         df (DataFrame): The input ASCWDS workplace DataFrame.
         columns_to_identify_duplicates (List[str]): List of column names used to highlight duplicates.
         column_to_sort_on (str): The name of the column to sort on (sorted in descending order).
-        sort_descending (bool): If true, the column to sort on is sorted descending, otherwise ascending.
+        sort_ascending (bool): If true, the column to sort on is sorted ascending, otherwise descending.
 
     Returns:
         DataFrame: A DataFrame with duplicate location_ids in the same import date removed.
     """
     temp_col = "row_number"
-    if sort_descending == False:
+    if sort_ascending == True:
         df = df.withColumn(
             temp_col,
             F.row_number().over(

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -3717,8 +3717,13 @@ class MergeCoverageData:
         (date(2024, 2, 1), "1-002", date(2023, 2, 1)),
         (date(2024, 2, 1), "1-002", date(2023, 2, 1)),
     ]
-    expected_remove_duplicate_locationids_rows = [
+    expected_remove_duplicate_locationids_descending_rows = [
         (date(2024, 1, 1), "1-001", date(2023, 2, 1)),
+        (date(2024, 2, 1), "1-001", date(2023, 2, 1)),
+        (date(2024, 2, 1), "1-002", date(2023, 2, 1)),
+    ]
+    expected_remove_duplicate_locationids_rows = [
+        (date(2024, 1, 1), "1-001", date(2023, 1, 1)),
         (date(2024, 2, 1), "1-001", date(2023, 2, 1)),
         (date(2024, 2, 1), "1-002", date(2023, 2, 1)),
     ]

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -3602,6 +3602,24 @@ class CleaningUtilsData:
         ("loc 3", 0.5, None, None),
     ]
 
+    remove_duplicate_locationids_rows = [
+        (date(2024, 1, 1), "1-001", date(2023, 1, 1)),
+        (date(2024, 1, 1), "1-001", date(2023, 2, 1)),
+        (date(2024, 2, 1), "1-001", date(2023, 2, 1)),
+        (date(2024, 2, 1), "1-002", date(2023, 2, 1)),
+        (date(2024, 2, 1), "1-002", date(2023, 2, 1)),
+    ]
+    expected_remove_duplicate_locationids_descending_rows = [
+        (date(2024, 1, 1), "1-001", date(2023, 2, 1)),
+        (date(2024, 2, 1), "1-001", date(2023, 2, 1)),
+        (date(2024, 2, 1), "1-002", date(2023, 2, 1)),
+    ]
+    expected_remove_duplicate_locationids_ascending_rows = [
+        (date(2024, 1, 1), "1-001", date(2023, 1, 1)),
+        (date(2024, 2, 1), "1-001", date(2023, 2, 1)),
+        (date(2024, 2, 1), "1-002", date(2023, 2, 1)),
+    ]
+
 
 @dataclass
 class MergeIndCQCData:
@@ -3716,24 +3734,6 @@ class MergeCoverageData:
         ("1-000000003", date(2024, 3, 1), date(2024, 3, 1), "Name 3", "IJ5 6KL", "Independent", "N", None, date(2024, 1, 1), "4", 6),
     ]
     # fmt: on
-
-    remove_duplicate_locationids_rows = [
-        (date(2024, 1, 1), "1-001", date(2023, 1, 1)),
-        (date(2024, 1, 1), "1-001", date(2023, 2, 1)),
-        (date(2024, 2, 1), "1-001", date(2023, 2, 1)),
-        (date(2024, 2, 1), "1-002", date(2023, 2, 1)),
-        (date(2024, 2, 1), "1-002", date(2023, 2, 1)),
-    ]
-    expected_remove_duplicate_locationids_descending_rows = [
-        (date(2024, 1, 1), "1-001", date(2023, 2, 1)),
-        (date(2024, 2, 1), "1-001", date(2023, 2, 1)),
-        (date(2024, 2, 1), "1-002", date(2023, 2, 1)),
-    ]
-    expected_remove_duplicate_locationids_ascending_rows = [
-        (date(2024, 1, 1), "1-001", date(2023, 1, 1)),
-        (date(2024, 2, 1), "1-001", date(2023, 2, 1)),
-        (date(2024, 2, 1), "1-002", date(2023, 2, 1)),
-    ]
 
     sample_in_ascwds_rows = [
         (None,),

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -3729,7 +3729,7 @@ class MergeCoverageData:
         (date(2024, 2, 1), "1-001", date(2023, 2, 1)),
         (date(2024, 2, 1), "1-002", date(2023, 2, 1)),
     ]
-    expected_remove_duplicate_locationids_rows = [
+    expected_remove_duplicate_locationids_ascending_rows = [
         (date(2024, 1, 1), "1-001", date(2023, 1, 1)),
         (date(2024, 2, 1), "1-001", date(2023, 2, 1)),
         (date(2024, 2, 1), "1-002", date(2023, 2, 1)),

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -1494,6 +1494,14 @@ class CleaningUtilsSchemas:
         ]
     )
 
+    remove_duplicate_locationids_schema = StructType(
+        [
+            StructField(AWPClean.ascwds_workplace_import_date, DateType(), True),
+            StructField(AWPClean.location_id, StringType(), True),
+            StructField(AWPClean.master_update_date, DateType(), True),
+        ]
+    )
+
 
 @dataclass
 class CQCProviderSchema:
@@ -1724,14 +1732,6 @@ class MergeCoverageData:
             StructField(AWPClean.master_update_date, DateType(), True),
             StructField(AWPClean.establishment_id, StringType(), True),
             StructField(AWPClean.total_staff, IntegerType(), True),
-        ]
-    )
-
-    remove_duplicate_locationids_schema = StructType(
-        [
-            StructField(AWPClean.ascwds_workplace_import_date, DateType(), True),
-            StructField(AWPClean.location_id, StringType(), True),
-            StructField(AWPClean.master_update_date, DateType(), True),
         ]
     )
 

--- a/tests/unit/test_cleaning_utils.py
+++ b/tests/unit/test_cleaning_utils.py
@@ -681,3 +681,56 @@ class CalculateFilledPostsFromBedsAndRatioTests(unittest.TestCase):
         self.assertEqual(
             returned_df.sort(IndCQC.location_id).collect(), expected_df.collect()
         )
+
+
+class RemoveDuplicatesBasedOnColumnOrderTests(unittest.TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.spark = utils.get_spark()
+
+    def test_remove_duplicate_locationids_returns_expected_rows_when_descending(self):
+        test_df = self.spark.createDataFrame(
+            Data.remove_duplicate_locationids_rows,
+            Schemas.remove_duplicate_locationids_schema,
+        )
+        returned_df = job.remove_duplicates_based_on_column_order(
+            test_df,
+            [AWPClean.ascwds_workplace_import_date, AWPClean.location_id],
+            AWPClean.master_update_date,
+            sort_ascending=False,
+        )
+
+        expected_df = self.spark.createDataFrame(
+            Data.expected_remove_duplicate_locationids_descending_rows,
+            Schemas.remove_duplicate_locationids_schema,
+        )
+        returned_data = returned_df.sort(
+            AWPClean.ascwds_workplace_import_date, AWPClean.location_id
+        ).collect()
+        expected_data = expected_df.collect()
+
+        self.assertEqual(returned_data, expected_data)
+
+    def test_remove_duplicate_locationids_returns_expected_rows_when_order_not_specified(
+        self,
+    ):
+        test_df = self.spark.createDataFrame(
+            Data.remove_duplicate_locationids_rows,
+            Schemas.remove_duplicate_locationids_schema,
+        )
+        returned_df = job.remove_duplicates_based_on_column_order(
+            test_df,
+            [AWPClean.ascwds_workplace_import_date, AWPClean.location_id],
+            AWPClean.master_update_date,
+        )
+
+        expected_df = self.spark.createDataFrame(
+            Data.expected_remove_duplicate_locationids_ascending_rows,
+            Schemas.remove_duplicate_locationids_schema,
+        )
+        returned_data = returned_df.sort(
+            AWPClean.ascwds_workplace_import_date, AWPClean.location_id
+        ).collect()
+        expected_data = expected_df.collect()
+
+        self.assertEqual(returned_data, expected_data)

--- a/tests/unit/test_merge_coverage_data.py
+++ b/tests/unit/test_merge_coverage_data.py
@@ -100,58 +100,6 @@ class MainTests(SetupForTests):
         )
 
 
-class RemoveDuplicatesBasedOnColumnOrderTests(SetupForTests):
-    def setUp(self) -> None:
-        super().setUp()
-
-    def test_remove_duplicate_locationids_returns_expected_rows_when_descending(self):
-        test_df = self.spark.createDataFrame(
-            Data.remove_duplicate_locationids_rows,
-            Schemas.remove_duplicate_locationids_schema,
-        )
-        returned_df = job.remove_duplicates_based_on_column_order(
-            test_df,
-            [AWPClean.ascwds_workplace_import_date, AWPClean.location_id],
-            AWPClean.master_update_date,
-            sort_ascending=False,
-        )
-
-        expected_df = self.spark.createDataFrame(
-            Data.expected_remove_duplicate_locationids_descending_rows,
-            Schemas.remove_duplicate_locationids_schema,
-        )
-        returned_data = returned_df.sort(
-            AWPClean.ascwds_workplace_import_date, AWPClean.location_id
-        ).collect()
-        expected_data = expected_df.collect()
-
-        self.assertEqual(returned_data, expected_data)
-
-    def test_remove_duplicate_locationids_returns_expected_rows_when_order_not_specified(
-        self,
-    ):
-        test_df = self.spark.createDataFrame(
-            Data.remove_duplicate_locationids_rows,
-            Schemas.remove_duplicate_locationids_schema,
-        )
-        returned_df = job.remove_duplicates_based_on_column_order(
-            test_df,
-            [AWPClean.ascwds_workplace_import_date, AWPClean.location_id],
-            AWPClean.master_update_date,
-        )
-
-        expected_df = self.spark.createDataFrame(
-            Data.expected_remove_duplicate_locationids_ascending_rows,
-            Schemas.remove_duplicate_locationids_schema,
-        )
-        returned_data = returned_df.sort(
-            AWPClean.ascwds_workplace_import_date, AWPClean.location_id
-        ).collect()
-        expected_data = expected_df.collect()
-
-        self.assertEqual(returned_data, expected_data)
-
-
 class JoinAscwdsIntoCqcLocationsTests(SetupForTests):
     def setUp(self) -> None:
         super().setUp()

--- a/tests/unit/test_merge_coverage_data.py
+++ b/tests/unit/test_merge_coverage_data.py
@@ -104,7 +104,35 @@ class RemoveDuplicatesBasedOnColumnOrderTests(SetupForTests):
     def setUp(self) -> None:
         super().setUp()
 
-    def test_remove_duplicate_locationids_returns_expected_rows(self):
+    def test_remove_duplicate_locationids_returns_expected_rows_when_descending(self):
+        test_df = self.spark.createDataFrame(
+            Data.remove_duplicate_locationids_rows,
+            Schemas.remove_duplicate_locationids_schema,
+        )
+        returned_df = job.remove_duplicates_based_on_column_order(
+            test_df,
+            [AWPClean.ascwds_workplace_import_date, AWPClean.location_id],
+            AWPClean.master_update_date,
+            sort_descending=True,
+        )
+
+        expected_df = self.spark.createDataFrame(
+            Data.expected_remove_duplicate_locationids_descending_rows,
+            Schemas.remove_duplicate_locationids_schema,
+        )
+        test_df.show()
+        expected_df.show()
+        returned_df.show()
+        returned_data = returned_df.sort(
+            AWPClean.ascwds_workplace_import_date, AWPClean.location_id
+        ).collect()
+        expected_data = expected_df.collect()
+
+        self.assertEqual(returned_data, expected_data)
+
+    def test_remove_duplicate_locationids_returns_expected_rows_when_order_not_specified(
+        self,
+    ):
         test_df = self.spark.createDataFrame(
             Data.remove_duplicate_locationids_rows,
             Schemas.remove_duplicate_locationids_schema,
@@ -119,7 +147,9 @@ class RemoveDuplicatesBasedOnColumnOrderTests(SetupForTests):
             Data.expected_remove_duplicate_locationids_rows,
             Schemas.remove_duplicate_locationids_schema,
         )
-
+        test_df.show()
+        expected_df.show()
+        returned_df.show()
         returned_data = returned_df.sort(
             AWPClean.ascwds_workplace_import_date, AWPClean.location_id
         ).collect()

--- a/tests/unit/test_merge_coverage_data.py
+++ b/tests/unit/test_merge_coverage_data.py
@@ -120,9 +120,6 @@ class RemoveDuplicatesBasedOnColumnOrderTests(SetupForTests):
             Data.expected_remove_duplicate_locationids_descending_rows,
             Schemas.remove_duplicate_locationids_schema,
         )
-        test_df.show()
-        expected_df.show()
-        returned_df.show()
         returned_data = returned_df.sort(
             AWPClean.ascwds_workplace_import_date, AWPClean.location_id
         ).collect()
@@ -147,9 +144,6 @@ class RemoveDuplicatesBasedOnColumnOrderTests(SetupForTests):
             Data.expected_remove_duplicate_locationids_rows,
             Schemas.remove_duplicate_locationids_schema,
         )
-        test_df.show()
-        expected_df.show()
-        returned_df.show()
         returned_data = returned_df.sort(
             AWPClean.ascwds_workplace_import_date, AWPClean.location_id
         ).collect()

--- a/tests/unit/test_merge_coverage_data.py
+++ b/tests/unit/test_merge_coverage_data.py
@@ -113,7 +113,7 @@ class RemoveDuplicatesBasedOnColumnOrderTests(SetupForTests):
             test_df,
             [AWPClean.ascwds_workplace_import_date, AWPClean.location_id],
             AWPClean.master_update_date,
-            sort_descending=True,
+            sort_ascending=False,
         )
 
         expected_df = self.spark.createDataFrame(

--- a/tests/unit/test_merge_coverage_data.py
+++ b/tests/unit/test_merge_coverage_data.py
@@ -141,7 +141,7 @@ class RemoveDuplicatesBasedOnColumnOrderTests(SetupForTests):
         )
 
         expected_df = self.spark.createDataFrame(
-            Data.expected_remove_duplicate_locationids_rows,
+            Data.expected_remove_duplicate_locationids_ascending_rows,
             Schemas.remove_duplicate_locationids_schema,
         )
         returned_data = returned_df.sort(

--- a/tests/unit/test_merge_coverage_data.py
+++ b/tests/unit/test_merge_coverage_data.py
@@ -55,6 +55,7 @@ class MainTests(SetupForTests):
     def setUp(self) -> None:
         super().setUp()
 
+    @patch("utils.cleaning_utils.remove_duplicates_based_on_column_order")
     @patch("utils.utils.filter_df_to_maximum_value_in_column")
     @patch("jobs.merge_coverage_data.join_ascwds_data_into_cqc_location_df")
     @patch("utils.utils.write_to_parquet")
@@ -65,6 +66,7 @@ class MainTests(SetupForTests):
         write_to_parquet_patch: Mock,
         join_ascwds_data_into_cqc_location_df: Mock,
         filter_to_maximum_value_in_column: Mock,
+        remove_duplicates_based_on_column_order: Mock,
     ):
         read_from_parquet_patch.side_effect = [
             self.test_clean_cqc_location_df,
@@ -84,6 +86,7 @@ class MainTests(SetupForTests):
 
         join_ascwds_data_into_cqc_location_df.assert_called_once()
         filter_to_maximum_value_in_column.assert_called_once()
+        self.assertEqual(remove_duplicates_based_on_column_order.call_count, 2)
 
         write_to_parquet_patch.assert_called_with(
             ANY,


### PR DESCRIPTION
# Description
Update the coverage deduplication step to use row number for deduplication

# How to test
Unit tests passing
Run in branch successful: https://eu-west-2.console.aws.amazon.com/states/home?region=eu-west-2#/v2/executions/details/arn:aws:states:eu-west-2:344210435447:execution:update-coverage-deduplication-Coverage-Pipeline:a4e46f3f-0fe7-4bca-a626-a1596dd54ad3

# Developer checklist
- [x] Unit test
- [x] Linked to Trello ticket: https://trello.com/c/lVqxxNlf/854-fix-deduplication-function-in-coverage-so-it-uses-row-number
- [x] Documentation up to date
