### PR TITLE
Add diagnostics to CT pipeline

### DIFF
--- a/terraform/pipeline/step-function.tf
+++ b/terraform/pipeline/step-function.tf
@@ -130,7 +130,9 @@ resource "aws_sfn_state_machine" "ingest_and_clean_capacity_tracker_data_state_m
     ingest_capacity_tracker_data_job_name     = module.ingest_capacity_tracker_data_job.job_name
     clean_capacity_tracker_care_home_job_name = module.clean_capacity_tracker_care_home_job.job_name
     clean_capacity_tracker_non_res_job_name   = module.clean_capacity_tracker_non_res_job.job_name
+    diagnostics_on_capacity_tracker_job_name  = module.diagnostics_on_capacity_tracker_job.job_name
     capacity_tracker_crawler_name             = module.capacity_tracker_crawler.crawler_name
+    ind_cqc_filled_posts_crawler_name         = module.ind_cqc_filled_posts_crawler.crawler_name
     dataset_bucket_uri                        = module.datasets_bucket.bucket_uri
     run_crawler_state_machine_arn             = aws_sfn_state_machine.run_crawler.arn
   })

--- a/terraform/pipeline/step-functions/IngestAndCleanCapacityTrackerDataPipeline-StepFunction.json
+++ b/terraform/pipeline/step-functions/IngestAndCleanCapacityTrackerDataPipeline-StepFunction.json
@@ -52,7 +52,23 @@
             }
           }
         ],
-        "Next": "Run capacity tracker crawler"
+        "Next": "Run diagnostics on capacity tracker data job"
+    },
+    "Run diagnostics on capacity tracker data job": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::glue:startJobRun.sync",
+      "Parameters": {
+        "JobName": "${diagnostics_on_capacity_tracker_job_name}",
+        "Arguments": {
+          "--estimate_filled_posts_source": "${dataset_bucket_uri}/domain=ind_cqc_filled_posts/dataset=ind_cqc_estimated_filled_posts/",
+          "--capacity_tracker_care_home_source": "${dataset_bucket_uri}/domain=capacity_tracker/dataset=capacity_tracker_care_home_cleaned/",
+          "--capacity_tracker_non_res_source": "${dataset_bucket_uri}/domain=capacity_tracker/dataset=capacity_tracker_non_residential_cleaned/",
+          "--care_home_diagnostics_destination": "${dataset_bucket_uri}/domain=ind_cqc_filled_posts/dataset=capacity_tracker_care_home_diagnostics/",
+          "--care_home_summary_diagnostics_destination": "${dataset_bucket_uri}/domain=ind_cqc_filled_posts/dataset=capacity_tracker_care_home_diagnostics_summary/",
+          "--non_res_diagnostics_destination": "${dataset_bucket_uri}/domain=ind_cqc_filled_posts/dataset=capacity_tracker_non_residential_diagnostics/"
+        }
+      },
+      "Next": "Run capacity tracker crawler"
     },
     "Run capacity tracker crawler": {
       "Type": "Task",
@@ -61,6 +77,18 @@
         "StateMachineArn": "arn:aws:states:eu-west-2:344210435447:stateMachine:main-RunCrawler",
         "Input": {
           "crawler_name": "${capacity_tracker_crawler_name}",
+          "AWS_STEP_FUNCTIONS_STARTED_BY_EXECUTION_ID.$": "$$.Execution.Id"
+        }
+      },
+      "Next": "Run ind cqc crawler"
+    },
+    "Run ind cqc crawler": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::states:startExecution.sync:2",
+      "Parameters": {
+        "StateMachineArn": "arn:aws:states:eu-west-2:344210435447:stateMachine:main-RunCrawler",
+        "Input": {
+          "crawler_name": "${ind_cqc_filled_posts_crawler_name}",
           "AWS_STEP_FUNCTIONS_STARTED_BY_EXECUTION_ID.$": "$$.Execution.Id"
         }
       },


### PR DESCRIPTION
# Description
Adding the capacity tracker diagnostics job into the capacity tracker pipeline as I'm forever running it after and rarely in any other situation!

# How to test
Unit tests passing
Run in branch: https://eu-west-2.console.aws.amazon.com/states/home?region=eu-west-2#/v2/executions/details/arn:aws:states:eu-west-2:344210435447:execution:add-diagnostics-to-ct-pipeline-IngestAndCleanCapacityTrackerDataPipeline:50c2c5d2-51b4-42ae-bdbf-fcfacc094018

# Developer checklist
- [x] Unit test
- [x] Linked to Trello ticket: https://trello.com/c/LKnS0srn/858-add-ct-diagnostics-to-ct-pipeline
- [x] Documentation up to date
