### PR TITLE
Fill ct nonres with filled post estimates

### DIFF
--- a/jobs/diagnostics_on_capacity_tracker.py
+++ b/jobs/diagnostics_on_capacity_tracker.py
@@ -196,7 +196,10 @@ def run_diagnostics_for_non_residential(
     non_res_diagnostics_df = (
         populate_estimate_filled_posts_and_source_in_the_order_of_the_column_list(
             non_res_diagnostics_df,
-            [CTNRClean.cqc_care_workers_employed_imputed, IndCQC.estimate_filled_posts],
+            [
+                CTNRClean.cqc_care_workers_employed_imputed_all_posts,
+                IndCQC.estimate_filled_posts,
+            ],
             CTNRClean.capacity_tracker_filled_post_estimate,
             CTNRClean.capacity_tracker_filled_post_estimate_source,
         )
@@ -258,7 +261,7 @@ def convert_to_all_posts_using_ratio(df: DataFrame) -> DataFrame:
         DataFrame: A dataframe with a new column containing the all-workers estimate.
     """
     df = df.withColumn(
-        CTNRClean.capacity_tracker_filled_post_estimate,
+        CTNRClean.cqc_care_workers_employed_imputed_all_posts,
         F.col(CTNRClean.cqc_care_workers_employed_imputed) / care_worker_ratio,
     )
     return df

--- a/jobs/diagnostics_on_capacity_tracker.py
+++ b/jobs/diagnostics_on_capacity_tracker.py
@@ -52,10 +52,14 @@ absolute_value_cutoff: float = 10.0
 percentage_value_cutoff: float = 0.25
 standardised_value_cutoff: float = 1.0
 number_of_days_in_rolling_average: int = 185  # Note: using 185 as a proxy for 6 months
-care_worker_ratio: dict = {"micro": 0.61, "small": 0.74, "medium_or_large": 0.79}
+care_worker_ratio: dict = {
+    "micro": 0.61,
+    "small": 0.74,
+    "medium_or_large": 0.79,
+}  # Ratios based on exploration of SPSS estimates of care workers to filled posts by org size in 2023 and 2024.
 org_size_care_worker_upper_limit: dict = {
-    "micro": 10 * care_worker_ratio["micro"],
-    "small": 50 * care_worker_ratio["small"],
+    "micro": 10 * care_worker_ratio["micro"],  # We define micro orgs as 1-9 posts
+    "small": 50 * care_worker_ratio["small"],  # We define small orgs as 10-49 posts
 }
 
 

--- a/jobs/estimate_ind_cqc_filled_posts.py
+++ b/jobs/estimate_ind_cqc_filled_posts.py
@@ -162,6 +162,8 @@ def main(
                 IndCQC.non_res_without_dormancy_model,
                 IndCQC.rolling_average_model,
             ],
+            IndCQC.estimate_filled_posts,
+            IndCQC.estimate_filled_posts_source,
         )
     )
 

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -7850,19 +7850,6 @@ class DiagnosticsOnCapacityTrackerData:
         ),
     ]
 
-    fill_gaps_with_filled_posts_rows = [
-        ("loc 1", 10.0, 15.0),
-        ("loc 2", None, 20.0),
-        ("loc 3", 25.0, None),
-        ("loc 4", None, None),
-    ]
-    expected_fill_gaps_with_filled_posts_rows = [
-        ("loc 1", 10.0, 15.0),
-        ("loc 2", 20.0, 20.0),
-        ("loc 3", 25.0, None),
-        ("loc 4", None, None),
-    ]
-
     convert_to_all_posts_using_ratio_rows = [
         ("loc 1", 10.0),
         ("loc 2", None),

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -7850,12 +7850,32 @@ class DiagnosticsOnCapacityTrackerData:
         ),
     ]
 
-    convert_to_all_posts_using_ratio_rows = [
-        ("loc 1", 10.0),
+    convert_to_all_posts_using_ratio_micro_rows = [
+        ("loc 1", 1.0),
+        ("loc 2", 6.0),
+        ("loc 3", None),
+    ]
+    expected_convert_to_all_posts_using_ratio_micro_rows = [
+        ("loc 1", 1.0, 1.6393),
+        ("loc 2", 6.0, 9.8361),
+        ("loc 3", None, None),
+    ]
+    convert_to_all_posts_using_ratio_small_rows = [
+        ("loc 1", 7.0),
+        ("loc 2", 36.0),
+        ("loc 3", None),
+    ]
+    expected_convert_to_all_posts_using_ratio_small_rows = [
+        ("loc 1", 7.0, 9.4595),
+        ("loc 2", 36.0, 48.6486),
+        ("loc 3", None, None),
+    ]
+    convert_to_all_posts_using_ratio_medium_or_large_rows = [
+        ("loc 1", 37.0),
         ("loc 2", None),
     ]
-    expected_convert_to_all_posts_using_ratio_rows = [
-        ("loc 1", 10.0, 13.513),
+    expected_convert_to_all_posts_using_ratio_medium_or_large_rows = [
+        ("loc 1", 37.0, 46.8354),
         ("loc 2", None, None),
     ]
 

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -4486,13 +4486,6 @@ class DiagnosticsOnCapacityTrackerSchemas:
             StructField(CTNRClean.service_user_count, IntegerType(), True),
         ]
     )
-    fill_gaps_with_filled_posts_schema = StructType(
-        [
-            StructField(IndCQC.location_id, StringType(), True),
-            StructField(CTNRClean.cqc_care_workers_employed_imputed, FloatType(), True),
-            StructField(IndCQC.estimate_filled_posts, FloatType(), True),
-        ]
-    )
     convert_to_all_posts_using_ratio_schema = StructType(
         [
             StructField(IndCQC.location_id, StringType(), True),

--- a/tests/unit/test_diagnostics_on_capacity_tracker.py
+++ b/tests/unit/test_diagnostics_on_capacity_tracker.py
@@ -9,9 +9,6 @@ from tests.test_file_schemas import (
     DiagnosticsOnCapacityTrackerSchemas as Schemas,
 )
 from utils import utils
-from utils.column_names.capacity_tracker_columns import (
-    CapacityTrackerNonResCleanColumns as CTNRClean,
-)
 from utils.column_names.ind_cqc_pipeline_columns import (
     PartitionKeys as Keys,
     IndCqcColumns as IndCQC,

--- a/tests/unit/test_diagnostics_on_capacity_tracker.py
+++ b/tests/unit/test_diagnostics_on_capacity_tracker.py
@@ -140,29 +140,6 @@ class JoinCapacityTrackerTests(DiagnosticsOnCapacityTrackerTests):
         )
 
 
-class FillGapsWithFilledPostEstimatesTests(DiagnosticsOnCapacityTrackerTests):
-    def setUp(self) -> None:
-        super().setUp()
-
-    def test_fill_gaps_with_filled_post_estimates_returns_correct_values(self):
-        test_df = self.spark.createDataFrame(
-            Data.fill_gaps_with_filled_posts_rows,
-            Schemas.fill_gaps_with_filled_posts_schema,
-        )
-        expected_df = self.spark.createDataFrame(
-            Data.expected_fill_gaps_with_filled_posts_rows,
-            Schemas.fill_gaps_with_filled_posts_schema,
-        )
-        returned_df = job.fill_gaps_with_filled_post_estimates(
-            test_df,
-            CTNRClean.cqc_care_workers_employed_imputed,
-            IndCQC.estimate_filled_posts,
-        )
-        self.assertEqual(
-            returned_df.sort(IndCQC.location_id).collect(), expected_df.collect()
-        )
-
-
 class ConvertToAllPostsUsingRatioTests(DiagnosticsOnCapacityTrackerTests):
     def setUp(self) -> None:
         super().setUp()

--- a/tests/unit/test_ind_cqc_filled_posts_utils.py
+++ b/tests/unit/test_ind_cqc_filled_posts_utils.py
@@ -30,7 +30,10 @@ class TestFilledPostsAndSourceAdded(TestIndCqcFilledPostUtils):
         )
 
         self.returned_df = job.populate_estimate_filled_posts_and_source_in_the_order_of_the_column_list(
-            self.input_df, ["model_name_1", "model_name_2", "model_name_3"]
+            self.input_df,
+            ["model_name_1", "model_name_2", "model_name_3"],
+            IndCQC.estimate_filled_posts,
+            IndCQC.estimate_filled_posts_source,
         )
 
     def test_populate_estimate_filled_posts_and_source_adds_new_columns(self):

--- a/utils/column_names/capacity_tracker_columns.py
+++ b/utils/column_names/capacity_tracker_columns.py
@@ -114,9 +114,7 @@ class CapacityTrackerNonResCleanColumns(CapacityTrackerNonResColumns):
     cqc_care_workers_employed_imputed: str = (
         CapacityTrackerNonResColumns.cqc_care_workers_employed + "_imputed"
     )
-    cqc_care_workers_employed_imputed_all_posts: str = (
-        cqc_care_workers_employed_imputed + "_all_posts"
-    )
+    capacity_tracker_all_posts: str = "capacity_tracker_all_posts"
     cqc_care_workers_employed_rolling_avg: str = (
         CapacityTrackerNonResColumns.cqc_care_workers_employed + "_rolling_avg"
     )

--- a/utils/column_names/capacity_tracker_columns.py
+++ b/utils/column_names/capacity_tracker_columns.py
@@ -115,7 +115,7 @@ class CapacityTrackerNonResCleanColumns(CapacityTrackerNonResColumns):
         CapacityTrackerNonResColumns.cqc_care_workers_employed + "_imputed"
     )
     cqc_care_workers_employed_imputed_all_posts: str = (
-        CapacityTrackerNonResColumns.cqc_care_workers_employed_imputed + "_all_posts"
+        cqc_care_workers_employed_imputed + "_all_posts"
     )
     cqc_care_workers_employed_rolling_avg: str = (
         CapacityTrackerNonResColumns.cqc_care_workers_employed + "_rolling_avg"

--- a/utils/column_names/capacity_tracker_columns.py
+++ b/utils/column_names/capacity_tracker_columns.py
@@ -114,6 +114,9 @@ class CapacityTrackerNonResCleanColumns(CapacityTrackerNonResColumns):
     cqc_care_workers_employed_imputed: str = (
         CapacityTrackerNonResColumns.cqc_care_workers_employed + "_imputed"
     )
+    cqc_care_workers_employed_imputed_all_posts: str = (
+        CapacityTrackerNonResColumns.cqc_care_workers_employed_imputed + "_all_posts"
+    )
     cqc_care_workers_employed_rolling_avg: str = (
         CapacityTrackerNonResColumns.cqc_care_workers_employed + "_rolling_avg"
     )

--- a/utils/column_names/capacity_tracker_columns.py
+++ b/utils/column_names/capacity_tracker_columns.py
@@ -105,6 +105,9 @@ class CapacityTrackerNonResColumns:
 @dataclass
 class CapacityTrackerNonResCleanColumns(CapacityTrackerNonResColumns):
     capacity_tracker_filled_post_estimate: str = "capacity_tracker_filled_post_estimate"
+    capacity_tracker_filled_post_estimate_source: str = (
+        capacity_tracker_filled_post_estimate + "_source"
+    )
     capacity_tracker_import_date: str = (
         CapacityTrackerCareHomeCleanColumns.capacity_tracker_import_date
     )

--- a/utils/ind_cqc_filled_posts_utils/utils.py
+++ b/utils/ind_cqc_filled_posts_utils/utils.py
@@ -33,7 +33,7 @@ def populate_estimate_filled_posts_and_source_in_the_order_of_the_column_list(
     """
     Populate the estimates and source columns using the hierarchy provided in the list.
 
-    The first item in the list is populated first. Subsequent gaps are filled by the following items in the list.
+    The first item in the list is populated first. Subsequent null values are filled by the following items in the list.
 
     Args:
         df(DataFrame): A data frame with estimates that need merging into a single column.

--- a/utils/ind_cqc_filled_posts_utils/utils.py
+++ b/utils/ind_cqc_filled_posts_utils/utils.py
@@ -27,31 +27,47 @@ def add_source_description_to_source_column(
 def populate_estimate_filled_posts_and_source_in_the_order_of_the_column_list(
     df: DataFrame,
     order_of_models_to_populate_estimate_filled_posts_with: list,
+    estimates_column_to_populate: str,
+    estimates_source_column_to_populate: str,
 ) -> DataFrame:
-    df = df.withColumn(IndCQC.estimate_filled_posts, F.lit(None).cast(IntegerType()))
+    """
+    Populate the estimates and source columns using the hierarchy provided in the list.
+
+    The first item in the list is populated first. Subsequent gaps are filled by the following items in the list.
+
+    Args:
+        df(DataFrame): A data frame with estimates that need merging into a single column.
+        order_of_models_to_populate_estimate_filled_posts_with (list): A list of column names of models.
+        estimates_column_to_populate (str): The name of the column to populate with estimates.
+        estimates_source_column_to_populate (str): The name of the column to populate with estimate sources.
+
+    Returns:
+        DataFrame: A data frame with estimates and estimates source column populated.
+    """
+    df = df.withColumn(estimates_column_to_populate, F.lit(None).cast(IntegerType()))
     df = df.withColumn(
-        IndCQC.estimate_filled_posts_source, F.lit(None).cast(StringType())
+        estimates_source_column_to_populate, F.lit(None).cast(StringType())
     )
 
     # TODO - replace for loop with better functionality
     # see https://trello.com/c/94jAj8cd/428-update-how-we-populate-estimates
     for model_name in order_of_models_to_populate_estimate_filled_posts_with:
         df = df.withColumn(
-            IndCQC.estimate_filled_posts,
+            estimates_column_to_populate,
             F.when(
                 (
-                    F.col(IndCQC.estimate_filled_posts).isNull()
+                    F.col(estimates_column_to_populate).isNull()
                     & (F.col(model_name).isNotNull())
                     & (F.col(model_name) >= 1.0)
                 ),
                 F.col(model_name),
-            ).otherwise(F.col(IndCQC.estimate_filled_posts)),
+            ).otherwise(F.col(estimates_column_to_populate)),
         )
 
         df = add_source_description_to_source_column(
             df,
-            IndCQC.estimate_filled_posts,
-            IndCQC.estimate_filled_posts_source,
+            estimates_column_to_populate,
+            estimates_source_column_to_populate,
             model_name,
         )
 


### PR DESCRIPTION
# Description
Ratio up the cqc care workers figure
Fill the gaps in ct non res estimates
Add a source column for ct estimates

# How to test
Unit tests passing
Successful run in branch: https://eu-west-2.console.aws.amazon.com/gluestudio/home?region=eu-west-2#/editor/job/fill-ct-nonres-with-filled-pos-diagnostics_on_capacity_tracker_job/runs
Data in athena looks correct in both estimates and source column

# Developer checklist
- [x] Unit test
- [x] Linked to Trello ticket: https://trello.com/c/5opsnTZR/872-fill-gaps-in-ct-data-with-filled-posts-estimates
- [x] Documentation up to date
