### PR TITLE
Refactor rolling average

### DIFF
--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -5127,6 +5127,31 @@ class ModelPrimaryServiceRollingAverage:
         ("1-008", CareHome.not_care_home, None, None, None),
     ]
 
+    # fmt: off
+    calculate_rolling_average_rows = [
+        ("1-001", PrimaryServiceType.care_home_only, 1672531200, 1.1),
+        ("1-002", PrimaryServiceType.care_home_only, 1672617600, 1.2),
+        ("1-003", PrimaryServiceType.care_home_only, 1672704000, 1.3),
+        ("1-004", PrimaryServiceType.care_home_only, 1672790400, 1.4),
+        ("1-005", PrimaryServiceType.care_home_only, 1672876800, 1.4),
+        ("1-006", PrimaryServiceType.care_home_only, 1672876800, 1.3),
+        ("1-007", PrimaryServiceType.non_residential, 1672531200, 10.0),
+        ("1-008", PrimaryServiceType.non_residential, 1672704000, 20.0),
+        ("1-009", PrimaryServiceType.non_residential, 1672876800, 30.0),
+    ]
+    expected_calculate_rolling_average_rows = [
+        ("1-001", PrimaryServiceType.care_home_only, 1672531200, 1.1, 1.1),
+        ("1-002", PrimaryServiceType.care_home_only, 1672617600, 1.2, 1.15),
+        ("1-003", PrimaryServiceType.care_home_only, 1672704000, 1.3, 1.2),
+        ("1-004", PrimaryServiceType.care_home_only, 1672790400, 1.4, 1.3),
+        ("1-005", PrimaryServiceType.care_home_only, 1672876800, 1.4, 1.35),
+        ("1-006", PrimaryServiceType.care_home_only, 1672876800, 1.3, 1.35),
+        ("1-007", PrimaryServiceType.non_residential, 1672531200, 10.0, 10.0),
+        ("1-008", PrimaryServiceType.non_residential, 1672704000, 20.0, 15.0),
+        ("1-009", PrimaryServiceType.non_residential, 1672876800, 30.0, 25.0),
+    ]
+    # fmt: on
+
 
 @dataclass
 class ModelImputationWithExtrapolationAndInterpolationData:

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -5152,6 +5152,23 @@ class ModelPrimaryServiceRollingAverage:
     ]
     # fmt: on
 
+    create_final_model_columns_rows = [
+        ("1-001", CareHome.care_home, 10, 1.6),
+        ("1-002", CareHome.care_home, 12, None),
+        ("1-003", CareHome.care_home, None, 1.8),
+        ("1-004", CareHome.not_care_home, 10, 45.0),
+        ("1-005", CareHome.not_care_home, 12, None),
+        ("1-006", CareHome.not_care_home, None, 50.0),
+    ]
+    expected_create_final_model_columns_rows = [
+        ("1-001", CareHome.care_home, 10, 1.6, 1.6, 16.0),
+        ("1-002", CareHome.care_home, 12, None, None, None),
+        ("1-003", CareHome.care_home, None, 1.8, 1.8, None),
+        ("1-004", CareHome.not_care_home, 10, 45.0, None, 45.0),
+        ("1-005", CareHome.not_care_home, 12, None, None, None),
+        ("1-006", CareHome.not_care_home, None, 50.0, None, 50.0),
+    ]
+
 
 @dataclass
 class ModelImputationWithExtrapolationAndInterpolationData:

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -5106,6 +5106,27 @@ class ModelPrimaryServiceRollingAverage:
     ]
     # fmt: on
 
+    single_column_to_average_rows = [
+        ("1-001", CareHome.care_home, 20.0, 1.6),
+        ("1-002", CareHome.care_home, 10.0, None),
+        ("1-003", CareHome.care_home, None, 1.8),
+        ("1-004", CareHome.care_home, None, None),
+        ("1-005", CareHome.not_care_home, 20.0, 1.6),
+        ("1-006", CareHome.not_care_home, 10.0, None),
+        ("1-007", CareHome.not_care_home, None, 1.6),
+        ("1-008", CareHome.not_care_home, None, None),
+    ]
+    expected_single_column_to_average_rows = [
+        ("1-001", CareHome.care_home, 20.0, 1.6, 1.6),
+        ("1-002", CareHome.care_home, 10.0, None, None),
+        ("1-003", CareHome.care_home, None, 1.8, 1.8),
+        ("1-004", CareHome.care_home, None, None, None),
+        ("1-005", CareHome.not_care_home, 20.0, 1.6, 20.0),
+        ("1-006", CareHome.not_care_home, 10.0, None, 10.0),
+        ("1-007", CareHome.not_care_home, None, 1.8, None),
+        ("1-008", CareHome.not_care_home, None, None, None),
+    ]
+
 
 @dataclass
 class ModelImputationWithExtrapolationAndInterpolationData:

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -2576,6 +2576,26 @@ class ModelPrimaryServiceRollingAverage:
         ]
     )
 
+    create_final_model_columns_schema = StructType(
+        [
+            StructField(IndCQC.location_id, StringType(), False),
+            StructField(IndCQC.care_home, StringType(), False),
+            StructField(IndCQC.number_of_beds, IntegerType(), True),
+            StructField("temp_column_to_average", DoubleType(), True),
+        ]
+    )
+    expected_create_final_model_columns_schema = StructType(
+        [
+            *create_final_model_columns_schema,
+            StructField(
+                IndCQC.rolling_average_model_filled_posts_per_bed_ratio,
+                DoubleType(),
+                True,
+            ),
+            StructField(IndCQC.rolling_average_model, DoubleType(), True),
+        ]
+    )
+
 
 @dataclass
 class ModelImputationWithExtrapolationAndInterpolationSchemas:

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -2527,7 +2527,7 @@ class ModelPrimaryServiceRollingAverage:
         [
             StructField(IndCQC.location_id, StringType(), False),
             StructField(IndCQC.care_home, StringType(), False),
-            StructField(IndCQC.unix_time, LongType(), False),
+            StructField(IndCQC.unix_time, IntegerType(), False),
             StructField(IndCQC.ascwds_filled_posts_dedup_clean, DoubleType(), True),
             StructField(IndCQC.filled_posts_per_bed_ratio, DoubleType(), True),
             StructField(IndCQC.primary_service_type, StringType(), False),
@@ -2557,7 +2557,22 @@ class ModelPrimaryServiceRollingAverage:
     expected_single_column_to_average_schema = StructType(
         [
             *single_column_to_average_schema,
-            StructField(IndCQC.column_to_average, DoubleType(), True),
+            StructField(IndCQC.temp_column_to_average, DoubleType(), True),
+        ]
+    )
+
+    calculate_rolling_average_schema = StructType(
+        [
+            StructField(IndCQC.location_id, StringType(), False),
+            StructField(IndCQC.primary_service_type, StringType(), False),
+            StructField(IndCQC.unix_time, IntegerType(), False),
+            StructField(IndCQC.temp_column_to_average, DoubleType(), True),
+        ]
+    )
+    expected_calculate_rolling_average_schema = StructType(
+        [
+            *calculate_rolling_average_schema,
+            StructField(IndCQC.temp_rolling_average, DoubleType(), True),
         ]
     )
 

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -2546,6 +2546,21 @@ class ModelPrimaryServiceRollingAverage:
         ]
     )
 
+    single_column_to_average_schema = StructType(
+        [
+            StructField(IndCQC.location_id, StringType(), False),
+            StructField(IndCQC.care_home, StringType(), False),
+            StructField(IndCQC.ascwds_filled_posts_dedup_clean, DoubleType(), True),
+            StructField(IndCQC.filled_posts_per_bed_ratio, DoubleType(), True),
+        ]
+    )
+    expected_single_column_to_average_schema = StructType(
+        [
+            *single_column_to_average_schema,
+            StructField(IndCQC.column_to_average, DoubleType(), True),
+        ]
+    )
+
 
 @dataclass
 class ModelImputationWithExtrapolationAndInterpolationSchemas:

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -2557,7 +2557,7 @@ class ModelPrimaryServiceRollingAverage:
     expected_single_column_to_average_schema = StructType(
         [
             *single_column_to_average_schema,
-            StructField(IndCQC.temp_column_to_average, DoubleType(), True),
+            StructField("temp_column_to_average", DoubleType(), True),
         ]
     )
 
@@ -2566,13 +2566,13 @@ class ModelPrimaryServiceRollingAverage:
             StructField(IndCQC.location_id, StringType(), False),
             StructField(IndCQC.primary_service_type, StringType(), False),
             StructField(IndCQC.unix_time, IntegerType(), False),
-            StructField(IndCQC.temp_column_to_average, DoubleType(), True),
+            StructField("temp_column_to_average", DoubleType(), True),
         ]
     )
     expected_calculate_rolling_average_schema = StructType(
         [
             *calculate_rolling_average_schema,
-            StructField(IndCQC.temp_rolling_average, DoubleType(), True),
+            StructField("temp_rolling_average", DoubleType(), True),
         ]
     )
 

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -2581,7 +2581,7 @@ class ModelPrimaryServiceRollingAverage:
             StructField(IndCQC.location_id, StringType(), False),
             StructField(IndCQC.care_home, StringType(), False),
             StructField(IndCQC.number_of_beds, IntegerType(), True),
-            StructField("temp_column_to_average", DoubleType(), True),
+            StructField("temp_rolling_average", DoubleType(), True),
         ]
     )
     expected_create_final_model_columns_schema = StructType(

--- a/tests/unit/test_model_primary_service_rolling_average.py
+++ b/tests/unit/test_model_primary_service_rolling_average.py
@@ -22,7 +22,7 @@ class MainTests(ModelPrimaryServiceRollingAverageTests):
     def setUp(self) -> None:
         super().setUp()
 
-        number_of_days = 89
+        number_of_days: int = 89
         self.estimates_df = self.spark.createDataFrame(
             Data.primary_service_rolling_average_rows,
             Schemas.primary_service_rolling_average_schema,

--- a/tests/unit/test_model_primary_service_rolling_average.py
+++ b/tests/unit/test_model_primary_service_rolling_average.py
@@ -17,6 +17,11 @@ class ModelPrimaryServiceRollingAverageTests(unittest.TestCase):
         warnings.filterwarnings("ignore", category=ResourceWarning)
         warnings.filterwarnings("ignore", category=DeprecationWarning)
 
+
+class MainTests(ModelPrimaryServiceRollingAverageTests):
+    def setUp(self) -> None:
+        super().setUp()
+
         number_of_days = 88
         self.estimates_df = self.spark.createDataFrame(
             Data.primary_service_rolling_average_rows,

--- a/tests/unit/test_model_primary_service_rolling_average.py
+++ b/tests/unit/test_model_primary_service_rolling_average.py
@@ -22,7 +22,7 @@ class MainTests(ModelPrimaryServiceRollingAverageTests):
     def setUp(self) -> None:
         super().setUp()
 
-        number_of_days = 88
+        number_of_days = 89
         self.estimates_df = self.spark.createDataFrame(
             Data.primary_service_rolling_average_rows,
             Schemas.primary_service_rolling_average_schema,

--- a/tests/unit/test_model_primary_service_rolling_average.py
+++ b/tests/unit/test_model_primary_service_rolling_average.py
@@ -105,8 +105,8 @@ class CreateSingleColumnToAverageTests(ModelPrimaryServiceRollingAverageTests):
     ):
         for i in range(len(self.returned_data)):
             self.assertEqual(
-                self.returned_data[i][IndCqc.temp_column_to_average],
-                self.expected_data[i][IndCqc.temp_column_to_average],
+                self.returned_data[i][job.TempCol.temp_column_to_average],
+                self.expected_data[i][job.TempCol.temp_column_to_average],
                 f"Returned row {i} does not match expected",
             )
 
@@ -140,8 +140,8 @@ class CalculateRollingAverageTests(ModelPrimaryServiceRollingAverageTests):
     ):
         for i in range(len(self.returned_data)):
             self.assertAlmostEqual(
-                self.returned_data[i][IndCqc.temp_rolling_average],
-                self.expected_data[i][IndCqc.temp_rolling_average],
+                self.returned_data[i][job.TempCol.temp_rolling_average],
+                self.expected_data[i][job.TempCol.temp_rolling_average],
                 2,
                 f"Returned row {i} does not match expected",
             )

--- a/utils/column_names/ind_cqc_pipeline_columns.py
+++ b/utils/column_names/ind_cqc_pipeline_columns.py
@@ -218,8 +218,6 @@ class IndCqcColumns:
     specialism_count: str = "specialism_count"
     specialisms: str = CQCLClean.specialisms
     standardised_residual: str = "standardised_residual"
-    temp_column_to_average: str = "temp_column_to_average"
-    temp_rolling_average: str = "temp_rolling_average"
     time_registered: str = "time_registered"
     total_staff_bounded: str = AWPClean.total_staff_bounded
     unix_time: str = "unix_time"

--- a/utils/column_names/ind_cqc_pipeline_columns.py
+++ b/utils/column_names/ind_cqc_pipeline_columns.py
@@ -51,6 +51,7 @@ class IndCqcColumns:
     care_home: str = CQCLClean.care_home
     care_home_model: str = "care_home_model"
     code: str = CQCLClean.code
+    column_to_average: str = "column_to_average"
     contacts: str = CQCLClean.contacts
     contemporary_ccg: str = ONSClean.contemporary_ccg
     contemporary_constituancy: str = ONSClean.contemporary_constituancy

--- a/utils/column_names/ind_cqc_pipeline_columns.py
+++ b/utils/column_names/ind_cqc_pipeline_columns.py
@@ -51,7 +51,6 @@ class IndCqcColumns:
     care_home: str = CQCLClean.care_home
     care_home_model: str = "care_home_model"
     code: str = CQCLClean.code
-    column_to_average: str = "column_to_average"
     contacts: str = CQCLClean.contacts
     contemporary_ccg: str = ONSClean.contemporary_ccg
     contemporary_constituancy: str = ONSClean.contemporary_constituancy
@@ -219,6 +218,8 @@ class IndCqcColumns:
     specialism_count: str = "specialism_count"
     specialisms: str = CQCLClean.specialisms
     standardised_residual: str = "standardised_residual"
+    temp_column_to_average: str = "temp_column_to_average"
+    temp_rolling_average: str = "temp_rolling_average"
     time_registered: str = "time_registered"
     total_staff_bounded: str = AWPClean.total_staff_bounded
     unix_time: str = "unix_time"

--- a/utils/estimate_filled_posts/models/primary_service_rolling_average.py
+++ b/utils/estimate_filled_posts/models/primary_service_rolling_average.py
@@ -31,14 +31,14 @@ def model_primary_service_rolling_average(
 
     Args:
         df (DataFrame): The input DataFrame.
-        ratio_column_to_average (str): The name of the column to average for care homes.
-        posts_column_to_average (str): The name of the column to average for non residential locations.
-        number_of_days (int): The number of days to include in the rolling average time period.
-        ratio_rolling_average_model_column_name (str): The name of the column to store the care home ratio rolling average.
-        posts_rolling_average_model_column_name (str): The name of the new column to store the rolling average.
+        ratio_column_to_average (str): The name of the filled posts per bed ratio column to average (for care homes only).
+        posts_column_to_average (str): The name of the filled posts column to average.
+        number_of_days (int): The number of days to include in the rolling average time period (where three days refers to the current day plus the previous two).
+        ratio_rolling_average_model_column_name (str): The name of the new column to store the care home filled posts per bed ratio rolling average.
+        posts_rolling_average_model_column_name (str): The name of the new column to store the filled posts rolling average.
 
     Returns:
-        DataFrame: The input DataFrame with the new column containing the rolling average.
+        DataFrame: The input DataFrame with the new column containing the two new rolling average columns.
     """
     df = create_single_column_to_average(
         df, ratio_column_to_average, posts_column_to_average
@@ -64,8 +64,8 @@ def create_single_column_to_average(
 
     Args:
         df (DataFrame): The input DataFrame.
-        ratio_column_to_average (str): The name of the column to average for care homes.
-        posts_column_to_average (str): The name of the column to average for non residential locations.
+        ratio_column_to_average (str): The name of the filled posts per bed ratio column to average (for care homes only).
+        posts_column_to_average (str): The name of the filled posts column to average.
 
     Returns:
         DataFrame: The input DataFrame with the new column containing a single column with the relevant column to average.
@@ -90,7 +90,7 @@ def calculate_rolling_average(df: DataFrame, number_of_days: int) -> DataFrame:
 
     Args:
         df (DataFrame): The input DataFrame.
-        number_of_days (int): The number of days to use for the rolling average calculations.
+        number_of_days (int): The number of days to include in the rolling average time period (where three days refers to the current day plus the previous two).
 
     Returns:
         DataFrame: The input DataFrame with the new column containing the calculated rolling average.
@@ -116,15 +116,15 @@ def create_final_model_columns(
     posts_rolling_average_model_column_name: str,
 ) -> DataFrame:
     """
-    Allocates values from temp_column_to_average to the correctly labelled columns.
+    Allocates values from temp_rolling_average to the correctly labelled columns.
 
-    `ratio_rolling_average_model_column_name` is only populated for care homes and replicates what is in the `temp_column_to_average`.
-    `posts_rolling_average_model_column_name`  replicates what is in the `temp_column_to_average` for non-care homes and for care homes, the column is multiplied by number of beds to get the equivalent filled posts.
+    `ratio_rolling_average_model_column_name` is only populated for care homes and replicates what is in the `temp_rolling_average`.
+    `posts_rolling_average_model_column_name` replicates what is in the `temp_rolling_average` for non-care homes and for care homes, the column is multiplied by number of beds to get the equivalent filled posts.
 
     Args:
         df (DataFrame): The input DataFrame.
-        ratio_rolling_average_model_column_name (str): The name of the column to store the care home ratio.
-        posts_rolling_average_model_column_name (str): The name of the new column to store the rolling average.
+        ratio_rolling_average_model_column_name (str): The name of the new column to store the care home filled posts per bed ratio rolling average.
+        posts_rolling_average_model_column_name (str): The name of the new column to store the filled posts rolling average.
 
     Returns:
         DataFrame: The input DataFrame with the two model columns added.

--- a/utils/estimate_filled_posts/models/primary_service_rolling_average.py
+++ b/utils/estimate_filled_posts/models/primary_service_rolling_average.py
@@ -45,7 +45,7 @@ def model_primary_service_rolling_average(
     )
     df = calculate_rolling_average(df, number_of_days)
     df = create_final_model_columns(
-        df, model_filled_posts_column_name, model_filled_posts_per_bed_ratio_column_name
+        df, model_filled_posts_per_bed_ratio_column_name, model_filled_posts_column_name
     )
     df = df.drop(TempCol.temp_column_to_average, TempCol.temp_rolling_average)
 
@@ -131,15 +131,15 @@ def create_final_model_columns(
         model_filled_posts_per_bed_ratio_column_name,
         F.when(
             F.col(IndCqc.care_home) == CareHome.care_home,
-            F.col(TempCol.temp_column_to_average),
+            F.col(TempCol.temp_rolling_average),
         ),
     )
     df = df.withColumn(
         model_filled_posts_column_name,
         F.when(
             F.col(IndCqc.care_home) == CareHome.care_home,
-            F.col(TempCol.temp_column_to_average) * F.col(IndCqc.number_of_beds),
-        ).otherwise(F.col(TempCol.temp_column_to_average)),
+            F.col(TempCol.temp_rolling_average) * F.col(IndCqc.number_of_beds),
+        ).otherwise(F.col(TempCol.temp_rolling_average)),
     )
 
     return df

--- a/utils/estimate_filled_posts/models/primary_service_rolling_average.py
+++ b/utils/estimate_filled_posts/models/primary_service_rolling_average.py
@@ -82,10 +82,10 @@ def create_single_column_to_average(
 
 def calculate_rolling_average(df: DataFrame, number_of_days: int) -> DataFrame:
     """
-    Calculates the rolling average of a specified column over a given window of days.
+    Calculates the rolling average of a specified column over a given window of days partitioned by primary service type.
 
-    Calculates the rolling average of a specified column over a given window of days.
-    One day is removed from the provided number_of_days value to reflect that the range is inclusive.
+    Calculates the rolling average of a specified column over a given window of days partitioned by primary service type.
+    One day is removed from the provided number_of_days value because the pyspark range between function is inclusive at both the start and end point whereas we only want it to be inclusive of the end point.
     For example, for a 3 day rolling average we want the current day plus the two days prior (not the three days prior).
 
     Args:

--- a/utils/estimate_filled_posts/models/primary_service_rolling_average.py
+++ b/utils/estimate_filled_posts/models/primary_service_rolling_average.py
@@ -110,13 +110,14 @@ def calculate_rolling_average(df: DataFrame, number_of_days: int) -> DataFrame:
 
 def create_final_model_columns(
     df: DataFrame,
-    model_filled_posts_column_name: str,
     model_filled_posts_per_bed_ratio_column_name: str,
+    model_filled_posts_column_name: str,
 ) -> DataFrame:
     """
     Allocates values from temp_column_to_average to the correctly labelled columns.
 
-    If the location is a care home, copy the .
+    `model_filled_posts_per_bed_ratio_column_name` is only populated for care homes and replicates what is in the `temp_column_to_average`.
+    `model_filled_posts_column_name`  replicates what is in the `temp_column_to_average` for non-care homes and for care homes, the column is multiplied by number of beds to get the equivalent filled posts.
 
     Args:
         df (DataFrame): The input DataFrame.
@@ -124,7 +125,7 @@ def create_final_model_columns(
         model_filled_posts_per_bed_ratio_column_name (str): The name of the column to store the care home ratio.
 
     Returns:
-        DataFrame: The input DataFrame with the correctly labelled columns and without the temporary column.
+        DataFrame: The input DataFrame with the two model columns added.
     """
     df = df.withColumn(
         model_filled_posts_per_bed_ratio_column_name,

--- a/utils/estimate_filled_posts/models/primary_service_rolling_average.py
+++ b/utils/estimate_filled_posts/models/primary_service_rolling_average.py
@@ -121,8 +121,8 @@ def create_final_model_columns(
 
     Args:
         df (DataFrame): The input DataFrame.
-        model_filled_posts_column_name (str): The name of the new column to store the rolling average.
         model_filled_posts_per_bed_ratio_column_name (str): The name of the column to store the care home ratio.
+        model_filled_posts_column_name (str): The name of the new column to store the rolling average.
 
     Returns:
         DataFrame: The input DataFrame with the two model columns added.


### PR DESCRIPTION
# Description
Refactored rolling average to use one singular column which is rolling averaged then split out to help with follow up work.

# How to test
No change to functionality, previous tests still passing and [branch still running ok](https://eu-west-2.console.aws.amazon.com/states/home?region=eu-west-2#/v2/executions/details/arn:aws:states:eu-west-2:344210435447:execution:rename-rolling-avg-variables-Ind-CQC-Filled-Post-Estimates-Pipeline:24f569ab-a68a-4f40-87e0-59e15da5d4e6)

# Developer checklist
- [X] Unit test
- [] Linked to Trello ticket
- [X] Documentation up to date
