### PR TITLE
Add diagnostics to non res ct

### DIFF
--- a/terraform/pipeline/glue.tf
+++ b/terraform/pipeline/glue.tf
@@ -874,6 +874,7 @@ module "diagnostics_on_capacity_tracker_job" {
     "--care_home_diagnostics_destination"         = "${module.datasets_bucket.bucket_uri}/domain=ind_cqc_filled_posts/dataset=capacity_tracker_care_home_diagnostics/"
     "--care_home_summary_diagnostics_destination" = "${module.datasets_bucket.bucket_uri}/domain=ind_cqc_filled_posts/dataset=capacity_tracker_care_home_diagnostics_summary/"
     "--non_res_diagnostics_destination"           = "${module.datasets_bucket.bucket_uri}/domain=ind_cqc_filled_posts/dataset=capacity_tracker_non_residential_diagnostics/"
+    "--non_res_summary_diagnostics_destination"   = "${module.datasets_bucket.bucket_uri}/domain=ind_cqc_filled_posts/dataset=capacity_tracker_non_residential_diagnostics_summary/"
   }
 }
 

--- a/terraform/pipeline/step-functions/IngestAndCleanCapacityTrackerDataPipeline-StepFunction.json
+++ b/terraform/pipeline/step-functions/IngestAndCleanCapacityTrackerDataPipeline-StepFunction.json
@@ -65,7 +65,8 @@
           "--capacity_tracker_non_res_source": "${dataset_bucket_uri}/domain=capacity_tracker/dataset=capacity_tracker_non_residential_cleaned/",
           "--care_home_diagnostics_destination": "${dataset_bucket_uri}/domain=ind_cqc_filled_posts/dataset=capacity_tracker_care_home_diagnostics/",
           "--care_home_summary_diagnostics_destination": "${dataset_bucket_uri}/domain=ind_cqc_filled_posts/dataset=capacity_tracker_care_home_diagnostics_summary/",
-          "--non_res_diagnostics_destination": "${dataset_bucket_uri}/domain=ind_cqc_filled_posts/dataset=capacity_tracker_non_residential_diagnostics/"
+          "--non_res_diagnostics_destination": "${dataset_bucket_uri}/domain=ind_cqc_filled_posts/dataset=capacity_tracker_non_residential_diagnostics/",
+          "--non_res_summary_diagnostics_destination": "${dataset_bucket_uri}/domain=ind_cqc_filled_posts/dataset=capacity_tracker_non_residential_diagnostics_summary/"
         }
       },
       "Next": "Run capacity tracker crawler"

--- a/tests/unit/test_diagnostics_on_capacity_tracker.py
+++ b/tests/unit/test_diagnostics_on_capacity_tracker.py
@@ -22,6 +22,7 @@ class DiagnosticsOnCapacityTrackerTests(unittest.TestCase):
     CARE_HOME_DIAGNOSTICS_DESTINATION = "some/other/directory"
     CARE_HOME_SUMMARY_DIAGNOSTICS_DESTINATION = "another/directory"
     NON_RES_DIAGNOSTICS_DESTINATION = "some/other/directory"
+    NON_RES_SUMMARY_DIAGNOSTICS_DESTINATION = "yet/another/directory"
     partition_keys = [Keys.year, Keys.month, Keys.day, Keys.import_date]
 
     def setUp(self):
@@ -63,10 +64,11 @@ class MainTests(DiagnosticsOnCapacityTrackerTests):
             self.CARE_HOME_DIAGNOSTICS_DESTINATION,
             self.CARE_HOME_SUMMARY_DIAGNOSTICS_DESTINATION,
             self.NON_RES_DIAGNOSTICS_DESTINATION,
+            self.NON_RES_SUMMARY_DIAGNOSTICS_DESTINATION,
         )
 
         self.assertEqual(read_from_parquet_patch.call_count, 3)
-        self.assertEqual(write_to_parquet_patch.call_count, 3)
+        self.assertEqual(write_to_parquet_patch.call_count, 4)
 
 
 class CheckConstantsTests(DiagnosticsOnCapacityTrackerTests):


### PR DESCRIPTION
# Description
Add residual and distribution steps to non residential capacity data now we have imputed.
Adds a summary dataset as well

# How to test
Unit tests passing
Run in branch: https://eu-west-2.console.aws.amazon.com/states/home?region=eu-west-2#/v2/executions/details/arn:aws:states:eu-west-2:344210435447:execution:add-diagnostics-to-non-res-ct-IngestAndCleanCapacityTrackerDataPipeline:c11ad3a7-bb46-46ab-86e5-06e3788af333
Summary data complete in athena

# Developer checklist
- [x] Unit test
- [x] Linked to Trello ticket: https://trello.com/c/zJGd2jSK/874-add-residuals-and-diagnostics-to-non-res-ct-diagnostics-function
- [x] Documentation up to date
