### PR TITLE
Impute missing ct res data

### DIFF
--- a/jobs/diagnostics_on_capacity_tracker.py
+++ b/jobs/diagnostics_on_capacity_tracker.py
@@ -82,7 +82,9 @@ def main(
     ct_non_res_df: DataFrame = utils.read_from_parquet(capacity_tracker_non_res_source)
 
     care_home_diagnostics_df = run_diagnostics_for_care_homes(
-        filled_posts_df, ct_care_home_df, CTCHClean.agency_and_non_agency_total_employed
+        filled_posts_df,
+        ct_care_home_df,
+        CTCHClean.agency_and_non_agency_total_employed,
     )
     non_res_diagnostics_df = run_diagnostics_for_non_residential(
         filled_posts_df, ct_non_res_df
@@ -135,7 +137,21 @@ def run_diagnostics_for_care_homes(
     care_home_diagnostics_df = join_capacity_tracker_data(
         filled_posts_df, ct_care_home_df, care_home=True
     )
-    # imputation here?
+    care_home_diagnostics_df = model_primary_service_rolling_average(
+        care_home_diagnostics_df,
+        CTCHClean.agency_and_non_agency_total_employed,
+        CTCHClean.agency_and_non_agency_total_employed,
+        number_of_days_in_rolling_average,
+        CTCHClean.agency_and_non_agency_total_employed_rolling_avg,
+        CTCHClean.agency_and_non_agency_total_employed_rolling_avg,
+    )
+    care_home_diagnostics_df = model_imputation_with_extrapolation_and_interpolation(
+        care_home_diagnostics_df,
+        CTCHClean.agency_and_non_agency_total_employed,
+        CTCHClean.agency_and_non_agency_total_employed_rolling_avg,
+        CTCHClean.agency_and_non_agency_total_employed_imputed,
+        care_home=True,
+    )
     list_of_models = dUtils.create_list_of_models()
     care_home_diagnostics_df = dUtils.restructure_dataframe_to_column_wise(
         care_home_diagnostics_df, column_for_comparison, list_of_models

--- a/jobs/diagnostics_on_capacity_tracker.py
+++ b/jobs/diagnostics_on_capacity_tracker.py
@@ -154,7 +154,9 @@ def run_diagnostics_for_care_homes(
     )
     list_of_models = dUtils.create_list_of_models()
     care_home_diagnostics_df = dUtils.restructure_dataframe_to_column_wise(
-        care_home_diagnostics_df, column_for_comparison, list_of_models
+        care_home_diagnostics_df,
+        CTCHClean.agency_and_non_agency_total_employed_imputed,
+        list_of_models,
     )
     care_home_diagnostics_df = dUtils.filter_to_known_values(
         care_home_diagnostics_df, IndCQC.estimate_value
@@ -166,7 +168,8 @@ def run_diagnostics_for_care_homes(
         care_home_diagnostics_df, window
     )
     care_home_diagnostics_df = dUtils.calculate_residuals(
-        care_home_diagnostics_df, column_for_comparison
+        care_home_diagnostics_df,
+        CTCHClean.agency_and_non_agency_total_employed_imputed,
     )
     care_home_diagnostics_df = dUtils.calculate_aggregate_residuals(
         care_home_diagnostics_df,

--- a/utils/column_names/capacity_tracker_columns.py
+++ b/utils/column_names/capacity_tracker_columns.py
@@ -51,6 +51,12 @@ class CapacityTrackerCareHomeCleanColumns(CapacityTrackerCareHomeColumns):
     agency_total_employed: str = "agency_total_employed"
     non_agency_total_employed: str = "non_agency_total_employed"
     agency_and_non_agency_total_employed: str = "agency_and_non_agency_total_employed"
+    agency_and_non_agency_total_employed_rolling_avg: str = (
+        agency_and_non_agency_total_employed + "_rolling_avg"
+    )
+    agency_and_non_agency_total_employed_imputed: str = (
+        agency_and_non_agency_total_employed + "_imputed"
+    )
 
 
 @dataclass


### PR DESCRIPTION
# Description
Add imputation for missing care home capacity tracker data

# How to test
Unit tests passing
Run in branch: https://eu-west-2.console.aws.amazon.com/states/home?region=eu-west-2#/v2/executions/details/arn:aws:states:eu-west-2:344210435447:execution:impute-missing-ct-res-data-IngestAndCleanCapacityTrackerDataPipeline:21fe9d23-c556-4b3a-b2c7-5c646906ce2a

# Developer checklist
- [x] Unit test
- [x] Linked to Trello ticket: https://trello.com/c/DtyKoA0R/859-impute-care-home-ct-gaps
- [x] Documentation up to date
