### PR TITLE
Removed number of beds check from raw API validation

### DIFF
--- a/utils/validation/validation_rules/locations_api_raw_validation_rules.py
+++ b/utils/validation/validation_rules/locations_api_raw_validation_rules.py
@@ -27,12 +27,6 @@ class LocationsAPIRawValidationRules:
             CQCL.location_id,
             Keys.import_date,
         ],
-        RuleName.min_values: {
-            CQCL.number_of_beds: 0,
-        },
-        RuleName.max_values: {
-            CQCL.number_of_beds: 500,
-        },
         RuleName.categorical_values_in_columns: {
             CQCL.care_home: CatValues.care_home_column_values.categorical_values,
             CQCL.registration_status: CatValues.registration_status_column_values.categorical_values,


### PR DESCRIPTION
# Description
Data currently failing this check but it's for a non-social care location.
This check exists in the cleaned file too (social care locations only) so I've removed from this file.