### PR TITLE
Remove invalid postcode

### DIFF
--- a/utils/cqc_location_dictionaries.py
+++ b/utils/cqc_location_dictionaries.py
@@ -39,7 +39,6 @@ class InvalidPostcodes:
         "HD1 1AD": "HD1 1RL",
         "HP20 1SN.": "HP20 1SN",
         "HU13 OEG": "HU13 0EG",
-        "HU13 0UF": "HU13 0JT",
         "HU17 ORH": "HU17 0RH",
         "HU21 0LS": "HU170LS",
         "L20 4QC": "L20 4QG",


### PR DESCRIPTION
# Description
Remove postcode from invalid postcode list. This postcode has been added to the ONS postcode directory instead as it now exists in the November ONS directory

# How to test
Unit tests passing

# Developer checklist
- [x] Unit test
- [x] Linked to Trello ticket: https://trello.com/c/4QAVE1cI/753-recheck-missing-postcode
- [x] Documentation up to date
