### PR TITLE
Blend asc pir review

### DIFF
--- a/terraform/pipeline/glue.tf
+++ b/terraform/pipeline/glue.tf
@@ -232,7 +232,6 @@ module "clean_ind_cqc_filled_posts_job" {
   job_parameters = {
     "--merged_ind_cqc_source"       = "${module.datasets_bucket.bucket_uri}/domain=ind_cqc_filled_posts/dataset=ind_cqc_merged_data/"
     "--cleaned_ind_cqc_destination" = "${module.datasets_bucket.bucket_uri}/domain=ind_cqc_filled_posts/dataset=ind_cqc_cleaned_data/"
-
   }
 }
 

--- a/tests/unit/test_blend_ascwds_pir.py
+++ b/tests/unit/test_blend_ascwds_pir.py
@@ -1,5 +1,5 @@
 import unittest
-from unittest.mock import ANY, Mock, patch
+from unittest.mock import Mock, patch
 import warnings
 
 from pyspark.sql import DataFrame

--- a/utils/ind_cqc_filled_posts_utils/ascwds_pir_utils/blend_ascwds_pir.py
+++ b/utils/ind_cqc_filled_posts_utils/ascwds_pir_utils/blend_ascwds_pir.py
@@ -126,7 +126,7 @@ def create_last_submission_columns(df: DataFrame) -> DataFrame:
     Returns:
         DataFrame: A dataframe with two extra columns containing the latest submission dates.
     """
-    w = w = (
+    w = (
         Window.partitionBy(IndCQC.location_id)
         .orderBy(IndCQC.cqc_location_import_date)
         .rowsBetween(Window.unboundedPreceding, Window.unboundedFollowing)

--- a/utils/ind_cqc_filled_posts_utils/ascwds_pir_utils/blend_ascwds_pir.py
+++ b/utils/ind_cqc_filled_posts_utils/ascwds_pir_utils/blend_ascwds_pir.py
@@ -196,9 +196,12 @@ def merge_people_directly_employed_modelled_into_ascwds_clean_column(
                     F.col(IndCQC.people_directly_employed_filled_posts)
                     - F.col(IndCQC.ascwds_filled_posts_dedup_clean_repeated)
                 )
-                / F.avg(
-                    F.col(IndCQC.people_directly_employed_filled_posts),
-                    F.col(IndCQC.ascwds_filled_posts_dedup_clean_repeated),
+                / (
+                    (
+                        F.col(IndCQC.people_directly_employed_filled_posts)
+                        + F.col(IndCQC.ascwds_filled_posts_dedup_clean_repeated)
+                    )
+                    / 2
                 )
                 > ThresholdValues.max_percentage_difference
             ),

--- a/utils/ind_cqc_filled_posts_utils/ascwds_pir_utils/blend_ascwds_pir.py
+++ b/utils/ind_cqc_filled_posts_utils/ascwds_pir_utils/blend_ascwds_pir.py
@@ -196,7 +196,10 @@ def merge_people_directly_employed_modelled_into_ascwds_clean_column(
                     F.col(IndCQC.people_directly_employed_filled_posts)
                     - F.col(IndCQC.ascwds_filled_posts_dedup_clean_repeated)
                 )
-                / F.col(IndCQC.ascwds_filled_posts_dedup_clean_repeated)
+                / F.avg(
+                    F.col(IndCQC.people_directly_employed_filled_posts),
+                    F.col(IndCQC.ascwds_filled_posts_dedup_clean_repeated),
+                )
                 > ThresholdValues.max_percentage_difference
             ),
             F.col(IndCQC.people_directly_employed_filled_posts),

--- a/utils/ind_cqc_filled_posts_utils/ascwds_pir_utils/blend_ascwds_pir.py
+++ b/utils/ind_cqc_filled_posts_utils/ascwds_pir_utils/blend_ascwds_pir.py
@@ -21,9 +21,9 @@ from utils.ind_cqc_filled_posts_utils.utils import (
 
 @dataclass
 class ThresholdValues:
-    max_percentage_difference = 0.5
-    max_absolute_difference = 100
-    months_in_two_years = 24
+    max_percentage_difference: float = 0.5
+    max_absolute_difference: int = 100
+    months_in_two_years: int = 24
 
 
 def blend_pir_and_ascwds_when_ascwds_out_of_date(


### PR DESCRIPTION
# Description
Changed the % function to use the average of ascwds & pir as the denominator, if you only use one (ascwds) then the rule can pass in one direction but fail the other - see below for example

![image](https://github.com/user-attachments/assets/2c9ae1c6-2ee5-41d5-9b9f-a5e8cbfa70d8)

Plus some other minor changes I spotted whilst reviewing code

# How to test
Original tests still passing
[Branch run](https://eu-west-2.console.aws.amazon.com/states/home?region=eu-west-2#/v2/executions/details/arn:aws:states:eu-west-2:344210435447:execution:blend-asc-pir-review-Ind-CQC-Filled-Post-Estimates-Pipeline:b6c12e53-3871-4d3b-81c5-b3ad0c0c6871)

# Developer checklist
- [X] Unit test
- [X] Documentation up to date
