### PR TITLE
Update location api schema

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -188,10 +188,10 @@ jobs:
       - attach_workspace:
           at: .
 
-      - aws-s3/sync:
-          aws-region: AWS_REGION
-          from: "s3://sfc-default-datasets/"
-          to: "s3://$(cat terraform/pipeline/datasets_bucket_name)/"
+      #- aws-s3/sync:
+          #aws-region: AWS_REGION
+          #from: "s3://sfc-default-datasets/"
+          #to: "s3://$(cat terraform/pipeline/datasets_bucket_name)/"
       
       - aws-s3/sync:
           aws-region: AWS_REGION

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -188,10 +188,10 @@ jobs:
       - attach_workspace:
           at: .
 
-      #- aws-s3/sync:
-          #aws-region: AWS_REGION
-          #from: "s3://sfc-default-datasets/"
-          #to: "s3://$(cat terraform/pipeline/datasets_bucket_name)/"
+      - aws-s3/sync:
+          aws-region: AWS_REGION
+          from: "s3://sfc-default-datasets/"
+          to: "s3://$(cat terraform/pipeline/datasets_bucket_name)/"
       
       - aws-s3/sync:
           aws-region: AWS_REGION

--- a/schemas/cqc_location_schema.py
+++ b/schemas/cqc_location_schema.py
@@ -525,5 +525,46 @@ LOCATION_SCHEMA = StructType(
             ),
             True,
         ),
+        StructField(
+            NewColNames.specialism,
+            ArrayType(
+                StructType(
+                    [
+                        StructField(NewColNames.code, StringType(), True),
+                        StructField(NewColNames.name, StringType(), True),
+                    ]
+                ),
+                True,
+            ),
+            True,
+        ),
+        StructField(
+            NewColNames.age_group,
+            ArrayType(
+                StructType(
+                    [
+                        StructField(NewColNames.code, StringType(), True),
+                        StructField(NewColNames.name, StringType(), True),
+                    ]
+                ),
+                True,
+            ),
+            True,
+        ),
+        StructField(
+            NewColNames.setting_services,
+            ArrayType(
+                StructType(
+                    [
+                        StructField(NewColNames.setting_type_code, StringType(), True),
+                        StructField(NewColNames.setting_type_name, StringType(), True),
+                        StructField(NewColNames.service_type_code, StringType(), True),
+                        StructField(NewColNames.service_type_name, StringType(), True),
+                    ]
+                ),
+                True,
+            ),
+            True,
+        ),
     ]
 )

--- a/terraform/pipeline/glue.tf
+++ b/terraform/pipeline/glue.tf
@@ -368,7 +368,7 @@ module "flatten_cqc_ratings_job" {
   datasets_bucket = module.datasets_bucket
 
   job_parameters = {
-    "--cqc_location_source"           = "${module.datasets_bucket.bucket_uri}/domain=CQC/dataset=locations_api/version=2.1.0/"
+    "--cqc_location_source"           = "${module.datasets_bucket.bucket_uri}/domain=CQC/dataset=locations_api/version=2.1.1/"
     "--ascwds_workplace_source"       = "${module.datasets_bucket.bucket_uri}/domain=ASCWDS/dataset=workplace/"
     "--cqc_ratings_destination"       = "${module.datasets_bucket.bucket_uri}/domain=SfC/dataset=sfc_cqc_ratings_for_data_requests/"
     "--benchmark_ratings_destination" = "${module.datasets_bucket.bucket_uri}/domain=SfC/dataset=sfc_cqc_ratings_for_benchmarks/"
@@ -398,7 +398,7 @@ module "clean_cqc_location_data_job" {
   number_of_workers = 5
 
   job_parameters = {
-    "--cqc_location_source"                   = "${module.datasets_bucket.bucket_uri}/domain=CQC/dataset=locations_api/version=2.1.0/"
+    "--cqc_location_source"                   = "${module.datasets_bucket.bucket_uri}/domain=CQC/dataset=locations_api/version=2.1.1/"
     "--cleaned_cqc_provider_source"           = "${module.datasets_bucket.bucket_uri}/domain=CQC/dataset=providers_api_cleaned/"
     "--cleaned_ons_postcode_directory_source" = "${module.datasets_bucket.bucket_uri}/domain=ONS/dataset=postcode_directory_cleaned/"
     "--cleaned_cqc_location_destination"      = "${module.datasets_bucket.bucket_uri}/domain=CQC/dataset=locations_api_cleaned/"
@@ -413,7 +413,7 @@ module "reconciliation_job" {
   datasets_bucket = module.datasets_bucket
 
   job_parameters = {
-    "--cqc_location_api_source"                    = "${module.datasets_bucket.bucket_uri}/domain=CQC/dataset=locations_api/version=2.1.0/"
+    "--cqc_location_api_source"                    = "${module.datasets_bucket.bucket_uri}/domain=CQC/dataset=locations_api/version=2.1.1/"
     "--ascwds_reconciliation_source"               = "${module.datasets_bucket.bucket_uri}/domain=SfC/dataset=sfc_workplace_for_reconciliation/"
     "--reconciliation_single_and_subs_destination" = "${module.datasets_bucket.bucket_uri}/domain=SfC/dataset=sfc_reconciliation_singles_and_subs"
     "--reconciliation_parents_destination"         = "${module.datasets_bucket.bucket_uri}/domain=SfC/dataset=sfc_reconciliation_parents"
@@ -464,7 +464,7 @@ module "validate_locations_api_cleaned_data_job" {
   glue_version    = "4.0"
 
   job_parameters = {
-    "--raw_cqc_location_source"      = "${module.datasets_bucket.bucket_uri}/domain=CQC/dataset=locations_api/version=2.1.0/"
+    "--raw_cqc_location_source"      = "${module.datasets_bucket.bucket_uri}/domain=CQC/dataset=locations_api/version=2.1.1/"
     "--cleaned_cqc_locations_source" = "${module.datasets_bucket.bucket_uri}/domain=CQC/dataset=locations_api_cleaned/"
     "--report_destination"           = "${module.datasets_bucket.bucket_uri}/domain=data_validation_reports/dataset=data_quality_report_locations_api_cleaned/"
   }
@@ -733,7 +733,7 @@ module "validate_locations_api_raw_data_job" {
   glue_version    = "4.0"
 
   job_parameters = {
-    "--raw_cqc_location_source" = "${module.datasets_bucket.bucket_uri}/domain=CQC/dataset=locations_api/version=2.1.0/"
+    "--raw_cqc_location_source" = "${module.datasets_bucket.bucket_uri}/domain=CQC/dataset=locations_api/version=2.1.1/"
     "--report_destination"      = "${module.datasets_bucket.bucket_uri}/domain=data_validation_reports/dataset=data_quality_report_locations_api_raw/"
   }
 }

--- a/terraform/pipeline/step-functions/BronzeValidationPipeline-StepFunction.json
+++ b/terraform/pipeline/step-functions/BronzeValidationPipeline-StepFunction.json
@@ -49,7 +49,7 @@
                 "Parameters": {
                   "JobName": "${validate_locations_api_raw_data_job_name}",
                   "Arguments": {
-                    "--raw_cqc_location_source": "${dataset_bucket_uri}/domain=CQC/dataset=locations_api/version=2.1.0/",
+                    "--raw_cqc_location_source": "${dataset_bucket_uri}/domain=CQC/dataset=locations_api/version=2.1.1/",
                     "--report_destination": "${dataset_bucket_uri}/domain=data_validation_reports/dataset=data_quality_report_locations_api_raw/"
                   }
                 },

--- a/terraform/pipeline/step-functions/BulkDownloadCQCAPIPipeline-StepFunction.json
+++ b/terraform/pipeline/step-functions/BulkDownloadCQCAPIPipeline-StepFunction.json
@@ -64,7 +64,7 @@
                         "Parameters": {
                           "JobName": "${flatten_cqc_ratings_job_name}",
                           "Arguments": {
-                            "--cqc_location_source": "${dataset_bucket_uri}/domain=CQC/dataset=locations_api/version=2.1.0/",
+                            "--cqc_location_source": "${dataset_bucket_uri}/domain=CQC/dataset=locations_api/version=2.1.1/",
                             "--ascwds_workplace_source": "${dataset_bucket_uri}/domain=ASCWDS/dataset=workplace/",
                             "--cqc_ratings_destination": "${dataset_bucket_uri}/domain=SfC/dataset=sfc_cqc_ratings_for_data_requests/",
                             "--benchmark_ratings_destination": "${dataset_bucket_uri}/domain=SfC/dataset=sfc_cqc_ratings_for_benchmarks/"

--- a/terraform/pipeline/step-functions/IndCqcFilledPostEstimatePipeline-StepFunction.json
+++ b/terraform/pipeline/step-functions/IndCqcFilledPostEstimatePipeline-StepFunction.json
@@ -51,7 +51,7 @@
                       "Parameters": {
                         "JobName": "${reconciliation_job_name}",
                         "Arguments": {
-                          "--cqc_location_api_source": "${dataset_bucket_uri}/domain=CQC/dataset=locations_api/version=2.1.0/",
+                          "--cqc_location_api_source": "${dataset_bucket_uri}/domain=CQC/dataset=locations_api/version=2.1.1/",
                           "--ascwds_reconciliation_source": "${dataset_bucket_uri}/domain=SfC/dataset=sfc_workplace_for_reconciliation/",
                           "--reconciliation_single_and_subs_destination": "${dataset_bucket_uri}/domain=SfC/dataset=sfc_reconciliation_singles_and_subs",
                           "--reconciliation_parents_destination": "${dataset_bucket_uri}/domain=SfC/dataset=sfc_reconciliation_parents"
@@ -133,7 +133,7 @@
               "Parameters": {
                 "JobName": "${clean_cqc_location_data_job_name}",
                 "Arguments": {
-                  "--cqc_location_source": "${dataset_bucket_uri}/domain=CQC/dataset=locations_api/version=2.1.0",
+                  "--cqc_location_source": "${dataset_bucket_uri}/domain=CQC/dataset=locations_api/version=2.1.1",
                   "--cleaned_cqc_provider_source": "${dataset_bucket_uri}/domain=CQC/dataset=providers_api_cleaned/",
                   "--cleaned_ons_postcode_directory_source": "${dataset_bucket_uri}/domain=ONS/dataset=postcode_directory_cleaned/",
                   "--cleaned_cqc_location_destination": "${dataset_bucket_uri}/domain=CQC/dataset=locations_api_cleaned/"

--- a/terraform/pipeline/step-functions/SilverValidationPipeline-StepFunction.json
+++ b/terraform/pipeline/step-functions/SilverValidationPipeline-StepFunction.json
@@ -49,7 +49,7 @@
                 "Parameters": {
                   "JobName": "${validate_locations_api_cleaned_data_job_name}",
                   "Arguments": {
-                    "--raw_cqc_location_source": "${dataset_bucket_uri}/domain=CQC/dataset=locations_api/version=2.1.0/",
+                    "--raw_cqc_location_source": "${dataset_bucket_uri}/domain=CQC/dataset=locations_api/version=2.1.1/",
                     "--cleaned_cqc_locations_source": "${dataset_bucket_uri}/domain=CQC/dataset=locations_api_cleaned/",
                     "--report_destination": "${dataset_bucket_uri}/domain=data_validation_reports/dataset=data_quality_report_locations_api_cleaned/"
                   }

--- a/utils/column_names/raw_data_files/cqc_location_api_columns.py
+++ b/utils/column_names/raw_data_files/cqc_location_api_columns.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass
 
 @dataclass
 class NewCqcLocationApiColumns:
+    age_group: str = "ageGroup"
     also_known_as: str = "alsoKnownAs"
     brand_id: str = "brandId"
     brand_name: str = "brandName"
@@ -84,6 +85,12 @@ class NewCqcLocationApiColumns:
     report_uri: str = "reportUri"
     reports: str = "reports"
     service_ratings: str = "serviceRatings"
+    setting_services: str = "settingServices"
+    setting_type_code: str = "settingtypeCode"
+    setting_type_name: str = "settingtypeName"
+    service_type_code: str = "servicetypeCode"
+    service_type_name: str = "servicetypeName"
+    specialism: str = "specialism"
     specialisms: str = "specialisms"
     status: str = "status"
     summary: str = "summary"


### PR DESCRIPTION
# Description
This PR updates the CQC locations schema with the changes being applied on 30th Jan. This version of the schema will be 2.1.1.

The other part of this ticket is updating the data in the main branch, which has been completed in EMR.

# How to test
Unit tests passing
Branch run successful: https://eu-west-2.console.aws.amazon.com/states/home?region=eu-west-2#/v2/executions/details/arn:aws:states:eu-west-2:344210435447:execution:update-location-api-schema-Ind-CQC-Filled-Post-Estimates-Pipeline:4a73de51-8008-4682-af7c-d4c5fc361d01
Will need a test API call on 30th Jan to confirm these changes work successfully.

# Developer checklist
- [x] Unit test
- [x] Linked to Trello ticket
- [x] Documentation up to date
