### PR TITLE
Calculate worker job role counts and convert into map column

### DIFF
--- a/jobs/estimate_ind_cqc_filled_posts_by_job_role.py
+++ b/jobs/estimate_ind_cqc_filled_posts_by_job_role.py
@@ -78,7 +78,7 @@ def main(
     count_job_roles_per_establishment_df = count_job_roles_per_establishment(
         cleaned_ascwds_worker_df
     )
-    count_job_roles_per_establishment_df = mapped_column(
+    count_job_roles_per_establishment_df = convert_jobrole_count_to_jobrole_map(
         count_job_roles_per_establishment_df
     )
 

--- a/jobs/estimate_ind_cqc_filled_posts_by_job_role.py
+++ b/jobs/estimate_ind_cqc_filled_posts_by_job_role.py
@@ -10,7 +10,7 @@ from utils.column_names.ind_cqc_pipeline_columns import (
 )
 from utils.ind_cqc_filled_posts_utils.ascwds_jobrole_count.ascwds_jobrole_count import (
     count_job_roles_per_establishment,
-    mapped_column,
+    convert_jobrole_count_to_jobrole_map,
 )
 
 PartitionKeys = [Keys.year, Keys.month, Keys.day, Keys.import_date]

--- a/jobs/estimate_ind_cqc_filled_posts_by_job_role.py
+++ b/jobs/estimate_ind_cqc_filled_posts_by_job_role.py
@@ -8,7 +8,10 @@ from utils.column_names.ind_cqc_pipeline_columns import (
     IndCqcColumns as IndCQC,
     PartitionKeys as Keys,
 )
-from utils.ind_cqc_filled_posts_utils.ascwds_jobrole_count.ascwds_jobrole_count import count_job_roles_per_establishment, mapped_column
+from utils.ind_cqc_filled_posts_utils.ascwds_jobrole_count.ascwds_jobrole_count import (
+    count_job_roles_per_establishment,
+    mapped_column,
+)
 
 PartitionKeys = [Keys.year, Keys.month, Keys.day, Keys.import_date]
 cleaned_ascwds_worker_columns_to_import = [
@@ -72,8 +75,12 @@ def main(
         selected_columns=cleaned_ascwds_worker_columns_to_import,
     )
 
-    count_job_roles_per_establishment_df = count_job_roles_per_establishment(cleaned_ascwds_worker_df)
-    count_job_roles_per_establishment_df = mapped_column(count_job_roles_per_establishment_df)
+    count_job_roles_per_establishment_df = count_job_roles_per_establishment(
+        cleaned_ascwds_worker_df
+    )
+    count_job_roles_per_establishment_df = mapped_column(
+        count_job_roles_per_establishment_df
+    )
 
     utils.write_to_parquet(
         estimated_ind_cqc_filled_posts_df,

--- a/jobs/estimate_ind_cqc_filled_posts_by_job_role.py
+++ b/jobs/estimate_ind_cqc_filled_posts_by_job_role.py
@@ -73,14 +73,14 @@ def main(
 
     # TODO 1. Make a window over establishmentid, import date and job role.
 
-    # TODO 2. Use the window to add a column called "temp_job_role_count". 
+    # TODO 2. Use the window to add a column called "temp_job_role_count".
     #         The values are a count of rows in window.
     #
     # TODO 3. Make another window over locationid and import date.    #
     #
     # TODO 3. Use create_map function to create a new column of type dictionary. Apply that function over the new window.
     #         create_map function arguments must be column or string.
-    #         For example: 
+    #         For example:
     #         df = df.withColumn(
     #           "map_column_name",
     #           F.create_map(job role column, temp_job_role_count column).alias("ascwds_main_job_role_counts").over(window)

--- a/jobs/estimate_ind_cqc_filled_posts_by_job_role.py
+++ b/jobs/estimate_ind_cqc_filled_posts_by_job_role.py
@@ -71,6 +71,20 @@ def main(
         selected_columns=cleaned_ascwds_worker_columns_to_import,
     )
 
+    # TODO 1. Make a window over establishmentid, import date and job role.
+
+    # TODO 2. Use the window to add a column called "temp_job_role_count". 
+    #         The values are a count of rows in window.
+    #
+    # TODO 3. Make another window over locationid and import date.    #
+    #
+    # TODO 3. Use create_map function to create a new column of type dictionary. Apply that function over the new window.
+    #         create_map function arguments must be column or string.
+    #         For example: 
+    #         df = df.withColumn(
+    #           "map_column_name",
+    #           F.create_map(job role column, temp_job_role_count column).alias("ascwds_main_job_role_counts").over(window)
+
     utils.write_to_parquet(
         estimated_ind_cqc_filled_posts_df,
         estimated_ind_cqc_filled_posts_by_job_role_destination,

--- a/jobs/estimate_ind_cqc_filled_posts_by_job_role.py
+++ b/jobs/estimate_ind_cqc_filled_posts_by_job_role.py
@@ -8,6 +8,7 @@ from utils.column_names.ind_cqc_pipeline_columns import (
     IndCqcColumns as IndCQC,
     PartitionKeys as Keys,
 )
+import utils.ind_cqc_filled_posts_utils.ascwds_jobrole_count.ascwds_jobrole_count as job
 
 PartitionKeys = [Keys.year, Keys.month, Keys.day, Keys.import_date]
 cleaned_ascwds_worker_columns_to_import = [
@@ -70,6 +71,9 @@ def main(
         cleaned_ascwds_worker_source,
         selected_columns=cleaned_ascwds_worker_columns_to_import,
     )
+
+    count_job_roles_per_establishment_df = job.count_job_roles_per_establishment(cleaned_ascwds_worker_df)
+    count_job_roles_per_establishment_df = job.mapped_column(count_job_roles_per_establishment_df)
 
     utils.write_to_parquet(
         estimated_ind_cqc_filled_posts_df,

--- a/jobs/estimate_ind_cqc_filled_posts_by_job_role.py
+++ b/jobs/estimate_ind_cqc_filled_posts_by_job_role.py
@@ -8,7 +8,7 @@ from utils.column_names.ind_cqc_pipeline_columns import (
     IndCqcColumns as IndCQC,
     PartitionKeys as Keys,
 )
-import utils.ind_cqc_filled_posts_utils.ascwds_jobrole_count.ascwds_jobrole_count as job
+from utils.ind_cqc_filled_posts_utils.ascwds_jobrole_count.ascwds_jobrole_count import count_job_roles_per_establishment, mapped_column
 
 PartitionKeys = [Keys.year, Keys.month, Keys.day, Keys.import_date]
 cleaned_ascwds_worker_columns_to_import = [
@@ -72,8 +72,8 @@ def main(
         selected_columns=cleaned_ascwds_worker_columns_to_import,
     )
 
-    count_job_roles_per_establishment_df = job.count_job_roles_per_establishment(cleaned_ascwds_worker_df)
-    count_job_roles_per_establishment_df = job.mapped_column(count_job_roles_per_establishment_df)
+    count_job_roles_per_establishment_df = count_job_roles_per_establishment(cleaned_ascwds_worker_df)
+    count_job_roles_per_establishment_df = mapped_column(count_job_roles_per_establishment_df)
 
     utils.write_to_parquet(
         estimated_ind_cqc_filled_posts_df,

--- a/jobs/estimate_ind_cqc_filled_posts_by_job_role.py
+++ b/jobs/estimate_ind_cqc_filled_posts_by_job_role.py
@@ -71,20 +71,6 @@ def main(
         selected_columns=cleaned_ascwds_worker_columns_to_import,
     )
 
-    # TODO 1. Make a window over establishmentid, import date and job role.
-
-    # TODO 2. Use the window to add a column called "temp_job_role_count".
-    #         The values are a count of rows in window.
-    #
-    # TODO 3. Make another window over locationid and import date.    #
-    #
-    # TODO 3. Use create_map function to create a new column of type dictionary. Apply that function over the new window.
-    #         create_map function arguments must be column or string.
-    #         For example:
-    #         df = df.withColumn(
-    #           "map_column_name",
-    #           F.create_map(job role column, temp_job_role_count column).alias("ascwds_main_job_role_counts").over(window)
-
     utils.write_to_parquet(
         estimated_ind_cqc_filled_posts_df,
         estimated_ind_cqc_filled_posts_by_job_role_destination,

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -9006,6 +9006,43 @@ class JobroleCountMapData:
         ("1", date(2025, 1, 1), "Care worker", 2),
     ]
 
+    workplace_with_two_different_roles_rows = [
+        ("1", date(2025, 1, 1), "Care worker"),
+        ("1", date(2025, 1, 1), "Senior care worker"),
+    ]
+
+    expected_workplace_with_two_different_roles_rows = [
+        ("1", date(2025, 1, 1), "Care worker", 1),
+        ("1", date(2025, 1, 1), "Senior care worker", 1),
+    ]
+
+    two_workplaces_with_same_jobrole_rows = [
+        ("1", date(2025, 1, 1), "Care worker"),
+        ("2", date(2025, 1, 1), "Care worker"),
+    ]
+
+    expected_two_workplaces_with_same_jobrole_rows = [
+        ("1", date(2025, 1, 1), "Care worker", 1),
+        ("2", date(2025, 1, 1), "Care worker", 1),
+    ]
+
+    workplace_across_different_importdates_same_jobrole_rows = [
+        ("1", date(2025, 1, 1), "Care worker"),
+        ("1", date(2025, 2, 1), "Care worker"),
+    ]
+
+    expected_workplace_across_different_importdates_same_jobrole_rows = [
+        ("1", date(2025, 1, 1), "Care worker", 1),
+        ("1", date(2025, 2, 1), "Care worker", 1),
+    ]
+
+    workplace_with_null_jobrole_rows = [
+        ("1", date(2025, 1, 1), None),
+    ]
+
+    expected_workplace_with_null_jobrole_rows = [
+        ("1", date(2025, 1, 1), None, 1),
+    ]
 
     template_jobrole_count_dict_rows = [
         ({

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -9042,4 +9042,42 @@ class AscwdsJobroleCountData:
     expected_workplace_with_null_jobrole_rows = [
         ("1", date(2025, 1, 1), None, 0),
     ]
+
+
+
+
+
+    workplace_with_two_workers_counted_rows = [
+        ("1", date(2025, 1, 1), "Care worker", 2),
+    ]
+ 
+    expected_workplace_with_two_workers_counted_rows = [
+        ("1", date(2025, 1, 1), {"Care worker": 2}),
+    ]
+
+    workplace_with_one_worker_in_two_roles_counted_rows = [
+        ("1", date(2025, 1, 1), "Care worker", 1),
+        ("1", date(2025, 1, 1), "Senior care worker", 1),
+    ]
+    expected_workplace_with_one_worker_in_two_roles_counted_rows = [
+        ("1", date(2025, 1, 1), {"Care worker": 1, "Senior care worker": 1}),
+    ]
+ 
+    two_workplaces_with_same_jobrole_counted_rows = [
+        ("1", date(2025, 1, 1), "Care worker", 1),
+        ("2", date(2025, 1, 1), "Care worker", 1),
+    ]
+    expected_two_workplaces_with_same_jobrole_counted_rows = [
+        ("1", date(2025, 1, 1), {"Care worker": 1}),
+        ("2", date(2025, 1, 1), {"Care worker": 1}),
+    ]
+ 
+    workplace_across_different_importdates_same_jobrole_counted_rows = [
+        ("1", date(2025, 1, 1), "Care worker", 1),
+        ("1", date(2025, 2, 1), "Care worker", 1),
+    ]
+    expected_workplace_across_different_importdates_same_jobrole_counted_rows = [
+        ("1", date(2025, 1, 1), {"Care worker": 1}),
+        ("1", date(2025, 2, 1), {"Care worker": 1}),
+    ]
     # fmt: on

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -4938,55 +4938,6 @@ class EstimateIndCQCFilledPostsByJobRoleData:
         ("Service A", MainJobRoleLabels.senior_management , date(2025, 1, 1), "104", None, "1-004", date(2025, 1, 1), 3.0, 0, 0.0, 0.0, 0.0),
     ]
     # fmt: on
-    
-    # fmt: off
-    workplace_with_two_workers_rows = [
-        ("1", date(2025, 1, 1), "Care worker"),
-        ("1", date(2025, 1, 1), "Care worker"),
-    ]
-
-    expected_workplace_with_two_workers_rows = [
-        ("1", date(2025, 1, 1), "Care worker", 2),
-    ]
-
-    workplace_with_two_different_roles_rows = [
-        ("1", date(2025, 1, 1), "Care worker"),
-        ("1", date(2025, 1, 1), "Senior care worker"),
-    ]
-
-    expected_workplace_with_two_different_roles_rows = [
-        ("1", date(2025, 1, 1), "Care worker", 1),
-        ("1", date(2025, 1, 1), "Senior care worker", 1),
-    ]
-
-    two_workplaces_with_same_jobrole_rows = [
-        ("1", date(2025, 1, 1), "Care worker"),
-        ("2", date(2025, 1, 1), "Care worker"),
-    ]
-
-    expected_two_workplaces_with_same_jobrole_rows = [
-        ("1", date(2025, 1, 1), "Care worker", 1),
-        ("2", date(2025, 1, 1), "Care worker", 1),
-    ]
-
-    workplace_across_different_importdates_same_jobrole_rows = [
-        ("1", date(2025, 1, 1), "Care worker"),
-        ("1", date(2025, 2, 1), "Care worker"),
-    ]
-
-    expected_workplace_across_different_importdates_same_jobrole_rows = [
-        ("1", date(2025, 1, 1), "Care worker", 1),
-        ("1", date(2025, 2, 1), "Care worker", 1),
-    ]
-
-    workplace_with_null_jobrole_rows = [
-        ("1", date(2025, 1, 1), None),
-    ]
-
-    expected_workplace_with_null_jobrole_rows = [
-        ("1", date(2025, 1, 1), None, 1),
-    ]
-    # fmt: on
 
 
 @dataclass
@@ -9040,3 +8991,54 @@ class BlendAscwdsPirData:
         ("loc 1", date(2023, 1, 1), date(2020, 1, 1), 10, 20.0),
     ]
     expected_drop_temporary_columns = [IndCQC.location_id]
+
+@dataclass
+class AscwdsJobroleCountData:
+# fmt: off
+    workplace_with_two_workers_rows = [
+        ("1", date(2025, 1, 1), "Care worker"),
+        ("1", date(2025, 1, 1), "Care worker"),
+    ]
+
+    expected_workplace_with_two_workers_rows = [
+        ("1", date(2025, 1, 1), "Care worker", 2),
+    ]
+
+    workplace_with_two_different_roles_rows = [
+        ("1", date(2025, 1, 1), "Care worker"),
+        ("1", date(2025, 1, 1), "Senior care worker"),
+    ]
+
+    expected_workplace_with_two_different_roles_rows = [
+        ("1", date(2025, 1, 1), "Care worker", 1),
+        ("1", date(2025, 1, 1), "Senior care worker", 1),
+    ]
+
+    two_workplaces_with_same_jobrole_rows = [
+        ("1", date(2025, 1, 1), "Care worker"),
+        ("2", date(2025, 1, 1), "Care worker"),
+    ]
+
+    expected_two_workplaces_with_same_jobrole_rows = [
+        ("1", date(2025, 1, 1), "Care worker", 1),
+        ("2", date(2025, 1, 1), "Care worker", 1),
+    ]
+
+    workplace_across_different_importdates_same_jobrole_rows = [
+        ("1", date(2025, 1, 1), "Care worker"),
+        ("1", date(2025, 2, 1), "Care worker"),
+    ]
+
+    expected_workplace_across_different_importdates_same_jobrole_rows = [
+        ("1", date(2025, 1, 1), "Care worker", 1),
+        ("1", date(2025, 2, 1), "Care worker", 1),
+    ]
+
+    workplace_with_null_jobrole_rows = [
+        ("1", date(2025, 1, 1), None),
+    ]
+
+    expected_workplace_with_null_jobrole_rows = [
+        ("1", date(2025, 1, 1), None, 1),
+    ]
+    # fmt: on

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -4938,6 +4938,55 @@ class EstimateIndCQCFilledPostsByJobRoleData:
         ("Service A", MainJobRoleLabels.senior_management , date(2025, 1, 1), "104", None, "1-004", date(2025, 1, 1), 3.0, 0, 0.0, 0.0, 0.0),
     ]
     # fmt: on
+    
+    # fmt: off
+    workplace_with_two_workers_rows = [
+        ("1", date(2025, 1, 1), "Care worker"),
+        ("1", date(2025, 1, 1), "Care worker"),
+    ]
+
+    expected_workplace_with_two_workers_rows = [
+        ("1", date(2025, 1, 1), "Care worker", 2),
+    ]
+
+    workplace_with_two_different_roles_rows = [
+        ("1", date(2025, 1, 1), "Care worker"),
+        ("1", date(2025, 1, 1), "Senior care worker"),
+    ]
+
+    expected_workplace_with_two_different_roles_rows = [
+        ("1", date(2025, 1, 1), "Care worker", 1),
+        ("1", date(2025, 1, 1), "Senior care worker", 1),
+    ]
+
+    two_workplaces_with_same_jobrole_rows = [
+        ("1", date(2025, 1, 1), "Care worker"),
+        ("2", date(2025, 1, 1), "Care worker"),
+    ]
+
+    expected_two_workplaces_with_same_jobrole_rows = [
+        ("1", date(2025, 1, 1), "Care worker", 1),
+        ("2", date(2025, 1, 1), "Care worker", 1),
+    ]
+
+    workplace_across_different_importdates_same_jobrole_rows = [
+        ("1", date(2025, 1, 1), "Care worker"),
+        ("1", date(2025, 2, 1), "Care worker"),
+    ]
+
+    expected_workplace_across_different_importdates_same_jobrole_rows = [
+        ("1", date(2025, 1, 1), "Care worker", 1),
+        ("1", date(2025, 2, 1), "Care worker", 1),
+    ]
+
+    workplace_with_null_jobrole_rows = [
+        ("1", date(2025, 1, 1), None),
+    ]
+
+    expected_workplace_with_null_jobrole_rows = [
+        ("1", date(2025, 1, 1), None, 1),
+    ]
+    # fmt: on
 
 
 @dataclass
@@ -8991,100 +9040,3 @@ class BlendAscwdsPirData:
         ("loc 1", date(2023, 1, 1), date(2020, 1, 1), 10, 20.0),
     ]
     expected_drop_temporary_columns = [IndCQC.location_id]
-
-
-@dataclass
-class JobroleCountMapData:
-
-    # fmt: off
-    workplace_with_two_workers_rows = [
-        ("1", date(2025, 1, 1), "Care worker"),
-        ("1", date(2025, 1, 1), "Care worker"),
-    ]
-
-    expected_workplace_with_two_workers_rows = [
-        ("1", date(2025, 1, 1), "Care worker", 2),
-    ]
-
-    workplace_with_two_different_roles_rows = [
-        ("1", date(2025, 1, 1), "Care worker"),
-        ("1", date(2025, 1, 1), "Senior care worker"),
-    ]
-
-    expected_workplace_with_two_different_roles_rows = [
-        ("1", date(2025, 1, 1), "Care worker", 1),
-        ("1", date(2025, 1, 1), "Senior care worker", 1),
-    ]
-
-    two_workplaces_with_same_jobrole_rows = [
-        ("1", date(2025, 1, 1), "Care worker"),
-        ("2", date(2025, 1, 1), "Care worker"),
-    ]
-
-    expected_two_workplaces_with_same_jobrole_rows = [
-        ("1", date(2025, 1, 1), "Care worker", 1),
-        ("2", date(2025, 1, 1), "Care worker", 1),
-    ]
-
-    workplace_across_different_importdates_same_jobrole_rows = [
-        ("1", date(2025, 1, 1), "Care worker"),
-        ("1", date(2025, 2, 1), "Care worker"),
-    ]
-
-    expected_workplace_across_different_importdates_same_jobrole_rows = [
-        ("1", date(2025, 1, 1), "Care worker", 1),
-        ("1", date(2025, 2, 1), "Care worker", 1),
-    ]
-
-    workplace_with_null_jobrole_rows = [
-        ("1", date(2025, 1, 1), None),
-    ]
-
-    expected_workplace_with_null_jobrole_rows = [
-        ("1", date(2025, 1, 1), None, 1),
-    ]
-
-    template_jobrole_count_dict_rows = [
-        ({
-        "Activities worker or co-ordinator" : 0,
-        "Administrative or office staff not care-providing" : 0,
-        "Advice Guidance and Advocacy" : 0,
-        "Allied Health Professional" : 0,
-        "Ancillary staff not care-providing" : 0,
-        "Any Childrens/young peoples job role" : 0,
-        "Assessment officer" : 0,
-        "Care co-ordinator" : 0,
-        "Care Worker" : 0,
-        "Community Support and Outreach Work" : 0,
-        "Data Analyst" : 0,
-        "Data Governance Manager" : 0,
-        "Deputy manager" : 0,
-        "Employment Support" : 0,
-        "First Line Manager" : 0,
-        "IT and Digital Support" : 0,
-        "IT Manager" : 0,
-        "IT Service Desk Manager" : 0,
-        "Learning and development lead" : 0,
-        "Managers and staff in care-related but not care-providing roles" : 0,
-        "Middle Management" : 0,
-        "Not known" : 0,
-        "Nursing Assistant" : 0,
-        "Occupational Therapist" : 0,
-        "Occupational therapist assistant" : 0,
-        "Other care-providing job role" : 0,
-        "Other non-care-providing job roles" : 0,
-        "Registered Manager" : 0,
-        "Registered Nurse" : 0,
-        "Registered Nursing Associate" : 0,
-        "Safeguarding and reviewing officer" : 0,
-        "Senior Care Worker" : 0,
-        "Senior Management" : 0,
-        "Social Worker" : 0,
-        "Software Developer" : 0,
-        "Supervisor" : 0,
-        "Support Worker" : 0,
-        "Team leader" : 0,
-        "Technician" : 0,
-        })
-    ]
-    # fmt: on

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -8992,9 +8992,10 @@ class BlendAscwdsPirData:
     ]
     expected_drop_temporary_columns = [IndCQC.location_id]
 
+
 @dataclass
 class AscwdsJobroleCountData:
-# fmt: off
+    # fmt: off
     workplace_with_two_workers_rows = [
         ("1", date(2025, 1, 1), "Care worker"),
         ("1", date(2025, 1, 1), "Care worker"),
@@ -9039,6 +9040,6 @@ class AscwdsJobroleCountData:
     ]
 
     expected_workplace_with_null_jobrole_rows = [
-        ("1", date(2025, 1, 1), None, 1),
+        ("1", date(2025, 1, 1), None, 0),
     ]
     # fmt: on

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -8991,3 +8991,63 @@ class BlendAscwdsPirData:
         ("loc 1", date(2023, 1, 1), date(2020, 1, 1), 10, 20.0),
     ]
     expected_drop_temporary_columns = [IndCQC.location_id]
+
+
+@dataclass
+class JobroleCountMapData:
+
+    # fmt: off
+    workplace_with_two_workers_rows = [
+        ("1", date(2025, 1, 1), "Care worker"),
+        ("1", date(2025, 1, 1), "Care worker"),
+    ]
+
+    expected_workplace_with_two_workers_rows = [
+        ("1", date(2025, 1, 1), "Care worker", 2),
+    ]
+
+
+    template_jobrole_count_dict_rows = [
+        ({
+        "Activities worker or co-ordinator" : 0,
+        "Administrative or office staff not care-providing" : 0,
+        "Advice Guidance and Advocacy" : 0,
+        "Allied Health Professional" : 0,
+        "Ancillary staff not care-providing" : 0,
+        "Any Childrens/young peoples job role" : 0,
+        "Assessment officer" : 0,
+        "Care co-ordinator" : 0,
+        "Care Worker" : 0,
+        "Community Support and Outreach Work" : 0,
+        "Data Analyst" : 0,
+        "Data Governance Manager" : 0,
+        "Deputy manager" : 0,
+        "Employment Support" : 0,
+        "First Line Manager" : 0,
+        "IT and Digital Support" : 0,
+        "IT Manager" : 0,
+        "IT Service Desk Manager" : 0,
+        "Learning and development lead" : 0,
+        "Managers and staff in care-related but not care-providing roles" : 0,
+        "Middle Management" : 0,
+        "Not known" : 0,
+        "Nursing Assistant" : 0,
+        "Occupational Therapist" : 0,
+        "Occupational therapist assistant" : 0,
+        "Other care-providing job role" : 0,
+        "Other non-care-providing job roles" : 0,
+        "Registered Manager" : 0,
+        "Registered Nurse" : 0,
+        "Registered Nursing Associate" : 0,
+        "Safeguarding and reviewing officer" : 0,
+        "Senior Care Worker" : 0,
+        "Senior Management" : 0,
+        "Social Worker" : 0,
+        "Software Developer" : 0,
+        "Supervisor" : 0,
+        "Support Worker" : 0,
+        "Team leader" : 0,
+        "Technician" : 0,
+        })
+    ]
+    # fmt: on

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -5434,7 +5434,7 @@ class BlendAscwdsPirData:
 @dataclass
 class AscwdsJobroleCountSchema:
 
-    workplace_with_two_workers_schema = StructType(
+    worker_schema = StructType(
         [
             StructField(AWKClean.establishment_id, StringType(), True),
             StructField(AWKClean.ascwds_worker_import_date, DateType(), True),
@@ -5442,9 +5442,9 @@ class AscwdsJobroleCountSchema:
         ]
     )
 
-    expected_workplace_with_two_workers_schema = StructType(
+    worker_with_jobrole_count_schema = StructType(
         [
-            *workplace_with_two_workers_schema,
+            *worker_schema,
             StructField("ascwds_main_job_role_counts", IntegerType(), True)
         ]
     )

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -5431,9 +5431,9 @@ class BlendAscwdsPirData:
         ]
     )
 
+
 @dataclass
 class AscwdsJobroleCountSchema:
-
     worker_schema = StructType(
         [
             StructField(AWKClean.establishment_id, StringType(), True),
@@ -5445,6 +5445,6 @@ class AscwdsJobroleCountSchema:
     worker_with_jobrole_count_schema = StructType(
         [
             *worker_schema,
-            StructField("ascwds_main_job_role_counts", IntegerType(), True)
+            StructField("ascwds_main_job_role_counts", IntegerType(), True),
         ]
     )

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -5445,6 +5445,14 @@ class AscwdsJobroleCountSchema:
     worker_with_jobrole_count_schema = StructType(
         [
             *worker_schema,
-            StructField("ascwds_main_job_role_counts", IntegerType(), True),
+            StructField(AWKClean.ascwds_main_job_role_counts, IntegerType(), True),
+        ]
+    )
+
+    worker_with_jobrole_map_schema = StructType(
+        [
+            StructField(AWKClean.establishment_id, StringType(), True),
+            StructField(AWKClean.ascwds_worker_import_date, DateType(), True),
+            StructField(AWKClean.ascwds_main_job_role_counts, MapType(StringType(), IntegerType()), True),
         ]
     )

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -11,6 +11,7 @@ from pyspark.sql.types import (
     DateType,
     DoubleType,
     BooleanType,
+    MapType,
 )
 
 from utils.column_names.capacity_tracker_columns import (
@@ -5427,5 +5428,23 @@ class BlendAscwdsPirData:
             StructField(
                 IndCQC.pir_people_directly_employed_filled_posts, FloatType(), True
             ),
+        ]
+    )
+
+
+@dataclass
+class JobroleCountMapData:
+    workplace_with_two_workers_schema = StructType(
+        [
+            StructField(AWKClean.establishment_id, StringType(), True),
+            StructField(AWKClean.ascwds_worker_import_date, DateType(), True),
+            StructField(AWKClean.main_job_role_clean_labelled, StringType(), True),
+        ]
+    )
+
+    expected_workplace_with_two_workers_schema = StructType(
+        [
+            *workplace_with_two_workers_schema,
+            StructField("ascwds_main_job_role_counts", IntegerType(), True)
         ]
     )

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -2329,6 +2329,21 @@ class EstimateIndCQCFilledPostsByJobRoleSchemas:
         ]
     )
 
+    workplace_with_two_workers_schema = StructType(
+        [
+            StructField(AWKClean.establishment_id, StringType(), True),
+            StructField(AWKClean.ascwds_worker_import_date, DateType(), True),
+            StructField(AWKClean.main_job_role_clean_labelled, StringType(), True),
+        ]
+    )
+
+    expected_workplace_with_two_workers_schema = StructType(
+        [
+            *workplace_with_two_workers_schema,
+            StructField("ascwds_main_job_role_counts", IntegerType(), True)
+        ]
+    )
+
 
 @dataclass
 class EstimateMissingAscwdsFilledPostsSchemas:
@@ -5428,23 +5443,5 @@ class BlendAscwdsPirData:
             StructField(
                 IndCQC.pir_people_directly_employed_filled_posts, FloatType(), True
             ),
-        ]
-    )
-
-
-@dataclass
-class JobroleCountMapData:
-    workplace_with_two_workers_schema = StructType(
-        [
-            StructField(AWKClean.establishment_id, StringType(), True),
-            StructField(AWKClean.ascwds_worker_import_date, DateType(), True),
-            StructField(AWKClean.main_job_role_clean_labelled, StringType(), True),
-        ]
-    )
-
-    expected_workplace_with_two_workers_schema = StructType(
-        [
-            *workplace_with_two_workers_schema,
-            StructField("ascwds_main_job_role_counts", IntegerType(), True)
         ]
     )

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -2329,21 +2329,6 @@ class EstimateIndCQCFilledPostsByJobRoleSchemas:
         ]
     )
 
-    workplace_with_two_workers_schema = StructType(
-        [
-            StructField(AWKClean.establishment_id, StringType(), True),
-            StructField(AWKClean.ascwds_worker_import_date, DateType(), True),
-            StructField(AWKClean.main_job_role_clean_labelled, StringType(), True),
-        ]
-    )
-
-    expected_workplace_with_two_workers_schema = StructType(
-        [
-            *workplace_with_two_workers_schema,
-            StructField("ascwds_main_job_role_counts", IntegerType(), True)
-        ]
-    )
-
 
 @dataclass
 class EstimateMissingAscwdsFilledPostsSchemas:
@@ -5443,5 +5428,23 @@ class BlendAscwdsPirData:
             StructField(
                 IndCQC.pir_people_directly_employed_filled_posts, FloatType(), True
             ),
+        ]
+    )
+
+@dataclass
+class AscwdsJobroleCountSchema:
+
+    workplace_with_two_workers_schema = StructType(
+        [
+            StructField(AWKClean.establishment_id, StringType(), True),
+            StructField(AWKClean.ascwds_worker_import_date, DateType(), True),
+            StructField(AWKClean.main_job_role_clean_labelled, StringType(), True),
+        ]
+    )
+
+    expected_workplace_with_two_workers_schema = StructType(
+        [
+            *workplace_with_two_workers_schema,
+            StructField("ascwds_main_job_role_counts", IntegerType(), True)
         ]
     )

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -5453,6 +5453,10 @@ class AscwdsJobroleCountSchema:
         [
             StructField(AWKClean.establishment_id, StringType(), True),
             StructField(AWKClean.ascwds_worker_import_date, DateType(), True),
-            StructField(AWKClean.ascwds_main_job_role_counts, MapType(StringType(), IntegerType()), True),
+            StructField(
+                AWKClean.ascwds_main_job_role_counts,
+                MapType(StringType(), IntegerType()),
+                True,
+            ),
         ]
     )

--- a/tests/unit/test_ascwds_jobrole_count.py
+++ b/tests/unit/test_ascwds_jobrole_count.py
@@ -149,12 +149,6 @@ class CountJobRolesPerEstablishmentTests(AscwdsJobroleCount):
             returned_df.columns, expected_workplace_with_two_workers_df.columns
         )
 
-
-
-
-
-
-
     def test_convert_jobrole_count_to_jobrole_map_converts_one_row_into_one_dict(self):
         test_workplace_with_two_workers_counted_df = self.spark.createDataFrame(
             Data.workplace_with_two_workers_counted_rows,
@@ -174,15 +168,18 @@ class CountJobRolesPerEstablishmentTests(AscwdsJobroleCount):
             expected_workplace_with_two_workers_counted_df.collect(),
         )
 
-
     def test_convert_jobrole_count_to_jobrole_map_converts_two_rows_into_one_dict(self):
-        test_workplace_with_one_worker_in_two_roles_counted_df = self.spark.createDataFrame(
-            Data.workplace_with_one_worker_in_two_roles_counted_rows,
-            Schemas.worker_with_jobrole_count_schema,
+        test_workplace_with_one_worker_in_two_roles_counted_df = (
+            self.spark.createDataFrame(
+                Data.workplace_with_one_worker_in_two_roles_counted_rows,
+                Schemas.worker_with_jobrole_count_schema,
+            )
         )
-        expected_workplace_with_one_worker_in_two_roles_counted_df = self.spark.createDataFrame(
-            Data.expected_workplace_with_one_worker_in_two_roles_counted_rows,
-            Schemas.worker_with_jobrole_map_schema,
+        expected_workplace_with_one_worker_in_two_roles_counted_df = (
+            self.spark.createDataFrame(
+                Data.expected_workplace_with_one_worker_in_two_roles_counted_rows,
+                Schemas.worker_with_jobrole_map_schema,
+            )
         )
 
         returned_df = convert_jobrole_count_to_jobrole_map(
@@ -194,15 +191,18 @@ class CountJobRolesPerEstablishmentTests(AscwdsJobroleCount):
             expected_workplace_with_one_worker_in_two_roles_counted_df.collect(),
         )
 
-
-    def test_convert_jobrole_count_to_jobrole_map_converts_two_establishments_with_same_role_into_two_dicts(self):
+    def test_convert_jobrole_count_to_jobrole_map_converts_two_establishments_with_same_role_into_two_dicts(
+        self,
+    ):
         test_two_workplaces_with_same_jobrole_counted_rows = self.spark.createDataFrame(
             Data.two_workplaces_with_same_jobrole_counted_rows,
             Schemas.worker_with_jobrole_count_schema,
         )
-        expected_two_workplaces_with_same_jobrole_counted_rows = self.spark.createDataFrame(
-            Data.expected_two_workplaces_with_same_jobrole_counted_rows,
-            Schemas.worker_with_jobrole_map_schema,
+        expected_two_workplaces_with_same_jobrole_counted_rows = (
+            self.spark.createDataFrame(
+                Data.expected_two_workplaces_with_same_jobrole_counted_rows,
+                Schemas.worker_with_jobrole_map_schema,
+            )
         )
 
         returned_df = convert_jobrole_count_to_jobrole_map(
@@ -214,11 +214,14 @@ class CountJobRolesPerEstablishmentTests(AscwdsJobroleCount):
             expected_two_workplaces_with_same_jobrole_counted_rows.collect(),
         )
 
-
-    def test_convert_jobrole_count_to_jobrole_map_converts_one_establishment_at_different_importdates_into_two_dicts(self):
-        test_workplace_across_different_importdates_same_jobrole_counted_df = self.spark.createDataFrame(
-            Data.workplace_across_different_importdates_same_jobrole_counted_rows,
-            Schemas.worker_with_jobrole_count_schema,
+    def test_convert_jobrole_count_to_jobrole_map_converts_one_establishment_at_different_importdates_into_two_dicts(
+        self,
+    ):
+        test_workplace_across_different_importdates_same_jobrole_counted_df = (
+            self.spark.createDataFrame(
+                Data.workplace_across_different_importdates_same_jobrole_counted_rows,
+                Schemas.worker_with_jobrole_count_schema,
+            )
         )
         expected_workplace_across_different_importdates_same_jobrole_counted_df = self.spark.createDataFrame(
             Data.expected_workplace_across_different_importdates_same_jobrole_counted_rows,

--- a/tests/unit/test_ascwds_jobrole_count.py
+++ b/tests/unit/test_ascwds_jobrole_count.py
@@ -1,0 +1,27 @@
+import unittest
+
+from utils import utils
+
+from tests.test_file_data import AscwdsJobroleCountData as Data
+from tests.test_file_schemas import AscwdsJobroleCountSchema as Schemas
+
+from utils.ind_cqc_filled_posts_utils.ascwds_jobrole_count.ascwds_jobrole_count import count_job_roles_per_establishment, mapped_column
+
+class AscwdsJobroleCount(unittest.TestCase):
+    def setUp(self):
+        self.spark = utils.get_spark()
+
+
+class CountJobRolesPerEstablishmentTests(AscwdsJobroleCount):
+
+    def test_count_job_roles_per_establishment_counts_two_workers_that_are_the_same(self):
+        test_workplace_with_two_workers_df = self.spark.createDataFrame(
+            Data.workplace_with_two_workers_rows,
+            Schemas.workplace_with_two_workers_schema,
+        )
+        expected_workplace_with_two_workers_df = self.spark.createDataFrame(
+            Data.expected_workplace_with_two_workers_rows,
+            Schemas.expected_workplace_with_two_workers_schema,
+        )
+
+        returned_df = count_job_roles_per_establishment(test_workplace_with_two_workers_df)

--- a/tests/unit/test_ascwds_jobrole_count.py
+++ b/tests/unit/test_ascwds_jobrole_count.py
@@ -11,7 +11,7 @@ from utils.column_names.cleaned_data_files.ascwds_worker_cleaned import (
 
 from utils.ind_cqc_filled_posts_utils.ascwds_jobrole_count.ascwds_jobrole_count import (
     count_job_roles_per_establishment,
-    mapped_column,
+    convert_jobrole_count_to_jobrole_map,
 )
 
 
@@ -147,4 +147,89 @@ class CountJobRolesPerEstablishmentTests(AscwdsJobroleCount):
 
         self.assertEqual(
             returned_df.columns, expected_workplace_with_two_workers_df.columns
+        )
+
+
+
+
+
+
+
+    def test_convert_jobrole_count_to_jobrole_map_converts_one_row_into_one_dict(self):
+        test_workplace_with_two_workers_counted_df = self.spark.createDataFrame(
+            Data.workplace_with_two_workers_counted_rows,
+            Schemas.worker_with_jobrole_count_schema,
+        )
+        expected_workplace_with_two_workers_counted_df = self.spark.createDataFrame(
+            Data.expected_workplace_with_two_workers_counted_rows,
+            Schemas.worker_with_jobrole_map_schema,
+        )
+
+        returned_df = convert_jobrole_count_to_jobrole_map(
+            test_workplace_with_two_workers_counted_df
+        )
+
+        self.assertEqual(
+            returned_df.sort(AWKClean.establishment_id).collect(),
+            expected_workplace_with_two_workers_counted_df.collect(),
+        )
+
+
+    def test_convert_jobrole_count_to_jobrole_map_converts_two_rows_into_one_dict(self):
+        test_workplace_with_one_worker_in_two_roles_counted_df = self.spark.createDataFrame(
+            Data.workplace_with_one_worker_in_two_roles_counted_rows,
+            Schemas.worker_with_jobrole_count_schema,
+        )
+        expected_workplace_with_one_worker_in_two_roles_counted_df = self.spark.createDataFrame(
+            Data.expected_workplace_with_one_worker_in_two_roles_counted_rows,
+            Schemas.worker_with_jobrole_map_schema,
+        )
+
+        returned_df = convert_jobrole_count_to_jobrole_map(
+            test_workplace_with_one_worker_in_two_roles_counted_df
+        )
+
+        self.assertEqual(
+            returned_df.sort(AWKClean.establishment_id).collect(),
+            expected_workplace_with_one_worker_in_two_roles_counted_df.collect(),
+        )
+
+
+    def test_convert_jobrole_count_to_jobrole_map_converts_two_establishments_with_same_role_into_two_dicts(self):
+        test_two_workplaces_with_same_jobrole_counted_rows = self.spark.createDataFrame(
+            Data.two_workplaces_with_same_jobrole_counted_rows,
+            Schemas.worker_with_jobrole_count_schema,
+        )
+        expected_two_workplaces_with_same_jobrole_counted_rows = self.spark.createDataFrame(
+            Data.expected_two_workplaces_with_same_jobrole_counted_rows,
+            Schemas.worker_with_jobrole_map_schema,
+        )
+
+        returned_df = convert_jobrole_count_to_jobrole_map(
+            test_two_workplaces_with_same_jobrole_counted_rows
+        )
+
+        self.assertEqual(
+            returned_df.sort(AWKClean.establishment_id).collect(),
+            expected_two_workplaces_with_same_jobrole_counted_rows.collect(),
+        )
+
+
+    def test_convert_jobrole_count_to_jobrole_map_converts_one_establishment_at_different_importdates_into_two_dicts(self):
+        test_workplace_across_different_importdates_same_jobrole_counted_df = self.spark.createDataFrame(
+            Data.workplace_across_different_importdates_same_jobrole_counted_rows,
+            Schemas.worker_with_jobrole_count_schema,
+        )
+        expected_workplace_across_different_importdates_same_jobrole_counted_df = self.spark.createDataFrame(
+            Data.expected_workplace_across_different_importdates_same_jobrole_counted_rows,
+            Schemas.worker_with_jobrole_map_schema,
+        )
+
+        returned_df = convert_jobrole_count_to_jobrole_map(
+            test_workplace_across_different_importdates_same_jobrole_counted_df
+        )
+
+        self.assertEqual(
+            returned_df.sort(AWKClean.establishment_id).collect(),
+            expected_workplace_across_different_importdates_same_jobrole_counted_df.collect(),
         )

--- a/tests/unit/test_ascwds_jobrole_count.py
+++ b/tests/unit/test_ascwds_jobrole_count.py
@@ -9,7 +9,11 @@ from utils.column_names.cleaned_data_files.ascwds_worker_cleaned import (
     AscwdsWorkerCleanedColumns as AWKClean,
 )
 
-from utils.ind_cqc_filled_posts_utils.ascwds_jobrole_count.ascwds_jobrole_count import count_job_roles_per_establishment, mapped_column
+from utils.ind_cqc_filled_posts_utils.ascwds_jobrole_count.ascwds_jobrole_count import (
+    count_job_roles_per_establishment,
+    mapped_column,
+)
+
 
 class AscwdsJobroleCount(unittest.TestCase):
     def setUp(self):
@@ -17,8 +21,9 @@ class AscwdsJobroleCount(unittest.TestCase):
 
 
 class CountJobRolesPerEstablishmentTests(AscwdsJobroleCount):
-
-    def test_count_job_roles_per_establishment_counts_two_workers_that_are_the_same(self):
+    def test_count_job_roles_per_establishment_counts_two_workers_that_are_the_same(
+        self,
+    ):
         test_workplace_with_two_workers_df = self.spark.createDataFrame(
             Data.workplace_with_two_workers_rows,
             Schemas.worker_schema,
@@ -28,6 +33,118 @@ class CountJobRolesPerEstablishmentTests(AscwdsJobroleCount):
             Schemas.worker_with_jobrole_count_schema,
         )
 
-        returned_df = count_job_roles_per_establishment(test_workplace_with_two_workers_df)
+        returned_df = count_job_roles_per_establishment(
+            test_workplace_with_two_workers_df
+        )
 
-        self.assertEqual(returned_df.sort(AWKClean.establishment_id).collect(), expected_workplace_with_two_workers_df.collect())
+        self.assertEqual(
+            returned_df.sort(AWKClean.establishment_id).collect(),
+            expected_workplace_with_two_workers_df.collect(),
+        )
+
+    def test_count_job_roles_per_establishment_counts_when_job_roles_are_different(
+        self,
+    ):
+        test_workplace_with_different_jobroles_df = self.spark.createDataFrame(
+            Data.workplace_with_two_different_roles_rows,
+            Schemas.worker_schema,
+        )
+        expected_workplace_with_different_jobroles_df = self.spark.createDataFrame(
+            Data.expected_workplace_with_two_different_roles_rows,
+            Schemas.worker_with_jobrole_count_schema,
+        )
+
+        returned_df = count_job_roles_per_establishment(
+            test_workplace_with_different_jobroles_df
+        )
+
+        self.assertEqual(
+            returned_df.sort(AWKClean.establishment_id).collect(),
+            expected_workplace_with_different_jobroles_df.collect(),
+        )
+
+    def test_count_job_roles_per_establishment_counts_when_jobrole_is_same_at_different_workplaces(
+        self,
+    ):
+        test_two_workplaces_with_same_jobrole_df = self.spark.createDataFrame(
+            Data.two_workplaces_with_same_jobrole_rows,
+            Schemas.worker_schema,
+        )
+        expected_two_workplaces_with_same_jobrole_df = self.spark.createDataFrame(
+            Data.expected_two_workplaces_with_same_jobrole_rows,
+            Schemas.worker_with_jobrole_count_schema,
+        )
+
+        returned_df = count_job_roles_per_establishment(
+            test_two_workplaces_with_same_jobrole_df
+        )
+
+        self.assertEqual(
+            returned_df.sort(AWKClean.establishment_id).collect(),
+            expected_two_workplaces_with_same_jobrole_df.collect(),
+        )
+
+    def test_count_job_roles_per_establishment_counts_when_importdate_is_different(
+        self,
+    ):
+        test_workplace_across_different_importdates_same_jobrole_df = (
+            self.spark.createDataFrame(
+                Data.workplace_across_different_importdates_same_jobrole_rows,
+                Schemas.worker_schema,
+            )
+        )
+        expected_workplace_across_different_importdates_same_jobrole_df = (
+            self.spark.createDataFrame(
+                Data.expected_workplace_across_different_importdates_same_jobrole_rows,
+                Schemas.worker_with_jobrole_count_schema,
+            )
+        )
+
+        returned_df = count_job_roles_per_establishment(
+            test_workplace_across_different_importdates_same_jobrole_df
+        )
+
+        self.assertEqual(
+            returned_df.sort(AWKClean.establishment_id).collect(),
+            expected_workplace_across_different_importdates_same_jobrole_df.collect(),
+        )
+
+    def test_count_job_roles_per_establishment_counts_when_jobrole_is_null(self):
+        test_workplace_with_null_jobrole_df = self.spark.createDataFrame(
+            Data.workplace_with_null_jobrole_rows,
+            Schemas.worker_schema,
+        )
+        expected_workplace_with_null_jobrole_df = self.spark.createDataFrame(
+            Data.expected_workplace_with_null_jobrole_rows,
+            Schemas.worker_with_jobrole_count_schema,
+        )
+
+        returned_df = count_job_roles_per_establishment(
+            test_workplace_with_null_jobrole_df
+        )
+
+        self.assertEqual(
+            returned_df.sort(AWKClean.establishment_id).collect(),
+            expected_workplace_with_null_jobrole_df.collect(),
+        )
+
+    def test_count_job_roles_per_establishment_adds_one_column(self):
+        test_workplace_with_two_workers_df = self.spark.createDataFrame(
+            Data.workplace_with_two_workers_rows,
+            Schemas.worker_schema,
+        )
+        expected_workplace_with_two_workers_df = self.spark.createDataFrame(
+            Data.expected_workplace_with_two_workers_rows,
+            Schemas.worker_with_jobrole_count_schema,
+        )
+
+        returned_df = count_job_roles_per_establishment(
+            test_workplace_with_two_workers_df
+        )
+
+        expected_workplace_with_two_workers_df.show()
+        returned_df.show()
+
+        self.assertEqual(
+            returned_df.columns, expected_workplace_with_two_workers_df.columns
+        )

--- a/tests/unit/test_ascwds_jobrole_count.py
+++ b/tests/unit/test_ascwds_jobrole_count.py
@@ -5,6 +5,10 @@ from utils import utils
 from tests.test_file_data import AscwdsJobroleCountData as Data
 from tests.test_file_schemas import AscwdsJobroleCountSchema as Schemas
 
+from utils.column_names.cleaned_data_files.ascwds_worker_cleaned import (
+    AscwdsWorkerCleanedColumns as AWKClean,
+)
+
 from utils.ind_cqc_filled_posts_utils.ascwds_jobrole_count.ascwds_jobrole_count import count_job_roles_per_establishment, mapped_column
 
 class AscwdsJobroleCount(unittest.TestCase):
@@ -25,3 +29,5 @@ class CountJobRolesPerEstablishmentTests(AscwdsJobroleCount):
         )
 
         returned_df = count_job_roles_per_establishment(test_workplace_with_two_workers_df)
+
+        self.assertEqual(returned_df.sort(AWKClean.establishment_id).collect(), expected_workplace_with_two_workers_df.collect())

--- a/tests/unit/test_ascwds_jobrole_count.py
+++ b/tests/unit/test_ascwds_jobrole_count.py
@@ -21,11 +21,11 @@ class CountJobRolesPerEstablishmentTests(AscwdsJobroleCount):
     def test_count_job_roles_per_establishment_counts_two_workers_that_are_the_same(self):
         test_workplace_with_two_workers_df = self.spark.createDataFrame(
             Data.workplace_with_two_workers_rows,
-            Schemas.workplace_with_two_workers_schema,
+            Schemas.worker_schema,
         )
         expected_workplace_with_two_workers_df = self.spark.createDataFrame(
             Data.expected_workplace_with_two_workers_rows,
-            Schemas.expected_workplace_with_two_workers_schema,
+            Schemas.worker_with_jobrole_count_schema,
         )
 
         returned_df = count_job_roles_per_establishment(test_workplace_with_two_workers_df)

--- a/utils/column_names/cleaned_data_files/ascwds_worker_cleaned.py
+++ b/utils/column_names/cleaned_data_files/ascwds_worker_cleaned.py
@@ -10,3 +10,4 @@ class AscwdsWorkerCleanedColumns(AscwdsWorkerColumns):
     ascwds_worker_import_date: str = "ascwds_worker_import_date"
     main_job_role_clean: str = AscwdsWorkerColumns.main_job_role_id + "_clean"
     main_job_role_clean_labelled: str = main_job_role_clean + "_labels"
+    ascwds_main_job_role_counts: str = "ascwds_main_job_role_counts"

--- a/utils/ind_cqc_filled_posts_utils/ascwds_jobrole_count/ascwds_jobrole_count.py
+++ b/utils/ind_cqc_filled_posts_utils/ascwds_jobrole_count/ascwds_jobrole_count.py
@@ -12,25 +12,25 @@ def count_job_roles_per_establishment(df: DataFrame) -> DataFrame:
         F.col(AWKClean.main_job_role_clean_labelled),
     ).agg(
         F.count(F.col(AWKClean.main_job_role_clean_labelled)).alias(
-            "ascwds_main_job_role_counts"
+            AWKClean.ascwds_main_job_role_counts
         )
     )
     return df
 
 
-def mapped_column(df_agg: DataFrame) -> DataFrame:
+def convert_jobrole_count_to_jobrole_map(df_agg: DataFrame) -> DataFrame:
     df_struct = df_agg.withColumn(
         "struct_column",
         F.struct(
             F.col(AWKClean.main_job_role_clean_labelled),
-            F.col("ascwds_main_job_role_counts"),
+            F.col(AWKClean.ascwds_main_job_role_counts),
         ),
     )
     df_mapped = df_struct.groupBy(
         F.col(AWKClean.establishment_id), F.col(AWKClean.ascwds_worker_import_date)
     ).agg(
         F.map_from_entries(F.collect_list("struct_column")).alias(
-            "ascwds_main_job_role_counts"
+            AWKClean.ascwds_main_job_role_counts
         )
     )
     return df_mapped

--- a/utils/ind_cqc_filled_posts_utils/ascwds_jobrole_count/ascwds_jobrole_count.py
+++ b/utils/ind_cqc_filled_posts_utils/ascwds_jobrole_count/ascwds_jobrole_count.py
@@ -10,14 +10,21 @@ def count_job_roles_per_establishment(df: DataFrame) -> DataFrame:
         F.col(AWKClean.establishment_id),
         F.col(AWKClean.ascwds_worker_import_date),
         F.col(AWKClean.main_job_role_clean_labelled),
-    ).agg(F.count(F.col(AWKClean.main_job_role_clean_labelled)).alias("job_count"))
+    ).agg(
+        F.count(F.col(AWKClean.main_job_role_clean_labelled)).alias(
+            "ascwds_main_job_role_counts"
+        )
+    )
     return df
 
 
 def mapped_column(df_agg: DataFrame) -> DataFrame:
     df_struct = df_agg.withColumn(
         "struct_column",
-        F.struct(F.col(AWKClean.main_job_role_clean_labelled), F.col("job_count")),
+        F.struct(
+            F.col(AWKClean.main_job_role_clean_labelled),
+            F.col("ascwds_main_job_role_counts"),
+        ),
     )
     df_mapped = df_struct.groupBy(
         F.col(AWKClean.establishment_id), F.col(AWKClean.ascwds_worker_import_date)

--- a/utils/ind_cqc_filled_posts_utils/ascwds_jobrole_count/ascwds_jobrole_count.py
+++ b/utils/ind_cqc_filled_posts_utils/ascwds_jobrole_count/ascwds_jobrole_count.py
@@ -6,11 +6,24 @@ from utils.column_names.cleaned_data_files.ascwds_worker_cleaned import (
 
 
 def count_job_roles_per_establishment(df: DataFrame) -> DataFrame:
-    df = df.groupBy(F.col(AWKClean.establishment_id),F.col(AWKClean.ascwds_worker_import_date),F.col(AWKClean.main_job_role_clean_labelled)).agg(F.count(F.col(AWKClean.main_job_role_clean_labelled)).alias("job_count"))
+    df = df.groupBy(
+        F.col(AWKClean.establishment_id),
+        F.col(AWKClean.ascwds_worker_import_date),
+        F.col(AWKClean.main_job_role_clean_labelled),
+    ).agg(F.count(F.col(AWKClean.main_job_role_clean_labelled)).alias("job_count"))
     return df
 
 
 def mapped_column(df_agg: DataFrame) -> DataFrame:
-    df_struct = df_agg.withColumn("struct_column",F.struct(F.col(AWKClean.main_job_role_clean_labelled),F.col("job_count")))
-    df_mapped = df_struct.groupBy(F.col(AWKClean.establishment_id),F.col(AWKClean.ascwds_worker_import_date)).agg(F.map_from_entries(F.collect_list("struct_column")).alias("ascwds_main_job_role_counts"))
+    df_struct = df_agg.withColumn(
+        "struct_column",
+        F.struct(F.col(AWKClean.main_job_role_clean_labelled), F.col("job_count")),
+    )
+    df_mapped = df_struct.groupBy(
+        F.col(AWKClean.establishment_id), F.col(AWKClean.ascwds_worker_import_date)
+    ).agg(
+        F.map_from_entries(F.collect_list("struct_column")).alias(
+            "ascwds_main_job_role_counts"
+        )
+    )
     return df_mapped

--- a/utils/ind_cqc_filled_posts_utils/ascwds_jobrole_count/ascwds_jobrole_count.py
+++ b/utils/ind_cqc_filled_posts_utils/ascwds_jobrole_count/ascwds_jobrole_count.py
@@ -6,6 +6,20 @@ from utils.column_names.cleaned_data_files.ascwds_worker_cleaned import (
 
 
 def count_job_roles_per_establishment(df: DataFrame) -> DataFrame:
+    """
+    Counts the number of rows per establishmentid, importdate and main job role.
+
+    This function groups the ASC-WDS worker dataset by establishmentid, importdate and main job role 
+    and adds a column with the count of rows per group.
+    Duplicate rows by establishmentid, importdate and main job role are removed.
+
+    Args:
+        cleaned_ascwds_worker_df (DataFrame): A dataframe containing cleaned ASC-WDS worker data.
+
+    Returns:
+        DataFrame: A dataframe with unique establishmentid, importdate and main job role and row count.
+    """
+
     df = df.groupBy(
         F.col(AWKClean.establishment_id),
         F.col(AWKClean.ascwds_worker_import_date),
@@ -18,8 +32,19 @@ def count_job_roles_per_establishment(df: DataFrame) -> DataFrame:
     return df
 
 
-def convert_jobrole_count_to_jobrole_map(df_agg: DataFrame) -> DataFrame:
-    df_struct = df_agg.withColumn(
+def convert_jobrole_count_to_jobrole_map(df: DataFrame) -> DataFrame:
+    """
+    Adds a column with a dictionary created from main job role and main job role count then
+    removes main job role and main job role count columns.
+
+    Args:
+        cleaned_ascwds_worker_df (DataFrame): A dataframe containing cleaned ASC-WDS worker data with a count per main job role.
+
+    Returns:
+        DataFrame: A dataframe with unique establishmentid, importdate and dictionary where key = main job role value = main job role count.
+    """
+
+    df_struct = df.withColumn(
         "struct_column",
         F.struct(
             F.col(AWKClean.main_job_role_clean_labelled),

--- a/utils/ind_cqc_filled_posts_utils/ascwds_jobrole_count/ascwds_jobrole_count.py
+++ b/utils/ind_cqc_filled_posts_utils/ascwds_jobrole_count/ascwds_jobrole_count.py
@@ -1,0 +1,16 @@
+from pyspark.sql import DataFrame, functions as F
+
+from utils.column_names.cleaned_data_files.ascwds_worker_cleaned import (
+    AscwdsWorkerCleanedColumns as AWKClean,
+)
+
+
+def count_job_roles_per_establishment(df: DataFrame) -> DataFrame:
+    df = df.groupBy(F.col(AWKClean.establishment_id),F.col(AWKClean.ascwds_worker_import_date),F.col(AWKClean.main_job_role_clean_labelled)).agg(F.count(F.col(AWKClean.main_job_role_clean_labelled)).alias("job_count"))
+    return df
+
+
+def mapped_column(df_agg: DataFrame) -> DataFrame:
+    df_struct = df_agg.withColumn("struct_column",F.struct(F.col(AWKClean.main_job_role_clean_labelled),F.col("job_count")))
+    df_mapped = df_struct.groupBy(F.col(AWKClean.establishment_id),F.col(AWKClean.ascwds_worker_import_date)).agg(F.map_from_entries(F.collect_list("struct_column")).alias("ascwds_main_job_role_counts"))
+    return df_mapped

--- a/utils/ind_cqc_filled_posts_utils/ascwds_jobrole_count/ascwds_jobrole_count.py
+++ b/utils/ind_cqc_filled_posts_utils/ascwds_jobrole_count/ascwds_jobrole_count.py
@@ -9,7 +9,7 @@ def count_job_roles_per_establishment(df: DataFrame) -> DataFrame:
     """
     Counts the number of rows per establishmentid, importdate and main job role.
 
-    This function groups the ASC-WDS worker dataset by establishmentid, importdate and main job role 
+    This function groups the ASC-WDS worker dataset by establishmentid, importdate and main job role
     and adds a column with the count of rows per group.
     Duplicate rows by establishmentid, importdate and main job role are removed.
 

--- a/utils/ind_cqc_filled_posts_utils/ascwds_jobrole_count/ascwds_jobrole_count.py
+++ b/utils/ind_cqc_filled_posts_utils/ascwds_jobrole_count/ascwds_jobrole_count.py
@@ -14,7 +14,7 @@ def count_job_roles_per_establishment(df: DataFrame) -> DataFrame:
     Duplicate rows by establishmentid, importdate and main job role are removed.
 
     Args:
-        cleaned_ascwds_worker_df (DataFrame): A dataframe containing cleaned ASC-WDS worker data.
+        df (DataFrame): A dataframe containing cleaned ASC-WDS worker data.
 
     Returns:
         DataFrame: A dataframe with unique establishmentid, importdate and main job role and row count.
@@ -38,7 +38,7 @@ def convert_jobrole_count_to_jobrole_map(df: DataFrame) -> DataFrame:
     removes main job role and main job role count columns.
 
     Args:
-        cleaned_ascwds_worker_df (DataFrame): A dataframe containing cleaned ASC-WDS worker data with a count per main job role.
+        df (DataFrame): A dataframe containing cleaned ASC-WDS worker data with a count per main job role.
 
     Returns:
         DataFrame: A dataframe with unique establishmentid, importdate and dictionary where key = main job role value = main job role count.

--- a/utils/ind_cqc_filled_posts_utils/ascwds_jobrole_count/template_jobrole_count_dict.py
+++ b/utils/ind_cqc_filled_posts_utils/ascwds_jobrole_count/template_jobrole_count_dict.py
@@ -1,0 +1,51 @@
+from utils.column_values.categorical_column_values import MainJobRoleLabels
+
+# Roy - Note - We have a dict in which the keys are job roles and values are counts per establishemnt.
+#              But it only includes job roles that exist at that establishment.
+#              If we need it to include all possible job roles (and set ones the establishment doesn't have to 0)
+#              Then I thought we could apply this template to all establishments, then update it with the actual counts.
+
+
+@dataclass
+class TemplateJobroleCountDict:
+    {
+        MainJobRoleLabels.not_known: 0,
+        MainJobRoleLabels.senior_management: 0,
+        MainJobRoleLabels.middle_management: 0,
+        MainJobRoleLabels.first_line_manager: 0,
+        MainJobRoleLabels.registered_manager: 0,
+        MainJobRoleLabels.supervisor: 0,
+        MainJobRoleLabels.social_worker: 0,
+        MainJobRoleLabels.senior_care_worker: 0,
+        MainJobRoleLabels.care_worker: 0,
+        MainJobRoleLabels.community_support_and_outreach: 0,
+        MainJobRoleLabels.employment_support: 0,
+        MainJobRoleLabels.advocacy: 0,
+        MainJobRoleLabels.occupational_therapist: 0,
+        MainJobRoleLabels.registered_nurse: 0,
+        MainJobRoleLabels.allied_health_professional: 0,
+        MainJobRoleLabels.technician: 0,
+        MainJobRoleLabels.other_care_role: 0,
+        MainJobRoleLabels.care_related_staff: 0,
+        MainJobRoleLabels.admin_staff: 0,
+        MainJobRoleLabels.ancillary_staff: 0,
+        MainJobRoleLabels.other_non_care_related_staff: 0,
+        MainJobRoleLabels.activites_worker: 0,
+        MainJobRoleLabels.safeguarding_officer: 0,
+        MainJobRoleLabels.occupational_therapist_assistant: 0,
+        MainJobRoleLabels.registered_nursing_associate: 0,
+        MainJobRoleLabels.nursing_assistant: 0,
+        MainJobRoleLabels.assessment_officer: 0,
+        MainJobRoleLabels.care_coordinator: 0,
+        MainJobRoleLabels.childrens_roles: 0,
+        MainJobRoleLabels.deputy_manager: 0,
+        MainJobRoleLabels.learning_and_development_lead: 0,
+        MainJobRoleLabels.team_leader: 0,
+        MainJobRoleLabels.data_analyst: 0,
+        MainJobRoleLabels.data_governance_manager: 0,
+        MainJobRoleLabels.it_and_digital_support: 0,
+        MainJobRoleLabels.it_manager: 0,
+        MainJobRoleLabels.it_service_desk_manager: 0,
+        MainJobRoleLabels.software_developer: 0,
+        MainJobRoleLabels.support_worker: 0,
+    }


### PR DESCRIPTION
# Description
Created a script in a subfolder in utils called ascwds_jobrole_count. First function counts job roles per establishmentid and import date, second functions converts main job role and main job role count into a map column.

The main job role and main job role count are removed when map column is added.

Only roles at the establishment are added to the map.

Made a new ticket for adding all potential job roles to map and setting value to 0 when establishment has none.

Trello ticket: https://trello.com/c/3hbzXeq6

# How to test

When main job role is counted, and main job role is null, then count is 0 (unit tested). However, a map column cannot have null keys. So if main job role in ASC-WDS worker cleaned is null then job will fail. 
Can't see any null main job role in cleaned worker data in Athena.

# Developer checklist
- [x] Unit test
- [x] Linked to Trello ticket
- [x] Documentation up to date
