### PR TITLE
Update version for CQC location API save destination

### DIFF
--- a/jobs/bulk_download_cqc_locations.py
+++ b/jobs/bulk_download_cqc_locations.py
@@ -48,7 +48,7 @@ if __name__ == "__main__":
         domain="CQC",
         dataset="locations_api",
         date=todays_date,
-        version="2.1.0",
+        version="2.1.1",
     )
 
     print(destination)


### PR DESCRIPTION
# Description
All the sources were changed last week to open data stored in v2.1.1 but new data is still set to save in v2.1.0.
This PR is to update where the new API data is saved.
