### PR TITLE
Amend ASCWDS ingest step to also ingest NMDSSC style CSVs

### DIFF
--- a/jobs/ingest_ascwds_dataset.py
+++ b/jobs/ingest_ascwds_dataset.py
@@ -82,6 +82,9 @@ def handle_job(
         source_key (str): The S3 prefix (key) of the file.
         destination (str): The destination directory for outputting parquet files.
         dataset (str): The dataset type, either 'ascwds' or 'nmdssc'.
+
+    Raises:
+        ValueError: If chosen method does not match 'ascwds' or 'nmdssc'.
     """
     file_sample = utils.read_partial_csv_content(source_bucket, source_key)
     delimiter = utils.identify_csv_delimiter(file_sample)

--- a/jobs/ingest_ascwds_dataset.py
+++ b/jobs/ingest_ascwds_dataset.py
@@ -49,7 +49,7 @@ def handle_job(
     if dataset == "ascwds":
         df = raise_error_if_mainjrid_includes_unknown_values(df)
     elif dataset == "nmdssc":
-        df = df  # TODO Add date adjustment function here
+        df = fix_nmdssc_dates(df)
     else:
         raise ValueError("Error: dataset must be either 'ascwds' or 'nmdssc'")
 
@@ -82,6 +82,27 @@ def raise_error_if_mainjrid_includes_unknown_values(df: DataFrame) -> DataFrame:
                 f"Error: this file contains {count_unknown} unknown mainjrid record(s)"
             )
 
+    return df
+
+
+def fix_nmdssc_dates(df: DataFrame) -> DataFrame:
+    """
+    Convert NMDS-SC date string format from MM/dd/yyyy to match the ASC-WDS string format of dd/MM/yyyy.
+
+    Args:
+        df (DataFrame): The DataFrame to adjust the date columns for.
+
+    Returns:
+        DataFrame: The DataFrame with the date columns adjusted.
+    """
+    DATE_COLUMN_SUFFIX = "date"
+    date_columns = [column for column in df.columns if DATE_COLUMN_SUFFIX in column]
+
+    for date_column in date_columns:
+        df = df.withColumn(
+            date_column,
+            F.date_format(F.to_date(df[date_column], "MM/dd/yyyy"), "dd/MM/yyyy"),
+        )
     return df
 
 

--- a/jobs/ingest_ascwds_dataset.py
+++ b/jobs/ingest_ascwds_dataset.py
@@ -10,6 +10,14 @@ from utils.column_names.raw_data_files.ascwds_worker_columns import (
 
 
 def main(source: str, destination: str, dataset: str = "ascwds"):
+    """
+    Main function to handle the ingestion of single or multiple ASCWDS/NMDSSC files.
+
+    Args:
+        source (str): The source CSV file or S3 directory.
+        destination (str): The destination directory for outputting parquet files.
+        dataset (str): The dataset type, either 'ascwds' or 'nmdssc'. Defaults to 'ascwds'.
+    """
     bucket, prefix = utils.split_s3_uri(source)
 
     if utils.is_csv(source):
@@ -21,12 +29,31 @@ def main(source: str, destination: str, dataset: str = "ascwds"):
 def ingest_single_file(
     source: str, bucket: str, prefix: str, destination: str, dataset: str
 ):
+    """
+    Handle the ingestion of a single CSV file.
+
+    Args:
+        source (str): The source file.
+        bucket (str): The S3 bucket name.
+        prefix (str): The S3 prefix (key) of the file.
+        destination (str): The destination directory for outputting parquet files.
+        dataset (str): The dataset type, either 'ascwds' or 'nmdssc'.
+    """
     print("Single file provided to job. Handling single file.")
     new_destination = utils.construct_destination_path(destination, prefix)
     handle_job(source, bucket, prefix, new_destination, dataset)
 
 
 def ingest_multiple_files(bucket: str, prefix: str, destination: str, dataset: str):
+    """
+    Handle the ingestion of multiple files.
+
+    Args:
+        bucket (str): The S3 bucket name.
+        prefix (str): The S3 prefix (key) of the files.
+        destination (str): The destination directory for outputting parquet files.
+        dataset (str): The dataset type, either 'ascwds' or 'nmdssc'.
+    """
     print("Multiple files provided to job. Handling each file...")
     objects_list = utils.get_s3_objects_list(bucket, prefix)
 
@@ -42,6 +69,20 @@ def ingest_multiple_files(bucket: str, prefix: str, destination: str, dataset: s
 def handle_job(
     source: str, source_bucket: str, source_key: str, destination: str, dataset: str
 ):
+    """
+    Handle the job of reading CSV file(s), processing then writing the data to parquet format.
+
+    ASCWDS and NMDSSC files are very similar in structure but have some differences in the data they contain.
+    - An error is raised if any new ASCWDS files contain unknown main job role IDs as this should no longer occur.
+    - NMDSSC files contain date columns in the format MM/dd/yyyy which are converted to dd/MM/yyyy to match ASCWDS date formats.
+
+    Args:
+        source (str): The source file.
+        source_bucket (str): The S3 bucket name.
+        source_key (str): The S3 prefix (key) of the file.
+        destination (str): The destination directory for outputting parquet files.
+        dataset (str): The dataset type, either 'ascwds' or 'nmdssc'.
+    """
     file_sample = utils.read_partial_csv_content(source_bucket, source_key)
     delimiter = utils.identify_csv_delimiter(file_sample)
 

--- a/jobs/ingest_ascwds_dataset.py
+++ b/jobs/ingest_ascwds_dataset.py
@@ -118,17 +118,22 @@ def collect_arguments():
         help="A destination directory for outputting parquet files",
         required=True,
     )
+    parser.add_argument(
+        "--dataset",
+        help="The dataset to be ingested (ascwds or nmdssc)",
+        default="ascwds",
+    )
 
     args, _ = parser.parse_known_args()
 
-    return args.source, args.destination
+    return args.source, args.destination, args.dataset
 
 
 if __name__ == "__main__":
     print("Spark job 'ingest_ascwds_dataset' starting...")
     print(f"Job parameters: {sys.argv}")
 
-    source, destination = collect_arguments()
-    main(source, destination)
+    source, destination, dataset = collect_arguments()
+    main(source, destination, dataset)
 
     print("Spark job 'ingest_ascwds_dataset' complete")

--- a/terraform/pipeline/glue.tf
+++ b/terraform/pipeline/glue.tf
@@ -86,7 +86,7 @@ module "ingest_ascwds_dataset_job" {
   job_parameters = {
     "--source"      = ""
     "--destination" = ""
-    "--dataset" = "ascwds"
+    "--dataset"     = "ascwds"
   }
 }
 

--- a/terraform/pipeline/glue.tf
+++ b/terraform/pipeline/glue.tf
@@ -86,6 +86,7 @@ module "ingest_ascwds_dataset_job" {
   job_parameters = {
     "--source"      = ""
     "--destination" = ""
+    "--dataset" = "ascwds"
   }
 }
 

--- a/terraform/pipeline/step-functions/IngestASCWDS-StepFunction.json
+++ b/terraform/pipeline/step-functions/IngestASCWDS-StepFunction.json
@@ -8,8 +8,9 @@
             "Parameters": {
                 "JobName": "${ingest_ascwds_job_name}",
                 "Arguments": {
+                    "--source.$": "$.jobs.ingest_ascwds_dataset.source",
                     "--destination": "s3://${dataset_bucket_name}/domain=ASCWDS/",
-                    "--source.$": "$.jobs.ingest_ascwds_dataset.source"
+                    "--dataset": "ascwds"
                 }
             },
             "Catch": [

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -113,6 +113,9 @@ class IngestASCWDSData:
     raise_mainjrid_error_with_known_value_rows = [("123", "1-001", "1")]
     raise_mainjrid_error_with_unknown_value_rows = [("123", "1-001", "-1")]
 
+    fix_nmdssc_dates_rows = [("100", "07/31/2021", "8", "10/01/2024")]
+    expected_fix_nmdssc_dates_rows = [("100", "31/07/2021", "8", "01/10/2024")]
+
 
 @dataclass
 class ASCWDSWorkerData:

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -120,6 +120,15 @@ class IngestASCWDSData:
         ]
     )
 
+    fix_nmdssc_dates_schema = StructType(
+        [
+            StructField(AWK.establishment_id, StringType(), True),
+            StructField(AWK.created_date, StringType(), True),
+            StructField(AWK.main_job_role_id, StringType(), True),
+            StructField(AWK.updated_date, StringType(), True),
+        ]
+    )
+
 
 @dataclass
 class ASCWDSWorkerSchemas:


### PR DESCRIPTION
# Description
By default this runs on ASCWDS only so it behaves in the same way it did previously.
However, I've added the option to select NMDSSC files which includes a date amendment not relevant to ASCWDS files, and excludes mainjrid not being -1 as that was fine to happen in NMDS files

# How to test
Ran all data in branch and behaves as expected.
Added unit tests for new functions

# Developer checklist
- [X] Unit test
- [X] Linked to [Trello ticket](https://trello.com/c/tAfQrIke/704-epic-10-add-an-nmds-option-into-the-ascwds-ingestion-job-must)
- [X] Documentation up to date
