### PR TITLE
Account for lastloggedin date column in ingest job

### DIFF
--- a/jobs/ingest_ascwds_dataset.py
+++ b/jobs/ingest_ascwds_dataset.py
@@ -7,6 +7,9 @@ from utils import utils
 from utils.column_names.raw_data_files.ascwds_worker_columns import (
     AscwdsWorkerColumns as AWK,
 )
+from utils.column_names.raw_data_files.ascwds_workplace_columns import (
+    AscwdsWorkplaceColumns as AWP,
+)
 
 
 def main(source: str, destination: str, dataset: str = "ascwds"):
@@ -146,6 +149,15 @@ def fix_nmdssc_dates(df: DataFrame) -> DataFrame:
         df = df.withColumn(
             date_column,
             F.date_format(F.to_date(df[date_column], "MM/dd/yyyy"), "dd/MM/yyyy"),
+        )
+
+    # last_logged_in is the only date column which doen't contain the word date so we need to handle it separately
+    if AWP.last_logged_in in df.columns:
+        df = df.withColumn(
+            AWP.last_logged_in,
+            F.date_format(
+                F.to_date(df[AWP.last_logged_in], "MM/dd/yyyy"), "dd/MM/yyyy"
+            ),
         )
     return df
 

--- a/jobs/ingest_ascwds_dataset.py
+++ b/jobs/ingest_ascwds_dataset.py
@@ -153,7 +153,6 @@ def fix_nmdssc_dates(df: DataFrame) -> DataFrame:
             F.date_format(F.to_date(df[date_column], "MM/dd/yyyy"), "dd/MM/yyyy"),
         )
 
-    # last_logged_in is the only date column which doen't contain the word date so we need to handle it separately
     if AWP.last_logged_in in df.columns:
         df = df.withColumn(
             AWP.last_logged_in,

--- a/jobs/ingest_ascwds_dataset.py
+++ b/jobs/ingest_ascwds_dataset.py
@@ -136,6 +136,8 @@ def fix_nmdssc_dates(df: DataFrame) -> DataFrame:
     """
     Convert NMDS-SC date string format from MM/dd/yyyy to match the ASC-WDS string format of dd/MM/yyyy.
 
+    All columns exept last_logged_in contain the word date so we use a suffix to identify them and account for the last_logged_in column separately.
+
     Args:
         df (DataFrame): The DataFrame to adjust the date columns for.
 

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -116,6 +116,13 @@ class IngestASCWDSData:
     fix_nmdssc_dates_rows = [("100", "07/31/2021", "8", "10/01/2024")]
     expected_fix_nmdssc_dates_rows = [("100", "31/07/2021", "8", "01/10/2024")]
 
+    fix_nmdssc_dates_with_last_logged_in_rows = [
+        ("100", "07/31/2021", "8", "10/01/2024")
+    ]
+    expected_fix_nmdssc_dates_with_last_logged_in_rows = [
+        ("100", "31/07/2021", "8", "01/10/2024")
+    ]
+
 
 @dataclass
 class ASCWDSWorkerData:

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -129,6 +129,15 @@ class IngestASCWDSData:
         ]
     )
 
+    fix_nmdssc_dates_with_last_logged_in_schema = StructType(
+        [
+            StructField(AWP.establishment_id, StringType(), True),
+            StructField(AWP.master_update_date, StringType(), True),
+            StructField(AWP.organisation_id, StringType(), True),
+            StructField(AWP.last_logged_in, StringType(), True),
+        ]
+    )
+
 
 @dataclass
 class ASCWDSWorkerSchemas:

--- a/tests/unit/test_ingest_ascwds_dataset.py
+++ b/tests/unit/test_ingest_ascwds_dataset.py
@@ -333,6 +333,20 @@ class FixNmdsscDatesTests(IngestASCWDSDatasetTests):
             self.expected_data[0][AWK.main_job_role_id],
         )
 
+    def test_fix_nmdssc_dates_amends_last_logged_in_column(self):
+        last_logged_in_df = self.spark.createDataFrame(
+            Data.fix_nmdssc_dates_with_last_logged_in_rows,
+            Schemas.fix_nmdssc_dates_with_last_logged_in_schema,
+        )
+
+        expected_df = self.spark.createDataFrame(
+            Data.expected_fix_nmdssc_dates_with_last_logged_in_rows,
+            Schemas.fix_nmdssc_dates_with_last_logged_in_schema,
+        )
+        returned_df = job.fix_nmdssc_dates(last_logged_in_df)
+
+        self.assertEqual(returned_df.collect(), expected_df.collect())
+
 
 if __name__ == "__main__":
     unittest.main(warnings="ignore")


### PR DESCRIPTION
# Description
lastloggedin doesn't have 'date' in the name so it isn't automatically captured. It's in the workplace file but not the worker file so set up as an if statement instead of appending to the list of date cols

# How to test
Added test function

# Developer checklist
- [X] Unit test
- [X] Documentation up to date
