### PR TITLE
Adapt func to fill missing struct cols

### DIFF
--- a/jobs/clean_cqc_location_data.py
+++ b/jobs/clean_cqc_location_data.py
@@ -110,7 +110,12 @@ def main(
     cqc_location_df = impute_historic_relationships(cqc_location_df)
     registered_locations_df = select_registered_locations_only(cqc_location_df)
 
-    registered_locations_df = impute_missing_struct_column(registered_locations_df)
+    registered_locations_df = impute_missing_struct_column(
+        registered_locations_df, CQCL.gac_service_types
+    )
+    registered_locations_df = impute_missing_struct_column(
+        registered_locations_df, CQCL.regulated_activities
+    )
     registered_locations_df = add_list_of_services_offered(registered_locations_df)
     registered_locations_df = remove_specialist_colleges(registered_locations_df)
     registered_locations_df = allocate_primary_service_type(registered_locations_df)

--- a/jobs/clean_cqc_location_data.py
+++ b/jobs/clean_cqc_location_data.py
@@ -110,7 +110,7 @@ def main(
     cqc_location_df = impute_historic_relationships(cqc_location_df)
     registered_locations_df = select_registered_locations_only(cqc_location_df)
 
-    registered_locations_df = impute_missing_gac_service_types(registered_locations_df)
+    registered_locations_df = impute_missing_struct_column(registered_locations_df)
     registered_locations_df = add_list_of_services_offered(registered_locations_df)
     registered_locations_df = remove_specialist_colleges(registered_locations_df)
     registered_locations_df = allocate_primary_service_type(registered_locations_df)
@@ -416,22 +416,23 @@ def get_relationships_where_type_is_predecessor(df: DataFrame) -> DataFrame:
     return df
 
 
-def impute_missing_gac_service_types(df: DataFrame) -> DataFrame:
+def impute_missing_struct_column(df: DataFrame, column_name: str) -> DataFrame:
     """
-    Imputes missing gacservicetypes in the DataFrame by filling with known values from other imports.
+    Imputes missing rows in a struct col in the DataFrame by filling with known values from other import_dates.
 
     The function performs the following steps:
-    1. Creates a new column 'imputed_gac_service_types' which copies gac_service_types if it contains data,
+    1. Creates a new column with the prefix 'imputed_' which copies the column if it contains data,
        and sets it to None if the array is empty.
-    2. Fills the missing values in 'imputed_gac_service_types' with the previous known value within the partition.
-    3. Fills any remaining missing values in 'imputed_gac_service_types' with the future known value within the partition.
+    2. Fills the missing values in 'imputed_' with the previous known value within the partition.
+    3. Fills any remaining missing values in 'imputed_' with the future known value within the partition.
 
     Args:
-        df (DataFrame): Input DataFrame containing 'location_id', 'cqc_location_import_date', and 'gac_service_types'.
+        df (DataFrame): Input DataFrame containing 'location_id', 'cqc_location_import_date', and a struct column to impute.
 
     Returns:
-        DataFrame: DataFrame with the 'imputed_gac_service_types' column containing imputed values.
+        DataFrame: DataFrame with the struct column containing imputed values.
     """
+    new_column_name = "imputed_" + column_name
     w_future = Window.partitionBy(CQCL.location_id).orderBy(
         CQCLClean.cqc_location_import_date
     )
@@ -440,30 +441,26 @@ def impute_missing_gac_service_types(df: DataFrame) -> DataFrame:
     )
 
     df = df.withColumn(
-        CQCLClean.imputed_gac_service_types,
+        new_column_name,
         F.when(
-            F.size(F.col(CQCL.gac_service_types)) > 0,
-            F.col(CQCL.gac_service_types),
+            F.size(F.col(column_name)) > 0,
+            F.col(column_name),
         ).otherwise(F.lit(None)),
     )
 
     df = df.withColumn(
-        CQCLClean.imputed_gac_service_types,
+        new_column_name,
         F.coalesce(
-            F.col(CQCLClean.imputed_gac_service_types),
-            F.last(CQCLClean.imputed_gac_service_types, ignorenulls=True).over(
-                w_future
-            ),
+            F.col(new_column_name),
+            F.last(new_column_name, ignorenulls=True).over(w_future),
         ),
     )
 
     df = df.withColumn(
-        CQCLClean.imputed_gac_service_types,
+        new_column_name,
         F.coalesce(
-            F.col(CQCLClean.imputed_gac_service_types),
-            F.first(CQCLClean.imputed_gac_service_types, ignorenulls=True).over(
-                w_historic
-            ),
+            F.col(new_column_name),
+            F.first(new_column_name, ignorenulls=True).over(w_historic),
         ),
     )
 

--- a/jobs/clean_cqc_location_data.py
+++ b/jobs/clean_cqc_location_data.py
@@ -35,7 +35,6 @@ from utils.cqc_location_utils.extract_registered_manager_names import (
     extract_registered_manager_names_from_imputed_regulated_activities_column,
 )
 from utils.raw_data_adjustments import remove_records_from_locations_data
-from utils.ind_cqc_filled_posts_utils.utils import get_selected_value
 
 
 cqcPartitionKeys = [Keys.year, Keys.month, Keys.day, Keys.import_date]
@@ -123,13 +122,9 @@ def main(
         CQCL.location_id,
     ).rowsBetween(Window.unboundedPreceding, Window.unboundedFollowing)
 
-    registered_locations_df = get_selected_value(
-        registered_locations_df,
-        window_spec,
-        CQCL.regulated_activities,
-        CQCL.regulated_activities,
+    registered_locations_df = registered_locations_df.withColumn(
         first_non_null_regulated_activity,
-        "first",
+        F.first(F.col(CQCL.regulated_activities)).over(window_spec),
     )
     #### TEMP CODE ####
 

--- a/jobs/clean_cqc_location_data.py
+++ b/jobs/clean_cqc_location_data.py
@@ -124,7 +124,7 @@ def main(
 
     registered_locations_df = registered_locations_df.withColumn(
         first_non_null_regulated_activity,
-        F.first(F.col(CQCL.regulated_activities)).over(window_spec),
+        F.size(F.first(F.col(CQCL.regulated_activities)).over(window_spec)),
     )
     #### TEMP CODE ####
 

--- a/jobs/clean_cqc_location_data.py
+++ b/jobs/clean_cqc_location_data.py
@@ -433,6 +433,7 @@ def impute_missing_struct_column(df: DataFrame, column_name: str) -> DataFrame:
 
     Args:
         df (DataFrame): Input DataFrame containing 'location_id', 'cqc_location_import_date', and a struct column to impute.
+        column_name (str): Name of struct column to impute
 
     Returns:
         DataFrame: DataFrame with the struct column containing imputed values.

--- a/jobs/clean_cqc_location_data.py
+++ b/jobs/clean_cqc_location_data.py
@@ -116,21 +116,9 @@ def main(
     registered_locations_df = impute_missing_struct_column(
         registered_locations_df, CQCL.regulated_activities
     )
-    #### TEMP CODE ####
-    first_non_null_regulated_activity: str = "first_non_null_regulated_activity"
-    window_spec = Window.partitionBy(
-        CQCL.location_id,
-    ).rowsBetween(Window.unboundedPreceding, Window.unboundedFollowing)
-
-    registered_locations_df = registered_locations_df.withColumn(
-        first_non_null_regulated_activity,
-        F.size(F.first(F.col(CQCL.regulated_activities)).over(window_spec)),
+    registered_locations_df = remove_locations_that_never_had_regulated_activities(
+        registered_locations_df
     )
-    #### TEMP CODE ####
-
-    # registered_locations_df = remove_locations_that_never_had_regulated_activities(
-    #     registered_locations_df
-    # )
     registered_locations_df = add_list_of_services_offered(registered_locations_df)
     registered_locations_df = remove_specialist_colleges(registered_locations_df)
     registered_locations_df = allocate_primary_service_type(registered_locations_df)

--- a/jobs/clean_cqc_location_data.py
+++ b/jobs/clean_cqc_location_data.py
@@ -32,7 +32,7 @@ from utils.column_names.cleaned_data_files.ons_cleaned import (
 )
 from utils.cqc_location_dictionaries import InvalidPostcodes
 from utils.cqc_location_utils.extract_registered_manager_names import (
-    extract_registered_manager_names_from_regulated_activities_column,
+    extract_registered_manager_names_from_imputed_regulated_activities_column,
 )
 from utils.raw_data_adjustments import remove_records_from_locations_data
 
@@ -123,7 +123,7 @@ def main(
         registered_locations_df
     )
     registered_locations_df = (
-        extract_registered_manager_names_from_regulated_activities_column(
+        extract_registered_manager_names_from_imputed_regulated_activities_column(
             registered_locations_df
         )
     )

--- a/jobs/clean_cqc_location_data.py
+++ b/jobs/clean_cqc_location_data.py
@@ -35,6 +35,7 @@ from utils.cqc_location_utils.extract_registered_manager_names import (
     extract_registered_manager_names_from_imputed_regulated_activities_column,
 )
 from utils.raw_data_adjustments import remove_records_from_locations_data
+from utils.ind_cqc_filled_posts_utils.utils import get_selected_value
 
 
 cqcPartitionKeys = [Keys.year, Keys.month, Keys.day, Keys.import_date]
@@ -116,9 +117,25 @@ def main(
     registered_locations_df = impute_missing_struct_column(
         registered_locations_df, CQCL.regulated_activities
     )
-    registered_locations_df = remove_locations_that_never_had_regulated_activities(
-        registered_locations_df
+    #### TEMP CODE ####
+    first_non_null_regulated_activity: str = "first_non_null_regulated_activity"
+    window_spec = Window.partitionBy(
+        CQCL.location_id,
+    ).rowsBetween(Window.unboundedPreceding, Window.unboundedFollowing)
+
+    raw_location_df = get_selected_value(
+        raw_location_df,
+        window_spec,
+        CQCL.regulated_activities,
+        CQCL.regulated_activities,
+        first_non_null_regulated_activity,
+        "first",
     )
+    #### TEMP CODE ####
+
+    # registered_locations_df = remove_locations_that_never_had_regulated_activities(
+    #     registered_locations_df
+    # )
     registered_locations_df = add_list_of_services_offered(registered_locations_df)
     registered_locations_df = remove_specialist_colleges(registered_locations_df)
     registered_locations_df = allocate_primary_service_type(registered_locations_df)

--- a/jobs/clean_cqc_location_data.py
+++ b/jobs/clean_cqc_location_data.py
@@ -116,6 +116,9 @@ def main(
     registered_locations_df = impute_missing_struct_column(
         registered_locations_df, CQCL.regulated_activities
     )
+    registered_locations_df = remove_locations_that_never_had_regulated_activities(
+        registered_locations_df
+    )
     registered_locations_df = add_list_of_services_offered(registered_locations_df)
     registered_locations_df = remove_specialist_colleges(registered_locations_df)
     registered_locations_df = allocate_primary_service_type(registered_locations_df)
@@ -470,6 +473,23 @@ def impute_missing_struct_column(df: DataFrame, column_name: str) -> DataFrame:
         ),
     )
 
+    return df
+
+
+def remove_locations_that_never_had_regulated_activities(df: DataFrame) -> DataFrame:
+    """
+    Removes locations who have never submitted regulated activities data.
+
+    Removes locations who have never submitted regulated activities data as it is
+    the activities that are regulated and not the location. This function removes any blank rows
+    from the imputed_regulatedactivities column, which are locations that have no data at any time point.
+
+    Args:
+        df (DataFrame): A dataframe with imputed_regulatedactivities
+
+    Returns:
+        DataFrame: A dataframe where blank imputed rows are removed.
+    """
     return df
 
 

--- a/jobs/clean_cqc_location_data.py
+++ b/jobs/clean_cqc_location_data.py
@@ -123,8 +123,8 @@ def main(
         CQCL.location_id,
     ).rowsBetween(Window.unboundedPreceding, Window.unboundedFollowing)
 
-    raw_location_df = get_selected_value(
-        raw_location_df,
+    registered_locations_df = get_selected_value(
+        registered_locations_df,
         window_spec,
         CQCL.regulated_activities,
         CQCL.regulated_activities,

--- a/jobs/clean_cqc_location_data.py
+++ b/jobs/clean_cqc_location_data.py
@@ -490,6 +490,7 @@ def remove_locations_that_never_had_regulated_activities(df: DataFrame) -> DataF
     Returns:
         DataFrame: A dataframe where blank imputed rows are removed.
     """
+    df = df.where(df[CQCLClean.imputed_regulated_activities].isNotNull())
     return df
 
 

--- a/jobs/merge_coverage_data.py
+++ b/jobs/merge_coverage_data.py
@@ -43,7 +43,7 @@ cleaned_cqc_locations_columns_to_import = [
     CQCLClean.dormancy,
     CQCLClean.care_home,
     CQCLClean.number_of_beds,
-    CQCLClean.regulated_activities,
+    CQCLClean.imputed_regulated_activities,
     CQCLClean.imputed_gac_service_types,
     CQCLClean.services_offered,
     CQCLClean.specialisms,

--- a/jobs/merge_ind_cqc_data.py
+++ b/jobs/merge_ind_cqc_data.py
@@ -37,7 +37,7 @@ cleaned_cqc_locations_columns_to_import = [
     CQCLClean.dormancy,
     CQCLClean.care_home,
     CQCLClean.number_of_beds,
-    CQCLClean.regulated_activities,
+    CQCLClean.imputed_regulated_activities,
     CQCLClean.imputed_gac_service_types,
     CQCLClean.services_offered,
     CQCLClean.specialisms,

--- a/jobs/prepare_features_non_res_ascwds_ind_cqc.py
+++ b/jobs/prepare_features_non_res_ascwds_ind_cqc.py
@@ -73,7 +73,7 @@ def main(
     features_df = add_array_column_count_to_data(
         df=features_df,
         new_col_name=IndCQC.activity_count,
-        col_to_check=IndCQC.regulated_activities,
+        col_to_check=IndCQC.imputed_regulated_activities,
     )
     features_df = add_array_column_count_to_data(
         df=features_df,

--- a/jobs/validate_locations_api_cleaned_data.py
+++ b/jobs/validate_locations_api_cleaned_data.py
@@ -54,9 +54,9 @@ def main(
     )
     rules = Rules.rules_to_check
 
-    rules[RuleName.size_of_dataset] = (
-        calculate_expected_size_of_cleaned_cqc_locations_dataset(raw_location_df)
-    )
+    rules[
+        RuleName.size_of_dataset
+    ] = calculate_expected_size_of_cleaned_cqc_locations_dataset(raw_location_df)
 
     cleaned_cqc_locations_df = add_column_with_length_of_string(
         cleaned_cqc_locations_df, [CQCL.location_id, CQCL.provider_id]

--- a/jobs/validate_locations_api_cleaned_data.py
+++ b/jobs/validate_locations_api_cleaned_data.py
@@ -79,13 +79,9 @@ def calculate_expected_size_of_cleaned_cqc_locations_dataset(
         CQCL.location_id,
     ).rowsBetween(Window.unboundedPreceding, Window.unboundedFollowing)
 
-    raw_location_df = get_selected_value(
-        raw_location_df,
-        window_spec,
-        CQCL.regulated_activities,
-        CQCL.regulated_activities,
+    raw_location_df = raw_location_df.withColumn(
         first_non_null_regulated_activity,
-        "first",
+        F.first(F.col(CQCL.regulated_activities)).over(window_spec),
     )
 
     expected_size = raw_location_df.where(

--- a/jobs/validate_locations_api_cleaned_data.py
+++ b/jobs/validate_locations_api_cleaned_data.py
@@ -17,7 +17,6 @@ from utils.column_values.categorical_column_values import (
     RegistrationStatus,
     Services,
 )
-from utils.ind_cqc_filled_posts_utils.utils import get_selected_value
 from utils.raw_data_adjustments import RecordsToRemoveInLocationsData
 from utils.validation.validation_rules.locations_api_cleaned_validation_rules import (
     LocationsAPICleanedValidationRules as Rules,
@@ -55,9 +54,9 @@ def main(
     )
     rules = Rules.rules_to_check
 
-    rules[
-        RuleName.size_of_dataset
-    ] = calculate_expected_size_of_cleaned_cqc_locations_dataset(raw_location_df)
+    rules[RuleName.size_of_dataset] = (
+        calculate_expected_size_of_cleaned_cqc_locations_dataset(raw_location_df)
+    )
 
     cleaned_cqc_locations_df = add_column_with_length_of_string(
         cleaned_cqc_locations_df, [CQCL.location_id, CQCL.provider_id]

--- a/jobs/validate_locations_api_cleaned_data.py
+++ b/jobs/validate_locations_api_cleaned_data.py
@@ -55,9 +55,9 @@ def main(
     )
     rules = Rules.rules_to_check
 
-    rules[RuleName.size_of_dataset] = (
-        calculate_expected_size_of_cleaned_cqc_locations_dataset(raw_location_df)
-    )
+    rules[
+        RuleName.size_of_dataset
+    ] = calculate_expected_size_of_cleaned_cqc_locations_dataset(raw_location_df)
 
     cleaned_cqc_locations_df = add_column_with_length_of_string(
         cleaned_cqc_locations_df, [CQCL.location_id, CQCL.provider_id]

--- a/jobs/validate_locations_api_cleaned_data.py
+++ b/jobs/validate_locations_api_cleaned_data.py
@@ -55,9 +55,9 @@ def main(
     )
     rules = Rules.rules_to_check
 
-    rules[
-        RuleName.size_of_dataset
-    ] = calculate_expected_size_of_cleaned_cqc_locations_dataset(raw_location_df)
+    rules[RuleName.size_of_dataset] = (
+        calculate_expected_size_of_cleaned_cqc_locations_dataset(raw_location_df)
+    )
 
     cleaned_cqc_locations_df = add_column_with_length_of_string(
         cleaned_cqc_locations_df, [CQCL.location_id, CQCL.provider_id]
@@ -75,10 +75,13 @@ def calculate_expected_size_of_cleaned_cqc_locations_dataset(
     raw_location_df: DataFrame,
 ) -> int:
     first_non_null_regulated_activity: str = "first_non_null_regulated_activity"
+    window_spec = Window.partitionBy(
+        CQCL.location_id,
+    ).rowsBetween(Window.unboundedPreceding, Window.unboundedFollowing)
 
     raw_location_df = get_selected_value(
         raw_location_df,
-        Window.partitionBy(CQCL.location_id),
+        window_spec,
         CQCL.regulated_activities,
         CQCL.regulated_activities,
         first_non_null_regulated_activity,

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -2279,6 +2279,46 @@ class CQCLocationsData:
     ]
     # fmt: on
 
+    remove_locations_that_never_had_regulated_activities_rows = [
+        (
+            "loc 1",
+            [
+                {
+                    "name": "Personal care",
+                    "code": "RA1",
+                    "contacts": [
+                        {
+                            "personfamilyname": "Doe",
+                            "persongivenname": "John",
+                            "personroles": ["Registered Manager"],
+                            "persontitle": "Mr",
+                        }
+                    ],
+                }
+            ],
+        ),
+        ("loc 2", None),
+    ]
+    expected_remove_locations_that_never_had_regulated_activities_rows = [
+        (
+            "loc 1",
+            [
+                {
+                    "name": "Personal care",
+                    "code": "RA1",
+                    "contacts": [
+                        {
+                            "personfamilyname": "Doe",
+                            "persongivenname": "John",
+                            "personroles": ["Registered Manager"],
+                            "persontitle": "Mr",
+                        }
+                    ],
+                }
+            ],
+        ),
+    ]
+
     list_of_services_rows = [
         (
             "location1",

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -7715,35 +7715,40 @@ class ValidationUtils:
 class ValidateLocationsAPICleanedData:
     # fmt: off
     raw_cqc_locations_rows = [
-        ("1-000000001", "20240101", LocationType.social_care_identifier, RegistrationStatus.registered, [{CQCL.name: "name", CQCL.description: Services.care_home_service_with_nursing}]),
-        ("1-000000002", "20240101", LocationType.social_care_identifier, RegistrationStatus.deregistered, [{CQCL.name: "name", CQCL.description: Services.care_home_service_with_nursing}]),
-        ("1-000000001", "20240201", LocationType.social_care_identifier, RegistrationStatus.registered, [{CQCL.name: "name", CQCL.description: Services.care_home_service_with_nursing}]),
-        ("1-000000002", "20240201", "not social care org", RegistrationStatus.deregistered, [{CQCL.name: "name", CQCL.description: Services.care_home_service_with_nursing}]),
+        ("1-000000001", "20240101", LocationType.social_care_identifier, RegistrationStatus.registered, [{CQCL.name: "name", CQCL.description: Services.care_home_service_with_nursing}], [{CQCL.name: "name", CQCL.code: "A1", CQCL.contacts: []}]),
+        ("1-000000002", "20240101", LocationType.social_care_identifier, RegistrationStatus.deregistered, [{CQCL.name: "name", CQCL.description: Services.care_home_service_with_nursing}], [{CQCL.name: "name", CQCL.code: "A1", CQCL.contacts: []}]),
+        ("1-000000001", "20240201", LocationType.social_care_identifier, RegistrationStatus.registered, [{CQCL.name: "name", CQCL.description: Services.care_home_service_with_nursing}], [{CQCL.name: "name", CQCL.code: "A1", CQCL.contacts: []}]),
+        ("1-000000002", "20240201", "not social care org", RegistrationStatus.deregistered, [{CQCL.name: "name", CQCL.description: Services.care_home_service_with_nursing}], [{CQCL.name: "name", CQCL.code: "A1", CQCL.contacts: []}]),
     ]
+    # fmt: on
 
+    # fmt: off
     cleaned_cqc_locations_rows = [
-        ("1-000000002", date(2024, 1, 1), date(2024, 1, 1), "Y", "name", "prov_1", "prov_name", Sector.independent, RegistrationStatus.registered, date(2024, 1, 1), "Y", 5, PrimaryServiceType.care_home_only, date(2024, 1, 1), "cssr", "region", date(2024, 1, 1), "cssr", "region", "RUI", None),
-        ("1-000000001", date(2024, 1, 9), date(2024, 1, 1), "Y", "name", "prov_1", "prov_name", Sector.independent, RegistrationStatus.registered, date(2024, 1, 1), "Y", 5, PrimaryServiceType.care_home_only, date(2024, 1, 1), "cssr", "region", date(2024, 1, 1), "cssr", "region", "RUI", None),
-        ("1-000000001", date(2024, 1, 1), date(2024, 1, 1), "Y", "name", "prov_1", "prov_name", Sector.independent, RegistrationStatus.registered, date(2024, 1, 1), "Y", 5, PrimaryServiceType.care_home_only, date(2024, 1, 1), "cssr", "region", date(2024, 1, 1), "cssr", "region", "RUI", None),
-        ("1-000000002", date(2024, 1, 9), date(2024, 1, 1), "Y", "name", "prov_1", "prov_name", Sector.independent, RegistrationStatus.registered, date(2024, 1, 1), "Y", 5, PrimaryServiceType.care_home_only, date(2024, 1, 1), "cssr", "region", date(2024, 1, 1), "cssr", "region", "RUI", None),
+        ("1-000000002", date(2024, 1, 1), date(2024, 1, 1), "Y", "name", "prov_1", "prov_name", Sector.independent, RegistrationStatus.registered, date(2024, 1, 1), "Y", 5, PrimaryServiceType.care_home_only, date(2024, 1, 1), "cssr", "region", date(2024, 1, 1), "cssr", "region", "RUI", None, [{CQCL.name: "name", CQCL.code: "A1", CQCL.contacts: []}]),
+        ("1-000000001", date(2024, 1, 9), date(2024, 1, 1), "Y", "name", "prov_1", "prov_name", Sector.independent, RegistrationStatus.registered, date(2024, 1, 1), "Y", 5, PrimaryServiceType.care_home_only, date(2024, 1, 1), "cssr", "region", date(2024, 1, 1), "cssr", "region", "RUI", None, [{CQCL.name: "name", CQCL.code: "A1", CQCL.contacts: []}]),
+        ("1-000000001", date(2024, 1, 1), date(2024, 1, 1), "Y", "name", "prov_1", "prov_name", Sector.independent, RegistrationStatus.registered, date(2024, 1, 1), "Y", 5, PrimaryServiceType.care_home_only, date(2024, 1, 1), "cssr", "region", date(2024, 1, 1), "cssr", "region", "RUI", None, [{CQCL.name: "name", CQCL.code: "A1", CQCL.contacts: []}]),
+        ("1-000000002", date(2024, 1, 9), date(2024, 1, 1), "Y", "name", "prov_1", "prov_name", Sector.independent, RegistrationStatus.registered, date(2024, 1, 1), "Y", 5, PrimaryServiceType.care_home_only, date(2024, 1, 1), "cssr", "region", date(2024, 1, 1), "cssr", "region", "RUI", None, [{CQCL.name: "name", CQCL.code: "A1", CQCL.contacts: []}]),
     ]
+    # fmt: on
     
 
+    # fmt: off
     calculate_expected_size_rows = [
-        ("loc_1", LocationType.social_care_identifier, RegistrationStatus.registered, [{CQCL.name: "name", CQCL.description: Services.care_home_service_with_nursing}]),
-        ("loc_2", "non social care org", RegistrationStatus.registered, [{CQCL.name: "name", CQCL.description: Services.care_home_service_with_nursing}]),
-        ("loc_3", None, RegistrationStatus.registered, [{CQCL.name: "name", CQCL.description: Services.care_home_service_with_nursing}]),
-        ("loc_4", LocationType.social_care_identifier, RegistrationStatus.deregistered, [{CQCL.name: "name", CQCL.description: Services.care_home_service_with_nursing}]),
-        ("loc_5", "non social care org", RegistrationStatus.deregistered, [{CQCL.name: "name", CQCL.description: Services.care_home_service_with_nursing}]),
-        ("loc_6", None, RegistrationStatus.deregistered,  [{CQCL.name: "name", CQCL.description: Services.care_home_service_with_nursing}]),
-        ("loc_7", LocationType.social_care_identifier, RegistrationStatus.registered, [{CQCL.name: "name", CQCL.description: Services.specialist_college_service}]),
-        ("loc_8", "non social care org", RegistrationStatus.registered, [{CQCL.name: "name", CQCL.description: Services.specialist_college_service}]),
-        ("loc_9", None, RegistrationStatus.registered, [{CQCL.name: "name", CQCL.description: Services.specialist_college_service}]),
-        ("loc_10", LocationType.social_care_identifier, RegistrationStatus.deregistered, [{CQCL.name: "name", CQCL.description: Services.specialist_college_service}]),
-        ("loc_11", "non social care org", RegistrationStatus.deregistered, [{CQCL.name: "name", CQCL.description: Services.specialist_college_service}]),
-        ("loc_12", None, RegistrationStatus.deregistered,  [{CQCL.name: "name", CQCL.description: Services.specialist_college_service}]),
-        (RecordsToRemoveInLocationsData.dental_practice, LocationType.social_care_identifier, RegistrationStatus.registered, None),
-        (RecordsToRemoveInLocationsData.temp_registration, LocationType.social_care_identifier, RegistrationStatus.registered, None),
+        ("loc_1", LocationType.social_care_identifier, RegistrationStatus.registered, [{CQCL.name: "name", CQCL.description: Services.care_home_service_with_nursing}], [{CQCL.name: "name", CQCL.code: "A1", CQCL.contacts: []}]),
+        ("loc_2", "non social care org", RegistrationStatus.registered, [{CQCL.name: "name", CQCL.description: Services.care_home_service_with_nursing}], [{CQCL.name: "name", CQCL.code: "A1", CQCL.contacts: []}]),
+        ("loc_3", None, RegistrationStatus.registered, [{CQCL.name: "name", CQCL.description: Services.care_home_service_with_nursing}], [{CQCL.name: "name", CQCL.code: "A1", CQCL.contacts: []}]),
+        ("loc_4", LocationType.social_care_identifier, RegistrationStatus.deregistered, [{CQCL.name: "name", CQCL.description: Services.care_home_service_with_nursing}], [{CQCL.name: "name", CQCL.code: "A1", CQCL.contacts: []}]),
+        ("loc_5", "non social care org", RegistrationStatus.deregistered, [{CQCL.name: "name", CQCL.description: Services.care_home_service_with_nursing}], [{CQCL.name: "name", CQCL.code: "A1", CQCL.contacts: []}]),
+        ("loc_6", None, RegistrationStatus.deregistered,  [{CQCL.name: "name", CQCL.description: Services.care_home_service_with_nursing}], [{CQCL.name: "name", CQCL.code: "A1", CQCL.contacts: []}]),
+        ("loc_7", LocationType.social_care_identifier, RegistrationStatus.registered, [{CQCL.name: "name", CQCL.description: Services.specialist_college_service}], [{CQCL.name: "name", CQCL.code: "A1", CQCL.contacts: []}]),
+        ("loc_8", "non social care org", RegistrationStatus.registered, [{CQCL.name: "name", CQCL.description: Services.specialist_college_service}], [{CQCL.name: "name", CQCL.code: "A1", CQCL.contacts: []}]),
+        ("loc_9", None, RegistrationStatus.registered, [{CQCL.name: "name", CQCL.description: Services.specialist_college_service}], [{CQCL.name: "name", CQCL.code: "A1", CQCL.contacts: []}]),
+        ("loc_10", LocationType.social_care_identifier, RegistrationStatus.deregistered, [{CQCL.name: "name", CQCL.description: Services.specialist_college_service}], [{CQCL.name: "name", CQCL.code: "A1", CQCL.contacts: []}]),
+        ("loc_11", "non social care org", RegistrationStatus.deregistered, [{CQCL.name: "name", CQCL.description: Services.specialist_college_service}], [{CQCL.name: "name", CQCL.code: "A1", CQCL.contacts: []}]),
+        ("loc_12", None, RegistrationStatus.deregistered,  [{CQCL.name: "name", CQCL.description: Services.specialist_college_service}], [{CQCL.name: "name", CQCL.code: "A1", CQCL.contacts: []}]),
+        ("loc_13", LocationType.social_care_identifier, RegistrationStatus.registered, [{CQCL.name: "name", CQCL.description: Services.care_home_service_with_nursing}], None),
+        (RecordsToRemoveInLocationsData.dental_practice, LocationType.social_care_identifier, RegistrationStatus.registered, None, [{CQCL.name: "name", CQCL.code: "A1", CQCL.contacts: []}]),
+        (RecordsToRemoveInLocationsData.temp_registration, LocationType.social_care_identifier, RegistrationStatus.registered, None, [{CQCL.name: "name", CQCL.code: "A1", CQCL.contacts: []}]),
     ]
     # fmt: on
 

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -7752,6 +7752,21 @@ class ValidateLocationsAPICleanedData:
     ]
     # fmt: on
 
+    identify_if_location_has_a_known_regulated_activity_rows = [
+        ("loc_1", []),
+        ("loc_1", [{CQCL.name: "name", CQCL.code: "A1", CQCL.contacts: []}]),
+        ("loc_1", None),
+        ("loc_2", []),
+        ("loc_3", None),
+    ]
+    expected_identify_if_location_has_a_known_regulated_activity_rows = [
+        ("loc_1", [], True),
+        ("loc_1", [{CQCL.name: "name", CQCL.code: "A1", CQCL.contacts: []}], True),
+        ("loc_1", None, True),
+        ("loc_2", [], False),
+        ("loc_3", None, False),
+    ]
+
 
 @dataclass
 class ValidateProvidersAPICleanedData:

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -2253,7 +2253,7 @@ class CQCLocationsData:
     ]
 
     # fmt: off
-    impute_missing_gac_service_types_rows = [
+    impute_missing_struct_column_rows = [
         ("1-001", date(2024, 1, 1), []),
         ("1-001", date(2024, 2, 1), None),
         ("1-001", date(2024, 3, 1), [{"name": "Name A", "description": "Desc A"}]),
@@ -2265,7 +2265,7 @@ class CQCLocationsData:
         ("1-002", date(2024, 1, 1), []),
         ("1-002", date(2024, 2, 1), None),
     ]
-    expected_impute_missing_gac_service_types_rows = [
+    expected_impute_missing_struct_column_rows = [
         ("1-001", date(2024, 1, 1), [], [{"name": "Name A", "description": "Desc A"}]),
         ("1-001", date(2024, 2, 1), None, [{"name": "Name A", "description": "Desc A"}]),
         ("1-001", date(2024, 3, 1), [{"name": "Name A", "description": "Desc A"}], [{"name": "Name A", "description": "Desc A"}]),

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -1110,7 +1110,7 @@ class CQCLocationsSchema:
         [
             StructField(CQCL.location_id, StringType(), True),
             StructField(
-                CQCL.regulated_activities,
+                CQCLClean.imputed_regulated_activities,
                 ArrayType(
                     StructType(
                         [

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -1341,7 +1341,7 @@ class ExtractRegisteredManagerNamesSchema:
             StructField(CQCL.location_id, StringType(), True),
             StructField(CQCLClean.cqc_location_import_date, DateType(), True),
             StructField(
-                CQCL.regulated_activities,
+                CQCL.imputed_regulated_activities,
                 ArrayType(
                     StructType(
                         [
@@ -1390,7 +1390,7 @@ class ExtractRegisteredManagerNamesSchema:
             StructField(CQCL.location_id, StringType(), True),
             StructField(CQCLClean.cqc_location_import_date, DateType(), True),
             StructField(
-                CQCL.regulated_activities,
+                CQCL.imputed_regulated_activities,
                 ArrayType(
                     StructType(
                         [
@@ -2371,7 +2371,7 @@ class NonResAscwdsFeaturesSchema(object):
             StructField(IndCQC.dormancy, StringType(), True),
             StructField(IndCQC.services_offered, ArrayType(StringType()), True),
             StructField(
-                IndCQC.regulated_activities,
+                IndCQC.imputed_regulated_activities,
                 ArrayType(
                     StructType(
                         [

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -1341,7 +1341,7 @@ class ExtractRegisteredManagerNamesSchema:
             StructField(CQCL.location_id, StringType(), True),
             StructField(CQCLClean.cqc_location_import_date, DateType(), True),
             StructField(
-                CQCL.imputed_regulated_activities,
+                CQCLClean.imputed_regulated_activities,
                 ArrayType(
                     StructType(
                         [

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -1390,7 +1390,7 @@ class ExtractRegisteredManagerNamesSchema:
             StructField(CQCL.location_id, StringType(), True),
             StructField(CQCLClean.cqc_location_import_date, DateType(), True),
             StructField(
-                CQCL.imputed_regulated_activities,
+                CQCLClean.imputed_regulated_activities,
                 ArrayType(
                     StructType(
                         [

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -4346,6 +4346,57 @@ class ValidateLocationsAPICleanedData:
         ]
     )
 
+    identify_if_location_has_a_known_regulated_activity_schema = StructType(
+        [
+            StructField(CQCL.location_id, StringType(), True),
+            StructField(
+                CQCL.regulated_activities,
+                ArrayType(
+                    StructType(
+                        [
+                            StructField(CQCL.name, StringType(), True),
+                            StructField(CQCL.code, StringType(), True),
+                            StructField(
+                                CQCL.contacts,
+                                ArrayType(
+                                    StructType(
+                                        [
+                                            StructField(
+                                                CQCL.person_family_name,
+                                                StringType(),
+                                                True,
+                                            ),
+                                            StructField(
+                                                CQCL.person_given_name,
+                                                StringType(),
+                                                True,
+                                            ),
+                                            StructField(
+                                                CQCL.person_roles,
+                                                ArrayType(StringType(), True),
+                                                True,
+                                            ),
+                                            StructField(
+                                                CQCL.person_title, StringType(), True
+                                            ),
+                                        ]
+                                    )
+                                ),
+                                True,
+                            ),
+                        ]
+                    )
+                ),
+            ),
+        ]
+    )
+    expected_identify_if_location_has_a_known_regulated_activity_schema = StructType(
+        [
+            *identify_if_location_has_a_known_regulated_activity_schema,
+            StructField("has_known_regulated_activity", BooleanType(), True),
+        ]
+    )
+
 
 @dataclass
 class ValidateProvidersAPICleanedData:

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -4183,6 +4183,45 @@ class ValidateLocationsAPICleanedData:
                     )
                 ),
             ),
+            StructField(
+                CQCL.regulated_activities,
+                ArrayType(
+                    StructType(
+                        [
+                            StructField(CQCL.name, StringType(), True),
+                            StructField(CQCL.code, StringType(), True),
+                            StructField(
+                                CQCL.contacts,
+                                ArrayType(
+                                    StructType(
+                                        [
+                                            StructField(
+                                                CQCL.person_family_name,
+                                                StringType(),
+                                                True,
+                                            ),
+                                            StructField(
+                                                CQCL.person_given_name,
+                                                StringType(),
+                                                True,
+                                            ),
+                                            StructField(
+                                                CQCL.person_roles,
+                                                ArrayType(StringType(), True),
+                                                True,
+                                            ),
+                                            StructField(
+                                                CQCL.person_title, StringType(), True
+                                            ),
+                                        ]
+                                    )
+                                ),
+                                True,
+                            ),
+                        ]
+                    )
+                ),
+            ),
         ]
     )
     cleaned_cqc_locations_schema = StructType(
@@ -4207,10 +4246,44 @@ class ValidateLocationsAPICleanedData:
             StructField(CQCLClean.current_cssr, StringType(), True),
             StructField(CQCLClean.current_region, StringType(), True),
             StructField(CQCLClean.current_rural_urban_ind_11, StringType(), True),
+            StructField(CQCLClean.services_offered, ArrayType(StringType())),
             StructField(
-                CQCLClean.services_offered,
+                CQCLClean.imputed_regulated_activities,
                 ArrayType(
-                    StringType(),
+                    StructType(
+                        [
+                            StructField(CQCL.name, StringType(), True),
+                            StructField(CQCL.code, StringType(), True),
+                            StructField(
+                                CQCL.contacts,
+                                ArrayType(
+                                    StructType(
+                                        [
+                                            StructField(
+                                                CQCL.person_family_name,
+                                                StringType(),
+                                                True,
+                                            ),
+                                            StructField(
+                                                CQCL.person_given_name,
+                                                StringType(),
+                                                True,
+                                            ),
+                                            StructField(
+                                                CQCL.person_roles,
+                                                ArrayType(StringType(), True),
+                                                True,
+                                            ),
+                                            StructField(
+                                                CQCL.person_title, StringType(), True
+                                            ),
+                                        ]
+                                    )
+                                ),
+                                True,
+                            ),
+                        ]
+                    )
                 ),
             ),
         ]
@@ -4227,6 +4300,45 @@ class ValidateLocationsAPICleanedData:
                         [
                             StructField(CQCL.name, StringType(), True),
                             StructField(CQCL.description, StringType(), True),
+                        ]
+                    )
+                ),
+            ),
+            StructField(
+                CQCL.regulated_activities,
+                ArrayType(
+                    StructType(
+                        [
+                            StructField(CQCL.name, StringType(), True),
+                            StructField(CQCL.code, StringType(), True),
+                            StructField(
+                                CQCL.contacts,
+                                ArrayType(
+                                    StructType(
+                                        [
+                                            StructField(
+                                                CQCL.person_family_name,
+                                                StringType(),
+                                                True,
+                                            ),
+                                            StructField(
+                                                CQCL.person_given_name,
+                                                StringType(),
+                                                True,
+                                            ),
+                                            StructField(
+                                                CQCL.person_roles,
+                                                ArrayType(StringType(), True),
+                                                True,
+                                            ),
+                                            StructField(
+                                                CQCL.person_title, StringType(), True
+                                            ),
+                                        ]
+                                    )
+                                ),
+                                True,
+                            ),
                         ]
                     )
                 ),

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -1072,7 +1072,7 @@ class CQCLocationsSchema:
         ]
     )
 
-    impute_missing_gac_service_types_schema = StructType(
+    impute_missing_struct_column_schema = StructType(
         [
             StructField(CQCL.location_id, StringType(), True),
             StructField(CQCLClean.cqc_location_import_date, DateType(), True),
@@ -1089,9 +1089,9 @@ class CQCLocationsSchema:
             ),
         ]
     )
-    expected_impute_missing_gac_service_types_schema = StructType(
+    expected_impute_missing_struct_column_schema = StructType(
         [
-            *impute_missing_gac_service_types_schema,
+            *impute_missing_struct_column_schema,
             StructField(
                 CQCLClean.imputed_gac_service_types,
                 ArrayType(

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -1106,6 +1106,51 @@ class CQCLocationsSchema:
         ]
     )
 
+    remove_locations_that_never_had_regulated_activities_schema = StructType(
+        [
+            StructField(CQCL.location_id, StringType(), True),
+            StructField(
+                CQCL.regulated_activities,
+                ArrayType(
+                    StructType(
+                        [
+                            StructField(CQCL.name, StringType(), True),
+                            StructField(CQCL.code, StringType(), True),
+                            StructField(
+                                CQCL.contacts,
+                                ArrayType(
+                                    StructType(
+                                        [
+                                            StructField(
+                                                CQCL.person_family_name,
+                                                StringType(),
+                                                True,
+                                            ),
+                                            StructField(
+                                                CQCL.person_given_name,
+                                                StringType(),
+                                                True,
+                                            ),
+                                            StructField(
+                                                CQCL.person_roles,
+                                                ArrayType(StringType(), True),
+                                                True,
+                                            ),
+                                            StructField(
+                                                CQCL.person_title, StringType(), True
+                                            ),
+                                        ]
+                                    )
+                                ),
+                                True,
+                            ),
+                        ]
+                    )
+                ),
+            ),
+        ]
+    )
+
     primary_service_type_schema = StructType(
         [
             StructField(CQCL.location_id, StringType(), True),

--- a/tests/unit/test_clean_cqc_location_data.py
+++ b/tests/unit/test_clean_cqc_location_data.py
@@ -422,6 +422,33 @@ class ImputeMissingStructColumnTests(CleanCQCLocationDatasetTests):
             )
 
 
+class RemoveLocationsThatNeverHadRegulatedActivitesTests(CleanCQCLocationDatasetTests):
+    def setUp(self) -> None:
+        super().setUp()
+        self.test_df = self.spark.createDataFrame(
+            Data.remove_locations_that_never_had_regulated_activities_rows,
+            Schemas.remove_locations_that_never_had_regulated_activities_schema,
+        )
+        self.returned_df = job.remove_locations_that_never_had_regulated_activities(
+            self.test_df
+        )
+        self.expected_df = self.spark.createDataFrame(
+            Data.expected_remove_locations_that_never_had_regulated_activities_rows,
+            Schemas.remove_locations_that_never_had_regulated_activities_schema,
+        )
+
+        self.returned_data = self.returned_df.sort(CQCL.location_id).collect()
+        self.expected_data = self.expected_df.collect()
+
+    def test_remove_locations_that_never_had_regulated_activities_returns_expected_data(
+        self,
+    ):
+        self.test_df.show()
+        self.returned_df.show()
+        self.expected_df.show()
+        self.assertEqual(self.returned_data, self.expected_data)
+
+
 class ListServicesOfferedTests(CleanCQCLocationDatasetTests):
     def setUp(self) -> None:
         super().setUp()

--- a/tests/unit/test_clean_cqc_location_data.py
+++ b/tests/unit/test_clean_cqc_location_data.py
@@ -443,9 +443,6 @@ class RemoveLocationsThatNeverHadRegulatedActivitesTests(CleanCQCLocationDataset
     def test_remove_locations_that_never_had_regulated_activities_returns_expected_data(
         self,
     ):
-        self.test_df.show()
-        self.returned_df.show()
-        self.expected_df.show()
         self.assertEqual(self.returned_data, self.expected_data)
 
 

--- a/tests/unit/test_clean_cqc_location_data.py
+++ b/tests/unit/test_clean_cqc_location_data.py
@@ -382,19 +382,19 @@ class GetRelationshipsWhereTypeIsPredecessorTests(CleanCQCLocationDatasetTests):
         self.assertEqual(returned_df.collect(), expected_df.collect())
 
 
-class ImputeMissingGacServiceTypesTests(CleanCQCLocationDatasetTests):
+class ImputeMissingStructColumnTests(CleanCQCLocationDatasetTests):
     def setUp(self) -> None:
         super().setUp()
-        self.test_impute_missing_gac_service_types_df = self.spark.createDataFrame(
-            Data.impute_missing_gac_service_types_rows,
-            Schemas.impute_missing_gac_service_types_schema,
+        self.test_impute_missing_struct_column_df = self.spark.createDataFrame(
+            Data.impute_missing_struct_column_rows,
+            Schemas.impute_missing_struct_column_schema,
         )
-        self.returned_df = job.impute_missing_gac_service_types(
-            self.test_impute_missing_gac_service_types_df
+        self.returned_df = job.impute_missing_struct_column(
+            self.test_impute_missing_struct_column_df, CQCLCleaned.gac_service_types
         )
         self.expected_df = self.spark.createDataFrame(
-            Data.expected_impute_missing_gac_service_types_rows,
-            Schemas.expected_impute_missing_gac_service_types_schema,
+            Data.expected_impute_missing_struct_column_rows,
+            Schemas.expected_impute_missing_struct_column_schema,
         )
 
         self.returned_data = self.returned_df.sort(
@@ -402,10 +402,10 @@ class ImputeMissingGacServiceTypesTests(CleanCQCLocationDatasetTests):
         ).collect()
         self.expected_data = self.expected_df.collect()
 
-    def test_impute_missing_gac_service_types_returns_expected_columns(self):
+    def test_impute_missing_struct_column_returns_expected_columns(self):
         self.assertTrue(self.returned_df.columns, self.expected_df.columns)
 
-    def test_original_gac_service_types_remains_unchanged(self):
+    def test_original_column_remains_unchanged(self):
         for i in range(len(self.returned_data)):
             self.assertEqual(
                 self.returned_data[i][CQCL.gac_service_types],
@@ -413,7 +413,7 @@ class ImputeMissingGacServiceTypesTests(CleanCQCLocationDatasetTests):
                 f"Returned value in row {i} does not match original",
             )
 
-    def test_impute_missing_gac_service_types_returns_expected_imputed_data(self):
+    def test_impute_missing_struct_column_returns_expected_imputed_data(self):
         for i in range(len(self.returned_data)):
             self.assertEqual(
                 self.returned_data[i][CQCLCleaned.imputed_gac_service_types],

--- a/tests/unit/test_extract_registered_manager_names.py
+++ b/tests/unit/test_extract_registered_manager_names.py
@@ -43,7 +43,7 @@ class ExtractRegisteredManagerNamesTests(ExtractRegisteredManagerNamesTests):
         group_and_collect_names_mock: Mock,
         join_names_column_into_original_df_mock: Mock,
     ):
-        job.extract_registered_manager_names_from_regulated_activities_column(
+        job.extract_registered_manager_names_from_imputed_regulated_activities_column(
             self.extract_registered_manager_df
         )
 
@@ -53,10 +53,8 @@ class ExtractRegisteredManagerNamesTests(ExtractRegisteredManagerNamesTests):
         join_names_column_into_original_df_mock.assert_called_once()
 
     def test_extract_registered_manager_names_returns_the_same_number_of_rows(self):
-        returned_df = (
-            job.extract_registered_manager_names_from_regulated_activities_column(
-                self.extract_registered_manager_df
-            )
+        returned_df = job.extract_registered_manager_names_from_imputed_regulated_activities_column(
+            self.extract_registered_manager_df
         )
         self.assertEqual(
             self.extract_registered_manager_df.count(), returned_df.count()

--- a/tests/unit/test_validate_locations_api_cleaned_data.py
+++ b/tests/unit/test_validate_locations_api_cleaned_data.py
@@ -59,7 +59,7 @@ class MainTests(ValidateLocationsAPICleanedDatasetTests):
 
 class CalculateExpectedSizeofDataset(ValidateLocationsAPICleanedDatasetTests):
     def setUp(self) -> None:
-        return super().setUp()
+        super().setUp()
 
     def test_calculate_expected_size_of_cleaned_cqc_locations_dataset_returns_correct_row_count(
         self,
@@ -67,10 +67,12 @@ class CalculateExpectedSizeofDataset(ValidateLocationsAPICleanedDatasetTests):
         test_df = self.spark.createDataFrame(
             Data.calculate_expected_size_rows, Schemas.calculate_expected_size_schema
         )
+
         expected_row_count = 1
         returned_row_count = (
             job.calculate_expected_size_of_cleaned_cqc_locations_dataset(test_df)
         )
+
         self.assertEqual(returned_row_count, expected_row_count)
 
 

--- a/utils/column_names/cleaned_data_files/cqc_location_cleaned.py
+++ b/utils/column_names/cleaned_data_files/cqc_location_cleaned.py
@@ -30,13 +30,13 @@ class CqcLocationCleanedColumns(NewCqcLocationApiColumns, ONSClean):
     imputed_regulated_activities: str = (
         "imputed_" + NewCqcLocationApiColumns.regulated_activities
     )
+    imputed_regulated_activities_exploded: str = "imputed_regulated_activities_exploded"
     imputed_relationships: str = "imputed_" + NewCqcLocationApiColumns.relationships
     ons_contemporary_import_date: str = ONSClean.contemporary_ons_import_date
     ons_current_import_date: str = ONSClean.current_ons_import_date
     primary_service_type: str = "primary_service_type"
     provider_name: str = "provider_name"
     registered_manager_names: str = "registered_manager_names"
-    regulated_activities_exploded: str = "regulated_activities_exploded"
     related_location: str = "related_location"
     relationships_exploded: str = NewCqcLocationApiColumns.relationships + "_exploded"
     relationships_predecessors_only: str = (

--- a/utils/column_names/cleaned_data_files/cqc_location_cleaned.py
+++ b/utils/column_names/cleaned_data_files/cqc_location_cleaned.py
@@ -27,6 +27,9 @@ class CqcLocationCleanedColumns(NewCqcLocationApiColumns, ONSClean):
         "imputed_" + NewCqcLocationApiColumns.gac_service_types
     )
     imputed_registration_date: str = "imputed_registration_date"
+    imputed_regulated_activities: str = (
+        "imputed_" + NewCqcLocationApiColumns.regulated_activities
+    )
     imputed_relationships: str = "imputed_" + NewCqcLocationApiColumns.relationships
     ons_contemporary_import_date: str = ONSClean.contemporary_ons_import_date
     ons_current_import_date: str = ONSClean.current_ons_import_date

--- a/utils/column_names/ind_cqc_pipeline_columns.py
+++ b/utils/column_names/ind_cqc_pipeline_columns.py
@@ -135,6 +135,7 @@ class IndCqcColumns:
         "imputed_filled_posts_per_bed_ratio_model"
     )
     imputed_registration_date: str = CQCLClean.imputed_registration_date
+    imputed_regulated_activities: str = CQCLClean.imputed_regulated_activities
     interpolation_model: str = "interpolation_model"
     last_ascwds_submission: str = "last_ascwds_submission"
     last_filled_posts: str = "last_filled_posts"
@@ -209,7 +210,6 @@ class IndCqcColumns:
     registered_manager_names: str = CQCLClean.registered_manager_names
     registration_date: str = CQCLClean.registration_date
     registration_status: str = CQCLClean.registration_status
-    imputed_regulated_activities: str = CQCLClean.imputed_regulated_activities
     related_location: str = CQCLClean.related_location
     residual: str = "residual"
     residuals_ascwds_filled_posts_clean_dedup_non_res_pir: str = (

--- a/utils/column_names/ind_cqc_pipeline_columns.py
+++ b/utils/column_names/ind_cqc_pipeline_columns.py
@@ -206,7 +206,7 @@ class IndCqcColumns:
     r2: str = "r2"
     registration_date: str = CQCLClean.registration_date
     registration_status: str = CQCLClean.registration_status
-    regulated_activities: str = CQCLClean.regulated_activities
+    imputed_regulated_activities: str = CQCLClean.imputed_regulated_activities
     related_location: str = CQCLClean.related_location
     residual: str = "residual"
     residuals_ascwds_filled_posts_clean_dedup_non_res_pir: str = (

--- a/utils/cqc_location_utils/extract_registered_manager_names.py
+++ b/utils/cqc_location_utils/extract_registered_manager_names.py
@@ -50,11 +50,11 @@ def extract_contacts_information(
     df = df.select(
         CQCL.location_id,
         CQCLClean.cqc_location_import_date,
-        CQCLClean.imputed_imputed_regulated_activities,
+        CQCLClean.imputed_regulated_activities,
     )
     exploded_activities_df = df.withColumn(
         CQCLClean.imputed_regulated_activities_exploded,
-        F.explode(CQCLClean.imputed_imputed_regulated_activities),
+        F.explode(CQCLClean.imputed_regulated_activities),
     )
     exploded_contacts_df = exploded_activities_df.withColumn(
         CQCLClean.contacts_exploded,

--- a/utils/cqc_location_utils/extract_registered_manager_names.py
+++ b/utils/cqc_location_utils/extract_registered_manager_names.py
@@ -8,7 +8,7 @@ from utils.column_names.cleaned_data_files.cqc_location_cleaned import (
 )
 
 
-def extract_registered_manager_names_from_regulated_activities_column(
+def extract_registered_manager_names_from_imputed_regulated_activities_column(
     df: DataFrame,
 ) -> DataFrame:
     """
@@ -20,7 +20,7 @@ def extract_registered_manager_names_from_regulated_activities_column(
     Registered manager names are deduplicated in the array so each name will only appear once in the array.
 
     Args:
-        df (DataFrame): Input DataFrame with regulated_activities column.
+        df (DataFrame): Input DataFrame with imputed_regulated_activities column.
 
     Returns:
         DataFrame: DataFrame with deduplicated registered manager names in a new column.
@@ -39,30 +39,33 @@ def extract_contacts_information(
     df: DataFrame,
 ) -> DataFrame:
     """
-    Explodes the regulated_activities array and then the contacts array in the DataFrame.
+    Explodes the imputed_regulated_activities array and then the contacts array in the DataFrame.
 
     Args:
-        df (DataFrame): Input DataFrame with regulated_activities array.
+        df (DataFrame): Input DataFrame with imputed_regulated_activities array.
 
     Returns:
         DataFrame: DataFrame with exploded contacts information.
     """
     df = df.select(
-        CQCL.location_id, CQCLClean.cqc_location_import_date, CQCL.regulated_activities
+        CQCL.location_id,
+        CQCLClean.cqc_location_import_date,
+        CQCLClean.imputed_imputed_regulated_activities,
     )
     exploded_activities_df = df.withColumn(
-        CQCLClean.regulated_activities_exploded, F.explode(CQCL.regulated_activities)
+        CQCLClean.imputed_regulated_activities_exploded,
+        F.explode(CQCLClean.imputed_imputed_regulated_activities),
     )
     exploded_contacts_df = exploded_activities_df.withColumn(
         CQCLClean.contacts_exploded,
         F.explode(
-            exploded_activities_df[CQCLClean.regulated_activities_exploded][
+            exploded_activities_df[CQCLClean.imputed_regulated_activities_exploded][
                 CQCL.contacts
             ]
         ),
     )
     exploded_contacts_df = exploded_contacts_df.drop(
-        CQCLClean.regulated_activities_exploded
+        CQCLClean.imputed_regulated_activities_exploded
     )
     return exploded_contacts_df
 


### PR DESCRIPTION
# Description
These changes fix validation errors caused by the new CQC historic data.

- make impute gac service types function more generic so it can also impute the registered activities column
- remove cqc locations that have never had a registered activity
- unit tests for the above
- adapt size of dataset validation to account for removed locations

# How to test
Unit tests passing
Branch run successful on test data: https://eu-west-2.console.aws.amazon.com/states/home?region=eu-west-2#/v2/executions/details/arn:aws:states:eu-west-2:344210435447:execution:adapt-func-to-fill-missing-str-Ind-CQC-Filled-Post-Estimates-Pipeline:ea04981f-0377-4fcd-81fe-049f11eeff0e 

# Developer checklist
- [x] Unit test
- [x] Linked to Trello ticket: https://trello.com/c/MRuajyj7/511-epic-4-create-emr-script-to-transform-csv-versions-of-care-directory-to-current-api-schemas-must
- [x] Documentation up to date
