### PR TITLE
Remove unused test_helpers script

### DIFF
--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,8 +1,0 @@
-import shutil
-
-
-def remove_file_path(path):
-    try:
-        shutil.rmtree(path)
-    except OSError:
-        pass


### PR DESCRIPTION
# Description
Removes an orphaned script. I believe this was used for the test file generator.

