### PR TITLE
Impute not known job role entries with previous/next known value

### DIFF
--- a/jobs/clean_ascwds_worker_data.py
+++ b/jobs/clean_ascwds_worker_data.py
@@ -1,6 +1,6 @@
 import sys
 
-from pyspark.sql import DataFrame, functions as F
+from pyspark.sql import DataFrame, functions as F, Window
 
 from utils import utils
 import utils.cleaning_utils as cUtils
@@ -108,6 +108,7 @@ def create_clean_main_job_role_column(df: DataFrame) -> DataFrame:
     df = df.withColumn(AWKClean.main_job_role_clean, F.col(AWKClean.main_job_role_id))
 
     df = replace_care_navigator_with_care_coordinator(df)
+    df = impute_not_known_job_roles(df)
     df = cUtils.apply_categorical_labels(
         df,
         ascwds_worker_labels_dict,
@@ -131,6 +132,47 @@ def replace_care_navigator_with_care_coordinator(df: DataFrame) -> DataFrame:
         DataFrame: The DataFrame with the replaced value.
     """
     return df.replace("41", "40", AWKClean.main_job_role_clean)
+
+
+def impute_not_known_job_roles(df: DataFrame) -> DataFrame:
+    """
+    Imputes not known job roles in the DataFrame by filling with known values from other import_dates.
+
+    The function performs the following steps:
+    1. Replaces 'not known' (labelled as '-1') job roles with None.
+    2. Fills the None values in with the previous known value within the partition.
+    3. Fills any remaining None values with the future known value within the partition.
+
+    Args:
+        df (DataFrame): Input DataFrame containing 'worker_id', 'ascwds_worker_import_date' and 'main_job_role_clean'.
+
+    Returns:
+        DataFrame: DataFrame with the 'main_job_role_clean' column with imputed values.
+    """
+    w_future = Window.partitionBy(AWKClean.worker_id).orderBy(
+        AWKClean.ascwds_worker_import_date
+    )
+    w_historic = w_future.rowsBetween(
+        Window.unboundedPreceding, Window.unboundedFollowing
+    )
+    not_known_identifier: str = "-1"
+
+    df = df.replace(not_known_identifier, None, AWKClean.main_job_role_clean)
+    df = df.withColumn(
+        AWKClean.main_job_role_clean,
+        F.coalesce(
+            F.col(AWKClean.main_job_role_clean),
+            F.last(AWKClean.main_job_role_clean, ignorenulls=True).over(w_future),
+        ),
+    )
+    df = df.withColumn(
+        AWKClean.main_job_role_clean,
+        F.coalesce(
+            F.col(AWKClean.main_job_role_clean),
+            F.first(AWKClean.main_job_role_clean, ignorenulls=True).over(w_historic),
+        ),
+    )
+    return df
 
 
 if __name__ == "__main__":

--- a/jobs/clean_ascwds_worker_data.py
+++ b/jobs/clean_ascwds_worker_data.py
@@ -45,6 +45,10 @@ def main(
         WORKPLACE_COLUMNS,
     )
 
+    ascwds_worker_df = cUtils.column_to_date(
+        ascwds_worker_df, PartitionKeys.import_date, AWKClean.ascwds_worker_import_date
+    )
+
     ascwds_worker_df = remove_duplicate_worker_in_raw_worker_data(ascwds_worker_df)
 
     ascwds_worker_df = remove_workers_without_workplaces(
@@ -52,10 +56,6 @@ def main(
     )
 
     ascwds_worker_df = create_clean_main_job_role_column(ascwds_worker_df)
-
-    ascwds_worker_df = cUtils.column_to_date(
-        ascwds_worker_df, PartitionKeys.import_date, AWKClean.ascwds_worker_import_date
-    )
 
     print(f"Exporting as parquet to {cleaned_worker_destination}")
     utils.write_to_parquet(

--- a/jobs/clean_ascwds_worker_data.py
+++ b/jobs/clean_ascwds_worker_data.py
@@ -142,6 +142,7 @@ def impute_not_known_job_roles(df: DataFrame) -> DataFrame:
     1. Replaces 'not known' (labelled as '-1') job roles with None.
     2. Fills the None values in with the previous known value within the partition.
     3. Fills any remaining None values with the future known value within the partition.
+    4. Replaces missing job role rows with the original 'not known' ('-1') value.
 
     Args:
         df (DataFrame): Input DataFrame containing 'worker_id', 'ascwds_worker_import_date' and 'main_job_role_clean'.
@@ -172,6 +173,7 @@ def impute_not_known_job_roles(df: DataFrame) -> DataFrame:
             F.first(AWKClean.main_job_role_clean, ignorenulls=True).over(w_historic),
         ),
     )
+    df = df.na.fill(not_known_identifier, subset=AWKClean.main_job_role_clean)
     return df
 
 

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -176,6 +176,52 @@ class ASCWDSWorkerData:
         ("40", "40"),
     ]
 
+    impute_not_known_job_roles_returns_next_known_value_when_before_first_known_value_rows = [
+        ("1001", date(2024, 1, 1), "-1"),
+        ("1001", date(2024, 3, 1), "8"),
+        ("1002", date(2024, 1, 1), "-1"),
+        ("1002", date(2024, 6, 1), "7"),
+    ]
+    expected_impute_not_known_job_roles_returns_next_known_value_when_before_first_known_value_rows = [
+        ("1001", date(2024, 1, 1), "8"),
+        ("1001", date(2024, 3, 1), "8"),
+        ("1002", date(2024, 1, 1), "7"),
+        ("1002", date(2024, 6, 1), "7"),
+    ]
+
+    impute_not_known_job_roles_returns_previously_known_value_when_after_known_value_rows = [
+        ("1001", date(2024, 3, 1), "8"),
+        ("1001", date(2024, 4, 1), "-1"),
+        ("1002", date(2024, 3, 1), "7"),
+        ("1002", date(2024, 8, 1), "-1"),
+    ]
+    expected_impute_not_known_job_roles_returns_previously_known_value_when_after_known_value_rows = [
+        ("1001", date(2024, 3, 1), "8"),
+        ("1001", date(2024, 4, 1), "8"),
+        ("1002", date(2024, 3, 1), "7"),
+        ("1002", date(2024, 8, 1), "7"),
+    ]
+
+    impute_not_known_job_roles_returns_previously_known_value_when_in_between_known_values_rows = [
+        ("1001", date(2024, 3, 1), "8"),
+        ("1001", date(2024, 4, 1), "-1"),
+        ("1001", date(2024, 5, 1), "-1"),
+        ("1001", date(2024, 6, 1), "7"),
+    ]
+    expected_impute_not_known_job_roles_returns_previously_known_value_when_in_between_known_values_rows = [
+        ("1001", date(2024, 3, 1), "8"),
+        ("1001", date(2024, 4, 1), "8"),
+        ("1001", date(2024, 5, 1), "8"),
+        ("1001", date(2024, 6, 1), "7"),
+    ]
+
+    impute_not_known_job_roles_returns_not_known_when_job_role_never_known_rows = [
+        ("1001", date(2024, 1, 1), "-1"),
+    ]
+    expected_impute_not_known_job_roles_returns_not_known_when_job_role_never_known_rows = [
+        ("1001", date(2024, 1, 1), "-1"),
+    ]
+
 
 @dataclass
 class ASCWDSWorkplaceData:

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -153,7 +153,7 @@ class ASCWDSWorkerData:
         ("141", date(2025, 1, 1), "41"),
     ]
     expected_create_clean_main_job_role_column_rows = [
-        ("101", date(2024, 1, 1), "-1", "-1", MainJobRoleLabels.not_known),
+        ("101", date(2024, 1, 1), "-1", "1", MainJobRoleLabels.senior_management),
         ("101", date(2025, 1, 1), "1", "1", MainJobRoleLabels.senior_management),
         ("102", date(2025, 1, 1), "-1", "-1", MainJobRoleLabels.not_known),
         ("103", date(2024, 1, 1), "3", "3", MainJobRoleLabels.first_line_manager),

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -177,6 +177,14 @@ class ASCWDSWorkerSchemas:
         ]
     )
 
+    impute_not_known_job_roles_schema = StructType(
+        [
+            StructField(AWKClean.worker_id, StringType(), True),
+            StructField(AWKClean.ascwds_worker_import_date, DateType(), True),
+            StructField(AWKClean.main_job_role_clean, StringType(), True),
+        ]
+    )
+
 
 @dataclass
 class ASCWDSWorkplaceSchemas:

--- a/tests/unit/test_clean_ascwds_worker_data.py
+++ b/tests/unit/test_clean_ascwds_worker_data.py
@@ -189,5 +189,85 @@ class ReplaceCareNavigatorWithCareCoordinatorTests(IngestASCWDSWorkerDatasetTest
         self.assertEqual(returned_data, expected_data)
 
 
+class ImputeNotKnownJobRolesTests(IngestASCWDSWorkerDatasetTests):
+    def setUp(self) -> None:
+        super().setUp()
+
+    def test_impute_not_known_job_roles_returns_next_known_value_when_before_first_known_value(
+        self,
+    ):
+        test_df = self.spark.createDataFrame(
+            ASCWDSWorkerData.impute_not_known_job_roles_returns_next_known_value_when_before_first_known_value_rows,
+            ASCWDSWorkerSchemas.impute_not_known_job_roles_schema,
+        )
+        returned_df = job.impute_not_known_job_roles(test_df)
+        expected_df = self.spark.createDataFrame(
+            ASCWDSWorkerData.expected_impute_not_known_job_roles_returns_next_known_value_when_before_first_known_value_rows,
+            ASCWDSWorkerSchemas.impute_not_known_job_roles_schema,
+        )
+
+        returned_data = returned_df.sort(
+            AWKClean.worker_id, AWKClean.ascwds_worker_import_date
+        ).collect()
+        expected_data = expected_df.collect()
+
+        self.assertEqual(returned_data, expected_data)
+
+    def test_impute_not_known_job_roles_returns_previously_known_value_when_after_known_value(
+        self,
+    ):
+        test_df = self.spark.createDataFrame(
+            ASCWDSWorkerData.impute_not_known_job_roles_returns_previously_known_value_when_after_known_value_rows,
+            ASCWDSWorkerSchemas.impute_not_known_job_roles_schema,
+        )
+        returned_df = job.impute_not_known_job_roles(test_df)
+        expected_df = self.spark.createDataFrame(
+            ASCWDSWorkerData.expected_impute_not_known_job_roles_returns_previously_known_value_when_after_known_value_rows,
+            ASCWDSWorkerSchemas.impute_not_known_job_roles_schema,
+        )
+
+        returned_data = returned_df.sort(
+            AWKClean.worker_id, AWKClean.ascwds_worker_import_date
+        ).collect()
+        expected_data = expected_df.collect()
+
+        self.assertEqual(returned_data, expected_data)
+
+    def test_impute_not_known_job_roles_returns_previously_known_value_when_in_between_known_values(
+        self,
+    ):
+        test_df = self.spark.createDataFrame(
+            ASCWDSWorkerData.impute_not_known_job_roles_returns_previously_known_value_when_in_between_known_values_rows,
+            ASCWDSWorkerSchemas.impute_not_known_job_roles_schema,
+        )
+        returned_df = job.impute_not_known_job_roles(test_df)
+        expected_df = self.spark.createDataFrame(
+            ASCWDSWorkerData.expected_impute_not_known_job_roles_returns_previously_known_value_when_in_between_known_values_rows,
+            ASCWDSWorkerSchemas.impute_not_known_job_roles_schema,
+        )
+
+        returned_data = returned_df.sort(
+            AWKClean.worker_id, AWKClean.ascwds_worker_import_date
+        ).collect()
+        expected_data = expected_df.collect()
+
+        self.assertEqual(returned_data, expected_data)
+
+    def test_impute_not_known_job_roles_returns_not_known_when_job_role_never_known(
+        self,
+    ):
+        test_df = self.spark.createDataFrame(
+            ASCWDSWorkerData.impute_not_known_job_roles_returns_not_known_when_job_role_never_known_rows,
+            ASCWDSWorkerSchemas.impute_not_known_job_roles_schema,
+        )
+        returned_df = job.impute_not_known_job_roles(test_df)
+        expected_df = self.spark.createDataFrame(
+            ASCWDSWorkerData.expected_impute_not_known_job_roles_returns_not_known_when_job_role_never_known_rows,
+            ASCWDSWorkerSchemas.impute_not_known_job_roles_schema,
+        )
+
+        self.assertEqual(returned_df.collect(), expected_df.collect())
+
+
 if __name__ == "__main__":
     unittest.main(warnings="ignore")


### PR DESCRIPTION
# Description
There have been instances in the past where ASCWDS devs have updated the website names but not updated the back end, which has led to job roles coming through as not known when they actually were known.

This function imputes the job role by first imputing with the previously known value followed by next known value. If neither are found, not known is returned

Number of not knowns is substantially reduced, see counts below

# How to test
Previous output
![image](https://github.com/user-attachments/assets/5b8f14ea-fac7-4586-8ba1-1fdf8c4df3e9)

New output
![image](https://github.com/user-attachments/assets/6aa02910-65ae-4011-b945-d034ebaad3c9)

# Developer checklist
- [X] Unit test
- [X] Linked to [Trello ticket](https://trello.com/c/9VZh7Y88/721-epic-2-impute-worker-records-which-are-1-must)
- [X] Documentation up to date
