### PR TITLE
Aggregate job role using mapped column 

### DIFF
--- a/jobs/estimate_ind_cqc_filled_posts_by_job_role.py
+++ b/jobs/estimate_ind_cqc_filled_posts_by_job_role.py
@@ -81,9 +81,10 @@ def main(
     )
 
     utils.write_to_parquet(
-        aggregated_job_roles_per_establishment_df,  # TEMP for testing outputs
+        estimated_ind_cqc_filled_posts_df,
         estimated_ind_cqc_filled_posts_by_job_role_destination,
         "overwrite",
+        PartitionKeys,
     )
 
 

--- a/jobs/estimate_ind_cqc_filled_posts_by_job_role.py
+++ b/jobs/estimate_ind_cqc_filled_posts_by_job_role.py
@@ -81,7 +81,7 @@ def main(
     )
 
     utils.write_to_parquet(
-        estimated_ind_cqc_filled_posts_df,
+        aggregated_job_roles_per_establishment_df,  # TEMP for testing outputs
         estimated_ind_cqc_filled_posts_by_job_role_destination,
         "overwrite",
         PartitionKeys,

--- a/jobs/estimate_ind_cqc_filled_posts_by_job_role.py
+++ b/jobs/estimate_ind_cqc_filled_posts_by_job_role.py
@@ -69,6 +69,12 @@ def main(
         selected_columns=cleaned_ascwds_worker_columns_to_import,
     )
 
+    aggregated_job_roles_per_establishment_df = (
+        JRutils.aggregate_ascwds_worker_job_roles_per_establishment(
+            cleaned_ascwds_worker_df, JRutils.list_of_job_roles
+        )
+    )
+
     estimated_ind_cqc_filled_posts_df = JRutils.count_registered_manager_names(
         estimated_ind_cqc_filled_posts_df
     )

--- a/jobs/estimate_ind_cqc_filled_posts_by_job_role.py
+++ b/jobs/estimate_ind_cqc_filled_posts_by_job_role.py
@@ -84,7 +84,6 @@ def main(
         aggregated_job_roles_per_establishment_df,  # TEMP for testing outputs
         estimated_ind_cqc_filled_posts_by_job_role_destination,
         "overwrite",
-        PartitionKeys,
     )
 
 

--- a/jobs/estimate_ind_cqc_filled_posts_by_job_role.py
+++ b/jobs/estimate_ind_cqc_filled_posts_by_job_role.py
@@ -15,6 +15,7 @@ cleaned_ascwds_worker_columns_to_import = [
 ]
 estimated_ind_cqc_filled_posts_columns_to_import = [
     IndCQC.cqc_location_import_date,
+    IndCQC.unix_time,
     IndCQC.location_id,
     IndCQC.name,
     IndCQC.provider_id,

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -9481,6 +9481,157 @@ class EstimateIndCQCFilledPostsByJobRoleUtilsData:
         MainJobRoleLabels.senior_management,
     ]
 
+    aggregate_ascwds_worker_job_roles_per_establishment_rows = [
+        ("101", date(2024, 1, 1), "1-001", MainJobRoleLabels.care_worker),
+    ]
+
+    aggregate_ascwds_worker_job_roles_per_establishment_when_all_job_roles_present_rows = [
+        ("101", date(2024, 1, 1), MainJobRoleLabels.care_worker),
+        ("101", date(2024, 1, 1), MainJobRoleLabels.care_worker),
+        ("101", date(2024, 1, 1), MainJobRoleLabels.registered_nurse),
+        ("102", date(2024, 1, 1), MainJobRoleLabels.senior_care_worker),
+        ("102", date(2024, 1, 1), MainJobRoleLabels.senior_management),
+        ("102", date(2024, 1, 2), MainJobRoleLabels.care_worker),
+    ]
+    expected_aggregate_ascwds_worker_job_roles_per_establishment_when_all_job_roles_present_rows = [
+        (
+            "101",
+            date(2024, 1, 1),
+            {
+                MainJobRoleLabels.care_worker: 2,
+                MainJobRoleLabels.registered_nurse: 1,
+                MainJobRoleLabels.senior_care_worker: 0,
+                MainJobRoleLabels.senior_management: 0,
+            },
+        ),
+        (
+            "102",
+            date(2024, 1, 1),
+            {
+                MainJobRoleLabels.care_worker: 0,
+                MainJobRoleLabels.registered_nurse: 0,
+                MainJobRoleLabels.senior_care_worker: 1,
+                MainJobRoleLabels.senior_management: 1,
+            },
+        ),
+        (
+            "102",
+            date(2024, 1, 2),
+            {
+                MainJobRoleLabels.care_worker: 1,
+                MainJobRoleLabels.registered_nurse: 0,
+                MainJobRoleLabels.senior_care_worker: 0,
+                MainJobRoleLabels.senior_management: 0,
+            },
+        ),
+    ]
+
+    aggregate_ascwds_worker_job_roles_per_establishment_when_some_job_roles_never_present_rows = [
+        ("101", date(2024, 1, 1), MainJobRoleLabels.senior_management),
+        ("101", date(2024, 1, 1), MainJobRoleLabels.registered_nurse),
+    ]
+    expected_aggregate_ascwds_worker_job_roles_per_establishment_when_some_job_roles_never_present_rows = [
+        (
+            "101",
+            date(2024, 1, 1),
+            {
+                MainJobRoleLabels.care_worker: 0,
+                MainJobRoleLabels.registered_nurse: 1,
+                MainJobRoleLabels.senior_care_worker: 0,
+                MainJobRoleLabels.senior_management: 1,
+            },
+        ),
+    ]
+
+    aggregate_ascwds_worker_job_roles_per_establishment_missing_roles_replaced_with_zero_rows = [
+        ("101", date(2024, 1, 1), MainJobRoleLabels.registered_nurse),
+    ]
+    expected_aggregate_ascwds_worker_job_roles_per_establishment_missing_roles_replaced_with_zero_rows = [
+        (
+            "101",
+            date(2024, 1, 1),
+            {
+                MainJobRoleLabels.care_worker: 0,
+                MainJobRoleLabels.registered_nurse: 1,
+                MainJobRoleLabels.senior_care_worker: 0,
+                MainJobRoleLabels.senior_management: 0,
+            },
+        ),
+    ]
+
+    aggregate_ascwds_worker_job_roles_per_establishment_when_single_establishment_has_multiple_dates_rows = [
+        ("101", date(2024, 1, 1), MainJobRoleLabels.senior_care_worker),
+        ("101", date(2024, 1, 1), MainJobRoleLabels.senior_management),
+        ("101", date(2024, 1, 2), MainJobRoleLabels.care_worker),
+    ]
+    expected_aggregate_ascwds_worker_job_roles_per_establishment_when_single_establishment_has_multiple_dates_rows = [
+        (
+            "101",
+            date(2024, 1, 1),
+            {
+                MainJobRoleLabels.care_worker: 0,
+                MainJobRoleLabels.registered_nurse: 0,
+                MainJobRoleLabels.senior_care_worker: 1,
+                MainJobRoleLabels.senior_management: 1,
+            },
+        ),
+        (
+            "101",
+            date(2024, 1, 2),
+            {
+                MainJobRoleLabels.care_worker: 1,
+                MainJobRoleLabels.registered_nurse: 0,
+                MainJobRoleLabels.senior_care_worker: 0,
+                MainJobRoleLabels.senior_management: 0,
+            },
+        ),
+    ]
+
+    aggregate_ascwds_worker_job_roles_per_establishment_when_multiple_establishments_on_the_same_date_rows = [
+        ("101", date(2024, 1, 1), MainJobRoleLabels.senior_care_worker),
+        ("101", date(2024, 1, 1), MainJobRoleLabels.senior_management),
+        ("102", date(2024, 1, 1), MainJobRoleLabels.care_worker),
+    ]
+    expected_aggregate_ascwds_worker_job_roles_per_establishment_when_multiple_establishments_on_the_same_date_rows = [
+        (
+            "101",
+            date(2024, 1, 1),
+            {
+                MainJobRoleLabels.care_worker: 0,
+                MainJobRoleLabels.registered_nurse: 0,
+                MainJobRoleLabels.senior_care_worker: 1,
+                MainJobRoleLabels.senior_management: 1,
+            },
+        ),
+        (
+            "101",
+            date(2024, 1, 2),
+            {
+                MainJobRoleLabels.care_worker: 1,
+                MainJobRoleLabels.registered_nurse: 0,
+                MainJobRoleLabels.senior_care_worker: 0,
+                MainJobRoleLabels.senior_management: 0,
+            },
+        ),
+    ]
+
+    aggregate_ascwds_worker_job_roles_per_establishment_when_unrecognised_role_present_rows = [
+        ("101", date(2024, 1, 1), MainJobRoleLabels.senior_care_worker),
+        ("101", date(2024, 1, 1), "unrecognised_role"),
+    ]
+    expected_aggregate_ascwds_worker_job_roles_per_establishment_when_unrecognised_role_present_rows = [
+        (
+            "101",
+            date(2024, 1, 1),
+            {
+                MainJobRoleLabels.care_worker: 0,
+                MainJobRoleLabels.registered_nurse: 0,
+                MainJobRoleLabels.senior_care_worker: 1,
+                MainJobRoleLabels.senior_management: 0,
+            },
+        ),
+    ]
+
     create_map_column_when_all_columns_populated_rows = [("123", 0, 10, 20, 30)]
     expected_create_map_column_when_all_columns_populated_rows = [
         (

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -9473,6 +9473,7 @@ class EstimateIndCQCFilledPostsByJobRoleData:
     ]
 
 
+@dataclass
 class EstimateIndCQCFilledPostsByJobRoleUtilsData:
     list_of_job_roles_for_tests = [
         MainJobRoleLabels.care_worker,

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -5916,6 +5916,15 @@ class EstimateIndCQCFilledPostsByJobRoleUtilsSchemas:
         ]
     )
 
+    aggregate_ascwds_worker_with_additional_column_schema = StructType(
+        [
+            StructField(IndCQC.establishment_id, StringType(), True),
+            StructField(IndCQC.ascwds_worker_import_date, DateType(), True),
+            StructField(IndCQC.location_id, StringType(), True),
+            StructField(IndCQC.main_job_role_clean_labelled, StringType(), True),
+        ]
+    )
+
     aggregate_ascwds_worker_schema = StructType(
         [
             StructField(IndCQC.establishment_id, StringType(), True),

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -5916,6 +5916,25 @@ class EstimateIndCQCFilledPostsByJobRoleUtilsSchemas:
         ]
     )
 
+    aggregate_ascwds_worker_schema = StructType(
+        [
+            StructField(IndCQC.establishment_id, StringType(), True),
+            StructField(IndCQC.ascwds_worker_import_date, DateType(), True),
+            StructField(IndCQC.main_job_role_clean_labelled, StringType(), True),
+        ]
+    )
+    expected_aggregate_ascwds_worker_schema = StructType(
+        [
+            StructField(IndCQC.establishment_id, StringType(), True),
+            StructField(IndCQC.ascwds_worker_import_date, DateType(), True),
+            StructField(
+                IndCQC.ascwds_job_role_counts,
+                MapType(StringType(), IntegerType()),
+                True,
+            ),
+        ]
+    )
+
     count_registered_manager_names_schema = StructType(
         [
             StructField(IndCQC.location_id, StringType(), True),

--- a/tests/unit/test_estimate_ind_cqc_filled_posts_by_job_role.py
+++ b/tests/unit/test_estimate_ind_cqc_filled_posts_by_job_role.py
@@ -34,10 +34,14 @@ class MainTests(EstimateIndCQCFilledPostsByJobRoleTests):
     @patch(
         "utils.estimate_filled_posts_by_job_role_utils.utils.count_registered_manager_names"
     )
+    @patch(
+        "utils.estimate_filled_posts_by_job_role_utils.utils.aggregate_ascwds_worker_job_roles_per_establishment"
+    )
     @patch("utils.utils.read_from_parquet")
     def test_main_function(
         self,
         read_from_parquet_mock: Mock,
+        aggregate_ascwds_worker_job_roles_per_establishment_mock: Mock,
         count_registered_manager_names_mock: Mock,
         write_to_parquet_mock: Mock,
     ):
@@ -60,6 +64,7 @@ class MainTests(EstimateIndCQCFilledPostsByJobRoleTests):
                 ),
             ]
         )
+        aggregate_ascwds_worker_job_roles_per_establishment_mock.assert_called_once()
         count_registered_manager_names_mock.assert_called_once()
 
         write_to_parquet_mock.assert_called_once_with(

--- a/tests/unit/test_estimate_ind_cqc_filled_posts_by_job_role.py
+++ b/tests/unit/test_estimate_ind_cqc_filled_posts_by_job_role.py
@@ -67,4 +67,6 @@ class MainTests(EstimateIndCQCFilledPostsByJobRoleTests):
         aggregate_ascwds_worker_job_roles_per_establishment_mock.assert_called_once()
         count_registered_manager_names_mock.assert_called_once()
 
-        write_to_parquet_mock.assert_called_once_with(ANY, self.OUTPUT_DIR, "overwrite")
+        write_to_parquet_mock.assert_called_once_with(
+            ANY, self.OUTPUT_DIR, "overwrite", PartitionKeys
+        )

--- a/tests/unit/test_estimate_ind_cqc_filled_posts_by_job_role.py
+++ b/tests/unit/test_estimate_ind_cqc_filled_posts_by_job_role.py
@@ -67,6 +67,4 @@ class MainTests(EstimateIndCQCFilledPostsByJobRoleTests):
         aggregate_ascwds_worker_job_roles_per_establishment_mock.assert_called_once()
         count_registered_manager_names_mock.assert_called_once()
 
-        write_to_parquet_mock.assert_called_once_with(
-            ANY, self.OUTPUT_DIR, "overwrite", PartitionKeys
-        )
+        write_to_parquet_mock.assert_called_once_with(ANY, self.OUTPUT_DIR, "overwrite")

--- a/tests/unit/test_estimate_ind_cqc_filled_posts_by_job_role_utils.py
+++ b/tests/unit/test_estimate_ind_cqc_filled_posts_by_job_role_utils.py
@@ -14,6 +14,151 @@ class EstimateIndCQCFilledPostsByJobRoleUtilsTests(unittest.TestCase):
         self.spark = utils.get_spark()
 
 
+class AggregateAscwdsWorkerJobRolesPerEstablishmentTests(
+    EstimateIndCQCFilledPostsByJobRoleUtilsTests
+):
+    def setUp(self) -> None:
+        super().setUp()
+
+    def test_aggregate_ascwds_worker_job_roles_per_establishment_returns_expected_columns(
+        self,
+    ):
+        test_df = self.spark.createDataFrame(
+            Data.aggregate_ascwds_worker_job_roles_per_establishment_rows,
+            Schemas.aggregate_ascwds_worker_schema,
+        )
+        returned_df = job.aggregate_ascwds_worker_job_roles_per_establishment(
+            test_df, Data.list_of_job_roles_for_tests
+        )
+        expected_df = self.spark.createDataFrame(
+            [],
+            Schemas.expected_aggregate_ascwds_worker_schema,
+        )
+        self.assertEqual(returned_df.columns, expected_df.columns)
+
+    def test_aggregate_ascwds_worker_job_roles_per_establishment_returns_expected_data_when_all_job_roles_present(
+        self,
+    ):
+        test_df = self.spark.createDataFrame(
+            Data.aggregate_ascwds_worker_job_roles_per_establishment_when_all_job_roles_present_rows,
+            Schemas.aggregate_ascwds_worker_schema,
+        )
+        returned_df = job.aggregate_ascwds_worker_job_roles_per_establishment(
+            test_df, Data.list_of_job_roles_for_tests
+        )
+        expected_df = self.spark.createDataFrame(
+            Data.expected_aggregate_ascwds_worker_job_roles_per_establishment_when_all_job_roles_present_rows,
+            Schemas.expected_aggregate_ascwds_worker_schema,
+        )
+        returned_data = returned_df.sort(
+            IndCQC.establishment_id, IndCQC.ascwds_worker_import_date
+        ).collect()
+        expected_data = expected_df.collect()
+
+        for i in range(len(returned_data)):
+            self.assertEqual(
+                returned_data[i][IndCQC.ascwds_job_role_counts],
+                expected_data[i][IndCQC.ascwds_job_role_counts],
+                f"Returned row {i} does not match expected",
+            )
+
+    def test_aggregate_ascwds_worker_job_roles_per_establishment_returns_expected_data_when_some_job_roles_never_present(
+        self,
+    ):
+        test_df = self.spark.createDataFrame(
+            Data.aggregate_ascwds_worker_job_roles_per_establishment_when_some_job_roles_never_present_rows,
+            Schemas.aggregate_ascwds_worker_schema,
+        )
+        returned_df = job.aggregate_ascwds_worker_job_roles_per_establishment(
+            test_df, Data.list_of_job_roles_for_tests
+        )
+        expected_df = self.spark.createDataFrame(
+            Data.expected_aggregate_ascwds_worker_job_roles_per_establishment_when_some_job_roles_never_present_rows,
+            Schemas.expected_aggregate_ascwds_worker_schema,
+        )
+        returned_data = returned_df.collect()
+        expected_data = expected_df.collect()
+
+        self.assertEqual(
+            returned_data[0][IndCQC.ascwds_job_role_counts],
+            expected_data[0][IndCQC.ascwds_job_role_counts],
+        )
+
+    def test_aggregate_ascwds_worker_job_roles_per_establishment_returns_expected_data_when_some_job_roles_never_present(
+        self,
+    ):
+        test_df = self.spark.createDataFrame(
+            Data.aggregate_ascwds_worker_job_roles_per_establishment_missing_roles_replaced_with_zero_rows,
+            Schemas.aggregate_ascwds_worker_schema,
+        )
+        returned_df = job.aggregate_ascwds_worker_job_roles_per_establishment(
+            test_df, Data.list_of_job_roles_for_tests
+        )
+        expected_df = self.spark.createDataFrame(
+            Data.expected_aggregate_ascwds_worker_job_roles_per_establishment_missing_roles_replaced_with_zero_rows,
+            Schemas.expected_aggregate_ascwds_worker_schema,
+        )
+        returned_data = returned_df.collect()
+        expected_data = expected_df.collect()
+
+        self.assertEqual(
+            returned_data[0][IndCQC.ascwds_job_role_counts],
+            expected_data[0][IndCQC.ascwds_job_role_counts],
+        )
+
+    def test_aggregate_ascwds_worker_job_roles_per_establishment_returns_expected_data_when_single_establishment_has_multiple_dates(
+        self,
+    ):
+        test_df = self.spark.createDataFrame(
+            Data.aggregate_ascwds_worker_job_roles_per_establishment_when_single_establishment_has_multiple_dates_rows,
+            Schemas.aggregate_ascwds_worker_schema,
+        )
+        returned_df = job.aggregate_ascwds_worker_job_roles_per_establishment(
+            test_df, Data.list_of_job_roles_for_tests
+        )
+        expected_df = self.spark.createDataFrame(
+            Data.expected_aggregate_ascwds_worker_job_roles_per_establishment_when_single_establishment_has_multiple_dates_rows,
+            Schemas.expected_aggregate_ascwds_worker_schema,
+        )
+        returned_data = returned_df.sort(
+            IndCQC.establishment_id, IndCQC.ascwds_worker_import_date
+        ).collect()
+        expected_data = expected_df.collect()
+
+        for i in range(len(returned_data)):
+            self.assertEqual(
+                returned_data[i][IndCQC.ascwds_job_role_counts],
+                expected_data[i][IndCQC.ascwds_job_role_counts],
+                f"Returned row {i} does not match expected",
+            )
+
+    def test_aggregate_ascwds_worker_job_roles_per_establishment_returns_expected_data_when_multiple_establishments_on_the_same_date(
+        self,
+    ):
+        test_df = self.spark.createDataFrame(
+            Data.aggregate_ascwds_worker_job_roles_per_establishment_when_multiple_establishments_on_the_same_date_rows,
+            Schemas.aggregate_ascwds_worker_schema,
+        )
+        returned_df = job.aggregate_ascwds_worker_job_roles_per_establishment(
+            test_df, Data.list_of_job_roles_for_tests
+        )
+        expected_df = self.spark.createDataFrame(
+            Data.expected_aggregate_ascwds_worker_job_roles_per_establishment_when_multiple_establishments_on_the_same_date_rows,
+            Schemas.expected_aggregate_ascwds_worker_schema,
+        )
+        returned_data = returned_df.sort(
+            IndCQC.establishment_id, IndCQC.ascwds_worker_import_date
+        ).collect()
+        expected_data = expected_df.collect()
+
+        for i in range(len(returned_data)):
+            self.assertEqual(
+                returned_data[i][IndCQC.ascwds_job_role_counts],
+                expected_data[i][IndCQC.ascwds_job_role_counts],
+                f"Returned row {i} does not match expected",
+            )
+
+
 class CreateMapColumnTests(EstimateIndCQCFilledPostsByJobRoleUtilsTests):
     def setUp(self) -> None:
         super().setUp()

--- a/tests/unit/test_estimate_ind_cqc_filled_posts_by_job_role_utils.py
+++ b/tests/unit/test_estimate_ind_cqc_filled_posts_by_job_role_utils.py
@@ -31,7 +31,6 @@ class CreateMapColumnTests(EstimateIndCQCFilledPostsByJobRoleUtilsTests):
             Data.expected_create_map_column_when_all_columns_populated_rows,
             Schemas.expected_create_map_column_schema,
         )
-        returned_df.show(truncate=False)
         returned_data = returned_df.collect()
         expected_data = expected_df.collect()
 
@@ -53,7 +52,6 @@ class CreateMapColumnTests(EstimateIndCQCFilledPostsByJobRoleUtilsTests):
             Data.expected_create_map_column_when_some_columns_populated_rows,
             Schemas.expected_create_map_column_schema,
         )
-        returned_df.show(truncate=False)
         returned_data = returned_df.collect()
         expected_data = expected_df.collect()
 
@@ -75,7 +73,6 @@ class CreateMapColumnTests(EstimateIndCQCFilledPostsByJobRoleUtilsTests):
             Data.expected_create_map_column_when_no_columns_populated_rows,
             Schemas.expected_create_map_column_schema,
         )
-        returned_df.show(truncate=False)
         returned_data = returned_df.collect()
         expected_data = expected_df.collect()
 

--- a/tests/unit/test_estimate_ind_cqc_filled_posts_by_job_role_utils.py
+++ b/tests/unit/test_estimate_ind_cqc_filled_posts_by_job_role_utils.py
@@ -25,7 +25,7 @@ class AggregateAscwdsWorkerJobRolesPerEstablishmentTests(
     ):
         test_df = self.spark.createDataFrame(
             Data.aggregate_ascwds_worker_job_roles_per_establishment_rows,
-            Schemas.aggregate_ascwds_worker_schema,
+            Schemas.aggregate_ascwds_worker_with_additional_column_schema,
         )
         returned_df = job.aggregate_ascwds_worker_job_roles_per_establishment(
             test_df, Data.list_of_job_roles_for_tests

--- a/tests/unit/test_estimate_ind_cqc_filled_posts_by_job_role_utils.py
+++ b/tests/unit/test_estimate_ind_cqc_filled_posts_by_job_role_utils.py
@@ -84,7 +84,7 @@ class AggregateAscwdsWorkerJobRolesPerEstablishmentTests(
             expected_data[0][IndCQC.ascwds_job_role_counts],
         )
 
-    def test_aggregate_ascwds_worker_job_roles_per_establishment_returns_expected_data_when_some_job_roles_never_present(
+    def test_aggregate_ascwds_worker_job_roles_per_establishment_returns_null_values_replaced_with_zeroes(
         self,
     ):
         test_df = self.spark.createDataFrame(

--- a/tests/unit/test_estimate_ind_cqc_filled_posts_by_job_role_utils.py
+++ b/tests/unit/test_estimate_ind_cqc_filled_posts_by_job_role_utils.py
@@ -158,6 +158,28 @@ class AggregateAscwdsWorkerJobRolesPerEstablishmentTests(
                 f"Returned row {i} does not match expected",
             )
 
+    def test_aggregate_ascwds_worker_job_roles_per_establishment_returns_expected_data_when_unrecognised_role_present(
+        self,
+    ):
+        test_df = self.spark.createDataFrame(
+            Data.aggregate_ascwds_worker_job_roles_per_establishment_when_unrecognised_role_present_rows,
+            Schemas.aggregate_ascwds_worker_schema,
+        )
+        returned_df = job.aggregate_ascwds_worker_job_roles_per_establishment(
+            test_df, Data.list_of_job_roles_for_tests
+        )
+        expected_df = self.spark.createDataFrame(
+            Data.expected_aggregate_ascwds_worker_job_roles_per_establishment_when_unrecognised_role_present_rows,
+            Schemas.expected_aggregate_ascwds_worker_schema,
+        )
+        returned_data = returned_df.collect()
+        expected_data = expected_df.collect()
+
+        self.assertEqual(
+            returned_data[0][IndCQC.ascwds_job_role_counts],
+            expected_data[0][IndCQC.ascwds_job_role_counts],
+        )
+
 
 class CreateMapColumnTests(EstimateIndCQCFilledPostsByJobRoleUtilsTests):
     def setUp(self) -> None:

--- a/utils/estimate_filled_posts_by_job_role_utils/utils.py
+++ b/utils/estimate_filled_posts_by_job_role_utils/utils.py
@@ -21,7 +21,7 @@ def aggregate_ascwds_worker_job_roles_per_establishment(
 
     Args:
         df (DataFrame): A dataframe containing cleaned ASC-WDS worker data.
-        list_of_columns_for_job_role (list): A list containing the ASC-WDS job role.
+        list_of_job_roles (list): A list containing the ASC-WDS job role.
 
     Returns:
         DataFrame: A dataframe with unique establishmentid and import date.


### PR DESCRIPTION
# Description
Aggregates the worker dataset by establishment_id and import date and creates a pivot table that has one column per job role count. Replace nulls with zero before creating a map column that contains job role names and counts. Drop the individual job role count columns.

# How to test
[Branch run](https://eu-west-2.console.aws.amazon.com/states/home?region=eu-west-2#/v2/executions/details/arn:aws:states:eu-west-2:344210435447:execution:add-agg-into-pipeline-Ind-CQC-Filled-Post-Estimates-Pipeline:3b838c74-af71-4474-a777-2f2901065552)

Athena output
![image](https://github.com/user-attachments/assets/a8726075-6fd4-4268-9bca-6a09f6d8c5c5)

# Developer checklist
- [X] Unit test
- [X] Linked to Trello ticket
- [X] Documentation up to date
