### PR TITLE
Add Turhan's merge function back in

### DIFF
--- a/jobs/estimate_ind_cqc_filled_posts_by_job_role.py
+++ b/jobs/estimate_ind_cqc_filled_posts_by_job_role.py
@@ -76,12 +76,17 @@ def main(
         )
     )
 
+    estimated_ind_cqc_filled_posts_by_job_role_df = JRutils.merge_dataframes(
+        estimated_ind_cqc_filled_posts_df,
+        aggregated_job_roles_per_establishment_df,
+    )
+
     estimated_ind_cqc_filled_posts_df = JRutils.count_registered_manager_names(
         estimated_ind_cqc_filled_posts_df
     )
 
     utils.write_to_parquet(
-        estimated_ind_cqc_filled_posts_df,
+        estimated_ind_cqc_filled_posts_by_job_role_df,
         estimated_ind_cqc_filled_posts_by_job_role_destination,
         "overwrite",
         PartitionKeys,

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -9473,6 +9473,7 @@ class EstimateIndCQCFilledPostsByJobRoleData:
     ]
 
 
+@dataclass
 class EstimateIndCQCFilledPostsByJobRoleUtilsData:
     list_of_job_roles_for_tests = [
         MainJobRoleLabels.care_worker,

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -9681,6 +9681,53 @@ class EstimateIndCQCFilledPostsByJobRoleUtilsData:
         )
     ]
 
+    # fmt: off
+    estimated_filled_posts_when_single_establishment_has_multiple_dates_rows = [
+        ("1-1001", CareHome.care_home, 3, date(2025, 1, 1), "1"),
+        ("1-1001", CareHome.care_home, 5, date(2025, 2, 1), "1"),
+        ("1-1001", CareHome.care_home, 7, date(2025, 3, 1), "1"),
+    ]
+    aggregated_job_role_breakdown_when_single_establishment_has_multiple_dates_rows = [
+        ("1", date(2025, 1, 1), {MainJobRoleLabels.care_worker: 0, MainJobRoleLabels.registered_nurse: 1}),
+        ("1", date(2025, 3, 1), {MainJobRoleLabels.care_worker: 1, MainJobRoleLabels.registered_nurse: 2}),
+        ("1", date(2025, 5, 1), {MainJobRoleLabels.care_worker: 2, MainJobRoleLabels.registered_nurse: 3}),
+    ]
+    expected_merge_dataframse_when_single_establishment_has_multiple_dates_rows = [
+        ("1-1001", CareHome.care_home, 3, date(2025, 1, 1), "1", {MainJobRoleLabels.care_worker: 0, MainJobRoleLabels.registered_nurse: 1}),
+        ("1-1001", CareHome.care_home, 5, date(2025, 2, 1), "1", None),
+        ("1-1001", CareHome.care_home, 7, date(2025, 3, 1), "1", {MainJobRoleLabels.care_worker: 1, MainJobRoleLabels.registered_nurse: 2}),
+    ]
+    # fmt: on
+
+    # fmt: off
+    estimated_filled_posts_when_multiple_establishments_on_the_same_date_rows = [
+        ("1-1001", CareHome.care_home, 3, date(2025, 1, 1), "1"),
+        ("1-1002", CareHome.care_home, 5, date(2025, 1, 1), "2"),
+        ("1-1003", CareHome.care_home, 7, date(2025, 1, 1), "3"),
+    ]
+    aggregated_job_role_breakdown_when_multiple_establishments_on_the_same_date_rows = [
+        ("1", date(2025, 1, 1), {MainJobRoleLabels.care_worker: 0, MainJobRoleLabels.registered_nurse: 1}),
+        ("2", date(2025, 1, 1), {MainJobRoleLabels.care_worker: 1, MainJobRoleLabels.registered_nurse: 2}),
+    ]
+    expected_merge_dataframse_when_multiple_establishments_on_the_same_date_rows = [
+        ("1-1001", CareHome.care_home, 3, date(2025, 1, 1), "1", {MainJobRoleLabels.care_worker: 0, MainJobRoleLabels.registered_nurse: 1}),
+        ("1-1002", CareHome.care_home, 5, date(2025, 1, 1), "2", {MainJobRoleLabels.care_worker: 1, MainJobRoleLabels.registered_nurse: 2}),
+        ("1-1003", CareHome.care_home, 7, date(2025, 1, 1), "3", None),
+    ]
+    # fmt: on
+
+    # fmt: off
+    estimated_filled_posts_when_establishments_do_not_match_rows = [
+        ("1-1001", CareHome.care_home, 3, date(2025, 1, 1), "1"),
+    ]
+    aggregated_job_role_breakdown_when_establishments_do_not_match_rows = [
+        ("2", date(2025, 1, 1), {MainJobRoleLabels.care_worker: 1, MainJobRoleLabels.registered_nurse: 2}),
+    ]
+    expected_merge_dataframse_when_establishments_do_not_match_rows = [
+        ("1-1001", CareHome.care_home, 3, date(2025, 1, 1), "1", None),
+    ]
+    # fmt: on
+
     count_registered_manager_names_when_location_has_one_registered_manager_rows = [
         ("1-0000000001", date(2025, 1, 1), ["John Doe"])
     ]

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -5944,6 +5944,37 @@ class EstimateIndCQCFilledPostsByJobRoleUtilsSchemas:
         ]
     )
 
+    estimated_filled_posts_schema = StructType(
+        [
+            StructField(IndCQC.location_id, StringType(), True),
+            StructField(IndCQC.care_home, StringType(), True),
+            StructField(IndCQC.number_of_beds, IntegerType(), True),
+            StructField(IndCQC.ascwds_workplace_import_date, DateType(), True),
+            StructField(IndCQC.establishment_id, StringType(), True),
+        ]
+    )
+    aggregated_job_role_breakdown_df = StructType(
+        [
+            StructField(IndCQC.establishment_id, StringType(), True),
+            StructField(IndCQC.ascwds_worker_import_date, DateType(), True),
+            StructField(
+                IndCQC.ascwds_job_role_counts,
+                MapType(StringType(), IntegerType()),
+                True,
+            ),
+        ]
+    )
+    merged_job_role_estimate_schema = StructType(
+        [
+            *estimated_filled_posts_schema,
+            StructField(
+                IndCQC.ascwds_job_role_counts,
+                MapType(StringType(), IntegerType()),
+                True,
+            ),
+        ]
+    )
+
     count_registered_manager_names_schema = StructType(
         [
             StructField(IndCQC.location_id, StringType(), True),

--- a/tests/unit/test_estimate_ind_cqc_filled_posts_by_job_role.py
+++ b/tests/unit/test_estimate_ind_cqc_filled_posts_by_job_role.py
@@ -34,6 +34,7 @@ class MainTests(EstimateIndCQCFilledPostsByJobRoleTests):
     @patch(
         "utils.estimate_filled_posts_by_job_role_utils.utils.count_registered_manager_names"
     )
+    @patch("utils.estimate_filled_posts_by_job_role_utils.utils.merge_dataframes")
     @patch(
         "utils.estimate_filled_posts_by_job_role_utils.utils.aggregate_ascwds_worker_job_roles_per_establishment"
     )
@@ -42,6 +43,7 @@ class MainTests(EstimateIndCQCFilledPostsByJobRoleTests):
         self,
         read_from_parquet_mock: Mock,
         aggregate_ascwds_worker_job_roles_per_establishment_mock: Mock,
+        merge_dataframes_mock: Mock,
         count_registered_manager_names_mock: Mock,
         write_to_parquet_mock: Mock,
     ):
@@ -65,6 +67,7 @@ class MainTests(EstimateIndCQCFilledPostsByJobRoleTests):
             ]
         )
         aggregate_ascwds_worker_job_roles_per_establishment_mock.assert_called_once()
+        merge_dataframes_mock.assert_called_once()
         count_registered_manager_names_mock.assert_called_once()
 
         write_to_parquet_mock.assert_called_once_with(

--- a/tests/unit/test_estimate_ind_cqc_filled_posts_by_job_role_utils.py
+++ b/tests/unit/test_estimate_ind_cqc_filled_posts_by_job_role_utils.py
@@ -158,6 +158,28 @@ class AggregateAscwdsWorkerJobRolesPerEstablishmentTests(
                 f"Returned row {i} does not match expected",
             )
 
+    def test_aggregate_ascwds_worker_job_roles_per_establishment_returns_expected_data_when_unrecognised_role_present(
+        self,
+    ):
+        test_df = self.spark.createDataFrame(
+            Data.aggregate_ascwds_worker_job_roles_per_establishment_when_unrecognised_role_present_rows,
+            Schemas.aggregate_ascwds_worker_schema,
+        )
+        returned_df = job.aggregate_ascwds_worker_job_roles_per_establishment(
+            test_df, Data.list_of_job_roles_for_tests
+        )
+        expected_df = self.spark.createDataFrame(
+            Data.expected_aggregate_ascwds_worker_job_roles_per_establishment_when_unrecognised_role_present_rows,
+            Schemas.expected_aggregate_ascwds_worker_schema,
+        )
+        returned_data = returned_df.collect()
+        expected_data = expected_df.collect()
+
+        self.assertEqual(
+            returned_data[0][IndCQC.ascwds_job_role_counts],
+            expected_data[0][IndCQC.ascwds_job_role_counts],
+        )
+
 
 class CreateMapColumnTests(EstimateIndCQCFilledPostsByJobRoleUtilsTests):
     def setUp(self) -> None:

--- a/utils/estimate_filled_posts_by_job_role_utils/utils.py
+++ b/utils/estimate_filled_posts_by_job_role_utils/utils.py
@@ -58,34 +58,39 @@ def create_map_column(columns: List[str]) -> F.Column:
 
 
 def merge_dataframes(
-    estimated_filled_posts_df: DataFrame, job_role_breakdown_df: DataFrame
+    estimated_filled_posts_df: DataFrame,
+    aggregated_job_roles_per_establishment_df: DataFrame,
 ) -> DataFrame:
     """
     Join the ASC-WDS job role count column from the aggregated worker file into the estimated filled post DataFrame, matched on establishment_id and import_date.
 
     Args:
         estimated_filled_posts_df (DataFrame): A dataframe containing estimated filled posts at workplace level.
-        job_role_breakdown_df (DataFrame): ASC-WDS job role breakdown dataframe aggregated at workplace level.
+        aggregated_job_roles_per_establishment_df (DataFrame): ASC-WDS job role breakdown dataframe aggregated at workplace level.
 
     Returns:
-        DataFrame: The IndCQC DataFrame merged to include job role count columns.
+        DataFrame: The estimated filled post DataFrame with the job role count map column joined in.
     """
 
     merged_df = (
         estimated_filled_posts_df.join(
-            job_role_breakdown_df,
+            aggregated_job_roles_per_establishment_df,
             (
                 estimated_filled_posts_df[IndCQC.establishment_id]
-                == job_role_breakdown_df[IndCQC.establishment_id]
+                == aggregated_job_roles_per_establishment_df[IndCQC.establishment_id]
             )
             & (
                 estimated_filled_posts_df[IndCQC.ascwds_workplace_import_date]
-                == job_role_breakdown_df[IndCQC.ascwds_worker_import_date]
+                == aggregated_job_roles_per_establishment_df[
+                    IndCQC.ascwds_worker_import_date
+                ]
             ),
             "left",
         )
-        .drop(job_role_breakdown_df[IndCQC.establishment_id])
-        .drop(job_role_breakdown_df[IndCQC.ascwds_worker_import_date])
+        .drop(aggregated_job_roles_per_establishment_df[IndCQC.establishment_id])
+        .drop(
+            aggregated_job_roles_per_establishment_df[IndCQC.ascwds_worker_import_date]
+        )
     )
 
     return merged_df


### PR DESCRIPTION
# Description
Adding the merge function back in. Updated test data to reflect that we're now using one map column instead of individual columns for each job role

# How to test
[Branch run](https://eu-west-2.console.aws.amazon.com/states/home?region=eu-west-2#/v2/executions/details/arn:aws:states:eu-west-2:344210435447:execution:turhans-merge-function-Ind-CQC-Filled-Post-Estimates-Pipeline:e27f8990-d854-4dec-aa6a-91a0676adcf3)

Athena outputs
![image](https://github.com/user-attachments/assets/21256175-f0fe-441d-ba8c-a7f4b125147e)

# Developer checklist
- [X] Unit test
- [X] Linked to Trello ticket
- [X] Documentation up to date
