### PR TITLE
Transform job role count map into ratios map

### DIFF
--- a/jobs/estimate_ind_cqc_filled_posts_by_job_role.py
+++ b/jobs/estimate_ind_cqc_filled_posts_by_job_role.py
@@ -81,6 +81,12 @@ def main(
         aggregated_job_roles_per_establishment_df,
     )
 
+    estimated_ind_cqc_filled_posts_by_job_role_df = (
+        JRutils.transform_job_role_count_map_to_ratios_map(
+            estimated_ind_cqc_filled_posts_by_job_role_df,
+        )
+    )
+
     estimated_ind_cqc_filled_posts_df = JRutils.count_registered_manager_names(
         estimated_ind_cqc_filled_posts_df
     )

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -9729,6 +9729,73 @@ class EstimateIndCQCFilledPostsByJobRoleUtilsData:
     ]
     # fmt: on
 
+    # fmt: off
+    transform_counts_map_to_ratios_map_when_only_one_count_value_above_zero_rows = [
+        ("1-001", 
+         {MainJobRoleLabels.care_worker: 1, MainJobRoleLabels.registered_nurse: 0}),
+    ]
+    expected_transform_counts_map_to_ratios_map_when_only_one_count_value_above_zero_rows = [
+        ("1-001", 
+         {MainJobRoleLabels.care_worker: 1, MainJobRoleLabels.registered_nurse: 0},
+         {MainJobRoleLabels.care_worker: 1.0, MainJobRoleLabels.registered_nurse: 0.0}),
+    ]
+    # fmt: on
+
+    # fmt: off
+    transform_counts_map_to_ratios_map_when_all_count_values_above_zero_rows = [
+        ("1-001", 
+         {MainJobRoleLabels.care_worker: 1, MainJobRoleLabels.registered_nurse: 2}),
+    ]
+    expected_transform_counts_map_to_ratios_map_when_all_count_values_above_zero_rows = [
+        ("1-001", 
+         {MainJobRoleLabels.care_worker: 1, MainJobRoleLabels.registered_nurse: 2},
+         {MainJobRoleLabels.care_worker: 0.333, MainJobRoleLabels.registered_nurse: 0.667}),
+    ]
+    # fmt: on
+
+    # fmt: off
+    transform_counts_map_to_ratios_map_when_all_count_values_are_null_rows = [
+        ("1-001", 
+         {MainJobRoleLabels.care_worker: None, MainJobRoleLabels.registered_nurse: None},
+        ),
+    ]
+    expected_transform_counts_map_to_ratios_map_when_all_count_values_are_null_rows = [
+        ("1-001", 
+         {MainJobRoleLabels.care_worker: None, MainJobRoleLabels.registered_nurse: None},
+         {MainJobRoleLabels.care_worker: None, MainJobRoleLabels.registered_nurse: None},
+        ),
+    ]
+    # fmt: on
+
+    # fmt: off
+    transform_counts_map_to_ratios_map_when_count_map_column_is_null_rows = [
+        ("1-001", 
+         None),
+    ]
+    expected_transform_counts_map_to_ratios_map_when_count_map_column_is_null_rows = [
+        ("1-001", 
+         None, 
+         None),
+    ]
+    # fmt: on
+
+    # fmt: off
+    transform_counts_map_to_ratios_map_at_multiple_establishments_rows = [
+        ("1-001", {MainJobRoleLabels.care_worker: 1, MainJobRoleLabels.registered_nurse: 2}),
+        ("1-002", {MainJobRoleLabels.care_worker: 2, MainJobRoleLabels.registered_nurse: 1}),
+    ]
+    expected_transform_counts_map_to_ratios_map_at_multiple_establishments_rows = [
+        ("1-001", 
+         {MainJobRoleLabels.care_worker: 1, MainJobRoleLabels.registered_nurse: 0},
+         {MainJobRoleLabels.care_worker: 1.0, MainJobRoleLabels.registered_nurse: 0.0}
+        ),
+        ("1-002", 
+         {MainJobRoleLabels.care_worker: 0, MainJobRoleLabels.registered_nurse: 1},
+         {MainJobRoleLabels.care_worker: 0.0, MainJobRoleLabels.registered_nurse: 1.0}
+        ),
+    ]
+    # fmt: on
+
     count_registered_manager_names_when_location_has_one_registered_manager_rows = [
         ("1-0000000001", date(2025, 1, 1), ["John Doe"])
     ]

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -9781,8 +9781,8 @@ class EstimateIndCQCFilledPostsByJobRoleUtilsData:
 
     # fmt: off
     transform_counts_map_to_ratios_map_at_multiple_establishments_rows = [
-        ("1-001", {MainJobRoleLabels.care_worker: 1, MainJobRoleLabels.registered_nurse: 2}),
-        ("1-002", {MainJobRoleLabels.care_worker: 2, MainJobRoleLabels.registered_nurse: 1}),
+        ("1-001", {MainJobRoleLabels.care_worker: 1, MainJobRoleLabels.registered_nurse: 0}),
+        ("1-002", {MainJobRoleLabels.care_worker: 0, MainJobRoleLabels.registered_nurse: 1}),
     ]
     expected_transform_counts_map_to_ratios_map_at_multiple_establishments_rows = [
         ("1-001", 

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -5975,6 +5975,26 @@ class EstimateIndCQCFilledPostsByJobRoleUtilsSchemas:
         ]
     )
 
+    ascwds_job_role_count_map_to_ratios_map_schema = StructType(
+        [
+            StructField(IndCQC.location_id, StringType(), True),
+            StructField(
+                IndCQC.ascwds_job_role_counts,
+                MapType(StringType(), IntegerType()),
+                True,
+            ),
+        ]
+    )
+
+    expected_ascwds_job_role_count_map_to_ratios_map_schema = StructType(
+        [
+            *ascwds_job_role_count_map_to_ratios_map_schema,
+            StructField(
+                IndCQC.ascwds_job_role_ratios, MapType(StringType(), FloatType()), True
+            ),
+        ]
+    )
+
     count_registered_manager_names_schema = StructType(
         [
             StructField(IndCQC.location_id, StringType(), True),

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -12,6 +12,7 @@ from pyspark.sql.types import (
     DoubleType,
     BooleanType,
     MapType,
+    LongType,
 )
 
 from utils.column_names.capacity_tracker_columns import (
@@ -5980,7 +5981,7 @@ class EstimateIndCQCFilledPostsByJobRoleUtilsSchemas:
             StructField(IndCQC.location_id, StringType(), True),
             StructField(
                 IndCQC.ascwds_job_role_counts,
-                MapType(StringType(), IntegerType()),
+                MapType(StringType(), LongType()),
                 True,
             ),
         ]

--- a/tests/unit/test_estimate_ind_cqc_filled_posts_by_job_role.py
+++ b/tests/unit/test_estimate_ind_cqc_filled_posts_by_job_role.py
@@ -34,6 +34,9 @@ class MainTests(EstimateIndCQCFilledPostsByJobRoleTests):
     @patch(
         "utils.estimate_filled_posts_by_job_role_utils.utils.count_registered_manager_names"
     )
+    @patch(
+        "utils.estimate_filled_posts_by_job_role_utils.utils.transform_job_role_count_map_to_ratios_map"
+    )
     @patch("utils.estimate_filled_posts_by_job_role_utils.utils.merge_dataframes")
     @patch(
         "utils.estimate_filled_posts_by_job_role_utils.utils.aggregate_ascwds_worker_job_roles_per_establishment"
@@ -44,6 +47,7 @@ class MainTests(EstimateIndCQCFilledPostsByJobRoleTests):
         read_from_parquet_mock: Mock,
         aggregate_ascwds_worker_job_roles_per_establishment_mock: Mock,
         merge_dataframes_mock: Mock,
+        transform_job_role_count_map_to_ratios_map_mock: Mock,
         count_registered_manager_names_mock: Mock,
         write_to_parquet_mock: Mock,
     ):
@@ -68,6 +72,7 @@ class MainTests(EstimateIndCQCFilledPostsByJobRoleTests):
         )
         aggregate_ascwds_worker_job_roles_per_establishment_mock.assert_called_once()
         merge_dataframes_mock.assert_called_once()
+        transform_job_role_count_map_to_ratios_map_mock.assert_called_once()
         count_registered_manager_names_mock.assert_called_once()
 
         write_to_parquet_mock.assert_called_once_with(

--- a/tests/unit/test_estimate_ind_cqc_filled_posts_by_job_role_utils.py
+++ b/tests/unit/test_estimate_ind_cqc_filled_posts_by_job_role_utils.py
@@ -353,21 +353,37 @@ class TransformJobRoleCountsMapToRatiosMap(
     def setUp(self) -> None:
         super().setUp()
 
-    def test_transform_job_role_count_map_to_ratios_map_when_only_one_count_value_above_zero(
-        self,
-    ):
-        test_df = self.spark.createDataFrame(
+        self.test_df = self.spark.createDataFrame(
             Data.transform_counts_map_to_ratios_map_when_only_one_count_value_above_zero_rows,
             Schemas.ascwds_job_role_count_map_to_ratios_map_schema,
         )
-        returned_df = job.transform_job_role_count_map_to_ratios_map(test_df)
-        expected_df = self.spark.createDataFrame(
+        self.returned_df = job.transform_job_role_count_map_to_ratios_map(self.test_df)
+        self.expected_df = self.spark.createDataFrame(
             Data.expected_transform_counts_map_to_ratios_map_when_only_one_count_value_above_zero_rows,
             Schemas.expected_ascwds_job_role_count_map_to_ratios_map_schema,
         )
 
-        returned_data = returned_df.collect()
-        expected_data = expected_df.collect()
+        self.columns_added_by_function = [
+            column
+            for column in self.returned_df.columns
+            if column not in self.test_df.columns
+        ]
+
+    def test_transform_job_role_count_map_to_ratios_map_only_adds_one_columns(self):
+        self.assertEqual(len(self.columns_added_by_function), 1)
+
+    def test_transform_job_role_count_map_to_ratios_map_adds_correctly_named_column(
+        self,
+    ):
+        self.assertEqual(
+            self.columns_added_by_function[0], IndCQC.ascwds_job_role_ratios
+        )
+
+    def test_transform_job_role_count_map_to_ratios_map_when_only_one_count_value_above_zero(
+        self,
+    ):
+        returned_data = self.returned_df.collect()
+        expected_data = self.expected_df.collect()
 
         self.assertEqual(
             returned_data[0][IndCQC.ascwds_job_role_ratios],

--- a/tests/unit/test_estimate_ind_cqc_filled_posts_by_job_role_utils.py
+++ b/tests/unit/test_estimate_ind_cqc_filled_posts_by_job_role_utils.py
@@ -347,6 +347,124 @@ class MergeDataframesTests(EstimateIndCQCFilledPostsByJobRoleUtilsTests):
         self.assertEqual(returned_df.collect(), expected_df.collect())
 
 
+class TransformJobRoleCountsMapToRatiosMap(
+    EstimateIndCQCFilledPostsByJobRoleUtilsTests
+):
+    def setUp(self) -> None:
+        super().setUp()
+
+    def test_transform_job_role_count_map_to_ratios_map_when_only_one_count_value_above_zero(
+        self,
+    ):
+        test_df = self.spark.createDataFrame(
+            Data.transform_counts_map_to_ratios_map_when_only_one_count_value_above_zero_rows,
+            Schemas.ascwds_job_role_count_map_to_ratios_map_schema,
+        )
+        returned_df = job.transform_job_role_count_map_to_ratios_map(test_df)
+        expected_df = self.spark.createDataFrame(
+            Data.expected_transform_counts_map_to_ratios_map_when_only_one_count_value_above_zero_rows,
+            Schemas.expected_ascwds_job_role_count_map_to_ratios_map_schema,
+        )
+
+        returned_data = returned_df.collect()
+        expected_data = expected_df.collect()
+
+        self.assertEqual(
+            returned_data[0][IndCQC.ascwds_job_role_ratios],
+            expected_data[0][IndCQC.ascwds_job_role_ratios],
+        )
+
+    def test_transform_job_role_count_map_to_ratios_map_when_all_count_values_above_zero(
+        self,
+    ):
+        test_df = self.spark.createDataFrame(
+            Data.transform_counts_map_to_ratios_map_when_all_count_values_above_zero_rows,
+            Schemas.ascwds_job_role_count_map_to_ratios_map_schema,
+        )
+        returned_df = job.transform_job_role_count_map_to_ratios_map(test_df)
+        expected_df = self.spark.createDataFrame(
+            Data.expected_transform_counts_map_to_ratios_map_when_all_count_values_above_zero_rows,
+            Schemas.expected_ascwds_job_role_count_map_to_ratios_map_schema,
+        )
+
+        returned_data = returned_df.collect()
+        expected_data = expected_df.collect()
+
+        returned_ratio_dict: dict = returned_data[0][IndCQC.ascwds_job_role_ratios]
+        expected_ratio_dict: dict = expected_data[0][IndCQC.ascwds_job_role_ratios]
+
+        for i in list(expected_ratio_dict.keys()):
+            self.assertAlmostEqual(
+                returned_ratio_dict[i],
+                expected_ratio_dict[i],
+                places=3,
+                msg=f"Dict element {i} does not match",
+            )
+
+    def test_transform_job_role_count_map_to_ratios_map_when_all_count_values_are_null(
+        self,
+    ):
+        test_df = self.spark.createDataFrame(
+            Data.transform_counts_map_to_ratios_map_when_all_count_values_are_null_rows,
+            Schemas.ascwds_job_role_count_map_to_ratios_map_schema,
+        )
+        returned_df = job.transform_job_role_count_map_to_ratios_map(test_df)
+        expected_df = self.spark.createDataFrame(
+            Data.expected_transform_counts_map_to_ratios_map_when_all_count_values_are_null_rows,
+            Schemas.expected_ascwds_job_role_count_map_to_ratios_map_schema,
+        )
+
+        returned_data = returned_df.collect()
+        expected_data = expected_df.collect()
+
+        self.assertEqual(
+            returned_data[0][IndCQC.ascwds_job_role_ratios],
+            expected_data[0][IndCQC.ascwds_job_role_ratios],
+        )
+
+    def test_transform_job_role_count_map_to_ratios_map_when_when_count_map_column_is_null(
+        self,
+    ):
+        test_df = self.spark.createDataFrame(
+            Data.transform_counts_map_to_ratios_map_when_count_map_column_is_null_rows,
+            Schemas.ascwds_job_role_count_map_to_ratios_map_schema,
+        )
+        returned_df = job.transform_job_role_count_map_to_ratios_map(test_df)
+        expected_df = self.spark.createDataFrame(
+            Data.expected_transform_counts_map_to_ratios_map_when_count_map_column_is_null_rows,
+            Schemas.expected_ascwds_job_role_count_map_to_ratios_map_schema,
+        )
+
+        returned_data = returned_df.collect()
+        expected_data = expected_df.collect()
+
+        self.assertEqual(
+            returned_data[0][IndCQC.ascwds_job_role_ratios],
+            expected_data[0][IndCQC.ascwds_job_role_ratios],
+        )
+
+    def test_transform_job_role_count_map_to_ratios_map_returns_expected_ratios_given_multiple_establishments(
+        self,
+    ):
+        test_df = self.spark.createDataFrame(
+            Data.transform_counts_map_to_ratios_map_at_multiple_establishments_rows,
+            Schemas.ascwds_job_role_count_map_to_ratios_map_schema,
+        )
+        returned_df = job.transform_job_role_count_map_to_ratios_map(test_df)
+        expected_df = self.spark.createDataFrame(
+            Data.expected_transform_counts_map_to_ratios_map_at_multiple_establishments_rows,
+            Schemas.expected_ascwds_job_role_count_map_to_ratios_map_schema,
+        )
+
+        returned_data = returned_df.sort(IndCQC.location_id).collect()
+        expected_data = expected_df.sort(IndCQC.location_id).collect()
+
+        self.assertEqual(
+            returned_data[0][IndCQC.ascwds_job_role_ratios],
+            expected_data[0][IndCQC.ascwds_job_role_ratios],
+        )
+
+
 class CountRegisteredManagerNamesTests(EstimateIndCQCFilledPostsByJobRoleUtilsTests):
     def setUp(self) -> None:
         super().setUp()

--- a/utils/column_names/ind_cqc_pipeline_columns.py
+++ b/utils/column_names/ind_cqc_pipeline_columns.py
@@ -46,6 +46,7 @@ class IndCqcColumns:
     ascwds_filled_posts_source: str = ascwds_filled_posts + "_source"
     ascwds_filtering_rule: str = "ascwds_filtering_rule"
     ascwds_job_role_counts: str = "ascwds_job_role_counts"
+    ascwds_job_role_ratios: str = "ascwds_job_role_ratios"
     ascwds_worker_import_date: str = AWKClean.ascwds_worker_import_date
     ascwds_workplace_import_date: str = AWPClean.ascwds_workplace_import_date
     average_absolute_residual: str = "average_absolute_residual"

--- a/utils/estimate_filled_posts_by_job_role_utils/utils.py
+++ b/utils/estimate_filled_posts_by_job_role_utils/utils.py
@@ -1,4 +1,5 @@
 from pyspark.sql import DataFrame, functions as F
+from pyspark.sql.types import LongType
 from typing import List
 
 from utils.column_names.ind_cqc_pipeline_columns import IndCqcColumns as IndCQC
@@ -119,7 +120,7 @@ def transform_job_role_count_map_to_ratios_map(
             temp_ascwds_total_worker_records,
             F.aggregate(
                 F.map_values(F.col(IndCQC.ascwds_job_role_counts)),
-                F.lit(0),
+                F.lit(0).cast(LongType()),
                 lambda a, b: a + b,
             ),
         )

--- a/utils/estimate_filled_posts_by_job_role_utils/utils.py
+++ b/utils/estimate_filled_posts_by_job_role_utils/utils.py
@@ -132,7 +132,7 @@ def transform_job_role_count_map_to_ratios_map(
                 F.map_keys(F.col(IndCQC.ascwds_job_role_counts)),
                 F.transform(
                     F.map_values(F.col(IndCQC.ascwds_job_role_counts)),
-                    lambda v: v / F.col("ascwds_total_worker_records"),
+                    lambda v: v / F.col(temp_ascwds_total_worker_records),
                 ),
             ),
         )

--- a/utils/estimate_filled_posts_by_job_role_utils/utils.py
+++ b/utils/estimate_filled_posts_by_job_role_utils/utils.py
@@ -113,27 +113,33 @@ def transform_job_role_count_map_to_ratios_map(
         DataFrame: The estimated filled post by job role DataFrame with the job role ratio map column joined in.
     """
 
-    df = df.withColumn(
-        "ascwds_total_worker_records",
-        F.aggregate(
-            F.map_values(F.col(IndCQC.ascwds_job_role_counts)),
-            F.lit(0),
-            lambda a, b: a + b,
-        ),
-    )
-
-    df = df.withColumn(
-        IndCQC.ascwds_job_role_ratios,
-        F.map_from_arrays(
-            F.map_keys(F.col(IndCQC.ascwds_job_role_counts)),
-            F.transform(
+    estimated_ind_cqc_filled_posts_by_job_role_df = (
+        estimated_ind_cqc_filled_posts_by_job_role_df.withColumn(
+            "ascwds_total_worker_records",
+            F.aggregate(
                 F.map_values(F.col(IndCQC.ascwds_job_role_counts)),
-                lambda v: v / F.col("ascwds_total_worker_records"),
+                F.lit(0),
+                lambda a, b: a + b,
             ),
-        ),
+        )
     )
 
-    return df.drop("ascwds_total_worker_records")
+    estimated_ind_cqc_filled_posts_by_job_role_df = (
+        estimated_ind_cqc_filled_posts_by_job_role_df.withColumn(
+            IndCQC.ascwds_job_role_ratios,
+            F.map_from_arrays(
+                F.map_keys(F.col(IndCQC.ascwds_job_role_counts)),
+                F.transform(
+                    F.map_values(F.col(IndCQC.ascwds_job_role_counts)),
+                    lambda v: v / F.col("ascwds_total_worker_records"),
+                ),
+            ),
+        )
+    )
+
+    return estimated_ind_cqc_filled_posts_by_job_role_df.drop(
+        "ascwds_total_worker_records"
+    )
 
 
 def count_registered_manager_names(df: DataFrame) -> DataFrame:

--- a/utils/estimate_filled_posts_by_job_role_utils/utils.py
+++ b/utils/estimate_filled_posts_by_job_role_utils/utils.py
@@ -113,9 +113,10 @@ def transform_job_role_count_map_to_ratios_map(
         DataFrame: The estimated filled post by job role DataFrame with the job role ratio map column joined in.
     """
 
+    temp_ascwds_total_worker_records = "temp_ascwds_total_worker_records"
     estimated_ind_cqc_filled_posts_by_job_role_df = (
         estimated_ind_cqc_filled_posts_by_job_role_df.withColumn(
-            "ascwds_total_worker_records",
+            temp_ascwds_total_worker_records,
             F.aggregate(
                 F.map_values(F.col(IndCQC.ascwds_job_role_counts)),
                 F.lit(0),
@@ -138,7 +139,7 @@ def transform_job_role_count_map_to_ratios_map(
     )
 
     return estimated_ind_cqc_filled_posts_by_job_role_df.drop(
-        "ascwds_total_worker_records"
+        temp_ascwds_total_worker_records
     )
 
 

--- a/utils/estimate_filled_posts_by_job_role_utils/utils.py
+++ b/utils/estimate_filled_posts_by_job_role_utils/utils.py
@@ -96,7 +96,9 @@ def merge_dataframes(
     return merged_df
 
 
-def transform_job_role_count_map_to_ratios_map(df: DataFrame) -> DataFrame:
+def transform_job_role_count_map_to_ratios_map(
+    estimated_ind_cqc_filled_posts_by_job_role_df: DataFrame,
+) -> DataFrame:
     """
     Transform a job role count map column into a job role ratio map column.
 


### PR DESCRIPTION
# Description
I've added a utils function that transforms the job role count map into a ratios map.
It's makes a temporary column to hold the total job role count, then copies each key from the count map and changes each value to be the count / total count.

[Trello ticket](https://trello.com/c/FB3KvpJd)

# How to test
[Link to successful pipeline run](https://eu-west-2.console.aws.amazon.com/states/home?region=eu-west-2#/v2/executions/details/arn:aws:states:eu-west-2:344210435447:execution:transform-job-role-count-map-i-Ind-CQC-Filled-Post-Estimates-Pipeline:370890d6-0aaa-4aee-bf3c-d522ed82ecc5)

[Link to Athena output](https://eu-west-2.console.aws.amazon.com/athena/home?region=eu-west-2#/query-editor/history/f40d0a2e-2ff4-4365-8037-2744d97ef89e)

# Developer checklist
- [x] Unit test
- [x] Linked to Trello ticket
- [x] Documentation up to date
