### PR TITLE
Refactor counts map to ratios map to be generalised

### DIFF
--- a/jobs/estimate_ind_cqc_filled_posts_by_job_role.py
+++ b/jobs/estimate_ind_cqc_filled_posts_by_job_role.py
@@ -82,8 +82,10 @@ def main(
     )
 
     estimated_ind_cqc_filled_posts_by_job_role_df = (
-        JRutils.transform_job_role_count_map_to_ratios_map(
+        JRutils.transform_count_map_to_ratios_map(
             estimated_ind_cqc_filled_posts_by_job_role_df,
+            IndCQC.ascwds_job_role_counts,
+            IndCQC.ascwds_job_role_ratios,
         )
     )
 

--- a/jobs/estimate_ind_cqc_filled_posts_by_job_role.py
+++ b/jobs/estimate_ind_cqc_filled_posts_by_job_role.py
@@ -82,7 +82,7 @@ def main(
     )
 
     estimated_ind_cqc_filled_posts_by_job_role_df = (
-        JRutils.transform_count_map_to_ratios_map(
+        JRutils.transform_job_role_count_map_to_ratios_map(
             estimated_ind_cqc_filled_posts_by_job_role_df,
             IndCQC.ascwds_job_role_counts,
             IndCQC.ascwds_job_role_counts_total,

--- a/jobs/estimate_ind_cqc_filled_posts_by_job_role.py
+++ b/jobs/estimate_ind_cqc_filled_posts_by_job_role.py
@@ -85,6 +85,7 @@ def main(
         JRutils.transform_count_map_to_ratios_map(
             estimated_ind_cqc_filled_posts_by_job_role_df,
             IndCQC.ascwds_job_role_counts,
+            IndCQC.ascwds_job_role_counts_total,
             IndCQC.ascwds_job_role_ratios,
         )
     )

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -9729,72 +9729,100 @@ class EstimateIndCQCFilledPostsByJobRoleUtilsData:
     ]
     # fmt: on
 
+    test_count_map_column = IndCQC.ascwds_job_role_counts
+    test_count_map_values_total_column_name = IndCQC.ascwds_job_role_counts_total
+    test_ratio_map_column_name = IndCQC.ascwds_job_role_ratios
+
     # fmt: off
-    transform_counts_map_to_ratios_map_when_only_one_count_value_above_zero_rows = [
+    create_total_from_values_in_map_column_when_all_count_values_above_zero_rows = [
         ("1-001", 
-         {MainJobRoleLabels.care_worker: 1, MainJobRoleLabels.registered_nurse: 0}),
+         {MainJobRoleLabels.care_worker: 1, MainJobRoleLabels.registered_nurse: 2}
+        )
     ]
-    expected_transform_counts_map_to_ratios_map_when_only_one_count_value_above_zero_rows = [
+    expected_create_total_from_values_in_map_column_when_all_count_values_above_zero_rows = [
         ("1-001", 
-         {MainJobRoleLabels.care_worker: 1, MainJobRoleLabels.registered_nurse: 0},
-         {MainJobRoleLabels.care_worker: 1.0, MainJobRoleLabels.registered_nurse: 0.0}),
+         {MainJobRoleLabels.care_worker: 1, MainJobRoleLabels.registered_nurse: 2},
+         3
+        )
     ]
     # fmt: on
 
     # fmt: off
-    transform_counts_map_to_ratios_map_when_all_count_values_above_zero_rows = [
+    create_total_from_values_in_map_column_when_all_count_values_are_null_rows = [
         ("1-001", 
-         {MainJobRoleLabels.care_worker: 1, MainJobRoleLabels.registered_nurse: 2}),
+         {MainJobRoleLabels.care_worker: None, MainJobRoleLabels.registered_nurse: None}
+        )
     ]
-    expected_transform_counts_map_to_ratios_map_when_all_count_values_above_zero_rows = [
+    expected_create_total_from_values_in_map_column_when_all_count_values_are_null_rows = [
+        ("1-001", 
+         {MainJobRoleLabels.care_worker: None, MainJobRoleLabels.registered_nurse: None},
+         None
+        )
+    ]
+    # fmt: on
+
+    create_total_from_values_in_map_column_when_count_column_is_null_rows = [
+        ("1-001", None)
+    ]
+    expected_create_total_from_values_in_map_column_when_count_column_is_null_rows = [
+        ("1-001", None, None)
+    ]
+
+    # fmt: off
+    create_total_from_values_in_map_column_at_multiple_locations_rows = [
+        ("1-001", {MainJobRoleLabels.care_worker: 0, MainJobRoleLabels.registered_nurse: 1}),
+        ("1-002", {MainJobRoleLabels.care_worker: 2, MainJobRoleLabels.registered_nurse: 3}),
+    ]
+    expected_create_total_from_values_in_map_column_at_multiple_locations_rows = [
+        ("1-001", {MainJobRoleLabels.care_worker: 0, MainJobRoleLabels.registered_nurse: 1}, 1),
+        ("1-002", {MainJobRoleLabels.care_worker: 2, MainJobRoleLabels.registered_nurse: 3}, 5),
+    ]
+    # fmt: on
+
+    # fmt: off
+    create_ratios_from_counts_when_all_count_values_above_zero_rows = (
+        expected_create_total_from_values_in_map_column_when_all_count_values_above_zero_rows
+    )
+    expected_create_ratios_from_counts_when_all_count_values_above_zero_rows = [
         ("1-001", 
          {MainJobRoleLabels.care_worker: 1, MainJobRoleLabels.registered_nurse: 2},
+         3,
          {MainJobRoleLabels.care_worker: 0.333, MainJobRoleLabels.registered_nurse: 0.667}),
     ]
     # fmt: on
 
-    test_count_map_column = IndCQC.ascwds_job_role_counts
-    test_ratio_map_column_name = IndCQC.ascwds_job_role_ratios
-
     # fmt: off
-    transform_counts_map_to_ratios_map_when_all_count_values_are_null_rows = [
+    create_ratios_from_counts_when_all_count_values_are_null_rows = expected_create_total_from_values_in_map_column_when_all_count_values_are_null_rows
+    expected_create_ratios_from_counts_when_all_count_values_are_null_rows = [
         ("1-001", 
          {MainJobRoleLabels.care_worker: None, MainJobRoleLabels.registered_nurse: None},
-        ),
-    ]
-    expected_transform_counts_map_to_ratios_map_when_all_count_values_are_null_rows = [
-        ("1-001", 
-         {MainJobRoleLabels.care_worker: None, MainJobRoleLabels.registered_nurse: None},
+         None,
          {MainJobRoleLabels.care_worker: None, MainJobRoleLabels.registered_nurse: None},
         ),
     ]
     # fmt: on
 
-    # fmt: off
-    transform_counts_map_to_ratios_map_when_count_map_column_is_null_rows = [
-        ("1-001", 
-         None),
+    create_ratios_from_counts_when_count_map_column_is_null_rows = (
+        expected_create_total_from_values_in_map_column_when_count_column_is_null_rows
+    )
+    expected_create_ratios_from_counts_when_count_map_column_is_null_rows = [
+        ("1-001", None, None, None),
     ]
-    expected_transform_counts_map_to_ratios_map_when_count_map_column_is_null_rows = [
-        ("1-001", 
-         None, 
-         None),
-    ]
-    # fmt: on
 
     # fmt: off
-    transform_counts_map_to_ratios_map_at_multiple_establishments_rows = [
-        ("1-001", {MainJobRoleLabels.care_worker: 1, MainJobRoleLabels.registered_nurse: 0}),
-        ("1-002", {MainJobRoleLabels.care_worker: 0, MainJobRoleLabels.registered_nurse: 1}),
-    ]
-    expected_transform_counts_map_to_ratios_map_at_multiple_establishments_rows = [
+    create_ratios_from_counts_at_multiple_establishments_rows = (
+        expected_create_total_from_values_in_map_column_at_multiple_locations_rows
+    )
+    expected_create_ratios_from_counts_at_multiple_establishments_rows = [
         ("1-001", 
-         {MainJobRoleLabels.care_worker: 1, MainJobRoleLabels.registered_nurse: 0},
-         {MainJobRoleLabels.care_worker: 1.0, MainJobRoleLabels.registered_nurse: 0.0}
+         {MainJobRoleLabels.care_worker: 0, MainJobRoleLabels.registered_nurse: 1},
+         1,
+         {MainJobRoleLabels.care_worker: 0.0, MainJobRoleLabels.registered_nurse: 1.0}
         ),
         ("1-002", 
-         {MainJobRoleLabels.care_worker: 0, MainJobRoleLabels.registered_nurse: 1},
-         {MainJobRoleLabels.care_worker: 0.0, MainJobRoleLabels.registered_nurse: 1.0}
+         {MainJobRoleLabels.care_worker: 2, MainJobRoleLabels.registered_nurse: 3},
+         1,
+         {MainJobRoleLabels.care_worker: 0.4, MainJobRoleLabels.registered_nurse: 0.6}
         ),
     ]
     # fmt: on

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -9729,10 +9729,6 @@ class EstimateIndCQCFilledPostsByJobRoleUtilsData:
     ]
     # fmt: on
 
-    test_count_map_column = IndCQC.ascwds_job_role_counts
-    test_count_map_values_total_column_name = IndCQC.ascwds_job_role_counts_total
-    test_ratio_map_column_name = IndCQC.ascwds_job_role_ratios
-
     # fmt: off
     create_total_from_values_in_map_column_when_all_count_values_above_zero_rows = [
         ("1-001", 

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -9753,6 +9753,9 @@ class EstimateIndCQCFilledPostsByJobRoleUtilsData:
     ]
     # fmt: on
 
+    test_count_map_column = IndCQC.ascwds_job_role_counts
+    test_ratio_map_column_name = IndCQC.ascwds_job_role_ratios
+
     # fmt: off
     transform_counts_map_to_ratios_map_when_all_count_values_are_null_rows = [
         ("1-001", 

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -5976,7 +5976,7 @@ class EstimateIndCQCFilledPostsByJobRoleUtilsSchemas:
         ]
     )
 
-    create_total_from_values_in_map_column_shcema = StructType(
+    create_total_from_values_in_map_column_schema = StructType(
         [
             StructField(IndCQC.location_id, StringType(), True),
             StructField(
@@ -5987,7 +5987,7 @@ class EstimateIndCQCFilledPostsByJobRoleUtilsSchemas:
         ]
     )
 
-    expected_create_total_from_values_in_map_column_shcema = StructType(
+    expected_create_total_from_values_in_map_column_schema = StructType(
         [
             StructField(IndCQC.location_id, StringType(), True),
             StructField(
@@ -6000,7 +6000,7 @@ class EstimateIndCQCFilledPostsByJobRoleUtilsSchemas:
     )
 
     ascwds_job_role_count_map_to_ratios_map_schema = StructType(
-        [*expected_create_total_from_values_in_map_column_shcema]
+        [*expected_create_total_from_values_in_map_column_schema]
     )
 
     expected_ascwds_job_role_count_map_to_ratios_map_schema = StructType(

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -5976,7 +5976,7 @@ class EstimateIndCQCFilledPostsByJobRoleUtilsSchemas:
         ]
     )
 
-    ascwds_job_role_count_map_to_ratios_map_schema = StructType(
+    create_total_from_values_in_map_column_shcema = StructType(
         [
             StructField(IndCQC.location_id, StringType(), True),
             StructField(
@@ -5985,6 +5985,22 @@ class EstimateIndCQCFilledPostsByJobRoleUtilsSchemas:
                 True,
             ),
         ]
+    )
+
+    expected_create_total_from_values_in_map_column_shcema = StructType(
+        [
+            StructField(IndCQC.location_id, StringType(), True),
+            StructField(
+                IndCQC.ascwds_job_role_counts,
+                MapType(StringType(), LongType()),
+                True,
+            ),
+            StructField(IndCQC.ascwds_job_role_counts_total, LongType(), True),
+        ]
+    )
+
+    ascwds_job_role_count_map_to_ratios_map_schema = StructType(
+        [*expected_create_total_from_values_in_map_column_shcema]
     )
 
     expected_ascwds_job_role_count_map_to_ratios_map_schema = StructType(

--- a/tests/unit/test_estimate_ind_cqc_filled_posts_by_job_role_utils.py
+++ b/tests/unit/test_estimate_ind_cqc_filled_posts_by_job_role_utils.py
@@ -357,7 +357,9 @@ class TransformJobRoleCountsMapToRatiosMap(
             Data.transform_counts_map_to_ratios_map_when_only_one_count_value_above_zero_rows,
             Schemas.ascwds_job_role_count_map_to_ratios_map_schema,
         )
-        self.returned_df = job.transform_job_role_count_map_to_ratios_map(self.test_df)
+        self.returned_df = job.transform_count_map_to_ratios_map(
+            self.test_df, Data.test_count_map_column, Data.test_ratio_map_column_name
+        )
         self.expected_df = self.spark.createDataFrame(
             Data.expected_transform_counts_map_to_ratios_map_when_only_one_count_value_above_zero_rows,
             Schemas.expected_ascwds_job_role_count_map_to_ratios_map_schema,
@@ -397,7 +399,9 @@ class TransformJobRoleCountsMapToRatiosMap(
             Data.transform_counts_map_to_ratios_map_when_all_count_values_above_zero_rows,
             Schemas.ascwds_job_role_count_map_to_ratios_map_schema,
         )
-        returned_df = job.transform_job_role_count_map_to_ratios_map(test_df)
+        returned_df = job.transform_count_map_to_ratios_map(
+            test_df, Data.test_count_map_column, Data.test_ratio_map_column_name
+        )
         expected_df = self.spark.createDataFrame(
             Data.expected_transform_counts_map_to_ratios_map_when_all_count_values_above_zero_rows,
             Schemas.expected_ascwds_job_role_count_map_to_ratios_map_schema,
@@ -424,7 +428,9 @@ class TransformJobRoleCountsMapToRatiosMap(
             Data.transform_counts_map_to_ratios_map_when_all_count_values_are_null_rows,
             Schemas.ascwds_job_role_count_map_to_ratios_map_schema,
         )
-        returned_df = job.transform_job_role_count_map_to_ratios_map(test_df)
+        returned_df = job.transform_count_map_to_ratios_map(
+            test_df, Data.test_count_map_column, Data.test_ratio_map_column_name
+        )
         expected_df = self.spark.createDataFrame(
             Data.expected_transform_counts_map_to_ratios_map_when_all_count_values_are_null_rows,
             Schemas.expected_ascwds_job_role_count_map_to_ratios_map_schema,
@@ -445,7 +451,9 @@ class TransformJobRoleCountsMapToRatiosMap(
             Data.transform_counts_map_to_ratios_map_when_count_map_column_is_null_rows,
             Schemas.ascwds_job_role_count_map_to_ratios_map_schema,
         )
-        returned_df = job.transform_job_role_count_map_to_ratios_map(test_df)
+        returned_df = job.transform_count_map_to_ratios_map(
+            test_df, Data.test_count_map_column, Data.test_ratio_map_column_name
+        )
         expected_df = self.spark.createDataFrame(
             Data.expected_transform_counts_map_to_ratios_map_when_count_map_column_is_null_rows,
             Schemas.expected_ascwds_job_role_count_map_to_ratios_map_schema,
@@ -466,7 +474,9 @@ class TransformJobRoleCountsMapToRatiosMap(
             Data.transform_counts_map_to_ratios_map_at_multiple_establishments_rows,
             Schemas.ascwds_job_role_count_map_to_ratios_map_schema,
         )
-        returned_df = job.transform_job_role_count_map_to_ratios_map(test_df)
+        returned_df = job.transform_count_map_to_ratios_map(
+            test_df, Data.test_count_map_column, Data.test_ratio_map_column_name
+        )
         expected_df = self.spark.createDataFrame(
             Data.expected_transform_counts_map_to_ratios_map_at_multiple_establishments_rows,
             Schemas.expected_ascwds_job_role_count_map_to_ratios_map_schema,

--- a/tests/unit/test_estimate_ind_cqc_filled_posts_by_job_role_utils.py
+++ b/tests/unit/test_estimate_ind_cqc_filled_posts_by_job_role_utils.py
@@ -355,17 +355,17 @@ class TransformJobRoleCountsMapToRatiosMap(
         super().setUp()
 
         self.test_df = self.spark.createDataFrame(
-            Data.transform_counts_map_to_ratios_map_when_only_one_count_value_above_zero_rows,
-            Schemas.ascwds_job_role_count_map_to_ratios_map_schema,
+            Data.create_total_from_values_in_map_column_when_all_count_values_above_zero_rows,
+            Schemas.create_total_from_values_in_map_column_schema,
         )
         self.returned_df = job.transform_job_role_count_map_to_ratios_map(
             self.test_df,
-            Data.test_count_map_column,
-            Data.test_count_map_values_total_column_name,
-            Data.test_ratio_map_column_name,
+            IndCQC.ascwds_job_role_counts,
+            IndCQC.ascwds_job_role_counts_total,
+            IndCQC.ascwds_job_role_ratios,
         )
         self.expected_df = self.spark.createDataFrame(
-            Data.expected_transform_counts_map_to_ratios_map_when_only_one_count_value_above_zero_rows,
+            Data.expected_create_ratios_from_counts_when_all_count_values_above_zero_rows,
             Schemas.expected_ascwds_job_role_count_map_to_ratios_map_schema,
         )
 
@@ -388,9 +388,9 @@ class TransformJobRoleCountsMapToRatiosMap(
     ):
         job.transform_job_role_count_map_to_ratios_map(
             self.test_df,
-            Data.test_count_map_column,
-            Data.test_count_map_values_total_column_name,
-            Data.test_ratio_map_column_name,
+            IndCQC.ascwds_job_role_counts,
+            IndCQC.ascwds_job_role_counts_total,
+            IndCQC.ascwds_job_role_ratios,
         )
         create_total_from_values_in_map_column_mock.assert_called_once()
         create_ratios_map_from_count_map_and_total_mock.assert_called_once()
@@ -412,16 +412,16 @@ class CreateTotalFromValuesInMapColumn(EstimateIndCQCFilledPostsByJobRoleUtilsTe
 
         self.test_df = self.spark.createDataFrame(
             Data.create_total_from_values_in_map_column_when_all_count_values_above_zero_rows,
-            Schemas.create_total_from_values_in_map_column_shcema,
+            Schemas.create_total_from_values_in_map_column_schema,
         )
         self.returned_df = job.create_total_from_values_in_map_column(
             self.test_df,
-            Data.test_count_map_column,
-            Data.test_count_map_values_total_column_name,
+            IndCQC.ascwds_job_role_counts,
+            IndCQC.ascwds_job_role_counts_total,
         )
         self.expected_df = self.spark.createDataFrame(
             Data.expected_create_total_from_values_in_map_column_when_all_count_values_above_zero_rows,
-            Schemas.expected_create_total_from_values_in_map_column_shcema,
+            Schemas.expected_create_total_from_values_in_map_column_schema,
         )
 
         self.added_columns = [
@@ -439,7 +439,8 @@ class CreateTotalFromValuesInMapColumn(EstimateIndCQCFilledPostsByJobRoleUtilsTe
         self,
     ):
         self.assertEqual(
-            self.added_columns[0], Data.test_count_map_values_total_column_name
+            self.added_columns[0],
+            IndCQC.ascwds_job_role_counts_total,
         )
 
     def test_create_total_from_values_in_map_returns_expected_value_when_all_count_values_above_zero(
@@ -452,16 +453,16 @@ class CreateTotalFromValuesInMapColumn(EstimateIndCQCFilledPostsByJobRoleUtilsTe
     ):
         test_df = self.spark.createDataFrame(
             Data.create_total_from_values_in_map_column_when_all_count_values_are_null_rows,
-            Schemas.create_total_from_values_in_map_column_shcema,
+            Schemas.create_total_from_values_in_map_column_schema,
         )
         returned_df = job.create_total_from_values_in_map_column(
             test_df,
-            Data.test_count_map_column,
-            Data.test_count_map_values_total_column_name,
+            IndCQC.ascwds_job_role_counts,
+            IndCQC.ascwds_job_role_counts_total,
         )
         expected_df = self.spark.createDataFrame(
             Data.expected_create_total_from_values_in_map_column_when_all_count_values_are_null_rows,
-            Schemas.expected_create_total_from_values_in_map_column_shcema,
+            Schemas.expected_create_total_from_values_in_map_column_schema,
         )
 
         self.assertEqual(returned_df.collect(), expected_df.collect())
@@ -471,16 +472,16 @@ class CreateTotalFromValuesInMapColumn(EstimateIndCQCFilledPostsByJobRoleUtilsTe
     ):
         test_df = self.spark.createDataFrame(
             Data.create_total_from_values_in_map_column_when_count_column_is_null_rows,
-            Schemas.create_total_from_values_in_map_column_shcema,
+            Schemas.create_total_from_values_in_map_column_schema,
         )
         returned_df = job.create_total_from_values_in_map_column(
             test_df,
-            Data.test_count_map_column,
-            Data.test_count_map_values_total_column_name,
+            IndCQC.ascwds_job_role_counts,
+            IndCQC.ascwds_job_role_counts_total,
         )
         expected_df = self.spark.createDataFrame(
             Data.expected_create_total_from_values_in_map_column_when_count_column_is_null_rows,
-            Schemas.expected_create_total_from_values_in_map_column_shcema,
+            Schemas.expected_create_total_from_values_in_map_column_schema,
         )
 
         self.assertEqual(returned_df.collect(), expected_df.collect())
@@ -499,9 +500,9 @@ class CreateRatiosMapFromCountMapAndTotal(EstimateIndCQCFilledPostsByJobRoleUtil
         )
         returned_df = job.create_ratios_map_from_count_map_and_total(
             test_df,
-            Data.test_count_map_column,
-            Data.test_count_map_values_total_column_name,
-            Data.test_ratio_map_column_name,
+            IndCQC.ascwds_job_role_counts,
+            IndCQC.ascwds_job_role_counts_total,
+            IndCQC.ascwds_job_role_ratios,
         )
         expected_df = self.spark.createDataFrame(
             Data.expected_create_ratios_from_counts_when_all_count_values_above_zero_rows,
@@ -531,9 +532,9 @@ class CreateRatiosMapFromCountMapAndTotal(EstimateIndCQCFilledPostsByJobRoleUtil
         )
         returned_df = job.create_ratios_map_from_count_map_and_total(
             test_df,
-            Data.test_count_map_column,
-            Data.test_count_map_values_total_column_name,
-            Data.test_ratio_map_column_name,
+            IndCQC.ascwds_job_role_counts,
+            IndCQC.ascwds_job_role_counts_total,
+            IndCQC.ascwds_job_role_ratios,
         )
         expected_df = self.spark.createDataFrame(
             Data.expected_create_ratios_from_counts_when_all_count_values_are_null_rows,
@@ -557,9 +558,9 @@ class CreateRatiosMapFromCountMapAndTotal(EstimateIndCQCFilledPostsByJobRoleUtil
         )
         returned_df = job.create_ratios_map_from_count_map_and_total(
             test_df,
-            Data.test_count_map_column,
-            Data.test_count_map_values_total_column_name,
-            Data.test_ratio_map_column_name,
+            IndCQC.ascwds_job_role_counts,
+            IndCQC.ascwds_job_role_counts_total,
+            IndCQC.ascwds_job_role_ratios,
         )
         expected_df = self.spark.createDataFrame(
             Data.expected_create_ratios_from_counts_when_count_map_column_is_null_rows,
@@ -583,9 +584,9 @@ class CreateRatiosMapFromCountMapAndTotal(EstimateIndCQCFilledPostsByJobRoleUtil
         )
         returned_df = job.create_ratios_map_from_count_map_and_total(
             test_df,
-            Data.test_count_map_column,
-            Data.test_count_map_values_total_column_name,
-            Data.test_ratio_map_column_name,
+            IndCQC.ascwds_job_role_counts,
+            IndCQC.ascwds_job_role_counts_total,
+            IndCQC.ascwds_job_role_ratios,
         )
         expected_df = self.spark.createDataFrame(
             Data.expected_create_ratios_from_counts_at_multiple_establishments_rows,

--- a/utils/column_names/ind_cqc_pipeline_columns.py
+++ b/utils/column_names/ind_cqc_pipeline_columns.py
@@ -46,6 +46,7 @@ class IndCqcColumns:
     ascwds_filled_posts_source: str = ascwds_filled_posts + "_source"
     ascwds_filtering_rule: str = "ascwds_filtering_rule"
     ascwds_job_role_counts: str = "ascwds_job_role_counts"
+    ascwds_job_role_counts_total: str = "ascwds_job_role_counts_total"
     ascwds_job_role_ratios: str = "ascwds_job_role_ratios"
     ascwds_worker_import_date: str = AWKClean.ascwds_worker_import_date
     ascwds_workplace_import_date: str = AWPClean.ascwds_workplace_import_date

--- a/utils/estimate_filled_posts_by_job_role_utils/utils.py
+++ b/utils/estimate_filled_posts_by_job_role_utils/utils.py
@@ -97,7 +97,7 @@ def merge_dataframes(
     return merged_df
 
 
-def transform_count_map_to_ratios_map(
+def transform_job_role_count_map_to_ratios_map(
     estimated_ind_cqc_filled_posts_by_job_role_df: DataFrame,
     count_map_column: str,
     count_map_values_total_column_name: str,

--- a/utils/estimate_filled_posts_by_job_role_utils/utils.py
+++ b/utils/estimate_filled_posts_by_job_role_utils/utils.py
@@ -113,7 +113,8 @@ def transform_job_role_count_map_to_ratios_map(
     Args:
         estimated_ind_cqc_filled_posts_by_job_role_df (DataFrame): A dataframe containing a job role count map at workplace level.
         count_map_column (str): A map column of type any:long.
-        ratio_map_column_name (str): The name to give to the new ratio map column.
+        count_map_values_total_column_name (str): The name to give to the total values from count map column.
+        ratio_map_column_name (str): The name to give to the ratio map column.
 
     Returns:
         DataFrame: The estimated filled post by job role DataFrame with the job role ratio map column joined in.


### PR DESCRIPTION
# Description
Refactored the utils function for transforming job role counts map into a job role ratios map.
I've split the original function into two and changed the original function to call them.
We can also use one of these functions to make a sum of job role count map values (total worker records) if needed.

This function still drops the total worker records after it is done using it to make the ratios.

[Trello ticket](https://trello.com/c/AEXnmomG)

# How to test
[Link to successful pipeline run in branch ](https://eu-west-2.console.aws.amazon.com/states/home?region=eu-west-2#/v2/executions/details/arn:aws:states:eu-west-2:344210435447:execution:refactor-counts-map-to-ratios--Ind-CQC-Filled-Post-Estimates-Pipeline:882a31b5-4cd2-4d99-a165-b9f2ad62ca21)
[Link to Athena output](https://eu-west-2.console.aws.amazon.com/athena/home?region=eu-west-2#/query-editor/history/84ba7f84-247d-49da-977c-2c04a7898171)

# Developer checklist
- [x] Unit test
- [x] Linked to Trello ticket
- [x] Documentation up to date
