### PR TITLE
Updated df name and moved after JR breakdown function

### DIFF
--- a/jobs/estimate_ind_cqc_filled_posts_by_job_role.py
+++ b/jobs/estimate_ind_cqc_filled_posts_by_job_role.py
@@ -89,13 +89,15 @@ def main(
         )
     )
 
-    estimated_ind_cqc_filled_posts_df = JRutils.count_registered_manager_names(
-        estimated_ind_cqc_filled_posts_df
-    )
-
     estimated_ind_cqc_filled_posts_by_job_role_df = (
         JRutils.sum_job_role_count_split_by_service(
             estimated_ind_cqc_filled_posts_by_job_role_df, JRutils.list_of_job_roles
+        )
+    )
+
+    estimated_ind_cqc_filled_posts_by_job_role_df = (
+        JRutils.count_registered_manager_names(
+            estimated_ind_cqc_filled_posts_by_job_role_df
         )
     )
 


### PR DESCRIPTION
# Description
Noticed that the df name for registered managers hadn't been updated so this info isn't actually being added to the final output. Updated and moved to the end (after job role breakdown breakdown functions
