### PR TITLE
Reduce CQC location validation checks

### DIFF
--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -17,21 +17,21 @@ from utils.column_values.categorical_columns_by_dataset import (
     DiagnosticOnKnownFilledPostsCategoricalValues as CatValues,
 )
 from utils.column_values.categorical_column_values import (
-    RegistrationStatus,
-    PrimaryServiceType,
-    CareHome,
-    Sector,
-    MainJobRoleLabels,
-    LocationType,
-    CQCRatingsValues,
-    CQCCurrentOrHistoricValues,
-    ParentsOrSinglesAndSubs,
-    IsParent,
-    SingleSubDescription,
-    Services,
-    EstimateFilledPostsSource,
     AscwdsFilteringRule,
+    CareHome,
+    CQCCurrentOrHistoricValues,
+    CQCRatingsValues,
+    EstimateFilledPostsSource,
+    IsParent,
+    LocationType,
+    MainJobRoleLabels,
+    ParentsOrSinglesAndSubs,
+    PrimaryServiceType,
+    RegistrationStatus,
     RelatedLocation,
+    Sector,
+    Services,
+    SingleSubDescription,
 )
 from utils.ind_cqc_filled_posts_utils.ascwds_filled_posts_calculator.calculate_ascwds_filled_posts_difference_within_range import (
     ascwds_filled_posts_difference_within_range_source_description,
@@ -8085,14 +8085,13 @@ class ValidateASCWDSWorkerRawData:
 
 @dataclass
 class ValidateLocationsAPIRawData:
-    # fmt: off
     raw_cqc_locations_rows = [
-        ("1-000000001", "20240101", "Y", "prov_1", RegistrationStatus.registered, "2020-01-01", "location name", 5, "N"),
-        ("1-000000002", "20240101", "Y", "prov_1", RegistrationStatus.deregistered, "2020-01-01", "location name", 5, "N"),
-        ("1-000000001", "20240201", "Y", "prov_1", RegistrationStatus.registered, "2020-01-01", "location name", 5, "N"),
-        ("1-000000002", "20240201", "Y", "prov_1", RegistrationStatus.deregistered, "2020-01-01", "location name", 5, "N"),
+        ("1-00001", "20240101", "1-001", "name", LocationType.social_care_identifier),
+        ("1-00002", "20240101", "1-001", "name", LocationType.social_care_identifier),
+        ("1-00001", "20240201", "1-001", "name", LocationType.social_care_identifier),
+        ("1-00002", "20240201", "1-001", "name", LocationType.social_care_identifier),
+        ("1-00002", "20240201", "1-001", "name", LocationType.social_care_identifier),
     ]
-    # fmt: on
 
 
 @dataclass

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -4746,13 +4746,9 @@ class ValidateLocationsAPIRawData:
         [
             StructField(CQCL.location_id, StringType(), True),
             StructField(Keys.import_date, StringType(), True),
-            StructField(CQCL.care_home, StringType(), True),
             StructField(CQCL.provider_id, StringType(), True),
-            StructField(CQCL.registration_status, StringType(), True),
-            StructField(CQCL.registration_date, StringType(), True),
             StructField(CQCL.name, StringType(), True),
-            StructField(CQCL.number_of_beds, IntegerType(), True),
-            StructField(CQCL.dormancy, StringType(), True),
+            StructField(CQCL.type, StringType(), True),
         ]
     )
 

--- a/utils/column_values/categorical_columns_by_dataset.py
+++ b/utils/column_values/categorical_columns_by_dataset.py
@@ -2,7 +2,6 @@ from dataclasses import dataclass
 
 from utils.column_names.cleaned_data_files.cqc_location_cleaned import (
     CqcLocationCleanedColumns as CQCLClean,
-    NewCqcLocationApiColumns as CQCL,
 )
 from utils.column_names.cleaned_data_files.cqc_pir_cleaned import (
     CqcPIRCleanedColumns as PIRClean,
@@ -41,13 +40,6 @@ from utils.column_values.categorical_column_values import (
     RelatedLocation,
     InAscwds,
 )
-
-
-@dataclass
-class LocationApiRawCategoricalValues:
-    dormancy_column_values = Dormancy(CQCL.dormancy, contains_null_values=True)
-    registration_status_column_values = RegistrationStatus(CQCL.registration_status)
-    care_home_column_values = CareHome(CQCL.care_home)
 
 
 @dataclass

--- a/utils/validation/validation_rules/locations_api_raw_validation_rules.py
+++ b/utils/validation/validation_rules/locations_api_raw_validation_rules.py
@@ -6,10 +6,6 @@ from utils.column_names.raw_data_files.cqc_location_api_columns import (
 from utils.column_names.ind_cqc_pipeline_columns import (
     PartitionKeys as Keys,
 )
-from utils.column_values.categorical_columns_by_dataset import (
-    LocationApiRawCategoricalValues as CatValues,
-)
-
 from utils.validation.validation_rule_names import RuleNames as RuleName
 
 
@@ -19,22 +15,10 @@ class LocationsAPIRawValidationRules:
         RuleName.complete_columns: [
             CQCL.location_id,
             Keys.import_date,
-            CQCL.care_home,
-            CQCL.registration_status,
             CQCL.name,
         ],
         RuleName.index_columns: [
             CQCL.location_id,
             Keys.import_date,
         ],
-        RuleName.categorical_values_in_columns: {
-            CQCL.care_home: CatValues.care_home_column_values.categorical_values,
-            CQCL.registration_status: CatValues.registration_status_column_values.categorical_values,
-            CQCL.dormancy: CatValues.dormancy_column_values.categorical_values,
-        },
-        RuleName.distinct_values: {
-            CQCL.care_home: CatValues.care_home_column_values.count_of_categorical_values,
-            CQCL.registration_status: CatValues.registration_status_column_values.count_of_categorical_values,
-            CQCL.dormancy: CatValues.dormancy_column_values.count_of_categorical_values,
-        },
     }


### PR DESCRIPTION
# Description
The raw CQC locations data contained some DQ checks, but often these fail due to non-adult social care data. I've kept in the checks regarding each locationid being unique, but the checks for completeness are in the cleaned version of the data file, once data we're not interested in has been removed

I've simplified the test data accordingly

# How to test
Previous tests still passing, haven't rerun the branch as we've only removed checks, nothing new has been added

# Developer checklist
- [X] Unit test
- [X] Linked to Trello ticket
- [X] Documentation up to date
