### PR TITLE
Generalise add_list_of_services_offered function to create 'specialisms_offered' as well

### DIFF
--- a/jobs/clean_cqc_location_data.py
+++ b/jobs/clean_cqc_location_data.py
@@ -124,6 +124,11 @@ def main(
         registered_locations_df[CQCLClean.imputed_gac_service_types][CQCL.description],
         CQCLClean.services_offered,
     )
+    registered_locations_df = extract_from_struct(
+        registered_locations_df,
+        registered_locations_df[CQCLClean.specialisms][CQCL.name],
+        CQCLClean.specialisms_offered,
+    )
     registered_locations_df = remove_specialist_colleges(registered_locations_df)
     registered_locations_df = allocate_primary_service_type(registered_locations_df)
     registered_locations_df = realign_carehome_column_with_primary_service(

--- a/jobs/clean_cqc_location_data.py
+++ b/jobs/clean_cqc_location_data.py
@@ -119,7 +119,11 @@ def main(
     registered_locations_df = remove_locations_that_never_had_regulated_activities(
         registered_locations_df
     )
-    registered_locations_df = add_list_of_services_offered(registered_locations_df)
+    registered_locations_df = extract_from_struct(
+        registered_locations_df,
+        registered_locations_df[CQCLClean.imputed_gac_service_types][CQCL.description],
+        CQCLClean.services_offered,
+    )
     registered_locations_df = remove_specialist_colleges(registered_locations_df)
     registered_locations_df = allocate_primary_service_type(registered_locations_df)
     registered_locations_df = realign_carehome_column_with_primary_service(
@@ -494,21 +498,22 @@ def remove_locations_that_never_had_regulated_activities(df: DataFrame) -> DataF
     return df
 
 
-def add_list_of_services_offered(cqc_loc_df: DataFrame) -> DataFrame:
+def extract_from_struct(
+    df: DataFrame, source_struct_column_name: str, new_column_name: str
+) -> DataFrame:
     """
-    Adds a new column called 'services_offered' which contains an array of descriptions from the 'imputed_gac_service_types' field.
+    Extracts data from a specified struct column and stores it in a new column as an array.
 
     Args:
-        cqc_loc_df (DataFrame): The input DataFrame containing the 'imputed_gac_service_types' column.
+        df (DataFrame): The input DataFrame.
+        source_struct_column_name (str): The name of the column to extract data from.
+        new_column_name (str): The name of the new column where extracted data will be stored.
 
     Returns:
-        DataFrame: The DataFrame with the new 'services_offered' column added.
+        DataFrame: A new DataFrame with the extracted data stored in the specified column.
     """
-    cqc_loc_df = cqc_loc_df.withColumn(
-        CQCLClean.services_offered,
-        cqc_loc_df[CQCLClean.imputed_gac_service_types][CQCL.description],
-    )
-    return cqc_loc_df
+    df = df.withColumn(new_column_name, source_struct_column_name)
+    return df
 
 
 def allocate_primary_service_type(df: DataFrame) -> DataFrame:

--- a/jobs/merge_ind_cqc_data.py
+++ b/jobs/merge_ind_cqc_data.py
@@ -41,6 +41,7 @@ cleaned_cqc_locations_columns_to_import = [
     CQCLClean.imputed_gac_service_types,
     CQCLClean.services_offered,
     CQCLClean.specialisms,
+    CQCLClean.specialisms_offered,
     CQCLClean.related_location,
     CQCLClean.primary_service_type,
     CQCLClean.registered_manager_names,

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -2367,64 +2367,66 @@ class CQCLocationsData:
         ),
     ]
 
-    list_of_services_rows = [
+    extract_from_struct_rows = [
         (
-            "location1",
-            "provider1",
+            "1-001",
             [
                 {
-                    "name": "Homecare agencies",
-                    "description": "Domiciliary care service",
+                    CQCL.name: "Homecare agencies",
+                    CQCL.description: Services.domiciliary_care_service,
                 }
             ],
         ),
         (
-            "location2",
-            "provider2",
+            "1-002",
             [
                 {
-                    "name": "With nursing",
-                    "description": "Care home service with nursing",
-                }
-            ],
-        ),
-        (
-            "location3",
-            "provider3",
-            [
-                {
-                    "name": "Without nursing",
-                    "description": "Care home service without nursing",
-                }
-            ],
-        ),
-        (
-            "location4",
-            "provider4",
-            [
-                {
-                    "name": "With nursing",
-                    "description": "Care home service with nursing",
+                    CQCL.name: "With nursing",
+                    CQCL.description: Services.care_home_service_with_nursing,
                 },
                 {
-                    "name": "Without nursing",
-                    "description": "Care home service without nursing",
+                    CQCL.name: "Without nursing",
+                    CQCL.description: Services.care_home_service_without_nursing,
                 },
             ],
         ),
         (
-            "location5",
-            "provider5",
+            "1-003",
+            None,
+        ),
+    ]
+    expected_extract_from_struct_rows = [
+        (
+            "1-001",
             [
                 {
-                    "name": "Without nursing",
-                    "description": "Care home service without nursing",
-                },
-                {
-                    "name": "Fake",
-                    "description": "Fake service",
+                    CQCL.name: "Homecare agencies",
+                    CQCL.description: Services.domiciliary_care_service,
                 },
             ],
+            [Services.domiciliary_care_service],
+        ),
+        (
+            "1-002",
+            [
+                {
+                    CQCL.name: "With nursing",
+                    CQCL.description: Services.care_home_service_with_nursing,
+                },
+                {
+                    CQCL.name: "Without nursing",
+                    CQCL.description: Services.care_home_service_without_nursing,
+                },
+            ],
+            [
+                Services.care_home_service_with_nursing,
+                Services.care_home_service_without_nursing,
+            ],
+        ),
+        (
+            "1-003",
+            None,
+            None,
         ),
     ]
 
@@ -2993,71 +2995,6 @@ class CQCLocationsData:
         ),
     ]
 
-    expected_services_offered_rows = [
-        (
-            "location1",
-            "provider1",
-            [
-                {
-                    "name": "Homecare agencies",
-                    "description": "Domiciliary care service",
-                },
-            ],
-            ["Domiciliary care service"],
-        ),
-        (
-            "location2",
-            "provider2",
-            [
-                {
-                    "name": "With nursing",
-                    "description": "Care home service with nursing",
-                }
-            ],
-            ["Care home service with nursing"],
-        ),
-        (
-            "location3",
-            "provider3",
-            [
-                {
-                    "name": "Without nursing",
-                    "description": "Care home service without nursing",
-                }
-            ],
-            ["Care home service without nursing"],
-        ),
-        (
-            "location4",
-            "provider4",
-            [
-                {
-                    "name": "With nursing",
-                    "description": "Care home service with nursing",
-                },
-                {
-                    "name": "Without nursing",
-                    "description": "Care home service without nursing",
-                },
-            ],
-            ["Care home service with nursing", "Care home service without nursing"],
-        ),
-        (
-            "location5",
-            "provider5",
-            [
-                {
-                    "name": "Without nursing",
-                    "description": "Care home service without nursing",
-                },
-                {
-                    "name": "Fake",
-                    "description": "Fake service",
-                },
-            ],
-            ["Care home service without nursing", "Fake service"],
-        ),
-    ]
     # fmt: off
     remove_time_from_date_column_rows = [
         ("loc_1", "2018-01-01", "20240101", "2018-01-01"),

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -1209,6 +1209,34 @@ class CQCLocationsSchema:
         ]
     )
 
+    extract_from_struct_schema = StructType(
+        [
+            StructField(CQCL.location_id, StringType(), True),
+            StructField(
+                CQCLClean.gac_service_types,
+                ArrayType(
+                    StructType(
+                        [
+                            StructField(CQCL.name, StringType(), True),
+                            StructField(CQCL.description, StringType(), True),
+                        ]
+                    )
+                ),
+            ),
+        ]
+    )
+    expected_extract_from_struct_schema = StructType(
+        [
+            *extract_from_struct_schema,
+            StructField(
+                CQCLClean.services_offered,
+                ArrayType(
+                    StringType(),
+                ),
+            ),
+        ]
+    )
+
     primary_service_type_schema = StructType(
         [
             StructField(CQCL.location_id, StringType(), True),
@@ -1343,18 +1371,6 @@ class CQCLocationsSchema:
     expected_split_registered_schema = StructType(
         [
             *expected_ons_join_schema,
-        ]
-    )
-
-    expected_services_offered_schema = StructType(
-        [
-            *primary_service_type_schema,
-            StructField(
-                CQCLClean.services_offered,
-                ArrayType(
-                    StringType(),
-                ),
-            ),
         ]
     )
 

--- a/tests/unit/test_clean_cqc_location_data.py
+++ b/tests/unit/test_clean_cqc_location_data.py
@@ -446,36 +446,29 @@ class RemoveLocationsThatNeverHadRegulatedActivitesTests(CleanCQCLocationDataset
         self.assertEqual(self.returned_data, self.expected_data)
 
 
-class ListServicesOfferedTests(CleanCQCLocationDatasetTests):
+class ExtractFromStructTests(CleanCQCLocationDatasetTests):
     def setUp(self) -> None:
         super().setUp()
-        self.test_services_offered_df = self.spark.createDataFrame(
-            Data.list_of_services_rows,
-            schema=Schemas.primary_service_type_schema,
+        test_df = self.spark.createDataFrame(
+            Data.extract_from_struct_rows,
+            schema=Schemas.extract_from_struct_schema,
         )
-        self.returned_df = job.add_list_of_services_offered(
-            self.test_services_offered_df
+        self.returned_df = job.extract_from_struct(
+            test_df,
+            test_df[CQCL.gac_service_types][CQCL.description],
+            CQCLCleaned.services_offered,
         )
 
-    def test_add_list_of_services_offered_adds_column(self):
+    def test_extract_from_struct_adds_column(self):
         self.assertTrue(CQCLCleaned.services_offered in self.returned_df.columns)
 
-    def test_add_list_of_services_offered_returns_correct_data(self):
+    def test_extract_from_struct_returns_correct_data(self):
         expected_df = self.spark.createDataFrame(
-            Data.expected_services_offered_rows,
-            Schemas.expected_services_offered_schema,
+            Data.expected_extract_from_struct_rows,
+            Schemas.expected_extract_from_struct_schema,
         )
-
-        returned_data = (
-            self.returned_df.select(sorted(self.returned_df.columns))
-            .sort(CQCLCleaned.location_id)
-            .collect()
-        )
-        expected_data = (
-            expected_df.select(sorted(expected_df.columns))
-            .sort(CQCLCleaned.location_id)
-            .collect()
-        )
+        returned_data = self.returned_df.sort(CQCLCleaned.location_id).collect()
+        expected_data = expected_df.collect()
         self.assertEqual(returned_data, expected_data)
 
 

--- a/utils/column_names/cleaned_data_files/cqc_location_cleaned.py
+++ b/utils/column_names/cleaned_data_files/cqc_location_cleaned.py
@@ -43,3 +43,4 @@ class CqcLocationCleanedColumns(NewCqcLocationApiColumns, ONSClean):
         NewCqcLocationApiColumns.relationships + "_predecessors_only"
     )
     services_offered: str = "services_offered"
+    specialisms_offered: str = "specialisms_offered"

--- a/utils/column_names/ind_cqc_pipeline_columns.py
+++ b/utils/column_names/ind_cqc_pipeline_columns.py
@@ -239,6 +239,7 @@ class IndCqcColumns:
     services_offered: str = CQCLClean.services_offered
     specialism_count: str = "specialism_count"
     specialisms: str = CQCLClean.specialisms
+    specialisms_offered: str = CQCLClean.specialisms_offered
     standardised_residual: str = "standardised_residual"
     time_registered: str = "time_registered"
     total_staff_bounded: str = AWPClean.total_staff_bounded


### PR DESCRIPTION
# Description
Currently `add_list_of_services_offered` is used to extract the description from `df[gac_service_types][description]` and returns an array of the services offered.

I have another column I'll need to do this for `df[specialisms][name]` so I've generalised the function - primarily wording changes, the function itself is very basic.

# How to test
Simplified previous test data and still passing

[Branch run](https://eu-west-2.console.aws.amazon.com/states/home?region=eu-west-2#/v2/executions/details/arn:aws:states:eu-west-2:344210435447:execution:generalise-extract-from-struct-Ind-CQC-Filled-Post-Estimates-Pipeline:6792695b-fd8d-41ff-bc97-643db067663e)

# Developer checklist
- [X] Unit test
- [X] Linked to Trello ticket
- [X] Documentation up to date
