### PR TITLE
Remove jr counts when estimate source not ascwds

### DIFF
--- a/jobs/estimate_ind_cqc_filled_posts_by_job_role.py
+++ b/jobs/estimate_ind_cqc_filled_posts_by_job_role.py
@@ -33,6 +33,7 @@ estimated_ind_cqc_filled_posts_columns_to_import = [
     IndCQC.establishment_id,
     IndCQC.organisation_id,
     IndCQC.worker_records_bounded,
+    IndCQC.ascwds_filled_posts_dedup_clean,
     IndCQC.ascwds_pir_merged,
     IndCQC.ascwds_filtering_rule,
     IndCQC.current_ons_import_date,
@@ -80,6 +81,10 @@ def main(
     estimated_ind_cqc_filled_posts_by_job_role_df = JRutils.merge_dataframes(
         estimated_ind_cqc_filled_posts_df,
         aggregated_job_roles_per_establishment_df,
+    )
+
+    estimated_ind_cqc_filled_posts_by_job_role_df = JRutils.remove_ascwds_job_role_count_when_estimate_filled_posts_source_not_ascwds(
+        estimated_ind_cqc_filled_posts_by_job_role_df
     )
 
     estimated_ind_cqc_filled_posts_by_job_role_df = (

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -9942,6 +9942,46 @@ class EstimateIndCQCFilledPostsByJobRoleUtilsData:
     ]
     # fmt: on
 
+    # fmt: off
+    remove_ascwds_job_role_count_when_estimate_filled_posts_source_not_ascwds_rows = [
+        ("1-001", 
+         10.0, 
+         10.0,
+         EstimateFilledPostsSource.ascwds_pir_merged,
+         {MainJobRoleLabels.care_worker: 1, MainJobRoleLabels.registered_nurse: 2}),
+        ("1-002", 
+         None, 
+         20.0,
+         EstimateFilledPostsSource.ascwds_pir_merged,
+         {MainJobRoleLabels.care_worker: 1, MainJobRoleLabels.registered_nurse: 2}),
+        ("1-003", 
+         10.0, 
+         10.0,
+         EstimateFilledPostsSource.care_home_model,
+         {MainJobRoleLabels.care_worker: 1, MainJobRoleLabels.registered_nurse: 2}),
+    ]
+    # fmt: on
+
+    # fmt: off
+    expected_remove_ascwds_job_role_count_when_estimate_filled_posts_source_not_ascwds_rows = [
+        ("1-001", 
+         10.0, 
+         10.0,
+         EstimateFilledPostsSource.ascwds_pir_merged,
+         {MainJobRoleLabels.care_worker: 1, MainJobRoleLabels.registered_nurse: 2}),
+        ("1-002", 
+         None, 
+         20.0,
+         EstimateFilledPostsSource.ascwds_pir_merged,
+         None),
+        ("1-003", 
+         10.0, 
+         10.0,
+         EstimateFilledPostsSource.care_home_model,
+         None),
+    ]
+    # fmt: on
+
     count_registered_manager_names_when_location_has_one_registered_manager_rows = [
         ("1-0000000001", date(2025, 1, 1), ["John Doe"])
     ]

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -6058,6 +6058,22 @@ class EstimateIndCQCFilledPostsByJobRoleUtilsSchemas:
         ]
     )
 
+    remove_ascwds_job_role_count_when_estimate_filled_posts_source_not_ascwds_schema = (
+        StructType(
+            [
+                StructField(IndCQC.location_id, StringType(), True),
+                StructField(IndCQC.ascwds_filled_posts_dedup_clean, DoubleType(), True),
+                StructField(IndCQC.estimate_filled_posts, DoubleType(), True),
+                StructField(IndCQC.estimate_filled_posts_source, StringType(), True),
+                StructField(
+                    IndCQC.ascwds_job_role_counts,
+                    MapType(StringType(), IntegerType()),
+                    True,
+                ),
+            ]
+        )
+    )
+
     count_registered_manager_names_schema = StructType(
         [
             StructField(IndCQC.location_id, StringType(), True),

--- a/tests/unit/test_estimate_ind_cqc_filled_posts_by_job_role.py
+++ b/tests/unit/test_estimate_ind_cqc_filled_posts_by_job_role.py
@@ -41,6 +41,9 @@ class MainTests(EstimateIndCQCFilledPostsByJobRoleTests):
     @patch(
         "utils.estimate_filled_posts_by_job_role_utils.utils.sum_job_role_count_split_by_service"
     )
+    @patch(
+        "utils.estimate_filled_posts_by_job_role_utils.utils.remove_ascwds_job_role_count_when_estimate_filled_posts_source_not_ascwds"
+    )
     @patch("utils.estimate_filled_posts_by_job_role_utils.utils.merge_dataframes")
     @patch(
         "utils.estimate_filled_posts_by_job_role_utils.utils.aggregate_ascwds_worker_job_roles_per_establishment"
@@ -51,6 +54,7 @@ class MainTests(EstimateIndCQCFilledPostsByJobRoleTests):
         read_from_parquet_mock: Mock,
         aggregate_ascwds_worker_job_roles_per_establishment_mock: Mock,
         merge_dataframes_mock: Mock,
+        remove_ascwds_job_role_count_when_estimate_filled_posts_source_not_ascwds_mock: Mock,
         sum_job_role_count_split_by_service_mock: Mock,
         transform_job_role_count_map_to_ratios_map_mock: Mock,
         merge_columns_in_order_mock: Mock,
@@ -78,6 +82,7 @@ class MainTests(EstimateIndCQCFilledPostsByJobRoleTests):
         )
         aggregate_ascwds_worker_job_roles_per_establishment_mock.assert_called_once()
         merge_dataframes_mock.assert_called_once()
+        remove_ascwds_job_role_count_when_estimate_filled_posts_source_not_ascwds_mock.assert_called_once()
         sum_job_role_count_split_by_service_mock.assert_called_once()
         self.assertEqual(transform_job_role_count_map_to_ratios_map_mock.call_count, 2)
         merge_columns_in_order_mock.assert_called_once()

--- a/tests/unit/test_estimate_ind_cqc_filled_posts_by_job_role_utils.py
+++ b/tests/unit/test_estimate_ind_cqc_filled_posts_by_job_role_utils.py
@@ -600,6 +600,33 @@ class CreateRatiosMapFromCountMapAndTotal(EstimateIndCQCFilledPostsByJobRoleUtil
         )
 
 
+class RemoveAscwdsJobRoleCountWhenFilledPostsSourceNotAscwds(
+    EstimateIndCQCFilledPostsByJobRoleUtilsTests
+):
+    def setUp(self) -> None:
+        super().setUp()
+
+        self.test_df = self.spark.createDataFrame(
+            Data.remove_ascwds_job_role_count_when_estimate_filled_posts_source_not_ascwds_rows,
+            Schemas.remove_ascwds_job_role_count_when_estimate_filled_posts_source_not_ascwds_schema,
+        )
+        self.returned_df = job.remove_ascwds_job_role_count_when_estimate_filled_posts_source_not_ascwds(
+            self.test_df
+        )
+        self.returned_data = self.returned_df.sort(IndCQC.location_id).collect()
+
+    def test_remove_ascwds_job_role_count_when_estimate_filled_posts_source_not_ascwds_returns_null_as_expected(
+        self,
+    ):
+        expected_df = self.spark.createDataFrame(
+            Data.expected_remove_ascwds_job_role_count_when_estimate_filled_posts_source_not_ascwds_rows,
+            Schemas.remove_ascwds_job_role_count_when_estimate_filled_posts_source_not_ascwds_schema,
+        )
+        expected_data = expected_df.sort(IndCQC.location_id).collect()
+
+        self.assertEqual(self.returned_data, expected_data)
+
+
 class CountRegisteredManagerNamesTests(EstimateIndCQCFilledPostsByJobRoleUtilsTests):
     def setUp(self) -> None:
         super().setUp()

--- a/utils/estimate_filled_posts_by_job_role_utils/utils.py
+++ b/utils/estimate_filled_posts_by_job_role_utils/utils.py
@@ -108,8 +108,8 @@ def remove_ascwds_job_role_count_when_estimate_filled_posts_source_not_ascwds(
 
     When estimate filled posts source is not 'ascwds_pir_merged' and
     estimate filled posts is not equal to ascwds filled posts dedup clean.
-    This is to ensure that we're only using ascwds job role data when it has been used for estimated filled posts and
-    to remove duplicated ascwds job role data, by using a pre-deduplicated column as a reference.
+    This is to ensure that we're only using ascwds job role data when ascwds data has
+    been used for estimated filled posts.
 
     Args:
         df (DataFrame): The estimated filled post by job role DataFrame.

--- a/utils/estimate_filled_posts_by_job_role_utils/utils.py
+++ b/utils/estimate_filled_posts_by_job_role_utils/utils.py
@@ -3,6 +3,9 @@ from pyspark.sql.types import LongType
 from typing import List
 
 from utils.column_names.ind_cqc_pipeline_columns import IndCqcColumns as IndCQC
+from utils.column_values.categorical_column_values import (
+    EstimateFilledPostsSource,
+)
 from utils.value_labels.ascwds_worker.ascwds_worker_mainjrid import (
     AscwdsWorkerValueLabelsMainjrid,
 )
@@ -95,6 +98,40 @@ def merge_dataframes(
     )
 
     return merged_df
+
+
+def remove_ascwds_job_role_count_when_estimate_filled_posts_source_not_ascwds(
+    df: DataFrame,
+) -> DataFrame:
+    """
+    Changes ascwds job role counts column to null in the following cases.
+
+    When estimate filled posts source is not 'ascwds_pir_merged' and
+    estimate filled posts is not equal to ascwds filled posts dedup clean.
+    This is to ensure that we're only using ascwds job role data when it has been used for estimated filled posts and
+    to remove duplicated ascwds job role data, by using a pre-deduplicated column as a reference.
+
+    Args:
+        df (DataFrame): The estimated filled post by job role DataFrame.
+
+    Returns:
+        DataFrame: The estimated filled post by job role DataFrame with the ascwds job role count map column filtered.
+    """
+
+    return df.withColumn(
+        IndCQC.ascwds_job_role_counts,
+        F.when(
+            (
+                F.col(IndCQC.estimate_filled_posts_source)
+                == F.lit(EstimateFilledPostsSource.ascwds_pir_merged)
+            )
+            & (
+                F.col(IndCQC.estimate_filled_posts)
+                == F.col(IndCQC.ascwds_filled_posts_dedup_clean)
+            ),
+            F.col(IndCQC.ascwds_job_role_counts),
+        ).otherwise(F.lit(None)),
+    )
 
 
 def transform_job_role_count_map_to_ratios_map(


### PR DESCRIPTION
# Description
Added a utils function to remove ascwds job role counts when estimate filled posts source is not 'ascwds_pir_merged' and
estimate filled posts is not equal to ascwds filled posts dedup clean.
This is to ensure that we're only using ascwds job role data when it has been used for estimated filled posts and to remove duplicated ascwds job role data, by using a pre-deduplicated column as a reference.

[Trello](https://trello.com/c/dz3IZjCP)

# How to test
[Successful pipeline run](https://eu-west-2.console.aws.amazon.com/states/home?region=eu-west-2#/v2/executions/details/arn:aws:states:eu-west-2:344210435447:execution:remove-jr-counts-when-estimate-Ind-CQC-Filled-Post-Estimates-Pipeline:a86c2118-fa37-4c7e-bc8e-207471715025)

# Developer checklist
- [x] Unit test
- [x] Linked to Trello ticket
- [x] Documentation up to date
