### PR TITLE
Set min prediction value

### DIFF
--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -6262,6 +6262,21 @@ class EstimateFilledPostsModelsUtils:
         ),
     ]
 
+    set_min_prediction_value_when_below_minimum_rows = [
+        ("1-001", 0.5, -7.6),
+    ]
+    expected_set_min_prediction_value_when_below_minimum_rows = [
+        ("1-001", 0.5, 1.0),
+    ]
+
+    set_min_prediction_value_when_above_minimum_rows = [
+        ("1-001", 1.5, 1.5),
+    ]
+
+    set_min_prediction_value_when_null_rows = [
+        ("1-001", None, None),
+    ]
+
 
 @dataclass
 class MLModelMetrics:

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -3278,6 +3278,14 @@ class EstimateFilledPostsModelsUtils:
         ]
     )
 
+    set_min_prediction_value_schema = StructType(
+        [
+            StructField(IndCQC.location_id, StringType(), True),
+            StructField(IndCQC.filled_posts_per_bed_ratio, FloatType(), True),
+            StructField(IndCQC.prediction, FloatType(), True),
+        ]
+    )
+
 
 @dataclass
 class MLModelMetrics:

--- a/tests/unit/test_estimate_ind_cqc_filled_posts_models_utils.py
+++ b/tests/unit/test_estimate_ind_cqc_filled_posts_models_utils.py
@@ -54,3 +54,43 @@ class InsertPredictionsIntoPipelineTest(EstimateFilledPostsModelsUtilsTests):
         ).collect()[0]
 
         self.assertIsNone(expected_df[IndCqc.estimate_filled_posts])
+
+
+class SetMinimumPredictionValueTests(EstimateFilledPostsModelsUtilsTests):
+    def setUp(self) -> None:
+        super().setUp()
+
+    def test_set_min_prediction_value_replaces_predictions_below_minimum_value(self):
+        test_df = self.spark.createDataFrame(
+            Data.set_min_prediction_value_when_below_minimum_rows,
+            Schemas.set_min_prediction_value_schema,
+        )
+        returned_df = job.set_min_prediction_value(test_df, 1.0)
+
+        expected_df = self.spark.createDataFrame(
+            Data.expected_set_min_prediction_value_when_below_minimum_rows,
+            Schemas.set_min_prediction_value_schema,
+        )
+        self.assertEqual(returned_df.collect(), expected_df.collect())
+
+    def test_set_min_prediction_value_does_not_replace_predictions_above_minimum_value(
+        self,
+    ):
+        test_df = self.spark.createDataFrame(
+            Data.set_min_prediction_value_when_above_minimum_rows,
+            Schemas.set_min_prediction_value_schema,
+        )
+        returned_df = job.set_min_prediction_value(test_df, 1.0)
+        expected_df = test_df
+
+        self.assertEqual(returned_df.collect(), expected_df.collect())
+
+    def test_set_min_prediction_value_does_not_replace_null_predictions(self):
+        test_df = self.spark.createDataFrame(
+            Data.set_min_prediction_value_when_null_rows,
+            Schemas.set_min_prediction_value_schema,
+        )
+        returned_df = job.set_min_prediction_value(test_df, 1.0)
+        expected_df = test_df
+
+        self.assertEqual(returned_df.collect(), expected_df.collect())

--- a/utils/estimate_filled_posts/models/utils.py
+++ b/utils/estimate_filled_posts/models/utils.py
@@ -1,4 +1,4 @@
-from pyspark.sql import DataFrame
+from pyspark.sql import DataFrame, functions as F
 
 from utils.column_names.ind_cqc_pipeline_columns import IndCqcColumns as IndCqc
 
@@ -32,3 +32,23 @@ def insert_predictions_into_pipeline(
     )
 
     return locations_with_predictions
+
+
+def set_min_prediction_value(
+    df: DataFrame, min_prediction_value: float = 1.0
+) -> DataFrame:
+    """
+    Sets the minimum value of the 'prediction' column to a specified value (default is 1.0).
+    Args:
+        df (DataFrame): A dataframe containing the 'prediction' column.
+        min_prediction_value (float): The minimum value allowed in the 'prediction' column.
+    Returns:
+        DataFrame: A dataframe with the 'prediction' column set to the minimum value.
+    """
+    return df.withColumn(
+        IndCqc.prediction,
+        F.when(
+            F.col(IndCqc.prediction).isNotNull(),
+            F.greatest(F.col(IndCqc.prediction), F.lit(min_prediction_value)),
+        ).otherwise(F.lit(None)),
+    )


### PR DESCRIPTION
# WIP
This function is fully finished but uses code from PR726 so can' tbe checked until that PR has been merged into main.

# Description
Sometimes the model predicts negative values, however that is in instances where we genuinely think there are very few jobs, so this function will be used to set a minimum (defaults to 1 initially to match our current SPSS process).

The function isn't called anywhere yet so haven't run the branch.

# How to test
Tests passing

# Developer checklist
- [X] Unit test
- [X] Linked to [Trello ticket](https://trello.com/c/dy58Ijsd/736-epic-5-set-1-a-minimum-predicted-value-must)
- [X] Documentation up to date
