### PR TITLE
Move filtering of care home features to features job

### DIFF
--- a/jobs/prepare_features_care_home_ind_cqc.py
+++ b/jobs/prepare_features_care_home_ind_cqc.py
@@ -3,7 +3,6 @@ from typing import List
 
 from pyspark.sql import DataFrame
 
-
 from utils import utils
 from utils.column_names.ind_cqc_pipeline_columns import (
     IndCqcColumns as IndCQC,
@@ -20,10 +19,10 @@ from utils.feature_engineering_resources.feature_engineering_services import (
     FeatureEngineeringValueLabelsServices as ServicesFeatures,
 )
 from utils.features.helper import (
-    vectorise_dataframe,
-    column_expansion_with_dict,
     add_array_column_count_to_data,
+    column_expansion_with_dict,
     convert_categorical_variable_to_binary_variables_based_on_a_dictionary,
+    vectorise_dataframe,
 )
 
 
@@ -37,6 +36,9 @@ def main(
 
     filtered_loc_data = utils.select_rows_with_value(
         locations_df, IndCQC.care_home, CareHome.care_home
+    )
+    filtered_loc_data = utils.select_rows_with_non_null_value(
+        filtered_loc_data, IndCQC.number_of_beds
     )
 
     features_df = add_array_column_count_to_data(

--- a/tests/unit/test_prepare_features_care_home_ind_cqc.py
+++ b/tests/unit/test_prepare_features_care_home_ind_cqc.py
@@ -36,12 +36,14 @@ class CareHomeFeaturesIndCqcFilledPosts(unittest.TestCase):
     )
     @patch("jobs.prepare_features_care_home_ind_cqc.column_expansion_with_dict")
     @patch("jobs.prepare_features_care_home_ind_cqc.add_array_column_count_to_data")
+    @patch("utils.utils.select_rows_with_non_null_value")
     @patch("utils.utils.select_rows_with_value")
     @patch("utils.utils.read_from_parquet")
     def test_main(
         self,
         read_from_parquet_mock: Mock,
         select_rows_with_value_mock: Mock,
+        select_rows_with_non_null_value_mock: Mock,
         add_array_column_count_to_data_mock: Mock,
         column_expansion_with_dict_mock: Mock,
         convert_categorical_variable_to_binary_variables_based_on_a_dictionary_mock: Mock,
@@ -56,6 +58,7 @@ class CareHomeFeaturesIndCqcFilledPosts(unittest.TestCase):
         )
 
         self.assertEqual(select_rows_with_value_mock.call_count, 1)
+        self.assertEqual(select_rows_with_non_null_value_mock.call_count, 1)
         self.assertEqual(add_array_column_count_to_data_mock.call_count, 1)
         self.assertEqual(column_expansion_with_dict_mock.call_count, 1)
         self.assertEqual(

--- a/utils/estimate_filled_posts/models/care_homes.py
+++ b/utils/estimate_filled_posts/models/care_homes.py
@@ -18,7 +18,6 @@ def model_care_homes(
     metrics_destination: str,
 ) -> DataFrame:
     gbt_trained_model = GBTRegressionModel.load(model_source)
-    features_df = features_df.where(features_df[IndCqc.number_of_beds].isNotNull())
 
     care_home_predictions = gbt_trained_model.transform(features_df)
 


### PR DESCRIPTION
# Description
We have a features job which fully prepared the features for modelling, however one of the filtering steps appears in the model itself. This PR moves the filtering of features into the features job

# How to test
[Branch run](https://eu-west-2.console.aws.amazon.com/states/home?region=eu-west-2#/v2/executions/details/arn:aws:states:eu-west-2:344210435447:execution:move-ch-null-beds-filter-Ind-CQC-Filled-Post-Estimates-Pipeline:bb0581b7-7c81-40a8-bc1e-b63c4026239a)

# Developer checklist
- [X] Unit test
- [X] Linked to [Trello ticket](https://trello.com/c/3mZhk58h/738-epic-5-move-ch-beds-filtering-into-features-job)
- [X] Documentation up to date
