### PR TITLE
Unpack mapped column

### DIFF
--- a/jobs/estimate_ind_cqc_filled_posts_by_job_role.py
+++ b/jobs/estimate_ind_cqc_filled_posts_by_job_role.py
@@ -125,6 +125,11 @@ def main(
         )
     )
 
+    estimated_ind_cqc_filled_posts_by_job_role_df = JRutils.unpack_mapped_column(
+        estimated_ind_cqc_filled_posts_by_job_role_df,
+        IndCQC.estimate_filled_posts_by_job_role,
+    )
+
     estimated_ind_cqc_filled_posts_by_job_role_df = (
         JRutils.count_registered_manager_names(
             estimated_ind_cqc_filled_posts_by_job_role_df

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -10333,3 +10333,181 @@ class EstimateIndCQCFilledPostsByJobRoleUtilsData:
             },
         ),
     ]
+
+    unpacked_mapped_column_with_one_record_data = [
+        (
+            "10545",
+            date(2025, 1, 1),
+            {
+                MainJobRoleLabels.care_worker: 1.0,
+                MainJobRoleLabels.registered_nurse: 2.0,
+                MainJobRoleLabels.senior_care_worker: 3.0,
+                MainJobRoleLabels.senior_management: 4.0,
+            },
+        )
+    ]
+    expected_unpacked_mapped_column_with_one_record_data = [
+        (
+            "10545",
+            date(2025, 1, 1),
+            {
+                MainJobRoleLabels.care_worker: 1.0,
+                MainJobRoleLabels.registered_nurse: 2.0,
+                MainJobRoleLabels.senior_care_worker: 3.0,
+                MainJobRoleLabels.senior_management: 4.0,
+            },
+            1.0,
+            2.0,
+            3.0,
+            4.0,
+        )
+    ]
+
+    unpacked_mapped_column_with_two_establishments_data = [
+        (
+            "10545",
+            date(2025, 1, 1),
+            {
+                MainJobRoleLabels.care_worker: 1.0,
+                MainJobRoleLabels.registered_nurse: 2.0,
+                MainJobRoleLabels.senior_care_worker: 3.0,
+                MainJobRoleLabels.senior_management: 4.0,
+            },
+        ),
+        (
+            "10678",
+            date(2025, 1, 1),
+            {
+                MainJobRoleLabels.care_worker: 10.0,
+                MainJobRoleLabels.registered_nurse: 20.0,
+                MainJobRoleLabels.senior_care_worker: 30.0,
+                MainJobRoleLabels.senior_management: 40.0,
+            },
+        ),
+    ]
+    expected_unpacked_mapped_column_with_two_establishments_data = [
+        (
+            "10545",
+            date(2025, 1, 1),
+            {
+                MainJobRoleLabels.care_worker: 1.0,
+                MainJobRoleLabels.registered_nurse: 2.0,
+                MainJobRoleLabels.senior_care_worker: 3.0,
+                MainJobRoleLabels.senior_management: 4.0,
+            },
+            1.0,
+            2.0,
+            3.0,
+            4.0,
+        ),
+        (
+            "10678",
+            date(2025, 1, 1),
+            {
+                MainJobRoleLabels.care_worker: 10.0,
+                MainJobRoleLabels.registered_nurse: 20.0,
+                MainJobRoleLabels.senior_care_worker: 30.0,
+                MainJobRoleLabels.senior_management: 40.0,
+            },
+            10.0,
+            20.0,
+            30.0,
+            40.0,
+        ),
+    ]
+
+    unpacked_mapped_column_with_two_import_dates_data = [
+        (
+            "10545",
+            date(2025, 1, 1),
+            {
+                MainJobRoleLabels.care_worker: 1.0,
+                MainJobRoleLabels.registered_nurse: 2.0,
+                MainJobRoleLabels.senior_care_worker: 3.0,
+                MainJobRoleLabels.senior_management: 4.0,
+            },
+        ),
+        (
+            "10545",
+            date(2025, 1, 2),
+            {
+                MainJobRoleLabels.care_worker: 10.0,
+                MainJobRoleLabels.registered_nurse: 20.0,
+                MainJobRoleLabels.senior_care_worker: 30.0,
+                MainJobRoleLabels.senior_management: 40.0,
+            },
+        ),
+    ]
+    expected_unpacked_mapped_column_with_two_import_dates_data = [
+        (
+            "10545",
+            date(2025, 1, 1),
+            {
+                MainJobRoleLabels.care_worker: 1.0,
+                MainJobRoleLabels.registered_nurse: 2.0,
+                MainJobRoleLabels.senior_care_worker: 3.0,
+                MainJobRoleLabels.senior_management: 4.0,
+            },
+            1.0,
+            2.0,
+            3.0,
+            4.0,
+        ),
+        (
+            "10545",
+            date(2025, 1, 2),
+            {
+                MainJobRoleLabels.care_worker: 10.0,
+                MainJobRoleLabels.registered_nurse: 20.0,
+                MainJobRoleLabels.senior_care_worker: 30.0,
+                MainJobRoleLabels.senior_management: 40.0,
+            },
+            10.0,
+            20.0,
+            30.0,
+            40.0,
+        ),
+    ]
+
+    unpacked_mapped_column_with_null_values_data = [
+        (
+            "10545",
+            date(2025, 1, 1),
+            {
+                MainJobRoleLabels.care_worker: None,
+                MainJobRoleLabels.registered_nurse: None,
+                MainJobRoleLabels.senior_care_worker: None,
+                MainJobRoleLabels.senior_management: None,
+            },
+        ),
+        (
+            "10545",
+            date(2025, 2, 1),
+            None,
+        ),
+    ]
+    expected_unpacked_mapped_column_with_null_values_data = [
+        (
+            "10545",
+            date(2025, 1, 1),
+            {
+                MainJobRoleLabels.care_worker: None,
+                MainJobRoleLabels.registered_nurse: None,
+                MainJobRoleLabels.senior_care_worker: None,
+                MainJobRoleLabels.senior_management: None,
+            },
+            None,
+            None,
+            None,
+            None,
+        ),
+        (
+            "10545",
+            date(2025, 2, 1),
+            None,
+            None,
+            None,
+            None,
+            None,
+        ),
+    ]

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -10336,7 +10336,7 @@ class EstimateIndCQCFilledPostsByJobRoleUtilsData:
 
     unpacked_mapped_column_with_one_record_data = [
         (
-            "10545",
+            "1-001",
             date(2025, 1, 1),
             {
                 MainJobRoleLabels.care_worker: 1.0,
@@ -10348,7 +10348,7 @@ class EstimateIndCQCFilledPostsByJobRoleUtilsData:
     ]
     expected_unpacked_mapped_column_with_one_record_data = [
         (
-            "10545",
+            "1-001",
             date(2025, 1, 1),
             {
                 MainJobRoleLabels.care_worker: 1.0,
@@ -10363,37 +10363,37 @@ class EstimateIndCQCFilledPostsByJobRoleUtilsData:
         )
     ]
 
-    unpacked_mapped_column_with_two_establishments_data = [
+    unpacked_mapped_column_with_map_items_in_different_orders_data = [
         (
-            "10545",
+            "1-001",
             date(2025, 1, 1),
             {
-                MainJobRoleLabels.care_worker: 1.0,
                 MainJobRoleLabels.registered_nurse: 2.0,
-                MainJobRoleLabels.senior_care_worker: 3.0,
+                MainJobRoleLabels.care_worker: 1.0,
                 MainJobRoleLabels.senior_management: 4.0,
+                MainJobRoleLabels.senior_care_worker: 3.0,
             },
         ),
         (
-            "10678",
+            "1-002",
             date(2025, 1, 1),
             {
-                MainJobRoleLabels.care_worker: 10.0,
-                MainJobRoleLabels.registered_nurse: 20.0,
-                MainJobRoleLabels.senior_care_worker: 30.0,
                 MainJobRoleLabels.senior_management: 40.0,
+                MainJobRoleLabels.registered_nurse: 20.0,
+                MainJobRoleLabels.care_worker: 10.0,
+                MainJobRoleLabels.senior_care_worker: 30.0,
             },
         ),
     ]
-    expected_unpacked_mapped_column_with_two_establishments_data = [
+    expected_unpacked_mapped_column_with_map_items_in_different_orders_data = [
         (
-            "10545",
+            "1-001",
             date(2025, 1, 1),
             {
-                MainJobRoleLabels.care_worker: 1.0,
                 MainJobRoleLabels.registered_nurse: 2.0,
-                MainJobRoleLabels.senior_care_worker: 3.0,
+                MainJobRoleLabels.care_worker: 1.0,
                 MainJobRoleLabels.senior_management: 4.0,
+                MainJobRoleLabels.senior_care_worker: 3.0,
             },
             1.0,
             2.0,
@@ -10401,66 +10401,13 @@ class EstimateIndCQCFilledPostsByJobRoleUtilsData:
             4.0,
         ),
         (
-            "10678",
+            "1-002",
             date(2025, 1, 1),
             {
-                MainJobRoleLabels.care_worker: 10.0,
-                MainJobRoleLabels.registered_nurse: 20.0,
-                MainJobRoleLabels.senior_care_worker: 30.0,
                 MainJobRoleLabels.senior_management: 40.0,
-            },
-            10.0,
-            20.0,
-            30.0,
-            40.0,
-        ),
-    ]
-
-    unpacked_mapped_column_with_two_import_dates_data = [
-        (
-            "10545",
-            date(2025, 1, 1),
-            {
-                MainJobRoleLabels.care_worker: 1.0,
-                MainJobRoleLabels.registered_nurse: 2.0,
-                MainJobRoleLabels.senior_care_worker: 3.0,
-                MainJobRoleLabels.senior_management: 4.0,
-            },
-        ),
-        (
-            "10545",
-            date(2025, 1, 2),
-            {
-                MainJobRoleLabels.care_worker: 10.0,
                 MainJobRoleLabels.registered_nurse: 20.0,
-                MainJobRoleLabels.senior_care_worker: 30.0,
-                MainJobRoleLabels.senior_management: 40.0,
-            },
-        ),
-    ]
-    expected_unpacked_mapped_column_with_two_import_dates_data = [
-        (
-            "10545",
-            date(2025, 1, 1),
-            {
-                MainJobRoleLabels.care_worker: 1.0,
-                MainJobRoleLabels.registered_nurse: 2.0,
-                MainJobRoleLabels.senior_care_worker: 3.0,
-                MainJobRoleLabels.senior_management: 4.0,
-            },
-            1.0,
-            2.0,
-            3.0,
-            4.0,
-        ),
-        (
-            "10545",
-            date(2025, 1, 2),
-            {
                 MainJobRoleLabels.care_worker: 10.0,
-                MainJobRoleLabels.registered_nurse: 20.0,
                 MainJobRoleLabels.senior_care_worker: 30.0,
-                MainJobRoleLabels.senior_management: 40.0,
             },
             10.0,
             20.0,
@@ -10471,7 +10418,7 @@ class EstimateIndCQCFilledPostsByJobRoleUtilsData:
 
     unpacked_mapped_column_with_null_values_data = [
         (
-            "10545",
+            "1-001",
             date(2025, 1, 1),
             {
                 MainJobRoleLabels.care_worker: None,
@@ -10481,14 +10428,14 @@ class EstimateIndCQCFilledPostsByJobRoleUtilsData:
             },
         ),
         (
-            "10545",
+            "1-002",
             date(2025, 2, 1),
             None,
         ),
     ]
     expected_unpacked_mapped_column_with_null_values_data = [
         (
-            "10545",
+            "1-001",
             date(2025, 1, 1),
             {
                 MainJobRoleLabels.care_worker: None,
@@ -10502,7 +10449,7 @@ class EstimateIndCQCFilledPostsByJobRoleUtilsData:
             None,
         ),
         (
-            "10545",
+            "1-002",
             date(2025, 2, 1),
             None,
             None,

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -6197,3 +6197,24 @@ class EstimateIndCQCFilledPostsByJobRoleUtilsSchemas:
             ),
         ]
     )
+
+    unpacked_mapped_column_schema = StructType(
+        [
+            StructField(IndCQC.establishment_id, StringType(), True),
+            StructField(IndCQC.ascwds_worker_import_date, DateType(), True),
+            StructField(
+                IndCQC.estimate_filled_posts_by_job_role,
+                MapType(StringType(), FloatType()),
+                True,
+            ),
+        ]
+    )
+    expected_unpacked_mapped_column_schema = StructType(
+        [
+            *unpacked_mapped_column_schema,
+            StructField(MainJobRoleLabels.care_worker, FloatType(), True),
+            StructField(MainJobRoleLabels.registered_nurse, FloatType(), True),
+            StructField(MainJobRoleLabels.senior_care_worker, FloatType(), True),
+            StructField(MainJobRoleLabels.senior_management, FloatType(), True),
+        ]
+    )

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -6200,8 +6200,8 @@ class EstimateIndCQCFilledPostsByJobRoleUtilsSchemas:
 
     unpacked_mapped_column_schema = StructType(
         [
-            StructField(IndCQC.establishment_id, StringType(), True),
-            StructField(IndCQC.ascwds_worker_import_date, DateType(), True),
+            StructField(IndCQC.location_id, StringType(), True),
+            StructField(IndCQC.cqc_location_import_date, DateType(), True),
             StructField(
                 IndCQC.estimate_filled_posts_by_job_role,
                 MapType(StringType(), FloatType()),

--- a/tests/unit/test_estimate_ind_cqc_filled_posts_by_job_role.py
+++ b/tests/unit/test_estimate_ind_cqc_filled_posts_by_job_role.py
@@ -34,6 +34,7 @@ class MainTests(EstimateIndCQCFilledPostsByJobRoleTests):
     @patch(
         "utils.estimate_filled_posts_by_job_role_utils.utils.count_registered_manager_names"
     )
+    @patch("utils.estimate_filled_posts_by_job_role_utils.utils.unpack_mapped_column")
     @patch(
         "utils.estimate_filled_posts_by_job_role_utils.utils.create_estimate_filled_posts_by_job_role_map_column"
     )
@@ -62,6 +63,7 @@ class MainTests(EstimateIndCQCFilledPostsByJobRoleTests):
         transform_job_role_count_map_to_ratios_map_mock: Mock,
         merge_columns_in_order_mock: Mock,
         create_estimate_filled_posts_by_job_role_map_column_mock: Mock,
+        unpack_mapped_column_mock: Mock,
         count_registered_manager_names_mock: Mock,
         write_to_parquet_mock: Mock,
     ):
@@ -91,6 +93,7 @@ class MainTests(EstimateIndCQCFilledPostsByJobRoleTests):
         self.assertEqual(transform_job_role_count_map_to_ratios_map_mock.call_count, 2)
         merge_columns_in_order_mock.assert_called_once()
         create_estimate_filled_posts_by_job_role_map_column_mock.assert_called_once()
+        unpack_mapped_column_mock.assert_called_once()
         count_registered_manager_names_mock.assert_called_once()
 
         write_to_parquet_mock.assert_called_once_with(

--- a/tests/unit/test_estimate_ind_cqc_filled_posts_by_job_role_utils.py
+++ b/tests/unit/test_estimate_ind_cqc_filled_posts_by_job_role_utils.py
@@ -892,22 +892,14 @@ class UnpackingMappedColumnsTest(EstimateIndCQCFilledPostsByJobRoleUtilsTests):
         )
 
     def test_unpack_mapped_column_returns_expected_values_in_each_column(self):
-        """
-        'estimate_filled_posts_by_job_role' is dropped as the items in the mapped column are re-sorting
-        which is causing the test to fail, but that behaviour is ok and out of scope of this test.
-        """
         self.assertEqual(
-            self.returned_df.drop(IndCQC.estimate_filled_posts_by_job_role).collect(),
-            self.expected_df.drop(IndCQC.estimate_filled_posts_by_job_role).collect(),
+            self.returned_df.collect(),
+            self.expected_df.collect(),
         )
 
     def test_unpack_mapped_column_when_rows_have_map_items_in_differing_orders_returns_expected_values(
         self,
     ):
-        """
-        'estimate_filled_posts_by_job_role' is dropped as the items in the mapped column are re-sorting
-        which is causing the test to fail, but that behaviour is ok and out of scope of this test.
-        """
         test_df = self.spark.createDataFrame(
             Data.unpacked_mapped_column_with_map_items_in_different_orders_data,
             Schemas.unpacked_mapped_column_schema,
@@ -921,24 +913,14 @@ class UnpackingMappedColumnsTest(EstimateIndCQCFilledPostsByJobRoleUtilsTests):
             Schemas.expected_unpacked_mapped_column_schema,
         )
 
-        returned_data = (
-            returned_df.sort(IndCQC.location_id)
-            .drop(IndCQC.estimate_filled_posts_by_job_role)
-            .collect()
-        )
-        expected_data = expected_df.drop(
-            IndCQC.estimate_filled_posts_by_job_role
-        ).collect()
+        returned_data = returned_df.sort(IndCQC.location_id).collect()
+        expected_data = expected_df.collect()
 
         self.assertEqual(returned_data, expected_data)
 
     def test_unpack_mapped_column_with_null_values_returns_expected_values(
         self,
     ):
-        """
-        'estimate_filled_posts_by_job_role' is dropped as the items in the mapped column are re-sorting
-        which is causing the test to fail, but that behaviour is ok and out of scope of this test.
-        """
         test_df = self.spark.createDataFrame(
             Data.unpacked_mapped_column_with_null_values_data,
             Schemas.unpacked_mapped_column_schema,
@@ -952,13 +934,7 @@ class UnpackingMappedColumnsTest(EstimateIndCQCFilledPostsByJobRoleUtilsTests):
             Schemas.expected_unpacked_mapped_column_schema,
         )
 
-        returned_data = (
-            returned_df.sort(IndCQC.location_id)
-            .drop(IndCQC.estimate_filled_posts_by_job_role)
-            .collect()
-        )
-        expected_data = expected_df.drop(
-            IndCQC.estimate_filled_posts_by_job_role
-        ).collect()
+        returned_data = returned_df.sort(IndCQC.location_id).collect()
+        expected_data = expected_df.collect()
 
         self.assertEqual(returned_data, expected_data)

--- a/tests/unit/test_estimate_ind_cqc_filled_posts_by_job_role_utils.py
+++ b/tests/unit/test_estimate_ind_cqc_filled_posts_by_job_role_utils.py
@@ -892,7 +892,10 @@ class UnpackingMappedColumnsTest(EstimateIndCQCFilledPostsByJobRoleUtilsTests):
         )
 
     def test_unpack_mapped_column_returns_expected_values_in_each_column(self):
-        # note: dropping 'estimate_filled_posts_by_job_role' as the column is re-sorting which is causing the test to fail, but that behaviour is ok
+        """
+        'estimate_filled_posts_by_job_role' is dropped as the items in the mapped column are re-sorting
+        which is causing the test to fail, but that behaviour is ok and out of scope of this test.
+        """
         self.assertEqual(
             self.returned_df.drop(IndCQC.estimate_filled_posts_by_job_role).collect(),
             self.expected_df.drop(IndCQC.estimate_filled_posts_by_job_role).collect(),
@@ -901,6 +904,10 @@ class UnpackingMappedColumnsTest(EstimateIndCQCFilledPostsByJobRoleUtilsTests):
     def test_unpack_mapped_column_when_rows_have_map_items_in_differing_orders_returns_expected_values(
         self,
     ):
+        """
+        'estimate_filled_posts_by_job_role' is dropped as the items in the mapped column are re-sorting
+        which is causing the test to fail, but that behaviour is ok and out of scope of this test.
+        """
         test_df = self.spark.createDataFrame(
             Data.unpacked_mapped_column_with_map_items_in_different_orders_data,
             Schemas.unpacked_mapped_column_schema,
@@ -914,7 +921,6 @@ class UnpackingMappedColumnsTest(EstimateIndCQCFilledPostsByJobRoleUtilsTests):
             Schemas.expected_unpacked_mapped_column_schema,
         )
 
-        # note: dropping 'estimate_filled_posts_by_job_role' as the column is re-sorting which is causing the test to fail, but that behaviour is ok
         returned_data = (
             returned_df.sort(IndCQC.location_id)
             .drop(IndCQC.estimate_filled_posts_by_job_role)
@@ -929,6 +935,10 @@ class UnpackingMappedColumnsTest(EstimateIndCQCFilledPostsByJobRoleUtilsTests):
     def test_unpack_mapped_column_with_null_values_returns_expected_values(
         self,
     ):
+        """
+        'estimate_filled_posts_by_job_role' is dropped as the items in the mapped column are re-sorting
+        which is causing the test to fail, but that behaviour is ok and out of scope of this test.
+        """
         test_df = self.spark.createDataFrame(
             Data.unpacked_mapped_column_with_null_values_data,
             Schemas.unpacked_mapped_column_schema,
@@ -942,7 +952,6 @@ class UnpackingMappedColumnsTest(EstimateIndCQCFilledPostsByJobRoleUtilsTests):
             Schemas.expected_unpacked_mapped_column_schema,
         )
 
-        # note: dropping 'estimate_filled_posts_by_job_role' as the column is re-sorting which is causing the test to fail, but that behaviour is ok
         returned_data = (
             returned_df.sort(IndCQC.location_id)
             .drop(IndCQC.estimate_filled_posts_by_job_role)

--- a/tests/unit/test_estimate_ind_cqc_filled_posts_by_job_role_utils.py
+++ b/tests/unit/test_estimate_ind_cqc_filled_posts_by_job_role_utils.py
@@ -873,69 +873,68 @@ class UnpackingMappedColumnsTest(EstimateIndCQCFilledPostsByJobRoleUtilsTests):
     def setUp(self) -> None:
         super().setUp()
 
-    def test_unpack_mapped_column_when_one_record_in_mapped_column_return_dataframe_with_one_record_and_unpacked_job_role_counts(
-        self,
-    ):
         test_df = self.spark.createDataFrame(
             Data.unpacked_mapped_column_with_one_record_data,
             Schemas.unpacked_mapped_column_schema,
         )
+        self.returned_df = job.unpack_mapped_column(
+            test_df, IndCQC.estimate_filled_posts_by_job_role
+        )
 
-        expected_df = self.spark.createDataFrame(
+        self.expected_df = self.spark.createDataFrame(
             Data.expected_unpacked_mapped_column_with_one_record_data,
             Schemas.expected_unpacked_mapped_column_schema,
         )
 
-        return_df = job.unpack_mapped_column(
-            test_df, IndCQC.estimate_filled_posts_by_job_role
+    def test_unpack_mapped_column_returns_expected_columns(self):
+        self.assertEqual(
+            sorted(self.returned_df.columns), sorted(self.expected_df.columns)
         )
 
-        self.assertEqual(expected_df.collect(), return_df.collect())
+    def test_unpack_mapped_column_returns_expected_values_in_each_column(self):
+        # note: dropping 'estimate_filled_posts_by_job_role' as the column is re-sorting which is causing the test to fail, but that behaviour is ok
+        self.assertEqual(
+            self.returned_df.drop(IndCQC.estimate_filled_posts_by_job_role).collect(),
+            self.expected_df.drop(IndCQC.estimate_filled_posts_by_job_role).collect(),
+        )
 
-    def test_unpack_mapped_column_when_two_establishments_in_data_return_dataframe_with_two_establishments_and_unpacked_job_role_counts(
+    def test_unpack_mapped_column_when_rows_have_map_items_in_differing_orders_returns_expected_values(
         self,
     ):
         test_df = self.spark.createDataFrame(
-            Data.unpacked_mapped_column_with_two_establishments_data,
+            Data.unpacked_mapped_column_with_map_items_in_different_orders_data,
             Schemas.unpacked_mapped_column_schema,
         )
-
-        expected_df = self.spark.createDataFrame(
-            Data.expected_unpacked_mapped_column_with_two_establishments_data,
-            Schemas.expected_unpacked_mapped_column_schema,
-        )
-
-        return_df = job.unpack_mapped_column(
+        returned_df = job.unpack_mapped_column(
             test_df, IndCQC.estimate_filled_posts_by_job_role
         )
 
-        self.assertEqual(expected_df.collect(), return_df.collect())
-
-    def test_unpack_mapped_column_when_two_import_dates_in_data_return_dataframe_with_two_import_dates_and_unpacked_job_role_counts(
-        self,
-    ):
-        test_df = self.spark.createDataFrame(
-            Data.unpacked_mapped_column_with_two_import_dates_data,
-            Schemas.unpacked_mapped_column_schema,
-        )
-
         expected_df = self.spark.createDataFrame(
-            Data.expected_unpacked_mapped_column_with_two_import_dates_data,
+            Data.expected_unpacked_mapped_column_with_map_items_in_different_orders_data,
             Schemas.expected_unpacked_mapped_column_schema,
         )
 
-        return_df = job.unpack_mapped_column(
-            test_df, IndCQC.estimate_filled_posts_by_job_role
+        # note: dropping 'estimate_filled_posts_by_job_role' as the column is re-sorting which is causing the test to fail, but that behaviour is ok
+        returned_data = (
+            returned_df.sort(IndCQC.location_id)
+            .drop(IndCQC.estimate_filled_posts_by_job_role)
+            .collect()
         )
+        expected_data = expected_df.drop(
+            IndCQC.estimate_filled_posts_by_job_role
+        ).collect()
 
-        self.assertEqual(expected_df.collect(), return_df.collect())
+        self.assertEqual(returned_data, expected_data)
 
-    def test_unpack_mapped_column_when_null_values_in_data_return_dataframe_with_unpacked_job_role_counts(
+    def test_unpack_mapped_column_with_null_values_returns_expected_values(
         self,
     ):
         test_df = self.spark.createDataFrame(
             Data.unpacked_mapped_column_with_null_values_data,
             Schemas.unpacked_mapped_column_schema,
+        )
+        returned_df = job.unpack_mapped_column(
+            test_df, IndCQC.estimate_filled_posts_by_job_role
         )
 
         expected_df = self.spark.createDataFrame(
@@ -943,8 +942,14 @@ class UnpackingMappedColumnsTest(EstimateIndCQCFilledPostsByJobRoleUtilsTests):
             Schemas.expected_unpacked_mapped_column_schema,
         )
 
-        return_df = job.unpack_mapped_column(
-            test_df, IndCQC.estimate_filled_posts_by_job_role
+        # note: dropping 'estimate_filled_posts_by_job_role' as the column is re-sorting which is causing the test to fail, but that behaviour is ok
+        returned_data = (
+            returned_df.sort(IndCQC.location_id)
+            .drop(IndCQC.estimate_filled_posts_by_job_role)
+            .collect()
         )
+        expected_data = expected_df.drop(
+            IndCQC.estimate_filled_posts_by_job_role
+        ).collect()
 
-        self.assertEqual(expected_df.collect(), return_df.collect())
+        self.assertEqual(returned_data, expected_data)

--- a/tests/unit/test_estimate_ind_cqc_filled_posts_by_job_role_utils.py
+++ b/tests/unit/test_estimate_ind_cqc_filled_posts_by_job_role_utils.py
@@ -1,5 +1,5 @@
 import unittest
-from unittest.mock import ANY, call, patch, Mock
+from unittest.mock import patch, Mock
 
 from utils import utils
 from utils.column_names.ind_cqc_pipeline_columns import IndCqcColumns as IndCQC
@@ -867,3 +867,84 @@ class SumJobRoleCountSplitByServiceTests(EstimateIndCQCFilledPostsByJobRoleUtils
             .sort(IndCQC.primary_service_type)
             .collect(),
         )
+
+
+class UnpackingMappedColumnsTest(EstimateIndCQCFilledPostsByJobRoleUtilsTests):
+    def setUp(self) -> None:
+        super().setUp()
+
+    def test_unpack_mapped_column_when_one_record_in_mapped_column_return_dataframe_with_one_record_and_unpacked_job_role_counts(
+        self,
+    ):
+        test_df = self.spark.createDataFrame(
+            Data.unpacked_mapped_column_with_one_record_data,
+            Schemas.unpacked_mapped_column_schema,
+        )
+
+        expected_df = self.spark.createDataFrame(
+            Data.expected_unpacked_mapped_column_with_one_record_data,
+            Schemas.expected_unpacked_mapped_column_schema,
+        )
+
+        return_df = job.unpack_mapped_column(
+            test_df, IndCQC.estimate_filled_posts_by_job_role
+        )
+
+        self.assertEqual(expected_df.collect(), return_df.collect())
+
+    def test_unpack_mapped_column_when_two_establishments_in_data_return_dataframe_with_two_establishments_and_unpacked_job_role_counts(
+        self,
+    ):
+        test_df = self.spark.createDataFrame(
+            Data.unpacked_mapped_column_with_two_establishments_data,
+            Schemas.unpacked_mapped_column_schema,
+        )
+
+        expected_df = self.spark.createDataFrame(
+            Data.expected_unpacked_mapped_column_with_two_establishments_data,
+            Schemas.expected_unpacked_mapped_column_schema,
+        )
+
+        return_df = job.unpack_mapped_column(
+            test_df, IndCQC.estimate_filled_posts_by_job_role
+        )
+
+        self.assertEqual(expected_df.collect(), return_df.collect())
+
+    def test_unpack_mapped_column_when_two_import_dates_in_data_return_dataframe_with_two_import_dates_and_unpacked_job_role_counts(
+        self,
+    ):
+        test_df = self.spark.createDataFrame(
+            Data.unpacked_mapped_column_with_two_import_dates_data,
+            Schemas.unpacked_mapped_column_schema,
+        )
+
+        expected_df = self.spark.createDataFrame(
+            Data.expected_unpacked_mapped_column_with_two_import_dates_data,
+            Schemas.expected_unpacked_mapped_column_schema,
+        )
+
+        return_df = job.unpack_mapped_column(
+            test_df, IndCQC.estimate_filled_posts_by_job_role
+        )
+
+        self.assertEqual(expected_df.collect(), return_df.collect())
+
+    def test_unpack_mapped_column_when_null_values_in_data_return_dataframe_with_unpacked_job_role_counts(
+        self,
+    ):
+        test_df = self.spark.createDataFrame(
+            Data.unpacked_mapped_column_with_null_values_data,
+            Schemas.unpacked_mapped_column_schema,
+        )
+
+        expected_df = self.spark.createDataFrame(
+            Data.expected_unpacked_mapped_column_with_null_values_data,
+            Schemas.expected_unpacked_mapped_column_schema,
+        )
+
+        return_df = job.unpack_mapped_column(
+            test_df, IndCQC.estimate_filled_posts_by_job_role
+        )
+
+        self.assertEqual(expected_df.collect(), return_df.collect())

--- a/utils/estimate_filled_posts_by_job_role_utils/utils.py
+++ b/utils/estimate_filled_posts_by_job_role_utils/utils.py
@@ -307,6 +307,38 @@ def sum_job_role_count_split_by_service(
     return df_result
 
 
+def unpack_mapped_column(df: DataFrame, column_name: str) -> DataFrame:
+    """
+    Takes in two argument which is a DataFrame and also a Column Name which is a string. The column
+    that the column name is referencing must be a mapped column. The function has three main lines of code.
+    The first line of code explodes the mapped column of the dataframe by the keys of each record. So the DF
+    will be extended to include a record for each key available in each map. The second line of code converts that
+    column into a list of unique keys. The third line of code creates a list of PySpark Column objects, where each column represents a key
+    from the map column.
+
+    Args:
+        df (DataFrame): A dataframe containing the estimated CQC filled posts data with job role counts.
+        column_name (str): Mapped column which needs unpacking.
+
+    Returns:
+        DataFrame: A dataframe with unique establishmentid and import date.
+    """
+
+    df_keys = df.select(F.explode(F.map_keys(F.col(column_name)))).distinct()
+
+    list_keys = [row[0] for row in df_keys.collect()]
+    print(list_keys)
+
+    column_of_keys = [
+        F.col(column_name).getItem(key).alias(str(key)) for key in list_keys
+    ]
+    print(column_of_keys)
+
+    result_df = df.select("*", *column_of_keys)
+
+    return result_df
+
+
 def create_estimate_filled_posts_by_job_role_map_column(
     df: DataFrame,
 ) -> DataFrame:

--- a/utils/estimate_filled_posts_by_job_role_utils/utils.py
+++ b/utils/estimate_filled_posts_by_job_role_utils/utils.py
@@ -309,30 +309,23 @@ def sum_job_role_count_split_by_service(
 
 def unpack_mapped_column(df: DataFrame, column_name: str) -> DataFrame:
     """
-    Takes in two argument which is a DataFrame and also a Column Name which is a string. The column
-    that the column name is referencing must be a mapped column. The function has three main lines of code.
-    The first line of code explodes the mapped column of the dataframe by the keys of each record. So the DF
-    will be extended to include a record for each key available in each map. The second line of code converts that
-    column into a list of unique keys. The third line of code creates a list of PySpark Column objects, where each column represents a key
-    from the map column.
+    Unpacks a MapType column in a DataFrame into separate columns (sorted alphabetically), with keys as column names and values as row values.
 
     Args:
-        df (DataFrame): A dataframe containing the estimated CQC filled posts data with job role counts.
-        column_name (str): Mapped column which needs unpacking.
+        df (DataFrame): A PySpark DataFrame containing a MapType column.
+        column_name (str): The name of the MapType column to unpack.
 
     Returns:
-        DataFrame: A dataframe with unique establishmentid and import date.
+        DataFrame: A DataFrame with the map column expanded into multiple columns, sorted alphabetically by key.
     """
 
     df_keys = df.select(F.explode(F.map_keys(F.col(column_name)))).distinct()
 
-    list_keys = [row[0] for row in df_keys.collect()]
-    print(list_keys)
+    list_keys = sorted([row[0] for row in df_keys.collect()])
 
     column_of_keys = [
         F.col(column_name).getItem(key).alias(str(key)) for key in list_keys
     ]
-    print(column_of_keys)
 
     result_df = df.select("*", *column_of_keys)
 


### PR DESCRIPTION
# Description
Explodes the map column to individual columns for each job role (sorted in alphabetical order)

# How to test
Tests passing, Athena outputs look decent
[Branch run](https://eu-west-2.console.aws.amazon.com/states/home?region=eu-west-2#/v2/executions/details/arn:aws:states:eu-west-2:344210435447:execution:unpack-mapped-column-Ind-CQC-Filled-Post-Estimates-Pipeline:69746856-e4f3-4646-8baa-0c7ffd7e4998)

# Developer checklist
- [X] Unit test
- [X] Linked to [Trello ticket](https://trello.com/c/ISPO9Wox/724-epic-2-131-convert-map-column-to-individual-columns-for-each-role-must)
- [X] Documentation up to date
