### PR TITLE
Renamed other managerial to be more descriptive

### DIFF
--- a/utils/column_values/categorical_column_values.py
+++ b/utils/column_values/categorical_column_values.py
@@ -176,7 +176,7 @@ class MainJobRoleLabels(ColumnValues):
     allied_health_professional: str = "allied_health_professional"
     technician: str = "technician"
     other_care_role: str = "other_care_role"
-    care_related_staff: str = (
+    other_managerial_staff: str = (
         "managers_and_staff_in_care_related_but_not_care_providing_roles"
     )
     admin_staff: str = "administrative_or_office_staff_not_care_providing"
@@ -222,7 +222,7 @@ class MainJobRoleID(ColumnValues):
     allied_health_professional: str = "17"
     technician: str = "22"
     other_care_role: str = "23"
-    care_related_staff: str = "24"
+    other_managerial_staff: str = "24"
     admin_staff: str = "25"
     ancillary_staff: str = "26"
     other_non_care_related_staff: str = "27"

--- a/utils/value_labels/ascwds_worker/ascwds_worker_mainjrid.py
+++ b/utils/value_labels/ascwds_worker/ascwds_worker_mainjrid.py
@@ -31,7 +31,7 @@ class AscwdsWorkerValueLabelsMainjrid:
         "17": MainJobRoleLabels.allied_health_professional,
         "22": MainJobRoleLabels.technician,
         "23": MainJobRoleLabels.other_care_role,
-        "24": MainJobRoleLabels.care_related_staff,
+        "24": MainJobRoleLabels.other_managerial_staff,
         "25": MainJobRoleLabels.admin_staff,
         "26": MainJobRoleLabels.ancillary_staff,
         "27": MainJobRoleLabels.other_non_care_related_staff,


### PR DESCRIPTION
# Description
Renamed the generic managerial job role reference to be more descriptive (and imply that it's managers) in advance of us identifying managerial posts

# How to test
Not called in any code yet so just a reference, nothing to test
