### PR TITLE
Calc dif rm estimate and cqc

### DIFF
--- a/jobs/estimate_ind_cqc_filled_posts_by_job_role.py
+++ b/jobs/estimate_ind_cqc_filled_posts_by_job_role.py
@@ -136,6 +136,12 @@ def main(
         )
     )
 
+    estimated_ind_cqc_filled_posts_by_job_role_df = (
+        JRutils.calculate_difference_between_estimate_and_cqc_registered_managers(
+            estimated_ind_cqc_filled_posts_by_job_role_df
+        )
+    )
+
     utils.write_to_parquet(
         estimated_ind_cqc_filled_posts_by_job_role_df,
         estimated_ind_cqc_filled_posts_by_job_role_destination,

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -10460,14 +10460,14 @@ class EstimateIndCQCFilledPostsByJobRoleUtilsData:
     ]
 
     estimate_and_cqc_registered_manager_rows = [
-        ("1-001", 0.0, 1),
-        ("1-002", 10.0, 1),
-        ("1-003", None, 1),
-        ("1-004", 10.0, None),
+        ("1-001", 1, 0.0),
+        ("1-002", 1, 10.0),
+        ("1-003", 1, None),
+        ("1-004", None, 10.0),
     ]
     expected_estimate_and_cqc_registered_manager_rows = [
-        ("1-001", 0.0, 1, 1.0),
-        ("1-002", 10.0, 1, -9.0),
-        ("1-003", None, 1, None),
-        ("1-004", 10.0, None, None),
+        ("1-001", 1, 0.0, 1.0),
+        ("1-002", 1, 10.0, -9.0),
+        ("1-003", 1, None, None),
+        ("1-004", None, 10.0, None),
     ]

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -10460,14 +10460,14 @@ class EstimateIndCQCFilledPostsByJobRoleUtilsData:
     ]
 
     estimate_and_cqc_registered_manager_rows = [
-        ("1-001", 5.0, 10),
-        ("1-002", 10.0, 5),
-        ("1-003", None, 5),
+        ("1-001", 0.0, 1),
+        ("1-002", 10.0, 1),
+        ("1-003", None, 1),
         ("1-004", 10.0, None),
     ]
     expected_estimate_and_cqc_registered_manager_rows = [
-        ("1-001", 5.0, 10, -5.0),
-        ("1-002", 10.0, 5, 5.0),
-        ("1-003", None, 5, None),
+        ("1-001", 0.0, 1, 1.0),
+        ("1-002", 10.0, 1, -9.0),
+        ("1-003", None, 1, None),
         ("1-004", 10.0, None, None),
     ]

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -10458,3 +10458,16 @@ class EstimateIndCQCFilledPostsByJobRoleUtilsData:
             None,
         ),
     ]
+
+    estimate_and_cqc_registered_manager_rows = [
+        ("1-001", 5.0, 10),
+        ("1-002", 10.0, 5),
+        ("1-003", None, 5),
+        ("1-004", 10.0, None),
+    ]
+    expected_estimate_and_cqc_registered_manager_rows = [
+        ("1-001", 5.0, 10, -5.0),
+        ("1-002", 10.0, 5, 5.0),
+        ("1-003", None, 5, None),
+        ("1-004", 10.0, None, None),
+    ]

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -6218,3 +6218,21 @@ class EstimateIndCQCFilledPostsByJobRoleUtilsSchemas:
             StructField(MainJobRoleLabels.senior_management, FloatType(), True),
         ]
     )
+
+    estimate_and_cqc_registered_manager_schema = StructType(
+        [
+            StructField(IndCQC.location_id, StringType(), True),
+            StructField(MainJobRoleLabels.registered_manager, FloatType(), True),
+            StructField(IndCQC.registered_manager_count, IntegerType(), True),
+        ]
+    )
+    expected_estimate_and_cqc_registered_manager_schema = StructType(
+        [
+            *estimate_and_cqc_registered_manager_schema,
+            StructField(
+                IndCQC.difference_between_estimate_and_cqc_registered_managers,
+                FloatType(),
+                True,
+            ),
+        ]
+    )

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -6222,8 +6222,8 @@ class EstimateIndCQCFilledPostsByJobRoleUtilsSchemas:
     estimate_and_cqc_registered_manager_schema = StructType(
         [
             StructField(IndCQC.location_id, StringType(), True),
-            StructField(MainJobRoleLabels.registered_manager, FloatType(), True),
             StructField(IndCQC.registered_manager_count, IntegerType(), True),
+            StructField(MainJobRoleLabels.registered_manager, FloatType(), True),
         ]
     )
     expected_estimate_and_cqc_registered_manager_schema = StructType(

--- a/tests/unit/test_estimate_ind_cqc_filled_posts_by_job_role.py
+++ b/tests/unit/test_estimate_ind_cqc_filled_posts_by_job_role.py
@@ -32,6 +32,9 @@ class EstimateIndCQCFilledPostsByJobRoleTests(unittest.TestCase):
 class MainTests(EstimateIndCQCFilledPostsByJobRoleTests):
     @patch("utils.utils.write_to_parquet")
     @patch(
+        "utils.estimate_filled_posts_by_job_role_utils.utils.calculate_difference_between_estimate_and_cqc_registered_managers"
+    )
+    @patch(
         "utils.estimate_filled_posts_by_job_role_utils.utils.count_registered_manager_names"
     )
     @patch("utils.estimate_filled_posts_by_job_role_utils.utils.unpack_mapped_column")
@@ -65,6 +68,7 @@ class MainTests(EstimateIndCQCFilledPostsByJobRoleTests):
         create_estimate_filled_posts_by_job_role_map_column_mock: Mock,
         unpack_mapped_column_mock: Mock,
         count_registered_manager_names_mock: Mock,
+        calculate_difference_between_estimate_and_cqc_registered_managers_mock: Mock,
         write_to_parquet_mock: Mock,
     ):
         read_from_parquet_mock.side_effect = [
@@ -95,6 +99,7 @@ class MainTests(EstimateIndCQCFilledPostsByJobRoleTests):
         create_estimate_filled_posts_by_job_role_map_column_mock.assert_called_once()
         unpack_mapped_column_mock.assert_called_once()
         count_registered_manager_names_mock.assert_called_once()
+        calculate_difference_between_estimate_and_cqc_registered_managers_mock.assert_called_once()
 
         write_to_parquet_mock.assert_called_once_with(
             ANY, self.OUTPUT_DIR, "overwrite", PartitionKeys

--- a/tests/unit/test_estimate_ind_cqc_filled_posts_by_job_role_utils.py
+++ b/tests/unit/test_estimate_ind_cqc_filled_posts_by_job_role_utils.py
@@ -938,3 +938,46 @@ class UnpackingMappedColumnsTest(EstimateIndCQCFilledPostsByJobRoleUtilsTests):
         expected_data = expected_df.collect()
 
         self.assertEqual(returned_data, expected_data)
+
+
+class CalculateDifferenceBetweenEstimatedAndCqcRegisteredManagers(
+    EstimateIndCQCFilledPostsByJobRoleUtilsTests
+):
+    def setUp(self) -> None:
+        super().setUp()
+
+        self.test_df = self.spark.createDataFrame(
+            Data.estimate_and_cqc_registered_manager_rows,
+            Schemas.estimate_and_cqc_registered_manager_schema,
+        )
+        self.expected_df = self.spark.createDataFrame(
+            Data.expected_estimate_and_cqc_registered_manager_rows,
+            Schemas.expected_estimate_and_cqc_registered_manager_schema,
+        )
+        self.returned_df = (
+            job.calculate_difference_between_estimate_and_cqc_registered_managers(
+                self.test_df
+            )
+        )
+
+        self.new_columns_added = [
+            column
+            for column in self.returned_df.columns
+            if column not in self.test_df.columns
+        ]
+
+    def test_calculate_difference_between_estimate_and_cqc_registered_managers_adds_expected_column(
+        self,
+    ):
+        self.assertEqual(len(self.new_columns_added), 1)
+        self.assertEqual(
+            self.new_columns_added[0],
+            IndCQC.difference_between_estimate_and_cqc_registered_managers,
+        )
+
+    def test_calculate_difference_between_estimate_and_cqc_registered_managers_returns_expected_values(
+        self,
+    ):
+        expected_data = self.expected_df.collect()
+        returned_data = self.returned_df.collect()
+        self.assertEqual(expected_data, returned_data)

--- a/utils/column_names/ind_cqc_pipeline_columns.py
+++ b/utils/column_names/ind_cqc_pipeline_columns.py
@@ -107,6 +107,9 @@ class IndCqcColumns:
     current_region: str = ONSClean.current_region
     current_rural_urban_indicator_2011: str = ONSClean.current_rural_urban_ind_11
     current_sub_icb: str = ONSClean.current_sub_icb
+    difference_between_estimate_and_cqc_registered_managers: str = (
+        "difference_between_estimate_and_cqc_registered_managers"
+    )
     distribution_mean: str = "distribution_mean"
     distribution_standard_deviation: str = "distribution_standard_deviation"
     distribution_kurtosis: str = "distribution_kurtosis"

--- a/utils/estimate_filled_posts_by_job_role_utils/utils.py
+++ b/utils/estimate_filled_posts_by_job_role_utils/utils.py
@@ -369,11 +369,15 @@ def calculate_difference_between_estimate_and_cqc_registered_managers(
     """
     Calculates count of CQC registered managers minus our estimate of registered managers.
 
+    A positive value is when CQC have recorded more registered managers than we have estimated.
+    A negative value is when we have estimated more registered managers than CQC have recorded.
+    CQC have the official count of registered managers. Our estimate is based on records in ASC-WDS.
+
     Args:
         df (DataFrame): A dataframe which contains filled post estimates by job role and a count of registered managers from CQC.
 
     Returns:
-        DataFrame: A dataframe with an additional column showing our estimate minus count from CQC.
+        DataFrame: A dataframe with an additional column showing count from CQC minus our estimate of registered managers.
     """
     df = df.withColumn(
         IndCQC.difference_between_estimate_and_cqc_registered_managers,

--- a/utils/estimate_filled_posts_by_job_role_utils/utils.py
+++ b/utils/estimate_filled_posts_by_job_role_utils/utils.py
@@ -367,7 +367,7 @@ def calculate_difference_between_estimate_and_cqc_registered_managers(
     df: DataFrame,
 ) -> DataFrame:
     """
-    Calculates the difference between our estimate of registered managers and the count from CQC data.
+    Calculates count of CQC registered managers minus our estimate of registered managers.
 
     Args:
         df (DataFrame): A dataframe which contains filled post estimates by job role and a count of registered managers from CQC.
@@ -377,8 +377,8 @@ def calculate_difference_between_estimate_and_cqc_registered_managers(
     """
     df = df.withColumn(
         IndCQC.difference_between_estimate_and_cqc_registered_managers,
-        F.col(MainJobRoleLabels.registered_manager)
-        - F.col(IndCQC.registered_manager_count),
+        F.col(IndCQC.registered_manager_count)
+        - F.col(MainJobRoleLabels.registered_manager),
     )
 
     return df

--- a/utils/estimate_filled_posts_by_job_role_utils/utils.py
+++ b/utils/estimate_filled_posts_by_job_role_utils/utils.py
@@ -5,6 +5,7 @@ from typing import List
 from utils.column_names.ind_cqc_pipeline_columns import IndCqcColumns as IndCQC
 from utils.column_values.categorical_column_values import (
     EstimateFilledPostsSource,
+    MainJobRoleLabels,
 )
 from utils.value_labels.ascwds_worker.ascwds_worker_mainjrid import (
     AscwdsWorkerValueLabelsMainjrid,
@@ -357,6 +358,27 @@ def create_estimate_filled_posts_by_job_role_map_column(
                 lambda v: v * F.col(IndCQC.estimate_filled_posts),
             ),
         ),
+    )
+
+    return df
+
+
+def calculate_difference_between_estimate_and_cqc_registered_managers(
+    df: DataFrame,
+) -> DataFrame:
+    """
+    Calculates the difference between our estimate of registered managers and the count from CQC data.
+
+    Args:
+        df (DataFrame): A dataframe which contains filled post estimates by job role and a count of registered managers from CQC.
+
+    Returns:
+        DataFrame: A dataframe with an additional column showing our estimate minus count from CQC.
+    """
+    df = df.withColumn(
+        IndCQC.difference_between_estimate_and_cqc_registered_managers,
+        F.col(MainJobRoleLabels.registered_manager)
+        - F.col(IndCQC.registered_manager_count),
     )
 
     return df


### PR DESCRIPTION
# Description
Added a utils function to estimates by job role utils. 
Function is CQC registered managers minus estimated registered managers.
E.g. CQC says 1 RM, we estimate 10, result is -9. So we need to adjust our estimate by result to match CQC.

[Trello ticket](https://trello.com/c/2oKwVejf)

# How to test
Unit tests pass.
[Link to successful branch run](https://eu-west-2.console.aws.amazon.com/states/home?region=eu-west-2#/v2/executions/details/arn:aws:states:eu-west-2:344210435447:execution:calc-dif-rm-estimate-and-cqc-Ind-CQC-Filled-Post-Estimates-Pipeline:1c792325-73c5-4d9f-8275-345b3436f615) - I re-ran from the estimates by job role job and the crawler after updating function.
[Link to Athena](https://eu-west-2.console.aws.amazon.com/athena/home?region=eu-west-2#/query-editor/history/5edc5d80-c63d-4107-93a2-00fb5140ae85)

# Developer checklist
- [x] Unit test
- [x] Linked to Trello ticket
- [x] Documentation up to date
