### PR TITLE
Refactor create map column

### DIFF
--- a/jobs/estimate_ind_cqc_filled_posts_by_job_role.py
+++ b/jobs/estimate_ind_cqc_filled_posts_by_job_role.py
@@ -77,7 +77,7 @@ def main(
 
     aggregated_job_roles_per_establishment_df = (
         JRutils.aggregate_ascwds_worker_job_roles_per_establishment(
-            cleaned_ascwds_worker_df, JRutils.list_of_job_roles
+            cleaned_ascwds_worker_df, JRutils.list_of_job_roles_sorted
         )
     )
 
@@ -92,7 +92,8 @@ def main(
 
     estimated_ind_cqc_filled_posts_by_job_role_df = (
         JRutils.sum_job_role_count_split_by_service(
-            estimated_ind_cqc_filled_posts_by_job_role_df, JRutils.list_of_job_roles
+            estimated_ind_cqc_filled_posts_by_job_role_df,
+            JRutils.list_of_job_roles_sorted,
         )
     )
 
@@ -129,7 +130,7 @@ def main(
     )
 
     estimated_ind_cqc_filled_posts_by_job_role_df = model_job_role_ratio_interpolation(
-        estimated_ind_cqc_filled_posts_by_job_role_df
+        estimated_ind_cqc_filled_posts_by_job_role_df, JRutils.list_of_job_roles_sorted
     )
 
     estimated_ind_cqc_filled_posts_by_job_role_df = JRutils.unpack_mapped_column(

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -9785,6 +9785,17 @@ class EstimateIndCQCFilledPostsByJobRoleUtilsData:
             },
         )
     ]
+    expected_create_map_column_when_all_columns_populated_and_drop_columns_is_true_rows = [
+        (
+            "123",
+            {
+                MainJobRoleLabels.care_worker: 0,
+                MainJobRoleLabels.registered_nurse: 10,
+                MainJobRoleLabels.senior_care_worker: 20,
+                MainJobRoleLabels.senior_management: 30,
+            },
+        )
+    ]
     create_map_column_when_some_columns_populated_rows = [("123", 0, None, 20, None)]
     expected_create_map_column_when_some_columns_populated_rows = [
         (

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -6038,6 +6038,16 @@ class EstimateIndCQCFilledPostsByJobRoleUtilsSchemas:
             ),
         ]
     )
+    expected_create_map_column_when_drop_columns_is_true_schema = StructType(
+        [
+            StructField(IndCQC.establishment_id, StringType(), True),
+            StructField(
+                test_map_column,
+                MapType(StringType(), IntegerType()),
+                True,
+            ),
+        ]
+    )
 
     aggregate_ascwds_worker_with_additional_column_schema = StructType(
         [

--- a/tests/unit/test_estimate_ind_cqc_filled_posts_by_job_role_utils.py
+++ b/tests/unit/test_estimate_ind_cqc_filled_posts_by_job_role_utils.py
@@ -1094,9 +1094,6 @@ class ConvertMapWithAllNullValuesToNull(EstimateIndCQCFilledPostsByJobRoleUtilsT
 
         returned_df = job.convert_map_with_all_null_values_to_null(test_df)
 
-        expected_df.show(truncate=False)
-        returned_df.show(truncate=False)
-
         self.assertEqual(returned_df.collect(), expected_df.collect())
 
     def test_convert_map_with_all_null_values_to_null_when_map_has_some_null_returns_identical_dataframe(

--- a/utils/column_names/ind_cqc_pipeline_columns.py
+++ b/utils/column_names/ind_cqc_pipeline_columns.py
@@ -47,7 +47,6 @@ class IndCqcColumns:
     ascwds_filtering_rule: str = "ascwds_filtering_rule"
     ascwds_job_role_counts: str = "ascwds_job_role_counts"
     ascwds_job_role_ratios: str = "ascwds_job_role_ratios"
-    ascwds_job_role_ratios_temporary: str = "ascwds_job_role_ratios_temporary"
     ascwds_job_role_ratios_interpolated: str = "ascwds_job_role_ratios_interpolated"
     ascwds_job_role_ratios_exploded: str = "ascwds_job_role_ratios_exploded"
     ascwds_job_role_counts_by_primary_service: str = (

--- a/utils/column_names/ind_cqc_pipeline_columns.py
+++ b/utils/column_names/ind_cqc_pipeline_columns.py
@@ -47,6 +47,7 @@ class IndCqcColumns:
     ascwds_filtering_rule: str = "ascwds_filtering_rule"
     ascwds_job_role_counts: str = "ascwds_job_role_counts"
     ascwds_job_role_ratios: str = "ascwds_job_role_ratios"
+    ascwds_job_role_ratios_temporary: str = "ascwds_job_role_ratios_temporary"
     ascwds_job_role_ratios_interpolated: str = "ascwds_job_role_ratios_interpolated"
     ascwds_job_role_ratios_exploded: str = "ascwds_job_role_ratios_exploded"
     ascwds_job_role_counts_by_primary_service: str = (

--- a/utils/estimate_filled_posts_by_job_role_utils/models/interpolation.py
+++ b/utils/estimate_filled_posts_by_job_role_utils/models/interpolation.py
@@ -1,20 +1,17 @@
 from pyspark.sql import DataFrame, functions as F
+from typing import List
 
-from utils.column_names.ind_cqc_pipeline_columns import (
-    IndCqcColumns as IndCQC,
-)
+from utils.column_names.ind_cqc_pipeline_columns import IndCqcColumns as IndCQC
 from utils.estimate_filled_posts_by_job_role_utils.utils import (
-    unpack_mapped_column,
     create_map_column,
     pivot_interpolated_job_role_ratios,
     convert_map_with_all_null_values_to_null,
 )
-
 from utils.estimate_filled_posts.models.interpolation import model_interpolation
 
 
 def model_job_role_ratio_interpolation(
-    df: DataFrame,
+    df: DataFrame, column_list: List[str]
 ) -> DataFrame:
     """
     Performs interpolation on ascwds_job_role_ratio column
@@ -26,25 +23,10 @@ def model_job_role_ratio_interpolation(
         DataFrame: The DataFrame with the ascwds_job_role_ratio_interpolated column
 
     """
-
-    df_to_interpolate = unpack_mapped_column(df, IndCQC.ascwds_job_role_ratios)
-
-    df_keys = df_to_interpolate.select(
-        F.explode(F.map_keys(F.col(IndCQC.ascwds_job_role_ratios)))
-    ).distinct()
-    columns_to_interpolate = sorted([row[0] for row in df_keys.collect()])
-
-    df_to_interpolate = df_to_interpolate.withColumn(
-        IndCQC.ascwds_job_role_ratios_temporary,
-        create_map_column(columns_to_interpolate),
-    )
-
-    df_to_interpolate = df_to_interpolate.drop(*columns_to_interpolate)
-
-    df_to_interpolate = df_to_interpolate.select(
+    df_to_interpolate = df.select(
         IndCQC.location_id,
         IndCQC.unix_time,
-        F.explode(IndCQC.ascwds_job_role_ratios_temporary).alias(
+        F.explode(IndCQC.ascwds_job_role_ratios).alias(
             IndCQC.main_job_role_clean_labelled, IndCQC.ascwds_job_role_ratios_exploded
         ),
     )
@@ -67,12 +49,9 @@ def model_job_role_ratio_interpolation(
 
     df_to_interpolate = pivot_interpolated_job_role_ratios(df_to_interpolate)
 
-    df_to_interpolate = df_to_interpolate.withColumn(
-        IndCQC.ascwds_job_role_ratios_interpolated,
-        create_map_column(columns_to_interpolate),
+    df_to_interpolate = create_map_column(
+        df_to_interpolate, column_list, IndCQC.ascwds_job_role_ratios_interpolated
     )
-
-    df_to_interpolate = df_to_interpolate.drop(*columns_to_interpolate)
 
     df_joined = df.join(
         df_to_interpolate, on=[IndCQC.location_id, IndCQC.unix_time], how="inner"

--- a/utils/estimate_filled_posts_by_job_role_utils/models/interpolation.py
+++ b/utils/estimate_filled_posts_by_job_role_utils/models/interpolation.py
@@ -12,21 +12,21 @@ from utils.estimate_filled_posts.models.interpolation import model_interpolation
 
 
 def model_job_role_ratio_interpolation(
-    df: DataFrame, column_list: List[str]
+    df: DataFrame, job_role_column_list: List[str]
 ) -> DataFrame:
     """
     Performs interpolation on ascwds_job_role_ratio column
 
     Args:
         df (DataFrame): The input DataFrame containing the columng ascwds_job_role_ratio column
+        job_role_column_list (List[str]): List of all job roles in ASCWDS.
 
     Returns:
         DataFrame: The DataFrame with the ascwds_job_role_ratio_interpolated column
-
     """
     df_to_interpolate = unpack_mapped_column(df, IndCQC.ascwds_job_role_ratios)
     df_to_interpolate = create_map_column(
-        df_to_interpolate, column_list, IndCQC.ascwds_job_role_ratios_temporary
+        df_to_interpolate, job_role_column_list, IndCQC.ascwds_job_role_ratios_temporary
     )
 
     df_to_interpolate = df_to_interpolate.select(
@@ -56,7 +56,9 @@ def model_job_role_ratio_interpolation(
     df_to_interpolate = pivot_interpolated_job_role_ratios(df_to_interpolate)
 
     df_to_interpolate = create_map_column(
-        df_to_interpolate, column_list, IndCQC.ascwds_job_role_ratios_interpolated
+        df_to_interpolate,
+        job_role_column_list,
+        IndCQC.ascwds_job_role_ratios_interpolated,
     )
 
     df_joined = df.join(

--- a/utils/estimate_filled_posts_by_job_role_utils/models/interpolation.py
+++ b/utils/estimate_filled_posts_by_job_role_utils/models/interpolation.py
@@ -3,6 +3,7 @@ from typing import List
 
 from utils.column_names.ind_cqc_pipeline_columns import IndCqcColumns as IndCQC
 from utils.estimate_filled_posts_by_job_role_utils.utils import (
+    unpack_mapped_column,
     create_map_column,
     pivot_interpolated_job_role_ratios,
     convert_map_with_all_null_values_to_null,
@@ -23,10 +24,15 @@ def model_job_role_ratio_interpolation(
         DataFrame: The DataFrame with the ascwds_job_role_ratio_interpolated column
 
     """
-    df_to_interpolate = df.select(
+    df_to_interpolate = unpack_mapped_column(df, IndCQC.ascwds_job_role_ratios)
+    df_to_interpolate = create_map_column(
+        df_to_interpolate, column_list, IndCQC.ascwds_job_role_ratios_temporary
+    )
+
+    df_to_interpolate = df_to_interpolate.select(
         IndCQC.location_id,
         IndCQC.unix_time,
-        F.explode(IndCQC.ascwds_job_role_ratios).alias(
+        F.explode(IndCQC.ascwds_job_role_ratios_temporary).alias(
             IndCQC.main_job_role_clean_labelled, IndCQC.ascwds_job_role_ratios_exploded
         ),
     )

--- a/utils/estimate_filled_posts_by_job_role_utils/utils.py
+++ b/utils/estimate_filled_posts_by_job_role_utils/utils.py
@@ -60,7 +60,7 @@ def create_map_column(
 
     Args:
         df (DataFrame): DataFrame containing the list of columns to be mapped.
-        columns (List[str]): List of column names to be mapped.
+        column_list (List[str]): List of column names to be mapped.
         new_col_name (str): Name of the new mapped column to be added.
         drop_original_columns (bool, optional): If True, drops the original columns after creating
             the map column. Defaults to True.

--- a/utils/estimate_filled_posts_by_job_role_utils/utils.py
+++ b/utils/estimate_filled_posts_by_job_role_utils/utils.py
@@ -8,10 +8,10 @@ from utils.column_values.categorical_column_values import (
     MainJobRoleLabels,
 )
 from utils.value_labels.ascwds_worker.ascwds_worker_mainjrid import (
-    AscwdsWorkerValueLabelsMainjrid,
+    AscwdsWorkerValueLabelsMainjrid as AscwdsJobRoles,
 )
 
-list_of_job_roles = list(AscwdsWorkerValueLabelsMainjrid.labels_dict.values())
+list_of_job_roles_sorted = sorted(list(AscwdsJobRoles.labels_dict.values()))
 
 
 def aggregate_ascwds_worker_job_roles_per_establishment(
@@ -40,26 +40,45 @@ def aggregate_ascwds_worker_job_roles_per_establishment(
     )
     df = df.na.fill(0, subset=list_of_job_roles)
 
-    df = df.withColumn(
-        IndCQC.ascwds_job_role_counts, create_map_column(list_of_job_roles)
-    )
-
-    df = df.drop(*list_of_job_roles)
+    df = create_map_column(df, list_of_job_roles, IndCQC.ascwds_job_role_counts)
 
     return df
 
 
-def create_map_column(columns: List[str]) -> F.Column:
+def create_map_column(
+    df: DataFrame,
+    column_list: List[str],
+    new_col_name: str,
+    drop_original_columns: bool = True,
+) -> DataFrame:
     """
-    Creates a Spark map column from a list of columns where keys are column names and values are the respective column values.
+    Creates a new map column in a DataFrame by mapping the specified columns to their values.
+
+    This function generates a map column where the keys are the column names and the values are the corresponding column values.
+    The column list is sorted alphabetically before creating the map.
+    The original columns can be optionally dropped after the map column is created.
 
     Args:
+        df (DataFrame): DataFrame containing the list of columns to be mapped.
         columns (List[str]): List of column names to be mapped.
+        new_col_name (str): Name of the new mapped column to be added.
+        drop_original_columns (bool, optional): If True, drops the original columns after creating
+            the map column. Defaults to True.
 
     Returns:
-        F.Column: A Spark column containing a map of job role names to counts.
+        DataFrame: A DataFrame with the new map column added and optionally the original columns dropped.
     """
-    return F.create_map(*[x for col in columns for x in (F.lit(col), F.col(col))])
+    sorted_column_list = sorted(column_list)
+
+    map_columns = F.create_map(
+        *[x for col in sorted_column_list for x in (F.lit(col), F.col(col))]
+    )
+    df = df.withColumn(new_col_name, map_columns)
+
+    if drop_original_columns:
+        df = df.drop(*sorted_column_list)
+
+    return df
 
 
 def merge_dataframes(
@@ -294,10 +313,11 @@ def sum_job_role_count_split_by_service(
         .sum("value")
     )
 
-    df_explode_grouped_with_map_column = df_explode_grouped.withColumn(
+    df_explode_grouped_with_map_column = create_map_column(
+        df_explode_grouped,
+        list_of_job_roles,
         IndCQC.ascwds_job_role_counts_by_primary_service,
-        create_map_column(list_of_job_roles),
-    ).drop(*list_of_job_roles)
+    )
 
     df_result = df.join(
         df_explode_grouped_with_map_column,


### PR DESCRIPTION
# Description
Currently there is no ordering in the create map column function so at the start of most functions we need to explode the column, sort the column order, then re-map again. Given the size of the dataset, and the amount of times we need to do this, the job is taking longer and longer to run (currently 75 minutes, but we're doing this more and more so it will get longer)

The function now sorts the list of columns provided before converting to a map column, which will ensure that all of our map columns are already sorted in alphabetical order

Also added a bool which drops the individual columns as it looks like we always do this, but there's the option not to if required. Added an additional test for this functionality.

Updated the rest of the pipeline to account for this change in behaviour

# How to test
Updated any current tests according and added a new test for column dropping functionality

[Job ran successfully and 10 minutes quicker than main](https://eu-west-2.console.aws.amazon.com/gluestudio/home?region=eu-west-2#/editor/job/refactor-create-map-column-estimate_ind_cqc_filled_posts_by_job_role_job/runs)

# Developer checklist
- [X] Unit test
- [X] Linked to Trello ticket
- [X] Documentation up to date
