### PR TITLE
Added additional bucket so 1 bed gives a banding of 1 instead of zero

### DIFF
--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -4047,15 +4047,15 @@ class CleaningUtilsData:
     ]
 
     create_banded_bed_count_column_rows = [
-        ("1-001", CareHome.care_home, 5),
+        ("1-001", CareHome.care_home, 1),
         ("1-002", CareHome.care_home, 24),
         ("1-003", CareHome.care_home, 500),
         ("1-004", CareHome.not_care_home, None),
     ]
     expected_create_banded_bed_count_column_rows = [
-        ("1-001", CareHome.care_home, 5, 2.0),
-        ("1-002", CareHome.care_home, 24, 5.0),
-        ("1-003", CareHome.care_home, 500, 7.0),
+        ("1-001", CareHome.care_home, 1, 1.0),
+        ("1-002", CareHome.care_home, 24, 6.0),
+        ("1-003", CareHome.care_home, 500, 8.0),
         ("1-004", CareHome.not_care_home, None, None),
     ]
 

--- a/utils/cleaning_utils.py
+++ b/utils/cleaning_utils.py
@@ -316,7 +316,7 @@ def create_banded_bed_count_column(input_df: DataFrame) -> DataFrame:
     )
 
     set_banded_boundaries = Bucketizer(
-        splits=[0, 3, 5, 10, 15, 20, 25, 50, float("Inf")],
+        splits=[0, 1, 3, 5, 10, 15, 20, 25, 50, float("Inf")],
         inputCol=IndCQC.number_of_beds,
         outputCol=IndCQC.number_of_beds_banded,
     )


### PR DESCRIPTION
# Description
Turns out the models treat zero as unknown, and the bucketizer returns zero for the first band.

I've added an additional category starting at 1 into the bucketizer, so any bed value of 1 will now return a banded bed category of 1 instead of zero, which subsequently adds one onto all previous bands

# How to test
The number of the band doesn't matter, every band will now just be one larger than before - updated previous tests to account for this change

# Developer checklist
- [X] Unit test
- [X] Linked to [Trello ticket](https://trello.com/c/QspzTKPV/756-epic-5-change-min-banded-bed-value-to-be-1-must)
- [X] Documentation up to date
