### PR TITLE
Combine Models - 2 - Calculate and apply model ratios to adjust 'without_dormancy' to reflect 'with_dormancy' model

### DIFF
--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -6367,6 +6367,22 @@ class ModelNonResWithAndWithoutDormancyCombinedRows:
         ("1-006", date(2024, 8, 1), CareHome.not_care_home, "N", 4, 3.0, 3.0),
     ]
 
+    average_models_by_related_location_and_time_registered_rows = [
+        ("1-001", RelatedLocation.no_related_location, 1, 5.0, 14.0),
+        ("1-002", RelatedLocation.no_related_location, 1, 6.0, 15.0),
+        ("1-003", RelatedLocation.has_related_location, 1, 1.0, 10.0),
+        ("1-004", RelatedLocation.has_related_location, 1, 2.0, 11.0),
+        ("1-005", RelatedLocation.has_related_location, 2, 3.0, 12.0),
+        ("1-006", RelatedLocation.has_related_location, 2, 4.0, 13.0),
+        ("1-007", RelatedLocation.has_related_location, 2, 20.0, None),
+        ("1-008", RelatedLocation.has_related_location, 2, None, 20.0),
+    ]
+    expected_average_models_by_related_location_and_time_registered_rows = [
+        (RelatedLocation.no_related_location, 1, 5.5, 14.5),
+        (RelatedLocation.has_related_location, 1, 1.5, 10.5),
+        (RelatedLocation.has_related_location, 2, 3.5, 12.5),
+    ]
+
 
 @dataclass
 class ModelNonResPirLinearRegressionRows:

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -6383,13 +6383,33 @@ class ModelNonResWithAndWithoutDormancyCombinedRows:
         (RelatedLocation.has_related_location, 2, 3.5, 12.5),
     ]
 
-    calculate_adjustment_ratios_schema = [
+    calculate_adjustment_ratios_rows = [
         (RelatedLocation.no_related_location, 1, 5.0, 10.0),
         (RelatedLocation.has_related_location, 1, 4.5, 1.5),
     ]
-    expected_calculate_adjustment_ratios_schema = [
+    expected_calculate_adjustment_ratios_rows = [
         (RelatedLocation.no_related_location, 1, 5.0, 10.0, 0.5),
         (RelatedLocation.has_related_location, 1, 4.5, 1.5, 3.0),
+    ]
+
+    apply_model_ratios_returns_expected_values_when_all_values_known_rows = [
+        ("1-001", 5.0, 14.0, 0.25),
+        ("1-002", 6.0, 15.0, 2.0),
+    ]
+    expected_apply_model_ratios_returns_expected_values_when_all_values_known_rows = [
+        ("1-001", 5.0, 14.0, 0.25, 3.5),
+        ("1-002", 6.0, 15.0, 2.0, 30.0),
+    ]
+
+    apply_model_ratios_returns_none_when_none_values_present_rows = [
+        ("1-001", 5.0, None, 0.2),
+        ("1-002", 5.0, 10.0, None),
+        ("1-003", 5.0, None, None),
+    ]
+    expected_apply_model_ratios_returns_none_when_none_values_present_rows = [
+        ("1-001", 5.0, None, 0.2, None),
+        ("1-002", 5.0, 10.0, None, None),
+        ("1-003", 5.0, None, None, None),
     ]
 
 

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -6367,6 +6367,20 @@ class ModelNonResWithAndWithoutDormancyCombinedRows:
         ("1-006", date(2024, 8, 1), CareHome.not_care_home, "N", 4, 3.0, 3.0),
     ]
 
+    calculate_and_apply_model_ratios_rows = [
+        ("1-001", date(2022, 2, 1), "Y", 2, 3.0, None),
+        ("1-001", date(2023, 3, 1), "Y", 3, 4.0, 5.0),
+        ("1-002", date(2022, 2, 1), "Y", 4, 8.0, None),
+        ("1-002", date(2023, 3, 1), "Y", 5, 8.0, 4.0),
+        ("1-003", date(2022, 2, 1), "N", 2, 2.0, None),
+        ("1-003", date(2021, 3, 1), "N", 3, 4.0, None),
+        ("1-003", date(2022, 4, 1), "N", 4, 4.0, None),
+        ("1-003", date(2023, 5, 1), "N", 5, 6.0, 8.0),
+        ("1-003", date(2024, 6, 1), "N", 6, 6.0, 9.0),
+        ("1-004", date(2024, 5, 1), "Y", 1, 4.0, 2.0),
+        ("1-004", date(2024, 6, 1), "Y", 2, 5.0, 2.5),
+    ]
+
     average_models_by_related_location_and_time_registered_rows = [
         ("1-001", RelatedLocation.no_related_location, 1, 5.0, 14.0),
         ("1-002", RelatedLocation.no_related_location, 1, 6.0, 15.0),

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -6383,6 +6383,15 @@ class ModelNonResWithAndWithoutDormancyCombinedRows:
         (RelatedLocation.has_related_location, 2, 3.5, 12.5),
     ]
 
+    calculate_adjustment_ratios_schema = [
+        (RelatedLocation.no_related_location, 1, 5.0, 10.0),
+        (RelatedLocation.has_related_location, 1, 4.5, 1.5),
+    ]
+    expected_calculate_adjustment_ratios_schema = [
+        (RelatedLocation.no_related_location, 1, 5.0, 10.0, 0.5),
+        (RelatedLocation.has_related_location, 1, 4.5, 1.5, 3.0),
+    ]
+
 
 @dataclass
 class ModelNonResPirLinearRegressionRows:

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -48,6 +48,7 @@ from utils.column_names.ind_cqc_pipeline_columns import (
     ArchivePartitionKeys as ArchiveKeys,
     IndCqcColumns as IndCQC,
     PrimaryServiceRollingAverageColumns as RA_TempCol,
+    NonResWithAndWithoutDormancyCombinedColumns as NRModel_TempCol,
 )
 from utils.column_names.raw_data_files.ascwds_worker_columns import (
     AscwdsWorkerColumns as AWK,
@@ -3313,6 +3314,24 @@ class ModelNonResWithAndWithoutDormancyCombinedSchemas:
             StructField(IndCQC.time_registered, IntegerType(), True),
             StructField(IndCQC.non_res_without_dormancy_model, FloatType(), True),
             StructField(IndCQC.non_res_with_dormancy_model, FloatType(), True),
+        ]
+    )
+
+    average_models_by_related_location_and_time_registered_schema = StructType(
+        [
+            StructField(IndCQC.location_id, StringType(), True),
+            StructField(IndCQC.related_location, StringType(), True),
+            StructField(IndCQC.time_registered, IntegerType(), True),
+            StructField(IndCQC.non_res_with_dormancy_model, FloatType(), True),
+            StructField(IndCQC.non_res_without_dormancy_model, FloatType(), True),
+        ]
+    )
+    expected_average_models_by_related_location_and_time_registered_schema = StructType(
+        [
+            StructField(IndCQC.related_location, StringType(), True),
+            StructField(IndCQC.time_registered, IntegerType(), True),
+            StructField(NRModel_TempCol.avg_with_dormancy, FloatType(), True),
+            StructField(NRModel_TempCol.avg_without_dormancy, FloatType(), True),
         ]
     )
 

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -3335,6 +3335,21 @@ class ModelNonResWithAndWithoutDormancyCombinedSchemas:
         ]
     )
 
+    calculate_adjustment_ratios_schema = StructType(
+        [
+            StructField(IndCQC.related_location, StringType(), True),
+            StructField(IndCQC.time_registered, IntegerType(), True),
+            StructField(NRModel_TempCol.avg_with_dormancy, FloatType(), True),
+            StructField(NRModel_TempCol.avg_without_dormancy, FloatType(), True),
+        ]
+    )
+    expected_calculate_adjustment_ratios_schema = StructType(
+        [
+            *calculate_adjustment_ratios_schema,
+            StructField(NRModel_TempCol.adjustment_ratio, FloatType(), True),
+        ]
+    )
+
 
 @dataclass
 class ModelNonResPirLinearRegressionSchemas:

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -3317,6 +3317,28 @@ class ModelNonResWithAndWithoutDormancyCombinedSchemas:
         ]
     )
 
+    calculate_and_apply_model_ratios_schema = StructType(
+        [
+            StructField(IndCQC.location_id, StringType(), True),
+            StructField(IndCQC.cqc_location_import_date, DateType(), True),
+            StructField(IndCQC.related_location, StringType(), True),
+            StructField(IndCQC.time_registered, IntegerType(), True),
+            StructField(IndCQC.non_res_without_dormancy_model, FloatType(), True),
+            StructField(IndCQC.non_res_with_dormancy_model, FloatType(), True),
+        ]
+    )
+    expected_calculate_and_apply_model_ratios_schema = StructType(
+        [
+            *calculate_and_apply_model_ratios_schema,
+            StructField(NRModel_TempCol.avg_with_dormancy, FloatType(), True),
+            StructField(NRModel_TempCol.avg_without_dormancy, FloatType(), True),
+            StructField(NRModel_TempCol.adjustment_ratio, FloatType(), True),
+            StructField(
+                NRModel_TempCol.adjusted_without_dormancy_model, FloatType(), True
+            ),
+        ]
+    )
+
     average_models_by_related_location_and_time_registered_schema = StructType(
         [
             StructField(IndCQC.location_id, StringType(), True),

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -3350,6 +3350,23 @@ class ModelNonResWithAndWithoutDormancyCombinedSchemas:
         ]
     )
 
+    apply_model_ratios_schema = StructType(
+        [
+            StructField(IndCQC.location_id, StringType(), True),
+            StructField(IndCQC.non_res_with_dormancy_model, FloatType(), True),
+            StructField(IndCQC.non_res_without_dormancy_model, FloatType(), True),
+            StructField(NRModel_TempCol.adjustment_ratio, FloatType(), True),
+        ]
+    )
+    expected_apply_model_ratios_schema = StructType(
+        [
+            *apply_model_ratios_schema,
+            StructField(
+                NRModel_TempCol.adjusted_without_dormancy_model, FloatType(), True
+            ),
+        ]
+    )
+
 
 @dataclass
 class ModelNonResPirLinearRegressionSchemas:

--- a/tests/unit/test_model_non_res_with_and_without_dormancy_combined.py
+++ b/tests/unit/test_model_non_res_with_and_without_dormancy_combined.py
@@ -78,3 +78,33 @@ class AverageModelsByRelatedLocationAndTimeRegisteredTests(
                 places=3,
                 msg=f"Returned without dormancy average for row {i} does not match expected",
             )
+
+
+class CalculateAdjustmentRatiosTests(ModelNonResWithAndWithoutDormancyCombinedTests):
+    def setUp(self) -> None:
+        super().setUp()
+
+        test_df = self.spark.createDataFrame(
+            Data.calculate_adjustment_ratios_schema,
+            Schemas.calculate_adjustment_ratios_schema,
+        )
+        self.returned_df = job.calculate_adjustment_ratios(test_df)
+        self.expected_df = self.spark.createDataFrame(
+            Data.expected_calculate_adjustment_ratios_schema,
+            Schemas.expected_calculate_adjustment_ratios_schema,
+        )
+
+        self.returned_data = self.returned_df.sort(IndCqc.related_location).collect()
+        self.expected_data = self.expected_df.collect()
+
+    def test_average_models_returns_expected_columns(self):
+        self.assertEqual(self.returned_df.columns, self.expected_df.columns)
+
+    def test_average_models_returns_expected_ratios(self):
+        for i in range(len(self.returned_data)):
+            self.assertAlmostEqual(
+                self.returned_data[i][NRModel_TempCol.adjustment_ratio],
+                self.expected_data[i][NRModel_TempCol.adjustment_ratio],
+                places=3,
+                msg=f"Returned adjustment ratio for row {i} does not match expected",
+            )

--- a/tests/unit/test_model_non_res_with_and_without_dormancy_combined.py
+++ b/tests/unit/test_model_non_res_with_and_without_dormancy_combined.py
@@ -5,6 +5,7 @@ from utils import utils
 import utils.estimate_filled_posts.models.non_res_with_and_without_dormancy_combined as job
 from utils.column_names.ind_cqc_pipeline_columns import (
     IndCqcColumns as IndCqc,
+    NonResWithAndWithoutDormancyCombinedColumns as NRModel_TempCol,
 )
 from tests.test_file_data import ModelNonResWithAndWithoutDormancyCombinedRows as Data
 from tests.test_file_schemas import (
@@ -20,11 +21,10 @@ class ModelNonResWithAndWithoutDormancyCombinedTests(unittest.TestCase):
             Data.estimated_posts_rows, Schemas.estimated_posts_schema
         )
 
-    # TODO - this can be removed once process complete,
-    def test_data_looks_as_expected(self):
-        returned_df = job.combine_non_res_with_and_without_dormancy_models(self.test_df)
-        # returned_df.sort(IndCqc.location_id).show()
-        pass
+
+class MainTests(ModelNonResWithAndWithoutDormancyCombinedTests):
+    def setUp(self) -> None:
+        super().setUp()
 
     @patch("utils.utils.select_rows_with_value")
     def test_models_runs(self, select_rows_with_value_mock: Mock):
@@ -33,3 +33,48 @@ class ModelNonResWithAndWithoutDormancyCombinedTests(unittest.TestCase):
         select_rows_with_value_mock.assert_called_once()
 
     # TODO flesh out main tests to usual standard (expected columns/rows/anything else?)
+
+
+class AverageModelsByRelatedLocationAndTimeRegisteredTests(
+    ModelNonResWithAndWithoutDormancyCombinedTests
+):
+    def setUp(self) -> None:
+        super().setUp()
+
+        test_df = self.spark.createDataFrame(
+            Data.average_models_by_related_location_and_time_registered_rows,
+            Schemas.average_models_by_related_location_and_time_registered_schema,
+        )
+        self.returned_df = job.average_models_by_related_location_and_time_registered(
+            test_df
+        )
+        self.expected_df = self.spark.createDataFrame(
+            Data.expected_average_models_by_related_location_and_time_registered_rows,
+            Schemas.expected_average_models_by_related_location_and_time_registered_schema,
+        )
+
+        self.returned_data = self.returned_df.sort(
+            IndCqc.related_location, IndCqc.time_registered
+        ).collect()
+        self.expected_data = self.expected_df.collect()
+
+    def test_average_models_returns_expected_columns(self):
+        self.assertEqual(self.returned_df.columns, self.expected_df.columns)
+
+    def test_average_models_returns_expected_average_with_dormancy_values(self):
+        for i in range(len(self.returned_data)):
+            self.assertAlmostEqual(
+                self.returned_data[i][NRModel_TempCol.avg_with_dormancy],
+                self.expected_data[i][NRModel_TempCol.avg_with_dormancy],
+                places=3,
+                msg=f"Returned with dormancy average for row {i} does not match expected",
+            )
+
+    def test_average_models_returns_expected_average_without_dormancy_values(self):
+        for i in range(len(self.returned_data)):
+            self.assertAlmostEqual(
+                self.returned_data[i][NRModel_TempCol.avg_without_dormancy],
+                self.expected_data[i][NRModel_TempCol.avg_without_dormancy],
+                places=3,
+                msg=f"Returned without dormancy average for row {i} does not match expected",
+            )

--- a/tests/unit/test_model_non_res_with_and_without_dormancy_combined.py
+++ b/tests/unit/test_model_non_res_with_and_without_dormancy_combined.py
@@ -85,12 +85,12 @@ class CalculateAdjustmentRatiosTests(ModelNonResWithAndWithoutDormancyCombinedTe
         super().setUp()
 
         test_df = self.spark.createDataFrame(
-            Data.calculate_adjustment_ratios_schema,
+            Data.calculate_adjustment_ratios_rows,
             Schemas.calculate_adjustment_ratios_schema,
         )
         self.returned_df = job.calculate_adjustment_ratios(test_df)
         self.expected_df = self.spark.createDataFrame(
-            Data.expected_calculate_adjustment_ratios_schema,
+            Data.expected_calculate_adjustment_ratios_rows,
             Schemas.expected_calculate_adjustment_ratios_schema,
         )
 
@@ -107,4 +107,55 @@ class CalculateAdjustmentRatiosTests(ModelNonResWithAndWithoutDormancyCombinedTe
                 self.expected_data[i][NRModel_TempCol.adjustment_ratio],
                 places=3,
                 msg=f"Returned adjustment ratio for row {i} does not match expected",
+            )
+
+
+class ApplyModelRatiosTests(ModelNonResWithAndWithoutDormancyCombinedTests):
+    def setUp(self) -> None:
+        super().setUp()
+
+        test_df = self.spark.createDataFrame(
+            Data.apply_model_ratios_returns_expected_values_when_all_values_known_rows,
+            Schemas.apply_model_ratios_schema,
+        )
+        self.returned_df = job.apply_model_ratios(test_df)
+        self.expected_df = self.spark.createDataFrame(
+            Data.expected_apply_model_ratios_returns_expected_values_when_all_values_known_rows,
+            Schemas.expected_apply_model_ratios_schema,
+        )
+
+        self.returned_data = self.returned_df.sort(IndCqc.location_id).collect()
+        self.expected_data = self.expected_df.collect()
+
+    def test_apply_model_ratios_returns_expected_columns(self):
+        self.assertEqual(self.returned_df.columns, self.expected_df.columns)
+
+    def test_apply_model_ratios_returns_expected_values_when_all_values_known(self):
+        for i in range(len(self.returned_data)):
+            self.assertAlmostEqual(
+                self.returned_data[i][NRModel_TempCol.adjusted_without_dormancy_model],
+                self.expected_data[i][NRModel_TempCol.adjusted_without_dormancy_model],
+                places=3,
+                msg=f"Returned values for row {i} does not match expected",
+            )
+
+    def test_apply_model_ratios_returns_none_when_none_values_present(self):
+        test_df = self.spark.createDataFrame(
+            Data.apply_model_ratios_returns_none_when_none_values_present_rows,
+            Schemas.apply_model_ratios_schema,
+        )
+        returned_df = job.apply_model_ratios(test_df)
+        expected_df = self.spark.createDataFrame(
+            Data.expected_apply_model_ratios_returns_none_when_none_values_present_rows,
+            Schemas.expected_apply_model_ratios_schema,
+        )
+
+        returned_data = returned_df.sort(IndCqc.location_id).collect()
+        expected_data = expected_df.collect()
+
+        for i in range(len(returned_data)):
+            self.assertEqual(
+                returned_data[i][NRModel_TempCol.adjusted_without_dormancy_model],
+                expected_data[i][NRModel_TempCol.adjusted_without_dormancy_model],
+                f"Returned values for row {i} does not match expected",
             )

--- a/utils/column_names/ind_cqc_pipeline_columns.py
+++ b/utils/column_names/ind_cqc_pipeline_columns.py
@@ -270,3 +270,13 @@ class PrimaryServiceRollingAverageColumns:
     rolling_previous_period_sum: str = "rolling_previous_period_sum"
     single_period_rate_of_change: str = "single_period_rate_of_change"
     submission_count: str = "submission_count"
+
+
+@dataclass
+class NonResWithAndWithoutDormancyCombinedColumns:
+    """The names of the temporary columns used in the combining of the models process."""
+
+    adjusted_without_dormancy_model: str = "adjusted_without_dormancy_model"
+    adjustment_ratio: str = "adjustment_ratio"
+    avg_with_dormancy: str = "avg_with_dormancy"
+    avg_without_dormancy: str = "avg_without_dormancy"

--- a/utils/estimate_filled_posts/models/non_res_with_and_without_dormancy_combined.py
+++ b/utils/estimate_filled_posts/models/non_res_with_and_without_dormancy_combined.py
@@ -48,7 +48,6 @@ def combine_non_res_with_and_without_dormancy_models(
     return non_res_locations_df  # TODO add tests
 
 
-# TODO add tests
 def calculate_and_apply_model_ratios(df: DataFrame) -> DataFrame:
     """
     Calculates the ratio between 'with_dormancy' and 'without_dormancy' models by partitioning

--- a/utils/estimate_filled_posts/models/non_res_with_and_without_dormancy_combined.py
+++ b/utils/estimate_filled_posts/models/non_res_with_and_without_dormancy_combined.py
@@ -35,6 +35,8 @@ def combine_non_res_with_and_without_dormancy_models(
         locations_df, IndCqc.care_home, CareHome.not_care_home
     )
 
+    # TODO - 6 - convert time registered month bands to 6 monthly bands (capped at 10 years)
+
     non_res_locations_df = calculate_and_apply_model_ratios(non_res_locations_df)
 
     # TODO - 3 - calculate and apply residuals
@@ -112,7 +114,6 @@ def calculate_adjustment_ratios(df: DataFrame) -> DataFrame:
     return df
 
 
-# TODO add tests
 def apply_model_ratios(df: DataFrame) -> DataFrame:
     """
     Applies the adjustment ratio to 'without_dormancy' model predictions.

--- a/utils/estimate_filled_posts/models/non_res_with_and_without_dormancy_combined.py
+++ b/utils/estimate_filled_posts/models/non_res_with_and_without_dormancy_combined.py
@@ -24,6 +24,7 @@ def combine_non_res_with_and_without_dormancy_models(
     locations_df = locations_df.select(
         IndCqc.location_id,
         IndCqc.cqc_location_import_date,
+        IndCqc.care_home,
         IndCqc.related_location,
         IndCqc.time_registered,
         IndCqc.non_res_without_dormancy_model,
@@ -94,7 +95,6 @@ def average_models_by_related_location_and_time_registered(df: DataFrame) -> Dat
     return avg_df
 
 
-# TODO add tests
 def calculate_adjustment_ratios(df: DataFrame) -> DataFrame:
     """
     Calculates the adjustment ratio between 'with_dormancy' and 'without_dormancy' models.
@@ -107,11 +107,7 @@ def calculate_adjustment_ratios(df: DataFrame) -> DataFrame:
     """
     df = df.withColumn(
         TempColumns.adjustment_ratio,
-        F.when(
-            F.col(TempColumns.avg_without_dormancy) != 0,
-            F.col(TempColumns.avg_with_dormancy)
-            / F.col(TempColumns.avg_without_dormancy),
-        ).otherwise(1.0),
+        F.col(TempColumns.avg_with_dormancy) / F.col(TempColumns.avg_without_dormancy),
     )
     return df
 

--- a/utils/estimate_filled_posts/models/non_res_with_and_without_dormancy_combined.py
+++ b/utils/estimate_filled_posts/models/non_res_with_and_without_dormancy_combined.py
@@ -1,8 +1,9 @@
-from pyspark.sql import DataFrame
+from pyspark.sql import DataFrame, functions as F
 
 from utils import utils
 from utils.column_names.ind_cqc_pipeline_columns import (
     IndCqcColumns as IndCqc,
+    NonResWithAndWithoutDormancyCombinedColumns as TempColumns,
 )
 from utils.column_values.categorical_column_values import CareHome
 
@@ -33,7 +34,7 @@ def combine_non_res_with_and_without_dormancy_models(
         locations_df, IndCqc.care_home, CareHome.not_care_home
     )
 
-    # TODO - 2 - calculate and apply model ratios
+    non_res_locations_df = calculate_and_apply_model_ratios(non_res_locations_df)
 
     # TODO - 3 - calculate and apply residuals
 
@@ -41,4 +42,95 @@ def combine_non_res_with_and_without_dormancy_models(
 
     # TODO - 5 - set_min_value and insert predictions into pipeline
 
-    return locations_df
+    return non_res_locations_df  # TODO add tests
+
+
+# TODO add tests
+def calculate_and_apply_model_ratios(df: DataFrame) -> DataFrame:
+    """
+    Calculates the ratio between 'with_dormancy' and 'without_dormancy' models by partitioning
+    the dataset based on 'related_location' and 'time_registered'.
+
+    Args:
+        df (DataFrame): Input DataFrame with model predictions.
+
+    Returns:
+        DataFrame: DataFrame with partition-level ratios applied.
+    """
+    ratio_df = average_models_by_related_location_and_time_registered(df)
+
+    ratio_df = calculate_adjustment_ratios(ratio_df)
+
+    df = df.join(ratio_df, [IndCqc.related_location, IndCqc.time_registered], "left")
+
+    df = apply_model_ratios(df)
+
+    return df
+
+
+def average_models_by_related_location_and_time_registered(df: DataFrame) -> DataFrame:
+    """
+    Averages model predictions by 'related_location' and 'time_registered'.
+
+    Args:
+        df (DataFrame): DataFrame with model predictions.
+
+    Returns:
+        DataFrame: DataFrame with averaged model predictions.
+    """
+    both_models_known_df = df.where(
+        F.col(IndCqc.non_res_with_dormancy_model).isNotNull()
+        & F.col(IndCqc.non_res_without_dormancy_model).isNotNull()
+    )
+
+    avg_df = both_models_known_df.groupBy(
+        IndCqc.related_location, IndCqc.time_registered
+    ).agg(
+        F.avg(IndCqc.non_res_with_dormancy_model).alias(TempColumns.avg_with_dormancy),
+        F.avg(IndCqc.non_res_without_dormancy_model).alias(
+            TempColumns.avg_without_dormancy
+        ),
+    )
+    return avg_df
+
+
+# TODO add tests
+def calculate_adjustment_ratios(df: DataFrame) -> DataFrame:
+    """
+    Calculates the adjustment ratio between 'with_dormancy' and 'without_dormancy' models.
+
+    Args:
+        df (DataFrame): DataFrame with aggregated model predictions.
+
+    Returns:
+        DataFrame: DataFrame with adjustment ratios calculated.
+    """
+    df = df.withColumn(
+        TempColumns.adjustment_ratio,
+        F.when(
+            F.col(TempColumns.avg_without_dormancy) != 0,
+            F.col(TempColumns.avg_with_dormancy)
+            / F.col(TempColumns.avg_without_dormancy),
+        ).otherwise(1.0),
+    )
+    return df
+
+
+# TODO add tests
+def apply_model_ratios(df: DataFrame) -> DataFrame:
+    """
+    Applies the adjustment ratio to 'without_dormancy' model predictions.
+
+    Args:
+        df (DataFrame): DataFrame with model predictions and adjustment ratios.
+
+    Returns:
+        DataFrame: DataFrame with adjusted 'without_dormancy' model predictions.
+    """
+    df = df.withColumn(
+        TempColumns.adjusted_without_dormancy_model,
+        F.col(IndCqc.non_res_without_dormancy_model)
+        * F.col(TempColumns.adjustment_ratio),
+    )
+
+    return df


### PR DESCRIPTION
# Description
Calculate the ratio between 'with_dormancy' and 'without_dormancy' models by partitioning the dataset based on 'related_location' and 'time_registered', and looking at the average difference between them.

Then applying that ratio to the 'without_dormancy' model to get an 'adjusted_without_dormancy' model prediction.

# How to test
Not in the pipeline yet, tests passing

# Developer checklist
- [X] Unit test
- [X] Linked to [Trello ticket](https://trello.com/c/bQT92ch5/760-epic-5-combine-models-2-calculate-and-apply-model-ratios-must)
- [X] Documentation up to date
