### PR TITLE
Move step function crawlers before validation jobs

### DIFF
--- a/terraform/pipeline/step-functions/IndCqcFilledPostEstimatePipeline-StepFunction.json
+++ b/terraform/pipeline/step-functions/IndCqcFilledPostEstimatePipeline-StepFunction.json
@@ -62,7 +62,15 @@
                   }
                 }
               ],
-              "End": true
+              "Next": "Run ascwds crawler"
+            },
+            "Run ascwds crawler": {
+              "Type": "Task",
+              "End": true,
+              "Parameters": {
+                "Name": "${ascwds_crawler_name}"
+              },
+              "Resource": "arn:aws:states:::aws-sdk:glue:startCrawler"
             }
           }
         },
@@ -103,7 +111,15 @@
                           "--cleaned_ons_destination": "${dataset_bucket_uri}/domain=ONS/dataset=postcode_directory_cleaned/"
                         }
                       },
-                      "End": true
+                      "Next": "Run ons crawler"
+                    },
+                    "Run ons crawler": {
+                      "Type": "Task",
+                      "End": true,
+                      "Parameters": {
+                        "Name": "${ons_crawler_name}"
+                      },
+                      "Resource": "arn:aws:states:::aws-sdk:glue:startCrawler"
                     }
                   }
                 },
@@ -139,7 +155,15 @@
                   "--cleaned_cqc_location_destination": "${dataset_bucket_uri}/domain=CQC/dataset=locations_api_cleaned/"
                 }
               },
-              "End": true
+              "Next": "Run cqc crawler"
+            },
+            "Run cqc crawler": {
+              "Type": "Task",
+              "End": true,
+              "Parameters": {
+                "Name": "${cqc_crawler_name}"
+              },
+              "Resource": "arn:aws:states:::aws-sdk:glue:startCrawler"
             }
           }
         }
@@ -326,6 +350,14 @@
                   "--charts_destination": "${dataset_bucket_name}"
                 }
               },
+              "Next": "run ind crawler pre validations"
+            },
+            "run ind crawler pre validations": {
+              "Type": "Task",
+              "Parameters": {
+                "Name": "${ind_cqc_filled_posts_crawler_name}"
+              },
+              "Resource": "arn:aws:states:::aws-sdk:glue:startCrawler",
               "Next": "Start gold validation"
             },
             "Start gold validation": {
@@ -350,9 +382,9 @@
                   "--annual_filled_posts_archive_destination": "${dataset_bucket_uri}/domain=ind_cqc_filled_posts/dataset=archived_annual_filled_posts/"
                 }
               },
-              "Next": "run ind crawler"
+              "Next": "run ind crawler final"
             },
-            "run ind crawler": {
+            "run ind crawler final": {
               "Type": "Task",
               "Parameters": {
                 "Name": "${ind_cqc_filled_posts_crawler_name}"
@@ -375,45 +407,6 @@
                 }
               },
               "End": true
-            }
-          }
-        },
-        {
-          "StartAt": "Run ons crawler",
-          "States": {
-            "Run ons crawler": {
-              "Type": "Task",
-              "End": true,
-              "Parameters": {
-                "Name": "${ons_crawler_name}"
-              },
-              "Resource": "arn:aws:states:::aws-sdk:glue:startCrawler"
-            }
-          }
-        },
-        {
-          "StartAt": "Run ascwds crawler",
-          "States": {
-            "Run ascwds crawler": {
-              "Type": "Task",
-              "End": true,
-              "Parameters": {
-                "Name": "${ascwds_crawler_name}"
-              },
-              "Resource": "arn:aws:states:::aws-sdk:glue:startCrawler"
-            }
-          }
-        },
-        {
-          "StartAt": "Run cqc crawler",
-          "States": {
-            "Run cqc crawler": {
-              "Type": "Task",
-              "End": true,
-              "Parameters": {
-                "Name": "${cqc_crawler_name}"
-              },
-              "Resource": "arn:aws:states:::aws-sdk:glue:startCrawler"
             }
           }
         }


### PR DESCRIPTION
# Description
Our pipeline most frequently fails on the gold and silver validation steps, but the crawlers run after the validation steps, so you investigate the reason for the fail without first manually running the crawlers.

I've moved the crawlers so they run before the validation step, so if anything does fail, the data is ready to be viewed in Athena

Also added an additional IndCqc crawler before validation (kept the one afterwards too)

# How to test
[pipeline run succesfully](https://eu-west-2.console.aws.amazon.com/states/home?region=eu-west-2#/v2/executions/details/arn:aws:states:eu-west-2:344210435447:execution:move-crawlers-Ind-CQC-Filled-Post-Estimates-Pipeline:d035ba4e-0930-4fff-b5c8-89a7eb699f23)

![image](https://github.com/user-attachments/assets/55816f15-4cc6-420b-ac9c-48f1be309fbc)
