### PR TITLE
Clean banded beds

### DIFF
--- a/jobs/impute_ind_cqc_ascwds_and_pir.py
+++ b/jobs/impute_ind_cqc_ascwds_and_pir.py
@@ -14,6 +14,7 @@ from utils.estimate_filled_posts.models.primary_service_rolling_rate_of_change i
 from utils.estimate_filled_posts.models.imputation_with_extrapolation_and_interpolation import (
     model_imputation_with_extrapolation_and_interpolation,
 )
+from utils.estimate_filled_posts.models.utils import clean_number_of_beds_banded
 from utils.ind_cqc_filled_posts_utils.ascwds_pir_utils.blend_ascwds_pir import (
     blend_pir_and_ascwds_when_ascwds_out_of_date,
 )
@@ -79,6 +80,8 @@ def main(
         IndCQC.imputed_non_res_pir_people_directly_employed,
         care_home=False,
     )
+
+    df = clean_number_of_beds_banded(df)
 
     print(f"Exporting as parquet to {imputed_ind_cqc_ascwds_and_pir_destination}")
 

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -6406,6 +6406,27 @@ class ModelNonResPirLinearRegressionRows:
         ("1-003", date(2024, 4, 1), CareHome.care_home, 15.0),
     ]
 
+    clean_number_of_beds_banded_rows = [
+        ("1-001", PrimaryServiceType.care_home_only, 1.0),
+        ("1-002", PrimaryServiceType.care_home_only, 2.0),
+        ("1-003", PrimaryServiceType.care_home_only, 3.0),
+        ("1-004", PrimaryServiceType.care_home_only, 4.0),
+        ("1-005", PrimaryServiceType.care_home_with_nursing, 1.0),
+        ("1-006", PrimaryServiceType.care_home_with_nursing, 2.0),
+        ("1-007", PrimaryServiceType.care_home_with_nursing, 3.0),
+        ("1-008", PrimaryServiceType.care_home_with_nursing, 4.0),
+    ]
+    expected_clean_number_of_beds_banded_rows = [
+        ("1-001", PrimaryServiceType.care_home_only, 1.0, 2.0),
+        ("1-002", PrimaryServiceType.care_home_only, 2.0, 2.0),
+        ("1-003", PrimaryServiceType.care_home_only, 3.0, 3.0),
+        ("1-004", PrimaryServiceType.care_home_only, 4.0, 4.0),
+        ("1-005", PrimaryServiceType.care_home_with_nursing, 1.0, 3.0),
+        ("1-006", PrimaryServiceType.care_home_with_nursing, 2.0, 3.0),
+        ("1-007", PrimaryServiceType.care_home_with_nursing, 3.0, 3.0),
+        ("1-008", PrimaryServiceType.care_home_with_nursing, 4.0, 4.0),
+    ]
+
 
 @dataclass
 class EstimateFilledPostsModelsUtils:

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -6466,6 +6466,27 @@ class EstimateFilledPostsModelsUtils:
         ("1-001", None, None),
     ]
 
+    clean_number_of_beds_banded_rows = [
+        ("1-001", PrimaryServiceType.care_home_only, 1.0),
+        ("1-002", PrimaryServiceType.care_home_only, 2.0),
+        ("1-003", PrimaryServiceType.care_home_only, 3.0),
+        ("1-004", PrimaryServiceType.care_home_only, 4.0),
+        ("1-005", PrimaryServiceType.care_home_with_nursing, 1.0),
+        ("1-006", PrimaryServiceType.care_home_with_nursing, 2.0),
+        ("1-007", PrimaryServiceType.care_home_with_nursing, 3.0),
+        ("1-008", PrimaryServiceType.care_home_with_nursing, 4.0),
+    ]
+    expected_clean_number_of_beds_banded_rows = [
+        ("1-001", PrimaryServiceType.care_home_only, 1.0, 2.0),
+        ("1-002", PrimaryServiceType.care_home_only, 2.0, 2.0),
+        ("1-003", PrimaryServiceType.care_home_only, 3.0, 3.0),
+        ("1-004", PrimaryServiceType.care_home_only, 4.0, 4.0),
+        ("1-005", PrimaryServiceType.care_home_with_nursing, 1.0, 3.0),
+        ("1-006", PrimaryServiceType.care_home_with_nursing, 2.0, 3.0),
+        ("1-007", PrimaryServiceType.care_home_with_nursing, 3.0, 3.0),
+        ("1-008", PrimaryServiceType.care_home_with_nursing, 4.0, 4.0),
+    ]
+
 
 @dataclass
 class MLModelMetrics:

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -3347,6 +3347,20 @@ class ModelNonResPirLinearRegressionSchemas:
         ]
     )
 
+    clean_number_of_beds_banded_schema = StructType(
+        [
+            StructField(IndCQC.location_id, StringType(), False),
+            StructField(IndCQC.primary_service_type, StringType(), False),
+            StructField(IndCQC.number_of_beds_banded, DoubleType(), True),
+        ]
+    )
+    expected_clean_number_of_beds_banded_schema = StructType(
+        [
+            *clean_number_of_beds_banded_schema,
+            StructField(IndCQC.number_of_beds_banded_cleaned, DoubleType(), True),
+        ]
+    )
+
 
 @dataclass
 class EstimateFilledPostsModelsUtils:

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -3387,6 +3387,20 @@ class EstimateFilledPostsModelsUtils:
         ]
     )
 
+    clean_number_of_beds_banded_schema = StructType(
+        [
+            StructField(IndCQC.location_id, StringType(), False),
+            StructField(IndCQC.primary_service_type, StringType(), False),
+            StructField(IndCQC.number_of_beds_banded, DoubleType(), True),
+        ]
+    )
+    expected_clean_number_of_beds_banded_schema = StructType(
+        [
+            *clean_number_of_beds_banded_schema,
+            StructField(IndCQC.number_of_beds_banded_cleaned, DoubleType(), True),
+        ]
+    )
+
 
 @dataclass
 class MLModelMetrics:

--- a/tests/unit/test_estimate_ind_cqc_filled_posts_models_utils.py
+++ b/tests/unit/test_estimate_ind_cqc_filled_posts_models_utils.py
@@ -123,3 +123,37 @@ class SetMinimumValueTests(EstimateFilledPostsModelsUtilsTests):
         expected_df = test_df
 
         self.assertEqual(returned_df.collect(), expected_df.collect())
+
+
+class CleanNumberOfBedsBandedTests(EstimateFilledPostsModelsUtilsTests):
+    def setUp(self) -> None:
+        super().setUp()
+
+        test_df = self.spark.createDataFrame(
+            Data.clean_number_of_beds_banded_rows,
+            Schemas.clean_number_of_beds_banded_schema,
+        )
+        self.returned_df = job.clean_number_of_beds_banded(test_df)
+        self.expected_df = self.spark.createDataFrame(
+            Data.expected_clean_number_of_beds_banded_rows,
+            Schemas.expected_clean_number_of_beds_banded_schema,
+        )
+
+    def test_clean_number_of_beds_banded_returns_expected_columns(
+        self,
+    ):
+        self.assertEqual(
+            sorted(self.returned_df.columns),
+            sorted(self.expected_df.columns),
+        )
+
+    def test_clean_number_of_beds_banded_returns_expected_data(self):
+        returned_data = self.returned_df.sort(IndCqc.location_id).collect()
+        expected_data = self.expected_df.collect()
+
+        for i in range(len(returned_data)):
+            self.assertEqual(
+                returned_data[i],
+                expected_data[i],
+                f"Returned row {i} does not match expected",
+            )

--- a/tests/unit/test_impute_ind_cqc_ascwds_and_pir.py
+++ b/tests/unit/test_impute_ind_cqc_ascwds_and_pir.py
@@ -34,6 +34,7 @@ class ImputeIndCqcAscwdsAndPirTests(unittest.TestCase):
 
 class MainTests(ImputeIndCqcAscwdsAndPirTests):
     @patch("utils.utils.write_to_parquet")
+    @patch("jobs.impute_ind_cqc_ascwds_and_pir.clean_number_of_beds_banded")
     @patch(
         "jobs.impute_ind_cqc_ascwds_and_pir.blend_pir_and_ascwds_when_ascwds_out_of_date"
     )
@@ -42,6 +43,7 @@ class MainTests(ImputeIndCqcAscwdsAndPirTests):
         self,
         read_from_parquet_patch: Mock,
         blend_pir_and_ascwds_when_ascwds_out_of_date_mock: Mock,
+        clean_number_of_beds_banded_mock: Mock,
         write_to_parquet_patch: Mock,
     ):
         read_from_parquet_patch.return_value = self.test_cleaned_ind_cqc_df
@@ -52,10 +54,10 @@ class MainTests(ImputeIndCqcAscwdsAndPirTests):
             self.NON_RES_PIR_MODEL,
         )
 
-        self.assertEqual(read_from_parquet_patch.call_count, 1)
+        read_from_parquet_patch.assert_called_once()
         blend_pir_and_ascwds_when_ascwds_out_of_date_mock.assert_called_once()
-        self.assertEqual(write_to_parquet_patch.call_count, 1)
-        write_to_parquet_patch.assert_any_call(
+        clean_number_of_beds_banded_mock.assert_called_once()
+        write_to_parquet_patch.assert_called_once_with(
             ANY,
             self.ESTIMATES_DESTINATION,
             mode="overwrite",

--- a/utils/column_names/ind_cqc_pipeline_columns.py
+++ b/utils/column_names/ind_cqc_pipeline_columns.py
@@ -188,6 +188,7 @@ class IndCqcColumns:
     number_of_beds: str = CQCLClean.number_of_beds
     number_of_beds_at_provider: str = CQCLClean.number_of_beds + "at_provider"
     number_of_beds_banded: str = "number_of_beds_banded"
+    number_of_beds_banded_cleaned: str = number_of_beds_banded + "_cleaned"
     organisation_id: str = AWPClean.organisation_id
     percentage_of_residuals_within_absolute_value: str = (
         "percentage_of_residuals_within_absolute_value"


### PR DESCRIPTION
# Description
Beds are banded but the base is really low for the lower bands, and the results are really erratic as a result. This function groups together the lowest two or three bands which is sufficient (from EMR investigations) to keep valuable information but reduce erratic-ness.

This is a pre-requisite for the rolling average, so it's not used yet, but that PR is quite large to I've set up this PR to action separately

# How to test
Tests passing

# Developer checklist
- [X] Unit test
- [X] Linked to [Trello ticket](https://trello.com/c/CsTnxD9Y/772-epic-5-clean-banded-beds-must)
- [X] Documentation up to date
