### PR TITLE
Remove locs without provid (replacement PR)

### DIFF
--- a/jobs/clean_cqc_location_data.py
+++ b/jobs/clean_cqc_location_data.py
@@ -95,6 +95,9 @@ def main(
     )
 
     cqc_location_df = clean_provider_id_column(cqc_location_df)
+    cqc_location_df = utils.select_rows_with_non_null_value(
+        cqc_location_df, CQCL.provider_id
+    )
 
     cqc_location_df = remove_non_social_care_locations(cqc_location_df)
     cqc_location_df = remove_records_from_locations_data(cqc_location_df)

--- a/jobs/validate_locations_api_cleaned_data.py
+++ b/jobs/validate_locations_api_cleaned_data.py
@@ -34,6 +34,7 @@ PartitionKeys = [Keys.year, Keys.month, Keys.day, Keys.import_date]
 raw_cqc_locations_columns_to_import = [
     Keys.import_date,
     CQCL.location_id,
+    CQCL.provider_id,
     CQCL.type,
     CQCL.registration_status,
     CQCL.gac_service_types,
@@ -55,9 +56,9 @@ def main(
     )
     rules = Rules.rules_to_check
 
-    rules[
-        RuleName.size_of_dataset
-    ] = calculate_expected_size_of_cleaned_cqc_locations_dataset(raw_location_df)
+    rules[RuleName.size_of_dataset] = (
+        calculate_expected_size_of_cleaned_cqc_locations_dataset(raw_location_df)
+    )
 
     cleaned_cqc_locations_df = add_column_with_length_of_string(
         cleaned_cqc_locations_df, [CQCL.location_id, CQCL.provider_id]

--- a/jobs/validate_locations_api_cleaned_data.py
+++ b/jobs/validate_locations_api_cleaned_data.py
@@ -56,9 +56,9 @@ def main(
     )
     rules = Rules.rules_to_check
 
-    rules[RuleName.size_of_dataset] = (
-        calculate_expected_size_of_cleaned_cqc_locations_dataset(raw_location_df)
-    )
+    rules[
+        RuleName.size_of_dataset
+    ] = calculate_expected_size_of_cleaned_cqc_locations_dataset(raw_location_df)
 
     cleaned_cqc_locations_df = add_column_with_length_of_string(
         cleaned_cqc_locations_df, [CQCL.location_id, CQCL.provider_id]

--- a/jobs/validate_locations_api_cleaned_data.py
+++ b/jobs/validate_locations_api_cleaned_data.py
@@ -55,9 +55,9 @@ def main(
     )
     rules = Rules.rules_to_check
 
-    rules[RuleName.size_of_dataset] = (
-        calculate_expected_size_of_cleaned_cqc_locations_dataset(raw_location_df)
-    )
+    rules[
+        RuleName.size_of_dataset
+    ] = calculate_expected_size_of_cleaned_cqc_locations_dataset(raw_location_df)
 
     cleaned_cqc_locations_df = add_column_with_length_of_string(
         cleaned_cqc_locations_df, [CQCL.location_id, CQCL.provider_id]

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -7967,21 +7967,22 @@ class ValidateLocationsAPICleanedData:
 
     # fmt: off
     calculate_expected_size_rows = [
-        ("loc_1", LocationType.social_care_identifier, RegistrationStatus.registered, [{CQCL.name: "name", CQCL.description: Services.care_home_service_with_nursing}], [{CQCL.name: "name", CQCL.code: "A1", CQCL.contacts: []}]),
-        ("loc_2", "non social care org", RegistrationStatus.registered, [{CQCL.name: "name", CQCL.description: Services.care_home_service_with_nursing}], [{CQCL.name: "name", CQCL.code: "A1", CQCL.contacts: []}]),
-        ("loc_3", None, RegistrationStatus.registered, [{CQCL.name: "name", CQCL.description: Services.care_home_service_with_nursing}], [{CQCL.name: "name", CQCL.code: "A1", CQCL.contacts: []}]),
-        ("loc_4", LocationType.social_care_identifier, RegistrationStatus.deregistered, [{CQCL.name: "name", CQCL.description: Services.care_home_service_with_nursing}], [{CQCL.name: "name", CQCL.code: "A1", CQCL.contacts: []}]),
-        ("loc_5", "non social care org", RegistrationStatus.deregistered, [{CQCL.name: "name", CQCL.description: Services.care_home_service_with_nursing}], [{CQCL.name: "name", CQCL.code: "A1", CQCL.contacts: []}]),
-        ("loc_6", None, RegistrationStatus.deregistered,  [{CQCL.name: "name", CQCL.description: Services.care_home_service_with_nursing}], [{CQCL.name: "name", CQCL.code: "A1", CQCL.contacts: []}]),
-        ("loc_7", LocationType.social_care_identifier, RegistrationStatus.registered, [{CQCL.name: "name", CQCL.description: Services.specialist_college_service}], [{CQCL.name: "name", CQCL.code: "A1", CQCL.contacts: []}]),
-        ("loc_8", "non social care org", RegistrationStatus.registered, [{CQCL.name: "name", CQCL.description: Services.specialist_college_service}], [{CQCL.name: "name", CQCL.code: "A1", CQCL.contacts: []}]),
-        ("loc_9", None, RegistrationStatus.registered, [{CQCL.name: "name", CQCL.description: Services.specialist_college_service}], [{CQCL.name: "name", CQCL.code: "A1", CQCL.contacts: []}]),
-        ("loc_10", LocationType.social_care_identifier, RegistrationStatus.deregistered, [{CQCL.name: "name", CQCL.description: Services.specialist_college_service}], [{CQCL.name: "name", CQCL.code: "A1", CQCL.contacts: []}]),
-        ("loc_11", "non social care org", RegistrationStatus.deregistered, [{CQCL.name: "name", CQCL.description: Services.specialist_college_service}], [{CQCL.name: "name", CQCL.code: "A1", CQCL.contacts: []}]),
-        ("loc_12", None, RegistrationStatus.deregistered,  [{CQCL.name: "name", CQCL.description: Services.specialist_college_service}], [{CQCL.name: "name", CQCL.code: "A1", CQCL.contacts: []}]),
-        ("loc_13", LocationType.social_care_identifier, RegistrationStatus.registered, [{CQCL.name: "name", CQCL.description: Services.care_home_service_with_nursing}], None),
-        (RecordsToRemoveInLocationsData.dental_practice, LocationType.social_care_identifier, RegistrationStatus.registered, None, [{CQCL.name: "name", CQCL.code: "A1", CQCL.contacts: []}]),
-        (RecordsToRemoveInLocationsData.temp_registration, LocationType.social_care_identifier, RegistrationStatus.registered, None, [{CQCL.name: "name", CQCL.code: "A1", CQCL.contacts: []}]),
+        ("loc_1", "prov_1", LocationType.social_care_identifier, RegistrationStatus.registered, [{CQCL.name: "name", CQCL.description: Services.care_home_service_with_nursing}], [{CQCL.name: "name", CQCL.code: "A1", CQCL.contacts: []}]),
+        ("loc_2", "prov_1", "non social care org", RegistrationStatus.registered, [{CQCL.name: "name", CQCL.description: Services.care_home_service_with_nursing}], [{CQCL.name: "name", CQCL.code: "A1", CQCL.contacts: []}]),
+        ("loc_3", "prov_1", None, RegistrationStatus.registered, [{CQCL.name: "name", CQCL.description: Services.care_home_service_with_nursing}], [{CQCL.name: "name", CQCL.code: "A1", CQCL.contacts: []}]),
+        ("loc_4", "prov_1", LocationType.social_care_identifier, RegistrationStatus.deregistered, [{CQCL.name: "name", CQCL.description: Services.care_home_service_with_nursing}], [{CQCL.name: "name", CQCL.code: "A1", CQCL.contacts: []}]),
+        ("loc_5", "prov_1", "non social care org", RegistrationStatus.deregistered, [{CQCL.name: "name", CQCL.description: Services.care_home_service_with_nursing}], [{CQCL.name: "name", CQCL.code: "A1", CQCL.contacts: []}]),
+        ("loc_6", "prov_1", None, RegistrationStatus.deregistered,  [{CQCL.name: "name", CQCL.description: Services.care_home_service_with_nursing}], [{CQCL.name: "name", CQCL.code: "A1", CQCL.contacts: []}]),
+        ("loc_7", "prov_1", LocationType.social_care_identifier, RegistrationStatus.registered, [{CQCL.name: "name", CQCL.description: Services.specialist_college_service}], [{CQCL.name: "name", CQCL.code: "A1", CQCL.contacts: []}]),
+        ("loc_8", "prov_1", "non social care org", RegistrationStatus.registered, [{CQCL.name: "name", CQCL.description: Services.specialist_college_service}], [{CQCL.name: "name", CQCL.code: "A1", CQCL.contacts: []}]),
+        ("loc_9", "prov_1", None, RegistrationStatus.registered, [{CQCL.name: "name", CQCL.description: Services.specialist_college_service}], [{CQCL.name: "name", CQCL.code: "A1", CQCL.contacts: []}]),
+        ("loc_10", "prov_1", LocationType.social_care_identifier, RegistrationStatus.deregistered, [{CQCL.name: "name", CQCL.description: Services.specialist_college_service}], [{CQCL.name: "name", CQCL.code: "A1", CQCL.contacts: []}]),
+        ("loc_11", "prov_1", "non social care org", RegistrationStatus.deregistered, [{CQCL.name: "name", CQCL.description: Services.specialist_college_service}], [{CQCL.name: "name", CQCL.code: "A1", CQCL.contacts: []}]),
+        ("loc_12", "prov_1", None, RegistrationStatus.deregistered,  [{CQCL.name: "name", CQCL.description: Services.specialist_college_service}], [{CQCL.name: "name", CQCL.code: "A1", CQCL.contacts: []}]),
+        ("loc_13", "prov_1", LocationType.social_care_identifier, RegistrationStatus.registered, [{CQCL.name: "name", CQCL.description: Services.care_home_service_with_nursing}], None),
+        ("loc_14", None, LocationType.social_care_identifier, RegistrationStatus.registered, [{CQCL.name: "name", CQCL.description: Services.care_home_service_with_nursing}], [{CQCL.name: "name", CQCL.code: "A1", CQCL.contacts: []}]),
+        (RecordsToRemoveInLocationsData.dental_practice, "prov_1", LocationType.social_care_identifier, RegistrationStatus.registered, None, [{CQCL.name: "name", CQCL.code: "A1", CQCL.contacts: []}]),
+        (RecordsToRemoveInLocationsData.temp_registration, "prov_1", LocationType.social_care_identifier, RegistrationStatus.registered, None, [{CQCL.name: "name", CQCL.code: "A1", CQCL.contacts: []}]),
     ]
     # fmt: on
 

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -7985,19 +7985,32 @@ class ValidateLocationsAPICleanedData:
     ]
     # fmt: on
 
-    identify_if_location_has_a_known_regulated_activity_rows = [
+    identify_if_location_has_a_known_value_when_array_type_rows = [
         ("loc_1", []),
-        ("loc_1", [{CQCL.name: "name", CQCL.code: "A1", CQCL.contacts: []}]),
+        ("loc_1", [{CQCL.name: "name", CQCL.code: "A1"}]),
         ("loc_1", None),
         ("loc_2", []),
         ("loc_3", None),
     ]
-    expected_identify_if_location_has_a_known_regulated_activity_rows = [
+    expected_identify_if_location_has_a_known_value_when_array_type_rows = [
         ("loc_1", [], True),
-        ("loc_1", [{CQCL.name: "name", CQCL.code: "A1", CQCL.contacts: []}], True),
+        ("loc_1", [{CQCL.name: "name", CQCL.code: "A1"}], True),
         ("loc_1", None, True),
         ("loc_2", [], False),
         ("loc_3", None, False),
+    ]
+
+    identify_if_location_has_a_known_value_when_not_array_type_rows = [
+        ("loc_1", None),
+        ("loc_1", "prov_1"),
+        ("loc_1", None),
+        ("loc_2", None),
+    ]
+    expected_identify_if_location_has_a_known_value_when_not_array_type_rows = [
+        ("loc_1", None, True),
+        ("loc_1", "prov_1", True),
+        ("loc_1", None, True),
+        ("loc_2", None, False),
     ]
 
 

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -7948,10 +7948,10 @@ class ValidationUtils:
 class ValidateLocationsAPICleanedData:
     # fmt: off
     raw_cqc_locations_rows = [
-        ("1-000000001", "20240101", LocationType.social_care_identifier, RegistrationStatus.registered, [{CQCL.name: "name", CQCL.description: Services.care_home_service_with_nursing}], [{CQCL.name: "name", CQCL.code: "A1", CQCL.contacts: []}]),
-        ("1-000000002", "20240101", LocationType.social_care_identifier, RegistrationStatus.deregistered, [{CQCL.name: "name", CQCL.description: Services.care_home_service_with_nursing}], [{CQCL.name: "name", CQCL.code: "A1", CQCL.contacts: []}]),
-        ("1-000000001", "20240201", LocationType.social_care_identifier, RegistrationStatus.registered, [{CQCL.name: "name", CQCL.description: Services.care_home_service_with_nursing}], [{CQCL.name: "name", CQCL.code: "A1", CQCL.contacts: []}]),
-        ("1-000000002", "20240201", "not social care org", RegistrationStatus.deregistered, [{CQCL.name: "name", CQCL.description: Services.care_home_service_with_nursing}], [{CQCL.name: "name", CQCL.code: "A1", CQCL.contacts: []}]),
+        ("1-000000001", "1-001", "20240101", LocationType.social_care_identifier, RegistrationStatus.registered, [{CQCL.name: "name", CQCL.description: Services.care_home_service_with_nursing}], [{CQCL.name: "name", CQCL.code: "A1", CQCL.contacts: []}]),
+        ("1-000000002", "1-001", "20240101", LocationType.social_care_identifier, RegistrationStatus.deregistered, [{CQCL.name: "name", CQCL.description: Services.care_home_service_with_nursing}], [{CQCL.name: "name", CQCL.code: "A1", CQCL.contacts: []}]),
+        ("1-000000001", "1-001", "20240201", LocationType.social_care_identifier, RegistrationStatus.registered, [{CQCL.name: "name", CQCL.description: Services.care_home_service_with_nursing}], [{CQCL.name: "name", CQCL.code: "A1", CQCL.contacts: []}]),
+        ("1-000000002", "1-001", "20240201", "not social care org", RegistrationStatus.deregistered, [{CQCL.name: "name", CQCL.description: Services.care_home_service_with_nursing}], [{CQCL.name: "name", CQCL.code: "A1", CQCL.contacts: []}]),
     ]
     # fmt: on
 

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -4337,6 +4337,7 @@ class ValidateLocationsAPICleanedData:
     raw_cqc_locations_schema = StructType(
         [
             StructField(CQCL.location_id, StringType(), True),
+            StructField(CQCL.provider_id, StringType(), True),
             StructField(Keys.import_date, StringType(), True),
             StructField(CQCL.type, StringType(), True),
             StructField(CQCL.registration_status, StringType(), True),

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -4514,7 +4514,7 @@ class ValidateLocationsAPICleanedData:
         ]
     )
 
-    identify_if_location_has_a_known_regulated_activity_schema = StructType(
+    identify_if_location_has_a_known_value_when_array_type_schema = StructType(
         [
             StructField(CQCL.location_id, StringType(), True),
             StructField(
@@ -4524,45 +4524,32 @@ class ValidateLocationsAPICleanedData:
                         [
                             StructField(CQCL.name, StringType(), True),
                             StructField(CQCL.code, StringType(), True),
-                            StructField(
-                                CQCL.contacts,
-                                ArrayType(
-                                    StructType(
-                                        [
-                                            StructField(
-                                                CQCL.person_family_name,
-                                                StringType(),
-                                                True,
-                                            ),
-                                            StructField(
-                                                CQCL.person_given_name,
-                                                StringType(),
-                                                True,
-                                            ),
-                                            StructField(
-                                                CQCL.person_roles,
-                                                ArrayType(StringType(), True),
-                                                True,
-                                            ),
-                                            StructField(
-                                                CQCL.person_title, StringType(), True
-                                            ),
-                                        ]
-                                    )
-                                ),
-                                True,
-                            ),
                         ]
                     )
                 ),
             ),
         ]
     )
-    expected_identify_if_location_has_a_known_regulated_activity_schema = StructType(
+    expected_identify_if_location_has_a_known_value_when_array_type_schema = StructType(
         [
-            *identify_if_location_has_a_known_regulated_activity_schema,
-            StructField("has_known_regulated_activity", BooleanType(), True),
+            *identify_if_location_has_a_known_value_when_array_type_schema,
+            StructField("has_known_value", BooleanType(), True),
         ]
+    )
+
+    identify_if_location_has_a_known_value_when_not_array_type_schema = StructType(
+        [
+            StructField(CQCL.location_id, StringType(), True),
+            StructField(CQCL.provider_id, StringType(), True),
+        ]
+    )
+    expected_identify_if_location_has_a_known_value_when_not_array_type_schema = (
+        StructType(
+            [
+                *identify_if_location_has_a_known_value_when_not_array_type_schema,
+                StructField("has_known_value", BooleanType(), True),
+            ]
+        )
     )
 
 

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -4459,6 +4459,7 @@ class ValidateLocationsAPICleanedData:
     calculate_expected_size_schema = StructType(
         [
             StructField(CQCL.location_id, StringType(), True),
+            StructField(CQCL.provider_id, StringType(), True),
             StructField(CQCL.type, StringType(), True),
             StructField(CQCL.registration_status, StringType(), True),
             StructField(

--- a/tests/unit/test_validate_locations_api_cleaned_data.py
+++ b/tests/unit/test_validate_locations_api_cleaned_data.py
@@ -77,28 +77,26 @@ class CalculateExpectedSizeofDataset(ValidateLocationsAPICleanedDatasetTests):
         self.assertEqual(returned_row_count, expected_row_count)
 
 
-class IdentifyIfLocationHasAKnownRegulatedActivity(
-    ValidateLocationsAPICleanedDatasetTests
-):
+class IdentifyIfLocationHasAKnownValueTests(ValidateLocationsAPICleanedDatasetTests):
     def setUp(self) -> None:
         super().setUp()
 
-    def test_identify_if_location_has_a_known_regulated_activity_returns_correct_df(
+        self.has_known_value: str = "has_known_value"
+
+    def test_identify_if_location_has_a_known_value_when_array_type_returns_expected_values(
         self,
     ):
-        has_known_regulated_activity: str = "has_known_regulated_activity"
-
         test_df = self.spark.createDataFrame(
-            Data.identify_if_location_has_a_known_regulated_activity_rows,
-            Schemas.identify_if_location_has_a_known_regulated_activity_schema,
+            Data.identify_if_location_has_a_known_value_when_array_type_rows,
+            Schemas.identify_if_location_has_a_known_value_when_array_type_schema,
         )
 
-        returned_df = job.identify_if_location_has_a_known_regulated_activity(
-            test_df, has_known_regulated_activity
+        returned_df = job.identify_if_location_has_a_known_value(
+            test_df, CQCL.regulated_activities, self.has_known_value
         )
         expected_df = self.spark.createDataFrame(
-            Data.expected_identify_if_location_has_a_known_regulated_activity_rows,
-            Schemas.expected_identify_if_location_has_a_known_regulated_activity_schema,
+            Data.expected_identify_if_location_has_a_known_value_when_array_type_rows,
+            Schemas.expected_identify_if_location_has_a_known_value_when_array_type_schema,
         )
 
         returned_data = returned_df.sort(CQCL.location_id).collect()
@@ -106,9 +104,35 @@ class IdentifyIfLocationHasAKnownRegulatedActivity(
 
         for i in range(len(returned_data)):
             self.assertEqual(
-                returned_data[i][has_known_regulated_activity],
-                expected_data[i][has_known_regulated_activity],
-                f"Row {i} has a known regulated activity column which doesn't match expected",
+                returned_data[i][self.has_known_value],
+                expected_data[i][self.has_known_value],
+                f"Row {i} has known value column which doesn't match expected",
+            )
+
+    def test_identify_if_location_has_a_known_value_when_not_array_type_returns_expected_values(
+        self,
+    ):
+        test_df = self.spark.createDataFrame(
+            Data.identify_if_location_has_a_known_value_when_not_array_type_rows,
+            Schemas.identify_if_location_has_a_known_value_when_not_array_type_schema,
+        )
+
+        returned_df = job.identify_if_location_has_a_known_value(
+            test_df, CQCL.provider_id, self.has_known_value
+        )
+        expected_df = self.spark.createDataFrame(
+            Data.expected_identify_if_location_has_a_known_value_when_not_array_type_rows,
+            Schemas.expected_identify_if_location_has_a_known_value_when_not_array_type_schema,
+        )
+
+        returned_data = returned_df.sort(CQCL.location_id).collect()
+        expected_data = expected_df.collect()
+
+        for i in range(len(returned_data)):
+            self.assertEqual(
+                returned_data[i][self.has_known_value],
+                expected_data[i][self.has_known_value],
+                f"Row {i} has known value column which doesn't match expected",
             )
 
 


### PR DESCRIPTION
There is an issue with the WIP github app which is blocking PRs from being merged as it can't figure if PRs are WIP or not. This app has been disabled by Jackie but it doesn't seem to affect PRs currently open, so I'm closing the original and reopening this one.

# Description
Currently our pipeline is failing because a location is present which doesn’t have a provider id - it’s missing most other data too

if that location appears again with a known providerid then it will be populated and they will stay in our dataset, but for now, put in a step which deletes locations who have never had one

Update validations (expected size) to match

# How to test
Main branch validations are [currently failing](https://eu-west-2.console.aws.amazon.com/gluestudio/home?region=eu-west-2#/editor/job/main-validate_locations_api_cleaned_data_job/runs)
They now [pass in branch when run against main data](https://eu-west-2.console.aws.amazon.com/gluestudio/home?region=eu-west-2#/editor/job/remove-locs-without-provid-validate_locations_api_cleaned_data_job/runs)

# Developer checklist
- [X] Unit test
- [X] Linked to [Trello ticket](https://trello.com/c/k5Py4y0i/767-remove-locations-without-a-provider-id-must)
- [X] Documentation up to date