### PR TITLE
Recode rural urban sparse categories

### DIFF
--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -6112,6 +6112,21 @@ class ModelFeatures:
         ("1-001", None, 0),
     ]
 
+    group_rural_urban_sparse_categories_rows = [
+        ("1-001", "Rural"),
+        ("1-002", "Rural sparse"),
+        ("1-003", "Another with sparse in it"),
+        ("1-004", "Urban"),
+        ("1-005", "Sparse with a capital S"),
+    ]
+    expected_group_rural_urban_sparse_categories_rows = [
+        ("1-001", "Rural", "Rural"),
+        ("1-002", "Rural sparse", "Sparse setting"),
+        ("1-003", "Another with sparse in it", "Sparse setting"),
+        ("1-004", "Urban", "Urban"),
+        ("1-005", "Sparse with a capital S", "Sparse setting"),
+    ]
+
 
 @dataclass
 class ModelCareHomes:

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -3211,6 +3211,23 @@ class ModelFeatures:
         ]
     )
 
+    group_rural_urban_sparse_categories_schema = StructType(
+        [
+            StructField(IndCQC.location_id, StringType(), True),
+            StructField(IndCQC.current_rural_urban_indicator_2011, StringType(), True),
+        ]
+    )
+    expected_group_rural_urban_sparse_categories_schema = StructType(
+        [
+            *group_rural_urban_sparse_categories_schema,
+            StructField(
+                IndCQC.current_rural_urban_indicator_2011_for_non_res_model,
+                StringType(),
+                True,
+            ),
+        ]
+    )
+
 
 @dataclass
 class ModelCareHomes:

--- a/tests/unit/test_feature_helper.py
+++ b/tests/unit/test_feature_helper.py
@@ -250,7 +250,7 @@ class GroupRuralUrbanSparseCategoriesTests(LocationsFeatureEngineeringTests):
         self.expected_data = self.expected_df.collect()
 
     def test_group_rural_urban_sparse_categories_returns_expected_columns(self):
-        self.assertTrue(self.returned_df.columns, self.expected_df.columns)
+        self.assertEqual(self.returned_df.columns, self.expected_df.columns)
 
     def test_group_rural_urban_sparse_categories_returns_expected_data(self):
         for i in range(len(self.returned_data)):

--- a/tests/unit/test_feature_helper.py
+++ b/tests/unit/test_feature_helper.py
@@ -230,3 +230,36 @@ class CapIntegerAtMaxValueTests(LocationsFeatureEngineeringTests):
 
     def test_cap_integer_at_max_value_returns_expected_data(self):
         self.assertEqual(self.returned_data, self.expected_data)
+
+
+class GroupRuralUrbanSparseCategoriesTests(LocationsFeatureEngineeringTests):
+    def setUp(self) -> None:
+        super().setUp()
+
+        test_df = self.spark.createDataFrame(
+            Data.group_rural_urban_sparse_categories_rows,
+            Schemas.group_rural_urban_sparse_categories_schema,
+        )
+
+        self.returned_df = job.group_rural_urban_sparse_categories(test_df)
+        self.expected_df = self.spark.createDataFrame(
+            Data.expected_group_rural_urban_sparse_categories_rows,
+            Schemas.expected_group_rural_urban_sparse_categories_schema,
+        )
+        self.returned_data = self.returned_df.sort(IndCQC.location_id).collect()
+        self.expected_data = self.expected_df.collect()
+
+    def test_group_rural_urban_sparse_categories_returns_expected_columns(self):
+        self.assertTrue(self.returned_df.columns, self.expected_df.columns)
+
+    def test_group_rural_urban_sparse_categories_returns_expected_data(self):
+        for i in range(len(self.returned_data)):
+            self.assertEqual(
+                self.returned_data[i][
+                    IndCQC.current_rural_urban_indicator_2011_for_non_res_model
+                ],
+                self.expected_data[i][
+                    IndCQC.current_rural_urban_indicator_2011_for_non_res_model
+                ],
+                f"Returned value in row {i} does not match expected",
+            )

--- a/utils/column_names/ind_cqc_pipeline_columns.py
+++ b/utils/column_names/ind_cqc_pipeline_columns.py
@@ -116,6 +116,9 @@ class IndCqcColumns:
     current_ons_import_date: str = ONSClean.current_ons_import_date
     current_region: str = ONSClean.current_region
     current_rural_urban_indicator_2011: str = ONSClean.current_rural_urban_ind_11
+    current_rural_urban_indicator_2011_for_non_res_model: str = (
+        ONSClean.current_rural_urban_ind_11 + "_for_non_res_model"
+    )
     current_sub_icb: str = ONSClean.current_sub_icb
     difference_between_estimate_and_cqc_registered_managers: str = (
         "difference_between_estimate_and_cqc_registered_managers"

--- a/utils/features/helper.py
+++ b/utils/features/helper.py
@@ -99,3 +99,29 @@ def cap_integer_at_max_value(
         ).otherwise(None),
     )
     return df
+
+
+def group_rural_urban_sparse_categories(df: DataFrame) -> DataFrame:
+    """
+    Copies the values in the rural urban indicator column into a new column and replaces all categories which contains the word "sparse" with "Sparse setting".
+
+    Args:
+        df (DataFrame): Input DataFrame.
+
+    Returns:
+        DataFrame: DataFrame with the new rural urban indicator column with recoded sparse categories.
+    """
+    sparse_identifier: str = "sparse"
+    sparse_replacement_string: str = "Sparse setting"
+
+    df = df.withColumn(
+        IndCQC.current_rural_urban_indicator_2011_for_non_res_model,
+        F.when(
+            F.lower(F.col(IndCQC.current_rural_urban_indicator_2011)).contains(
+                sparse_identifier
+            ),
+            sparse_replacement_string,
+        ).otherwise(F.col(IndCQC.current_rural_urban_indicator_2011)),
+    )
+
+    return df


### PR DESCRIPTION
# Description
The bases for the various rural urban indicator 'sparse' categories are all small but they all appear similar in nature, so this ticket creates a separate column to group them into one new combined category alongside all the other original options.

The full options in the dataset are:
    "Rural hamlet and isolated dwellings in a **sparse** setting"
    "Rural hamlet and isolated dwellings"
    "Rural village"
    "Rural town and fringe in a **sparse** setting"
    "Rural town and fringe"
    "Urban city and town in a **sparse** setting"
    "Urban city and town"
    "Urban major conurbation"
    "Urban minor conurbation"
    "Rural village in a **sparse** setting"

# How to test
The column isn't used by the pipeline yet, it will become a feature in the non-res models in a future PR

# Developer checklist
- [X] Unit test
- [X] Linked to [Trello ticket](https://trello.com/c/ZGsqjFGR/780-epic-5-group-rural-urban-sparse-categories-must)
- [X] Documentation up to date
