### PR TITLE
Add date index column

### DIFF
--- a/jobs/prepare_features_care_home_ind_cqc.py
+++ b/jobs/prepare_features_care_home_ind_cqc.py
@@ -20,6 +20,7 @@ from utils.feature_engineering_resources.feature_engineering_services import (
 )
 from utils.features.helper import (
     add_array_column_count,
+    add_date_index_column,
     expand_encode_and_extract_features,
     vectorise_dataframe,
 )
@@ -40,8 +41,10 @@ def main(
         filtered_loc_data, IndCQC.number_of_beds
     )
 
+    features_df = add_date_index_column(filtered_loc_data)
+
     features_df = add_array_column_count(
-        df=filtered_loc_data,
+        df=features_df,
         new_col_name=IndCQC.service_count,
         col_to_check=IndCQC.services_offered,
     )

--- a/jobs/prepare_features_care_home_ind_cqc.py
+++ b/jobs/prepare_features_care_home_ind_cqc.py
@@ -87,6 +87,7 @@ def main(
     vectorised_features_df = vectorised_dataframe.select(
         IndCQC.location_id,
         IndCQC.cqc_location_import_date,
+        IndCQC.cqc_location_import_date_indexed,
         IndCQC.current_region,
         IndCQC.number_of_beds,
         IndCQC.pir_people_directly_employed,

--- a/jobs/prepare_features_non_res_ascwds_ind_cqc.py
+++ b/jobs/prepare_features_non_res_ascwds_ind_cqc.py
@@ -132,6 +132,11 @@ def main(
         features_df, IndCQC.dormancy
     )
 
+    features_df = add_date_index_column(features_df)
+    features_with_known_dormancy_df = add_date_index_column(
+        features_with_known_dormancy_df
+    )
+
     list_for_vectorisation_without_dormancy: List[str] = sorted(
         [
             IndCQC.service_count,

--- a/jobs/prepare_features_non_res_ascwds_ind_cqc.py
+++ b/jobs/prepare_features_non_res_ascwds_ind_cqc.py
@@ -29,6 +29,7 @@ from utils.feature_engineering_resources.feature_engineering_specialisms import 
 )
 from utils.features.helper import (
     add_array_column_count,
+    add_date_index_column,
     expand_encode_and_extract_features,
     vectorise_dataframe,
 )

--- a/jobs/prepare_features_non_res_ascwds_ind_cqc.py
+++ b/jobs/prepare_features_non_res_ascwds_ind_cqc.py
@@ -38,6 +38,7 @@ from utils.features.helper import (
 vectorised_features_column_list: List[str] = [
     IndCQC.location_id,
     IndCQC.cqc_location_import_date,
+    IndCQC.cqc_location_import_date_indexed,
     IndCQC.current_region,
     IndCQC.current_rural_urban_indicator_2011,
     IndCQC.dormancy,

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -6112,6 +6112,21 @@ class ModelFeatures:
         ("1-001", None, 0),
     ]
 
+    add_date_index_column_rows = [
+        ("1-0001", CareHome.not_care_home, date(2024, 10, 1)),
+        ("1-0002", CareHome.not_care_home, date(2024, 12, 1)),
+        ("1-0003", CareHome.not_care_home, date(2024, 12, 1)),
+        ("1-0004", CareHome.not_care_home, date(2025, 2, 1)),
+        ("1-0005", CareHome.care_home, date(2025, 2, 1)),
+    ]
+    expected_add_date_index_column_rows = [
+        ("1-0001", CareHome.not_care_home, date(2024, 10, 1), 1),
+        ("1-0002", CareHome.not_care_home, date(2024, 12, 1), 2),
+        ("1-0003", CareHome.not_care_home, date(2024, 12, 1), 2),
+        ("1-0004", CareHome.not_care_home, date(2025, 2, 1), 3),
+        ("1-0005", CareHome.care_home, date(2025, 2, 1), 1),
+    ]
+
 
 @dataclass
 class ModelCareHomes:

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -3211,6 +3211,20 @@ class ModelFeatures:
         ]
     )
 
+    add_date_index_column_schema = StructType(
+        [
+            StructField(IndCQC.location_id, StringType(), True),
+            StructField(IndCQC.care_home, StringType(), True),
+            StructField(IndCQC.cqc_location_import_date, DateType(), True),
+        ]
+    )
+    expected_add_date_index_column_schema = StructType(
+        [
+            *add_date_index_column_schema,
+            StructField(IndCQC.cqc_location_import_date_indexed, IntegerType(), True),
+        ]
+    )
+
 
 @dataclass
 class ModelCareHomes:

--- a/tests/unit/test_feature_helper.py
+++ b/tests/unit/test_feature_helper.py
@@ -248,7 +248,7 @@ class AddDateIndexColumnTests(LocationsFeatureEngineeringTests):
         self.expected_data = self.expected_df.collect()
 
     def test_add_date_index_column_returns_expected_columns(self):
-        self.assertTrue(self.returned_df.columns, self.expected_df.columns)
+        self.assertEqual(self.returned_df.columns, self.expected_df.columns)
 
     def test_add_date_index_column_returns_expected_data(self):
         self.assertEqual(self.returned_data, self.expected_data)

--- a/tests/unit/test_feature_helper.py
+++ b/tests/unit/test_feature_helper.py
@@ -230,3 +230,25 @@ class CapIntegerAtMaxValueTests(LocationsFeatureEngineeringTests):
 
     def test_cap_integer_at_max_value_returns_expected_data(self):
         self.assertEqual(self.returned_data, self.expected_data)
+
+
+class AddDateIndexColumnTests(LocationsFeatureEngineeringTests):
+    def setUp(self) -> None:
+        super().setUp()
+
+        test_df = self.spark.createDataFrame(
+            Data.add_date_index_column_rows, Schemas.add_date_index_column_schema
+        )
+        self.returned_df = job.add_date_index_column(test_df)
+        self.expected_df = self.spark.createDataFrame(
+            Data.expected_add_date_index_column_rows,
+            Schemas.expected_add_date_index_column_schema,
+        )
+        self.returned_data = self.returned_df.sort(IndCQC.location_id).collect()
+        self.expected_data = self.expected_df.collect()
+
+    def test_add_date_index_column_returns_expected_columns(self):
+        self.assertTrue(self.returned_df.columns, self.expected_df.columns)
+
+    def test_add_date_index_column_returns_expected_data(self):
+        self.assertEqual(self.returned_data, self.expected_data)

--- a/tests/unit/test_prepare_features_care_home_ind_cqc.py
+++ b/tests/unit/test_prepare_features_care_home_ind_cqc.py
@@ -31,6 +31,7 @@ class CareHomeFeaturesIndCqcFilledPosts(unittest.TestCase):
 
     @patch("utils.utils.write_to_parquet")
     @patch("jobs.prepare_features_care_home_ind_cqc.vectorise_dataframe")
+    @patch("jobs.prepare_features_care_home_ind_cqc.add_date_index_column")
     @patch("jobs.prepare_features_care_home_ind_cqc.add_array_column_count")
     @patch("utils.utils.select_rows_with_non_null_value")
     @patch("utils.utils.select_rows_with_value")
@@ -41,6 +42,7 @@ class CareHomeFeaturesIndCqcFilledPosts(unittest.TestCase):
         select_rows_with_value_mock: Mock,
         select_rows_with_non_null_value_mock: Mock,
         add_array_column_count_mock: Mock,
+        add_date_index_column_mock: Mock,
         vectorise_dataframe_mock: Mock,
         write_to_parquet_mock: Mock,
     ):
@@ -54,6 +56,7 @@ class CareHomeFeaturesIndCqcFilledPosts(unittest.TestCase):
         self.assertEqual(select_rows_with_value_mock.call_count, 1)
         self.assertEqual(select_rows_with_non_null_value_mock.call_count, 1)
         self.assertEqual(add_array_column_count_mock.call_count, 1)
+        self.assertEqual(add_date_index_column_mock.call_count, 1)
         self.assertEqual(vectorise_dataframe_mock.call_count, 1)
 
         write_to_parquet_mock.assert_called_once_with(

--- a/tests/unit/test_prepare_features_non_res_ascwds_ind_cqc.py
+++ b/tests/unit/test_prepare_features_non_res_ascwds_ind_cqc.py
@@ -27,6 +27,7 @@ class NonResLocationsFeatureEngineeringTests(unittest.TestCase):
     @patch("utils.utils.write_to_parquet")
     @patch("jobs.prepare_features_non_res_ascwds_ind_cqc.vectorise_dataframe")
     @patch("utils.utils.select_rows_with_non_null_value")
+    @patch("jobs.prepare_features_non_res_ascwds_ind_cqc.add_date_index_column")
     @patch("jobs.prepare_features_non_res_ascwds_ind_cqc.add_array_column_count")
     @patch("utils.utils.select_rows_with_value")
     @patch("utils.utils.read_from_parquet")
@@ -35,6 +36,7 @@ class NonResLocationsFeatureEngineeringTests(unittest.TestCase):
         read_from_parquet_mock: Mock,
         select_rows_with_value_mock: Mock,
         add_array_column_count_mock: Mock,
+        add_date_index_column_mock: Mock,
         select_rows_with_non_null_value_mock: Mock,
         vectorise_dataframe_mock: Mock,
         write_to_parquet_mock: Mock,
@@ -49,6 +51,7 @@ class NonResLocationsFeatureEngineeringTests(unittest.TestCase):
 
         self.assertEqual(select_rows_with_value_mock.call_count, 1)
         self.assertEqual(add_array_column_count_mock.call_count, 3)
+        self.assertEqual(add_date_index_column_mock.call_count, 2)
         self.assertEqual(select_rows_with_non_null_value_mock.call_count, 1)
         self.assertEqual(vectorise_dataframe_mock.call_count, 2)
 

--- a/utils/column_names/ind_cqc_pipeline_columns.py
+++ b/utils/column_names/ind_cqc_pipeline_columns.py
@@ -99,6 +99,9 @@ class IndCqcColumns:
     )
     contemporary_sub_icb: str = ONSClean.contemporary_sub_icb
     cqc_location_import_date: str = CQCLClean.cqc_location_import_date
+    cqc_location_import_date_indexed: str = (
+        CQCLClean.cqc_location_import_date + "_indexed"
+    )
     cqc_pir_import_date: str = CQCPIRClean.cqc_pir_import_date
     cqc_sector: str = CQCLClean.cqc_sector
     current_ccg: str = ONSClean.current_ccg

--- a/utils/features/helper.py
+++ b/utils/features/helper.py
@@ -8,6 +8,19 @@ from utils.column_names.ind_cqc_pipeline_columns import IndCqcColumns as IndCQC
 
 
 def vectorise_dataframe(df: DataFrame, list_for_vectorisation: List[str]) -> DataFrame:
+    """
+    Combines specified columns into a single feature vector for the modelling process.
+
+    This function uses `VectorAssembler` to merge multiple input columns into a single vector column.
+    Invalid values are skipped to prevent transformation errors.
+
+    Args:
+        df (DataFrame): Input DataFrame containing columns to be vectorised.
+        list_for_vectorisation (List[str]): List of column names to be combined into the feature vector.
+
+    Returns:
+        DataFrame: A DataFrame with an additional 'features' column.
+    """
     loc_df = VectorAssembler(
         inputCols=list_for_vectorisation,
         outputCol=IndCQC.features,

--- a/utils/features/helper.py
+++ b/utils/features/helper.py
@@ -1,6 +1,6 @@
 from typing import Dict, List, Tuple
 
-from pyspark.sql import DataFrame, functions as F
+from pyspark.sql import DataFrame, Window, functions as F
 from pyspark.sql.types import IntegerType
 from pyspark.ml.feature import VectorAssembler
 
@@ -112,3 +112,29 @@ def cap_integer_at_max_value(
         ).otherwise(None),
     )
     return df
+
+
+def add_date_index_column(df: DataFrame) -> DataFrame:
+    """
+    Creates an index column in the DataFrame based on the cqc_location_import_date column, partitioned by care_home.
+
+    dense_rank has been used as it doesn't leave gaps in ranking sequence when there are ties.
+    For example, if three rows have the same date then they would all receive the same index value.
+    The first date after this would receive the next index value.
+    The difference with rank is that it leaves gaps in the sequence, so the first three dates would be indexed at 1 and the next date would be 4.
+
+    Args:
+        df (DataFrame): Input DataFrame.
+
+    Returns:
+        DataFrame: DataFrame with an added index column.
+    """
+    windowSpec = Window.partitionBy(IndCQC.care_home).orderBy(
+        IndCQC.cqc_location_import_date
+    )
+
+    df_with_index = df.withColumn(
+        IndCQC.cqc_location_import_date_indexed, F.dense_rank().over(windowSpec)
+    )
+
+    return df_with_index

--- a/utils/validation/validation_rules/care_home_ind_cqc_features_validation_rules.py
+++ b/utils/validation/validation_rules/care_home_ind_cqc_features_validation_rules.py
@@ -29,6 +29,7 @@ class CareHomeIndCqcFeaturesValidationRules:
             IndCqcColumns.number_of_beds: 1,
             IndCqcColumns.pir_people_directly_employed: 0,
             IndCqcColumns.ascwds_pir_merged: 1.0,
+            IndCqcColumns.cqc_location_import_date_indexed: 1,
         },
         RuleName.max_values: {
             IndCqcColumns.number_of_beds: 500,

--- a/utils/validation/validation_rules/non_res_ascwds_inc_dormancy_ind_cqc_features_validation_rules.py
+++ b/utils/validation/validation_rules/non_res_ascwds_inc_dormancy_ind_cqc_features_validation_rules.py
@@ -36,6 +36,7 @@ class NonResASCWDSIncDormancyIndCqcFeaturesValidationRules:
             # IndCqcColumns.service_count: 1, # Temporarily removed whilst we fix DQ
             IndCqcColumns.activity_count: 0,
             IndCqcColumns.specialism_count: 0,
+            IndCqcColumns.cqc_location_import_date_indexed: 1,
         },
         RuleName.max_values: {
             IndCqcColumns.ascwds_pir_merged: 3000.0,

--- a/utils/validation/validation_rules/non_res_ascwds_without_dormancy_ind_cqc_features_validation_rules.py
+++ b/utils/validation/validation_rules/non_res_ascwds_without_dormancy_ind_cqc_features_validation_rules.py
@@ -35,6 +35,7 @@ class NonResASCWDSWithoutDormancyIndCqcFeaturesValidationRules:
             # IndCqcColumns.service_count: 1, # Temporarily removed whilst we fix DQ
             IndCqcColumns.activity_count: 0,
             IndCqcColumns.specialism_count: 0,
+            IndCqcColumns.cqc_location_import_date_indexed: 1,
         },
         RuleName.max_values: {
             IndCqcColumns.ascwds_pir_merged: 3000.0,


### PR DESCRIPTION
# Description
The models we're using can't take dates as features so we're converting them to a date index, which basically means that the first date which appears in the file is given an index of 1, the second date to appear gets 2 and so on.

# How to test
tests passing, not in the pipeline as a feature output yet, will be added alongside model transition

# Developer checklist
- [X] Unit test
- [X] Linked to [Trello ticket](https://trello.com/c/JakRnYdC/779-epic-5-create-date-index-column-must)
- [X] Documentation up to date
