### PR TITLE
Combine Models - 4 - Combine predictions

### DIFF
--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -6384,14 +6384,6 @@ class ModelNonResWithAndWithoutDormancyCombinedRows:
         (RelatedLocation.no_related_location, 1, 5.0, 10.0, 0.5),
         (RelatedLocation.has_related_location, 1, 4.5, 1.5, 3.0),
     ]
-    calculate_adjustment_ratios_when_without_dormancy_is_zero_or_null_returns_one_rows = [
-        (RelatedLocation.no_related_location, 1, 5.0, 0.0),
-        (RelatedLocation.has_related_location, 1, 4.5, None),
-    ]
-    expected_calculate_adjustment_ratios_when_without_dormancy_is_zero_or_null_returns_one_rows = [
-        (RelatedLocation.no_related_location, 1, 5.0, 0.0, 1.0),
-        (RelatedLocation.has_related_location, 1, 4.5, None, 1.0),
-    ]
 
     calculate_adjustment_ratios_when_without_dormancy_is_zero_or_null_returns_one_rows = [
         (RelatedLocation.no_related_location, 1, 5.0, 0.0),

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -6482,6 +6482,19 @@ class ModelNonResWithAndWithoutDormancyCombinedRows:
         ("1-003", None, None, None),
     ]
 
+    combine_model_predictions_rows = [
+        ("1-001", 10.0, 15.0),
+        ("1-002", 11.0, None),
+        ("1-003", None, 16.0),
+        ("1-004", None, None),
+    ]
+    expected_combine_model_predictions_rows = [
+        ("1-001", 10.0, 15.0, 10.0),
+        ("1-002", 11.0, None, 11.0),
+        ("1-003", None, 16.0, 16.0),
+        ("1-004", None, None, None),
+    ]
+
 
 @dataclass
 class ModelNonResPirLinearRegressionRows:

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -3326,7 +3326,9 @@ class ModelNonResWithAndWithoutDormancyCombinedSchemas:
             StructField(NRModel_TempCol.avg_without_dormancy, FloatType(), True),
             StructField(NRModel_TempCol.adjustment_ratio, FloatType(), True),
             StructField(
-                NRModel_TempCol.without_dormancy_model_adjusted, FloatType(), True
+                NRModel_TempCol.non_res_without_dormancy_model_adjusted,
+                FloatType(),
+                True,
             ),
         ]
     )
@@ -3376,7 +3378,9 @@ class ModelNonResWithAndWithoutDormancyCombinedSchemas:
         [
             *apply_model_ratios_schema,
             StructField(
-                NRModel_TempCol.without_dormancy_model_adjusted, FloatType(), True
+                NRModel_TempCol.non_res_without_dormancy_model_adjusted,
+                FloatType(),
+                True,
             ),
         ]
     )
@@ -3387,7 +3391,9 @@ class ModelNonResWithAndWithoutDormancyCombinedSchemas:
             StructField(IndCQC.cqc_location_import_date, DateType(), True),
             StructField(IndCQC.non_res_with_dormancy_model, FloatType(), True),
             StructField(
-                NRModel_TempCol.without_dormancy_model_adjusted, FloatType(), True
+                NRModel_TempCol.non_res_without_dormancy_model_adjusted,
+                FloatType(),
+                True,
             ),
         ]
     )
@@ -3396,7 +3402,7 @@ class ModelNonResWithAndWithoutDormancyCombinedSchemas:
             *calculate_and_apply_residuals_schema,
             StructField(NRModel_TempCol.residual_at_overlap, FloatType(), True),
             StructField(
-                NRModel_TempCol.without_dormancy_model_adjusted_and_residual_applied,
+                NRModel_TempCol.non_res_without_dormancy_model_adjusted_and_residual_applied,
                 FloatType(),
                 True,
             ),
@@ -3410,7 +3416,9 @@ class ModelNonResWithAndWithoutDormancyCombinedSchemas:
             StructField(NRModel_TempCol.first_overlap_date, DateType(), True),
             StructField(IndCQC.non_res_with_dormancy_model, FloatType(), True),
             StructField(
-                NRModel_TempCol.without_dormancy_model_adjusted, FloatType(), True
+                NRModel_TempCol.non_res_without_dormancy_model_adjusted,
+                FloatType(),
+                True,
             ),
         ]
     )
@@ -3425,7 +3433,9 @@ class ModelNonResWithAndWithoutDormancyCombinedSchemas:
         [
             StructField(IndCQC.location_id, StringType(), True),
             StructField(
-                NRModel_TempCol.without_dormancy_model_adjusted, FloatType(), True
+                NRModel_TempCol.non_res_without_dormancy_model_adjusted,
+                FloatType(),
+                True,
             ),
             StructField(NRModel_TempCol.residual_at_overlap, FloatType(), True),
         ]
@@ -3434,7 +3444,7 @@ class ModelNonResWithAndWithoutDormancyCombinedSchemas:
         [
             *apply_residuals_schema,
             StructField(
-                NRModel_TempCol.without_dormancy_model_adjusted_and_residual_applied,
+                NRModel_TempCol.non_res_without_dormancy_model_adjusted_and_residual_applied,
                 FloatType(),
                 True,
             ),
@@ -3446,7 +3456,7 @@ class ModelNonResWithAndWithoutDormancyCombinedSchemas:
             StructField(IndCQC.location_id, StringType(), True),
             StructField(IndCQC.non_res_with_dormancy_model, FloatType(), True),
             StructField(
-                NRModel_TempCol.without_dormancy_model_adjusted_and_residual_applied,
+                NRModel_TempCol.non_res_without_dormancy_model_adjusted_and_residual_applied,
                 FloatType(),
                 True,
             ),

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -3441,6 +3441,24 @@ class ModelNonResWithAndWithoutDormancyCombinedSchemas:
         ]
     )
 
+    combine_model_predictions_schema = StructType(
+        [
+            StructField(IndCQC.location_id, StringType(), True),
+            StructField(IndCQC.non_res_with_dormancy_model, FloatType(), True),
+            StructField(
+                NRModel_TempCol.without_dormancy_model_adjusted_and_residual_applied,
+                FloatType(),
+                True,
+            ),
+        ]
+    )
+    expected_combine_model_predictions_schema = StructType(
+        [
+            *combine_model_predictions_schema,
+            StructField(IndCQC.prediction, FloatType(), True),
+        ]
+    )
+
 
 @dataclass
 class ModelNonResPirLinearRegressionSchemas:

--- a/tests/unit/test_model_non_res_with_and_without_dormancy_combined.py
+++ b/tests/unit/test_model_non_res_with_and_without_dormancy_combined.py
@@ -339,34 +339,6 @@ class ApplyResidualsTests(ModelNonResWithAndWithoutDormancyCombinedTests):
                 msg=f"Returned value for row {i} does not match expected",
             )
 
-    def test_apply_residuals_returns_expected_values_when_data_contains_null_values(
-        self,
-    ):
-        test_df = self.spark.createDataFrame(
-            Data.apply_residuals_when_null_values_present_rows,
-            Schemas.apply_residuals_schema,
-        )
-        returned_df = job.apply_residuals(test_df)
-        expected_df = self.spark.createDataFrame(
-            Data.expected_apply_residuals_when_null_values_present_rows,
-            Schemas.expected_apply_residuals_schema,
-        )
-
-        returned_data = returned_df.sort(IndCqc.location_id).collect()
-        expected_data = expected_df.collect()
-
-        for i in range(len(self.returned_data)):
-            self.assertAlmostEqual(
-                returned_data[i][
-                    NRModel_TempCol.non_res_without_dormancy_model_adjusted_and_residual_applied
-                ],
-                expected_data[i][
-                    NRModel_TempCol.non_res_without_dormancy_model_adjusted_and_residual_applied
-                ],
-                places=3,
-                msg=f"Returned value for row {i} does not match expected",
-            )
-
 
 class CombineModelPredictionsTests(ModelNonResWithAndWithoutDormancyCombinedTests):
     def setUp(self) -> None:

--- a/tests/unit/test_model_non_res_with_and_without_dormancy_combined.py
+++ b/tests/unit/test_model_non_res_with_and_without_dormancy_combined.py
@@ -358,3 +358,33 @@ class ApplyResidualsTests(ModelNonResWithAndWithoutDormancyCombinedTests):
                 places=3,
                 msg=f"Returned value for row {i} does not match expected",
             )
+
+
+class CombineModelPredictionsTests(ModelNonResWithAndWithoutDormancyCombinedTests):
+    def setUp(self) -> None:
+        super().setUp()
+
+        test_df = self.spark.createDataFrame(
+            Data.combine_model_predictions_rows,
+            Schemas.combine_model_predictions_schema,
+        )
+        self.returned_df = job.combine_model_predictions(test_df)
+        self.expected_df = self.spark.createDataFrame(
+            Data.expected_combine_model_predictions_rows,
+            Schemas.expected_combine_model_predictions_schema,
+        )
+
+        self.returned_data = self.returned_df.sort(IndCqc.location_id).collect()
+        self.expected_data = self.expected_df.collect()
+
+    def test_combine_model_predictions_returns_expected_columns(self):
+        self.assertEqual(self.returned_df.columns, self.expected_df.columns)
+
+    def test_combine_model_predictions_returns_expected_prediction_values(self):
+        for i in range(len(self.returned_data)):
+            self.assertAlmostEqual(
+                self.returned_data[i][IndCqc.prediction],
+                self.expected_data[i][IndCqc.prediction],
+                places=3,
+                msg=f"Returned prediction value for row {i} does not match expected",
+            )

--- a/tests/unit/test_model_non_res_with_and_without_dormancy_combined.py
+++ b/tests/unit/test_model_non_res_with_and_without_dormancy_combined.py
@@ -182,8 +182,12 @@ class ApplyModelRatiosTests(ModelNonResWithAndWithoutDormancyCombinedTests):
     def test_apply_model_ratios_returns_expected_values_when_all_values_known(self):
         for i in range(len(self.returned_data)):
             self.assertAlmostEqual(
-                self.returned_data[i][NRModel_TempCol.without_dormancy_model_adjusted],
-                self.expected_data[i][NRModel_TempCol.without_dormancy_model_adjusted],
+                self.returned_data[i][
+                    NRModel_TempCol.non_res_without_dormancy_model_adjusted
+                ],
+                self.expected_data[i][
+                    NRModel_TempCol.non_res_without_dormancy_model_adjusted
+                ],
                 places=3,
                 msg=f"Returned values for row {i} does not match expected",
             )
@@ -204,8 +208,12 @@ class ApplyModelRatiosTests(ModelNonResWithAndWithoutDormancyCombinedTests):
 
         for i in range(len(returned_data)):
             self.assertEqual(
-                returned_data[i][NRModel_TempCol.without_dormancy_model_adjusted],
-                expected_data[i][NRModel_TempCol.without_dormancy_model_adjusted],
+                returned_data[i][
+                    NRModel_TempCol.non_res_without_dormancy_model_adjusted
+                ],
+                expected_data[i][
+                    NRModel_TempCol.non_res_without_dormancy_model_adjusted
+                ],
                 f"Returned values for row {i} does not match expected",
             )
 
@@ -248,10 +256,10 @@ class CalculateAndApplyResidualsTests(ModelNonResWithAndWithoutDormancyCombinedT
         for i in range(len(self.returned_data)):
             self.assertAlmostEqual(
                 self.returned_data[i][
-                    NRModel_TempCol.without_dormancy_model_adjusted_and_residual_applied
+                    NRModel_TempCol.non_res_without_dormancy_model_adjusted_and_residual_applied
                 ],
                 self.expected_data[i][
-                    NRModel_TempCol.without_dormancy_model_adjusted_and_residual_applied
+                    NRModel_TempCol.non_res_without_dormancy_model_adjusted_and_residual_applied
                 ],
                 places=3,
                 msg=f"Returned residual for row {i} does not match expected",
@@ -322,10 +330,10 @@ class ApplyResidualsTests(ModelNonResWithAndWithoutDormancyCombinedTests):
         for i in range(len(self.returned_data)):
             self.assertAlmostEqual(
                 self.returned_data[i][
-                    NRModel_TempCol.without_dormancy_model_adjusted_and_residual_applied
+                    NRModel_TempCol.non_res_without_dormancy_model_adjusted_and_residual_applied
                 ],
                 self.expected_data[i][
-                    NRModel_TempCol.without_dormancy_model_adjusted_and_residual_applied
+                    NRModel_TempCol.non_res_without_dormancy_model_adjusted_and_residual_applied
                 ],
                 places=3,
                 msg=f"Returned value for row {i} does not match expected",
@@ -350,10 +358,10 @@ class ApplyResidualsTests(ModelNonResWithAndWithoutDormancyCombinedTests):
         for i in range(len(self.returned_data)):
             self.assertAlmostEqual(
                 returned_data[i][
-                    NRModel_TempCol.without_dormancy_model_adjusted_and_residual_applied
+                    NRModel_TempCol.non_res_without_dormancy_model_adjusted_and_residual_applied
                 ],
                 expected_data[i][
-                    NRModel_TempCol.without_dormancy_model_adjusted_and_residual_applied
+                    NRModel_TempCol.non_res_without_dormancy_model_adjusted_and_residual_applied
                 ],
                 places=3,
                 msg=f"Returned value for row {i} does not match expected",

--- a/utils/column_names/ind_cqc_pipeline_columns.py
+++ b/utils/column_names/ind_cqc_pipeline_columns.py
@@ -290,7 +290,9 @@ class NonResWithAndWithoutDormancyCombinedColumns:
     avg_without_dormancy: str = "avg_without_dormancy"
     first_overlap_date: str = "first_overlap_date"
     residual_at_overlap: str = "residual_at_overlap"
-    without_dormancy_model_adjusted: str = "without_dormancy_model_adjusted"
-    without_dormancy_model_adjusted_and_residual_applied: str = (
-        "without_dormancy_model_adjusted_and_residual_applied"
+    non_res_without_dormancy_model_adjusted: str = (
+        "non_res_without_dormancy_model_adjusted"
+    )
+    non_res_without_dormancy_model_adjusted_and_residual_applied: str = (
+        "non_res_without_dormancy_model_adjusted_and_residual_applied"
     )

--- a/utils/estimate_filled_posts/models/non_res_with_and_without_dormancy_combined.py
+++ b/utils/estimate_filled_posts/models/non_res_with_and_without_dormancy_combined.py
@@ -236,8 +236,11 @@ def apply_residuals(df: DataFrame) -> DataFrame:
 
 def combine_model_predictions(df: DataFrame) -> DataFrame:
     """
-    Use the 'with_dormancy' model predictions when not null. Otherwise use the
-    'non_res_without_dormancy_model_adjusted_and_residual_applied' predictions wheen not null.
+    Coalesces the models in the order provided into a single column called 'prediction'.
+
+    The 'non_res_with_dormancy_model' values are used when they are not null.
+    If they are null, the 'non_res_without_dormancy_model_adjusted_and_residual_applied' are used.
+    If both are null, the prediction will be null.
 
     Args:
         df (DataFrame): DataFrame with model predictions.

--- a/utils/estimate_filled_posts/models/non_res_with_and_without_dormancy_combined.py
+++ b/utils/estimate_filled_posts/models/non_res_with_and_without_dormancy_combined.py
@@ -42,7 +42,7 @@ def combine_non_res_with_and_without_dormancy_models(
 
     combined_models_df = calculate_and_apply_residuals(combined_models_df)
 
-    # TODO - 4 - combine model predictions
+    combined_models_df = combine_model_predictions(combined_models_df)
 
     # TODO - 5 - set_min_value and insert predictions into pipeline
 
@@ -231,4 +231,26 @@ def apply_residuals(df: DataFrame) -> DataFrame:
             + F.col(TempColumns.residual_at_overlap),
         ).otherwise(F.col(TempColumns.without_dormancy_model_adjusted)),
     )
+    return df
+
+
+def combine_model_predictions(df: DataFrame) -> DataFrame:
+    """
+    Uses the 'with_dormancy' model predictions where available, otherwise uses the
+    'without_dormancy_model_adjusted_and_residual_applied' predictions.
+
+    Args:
+        df (DataFrame): DataFrame with model predictions.
+
+    Returns:
+        DataFrame: DataFrame with combined model predictions.
+    """
+    df = df.withColumn(
+        IndCqc.prediction,
+        F.coalesce(
+            IndCqc.non_res_with_dormancy_model,
+            TempColumns.without_dormancy_model_adjusted_and_residual_applied,
+        ),
+    )
+
     return df

--- a/utils/estimate_filled_posts/models/non_res_with_and_without_dormancy_combined.py
+++ b/utils/estimate_filled_posts/models/non_res_with_and_without_dormancy_combined.py
@@ -236,8 +236,8 @@ def apply_residuals(df: DataFrame) -> DataFrame:
 
 def combine_model_predictions(df: DataFrame) -> DataFrame:
     """
-    Uses the 'with_dormancy' model predictions where available, otherwise uses the
-    'without_dormancy_model_adjusted_and_residual_applied' predictions.
+    Use the 'with_dormancy' model predictions when not null. Otherwise use the
+    'without_dormancy_model_adjusted_and_residual_applied' predictions wheen not null.
 
     Args:
         df (DataFrame): DataFrame with model predictions.

--- a/utils/estimate_filled_posts/models/non_res_with_and_without_dormancy_combined.py
+++ b/utils/estimate_filled_posts/models/non_res_with_and_without_dormancy_combined.py
@@ -134,7 +134,7 @@ def apply_model_ratios(df: DataFrame) -> DataFrame:
         DataFrame: DataFrame with adjusted 'without_dormancy' model predictions.
     """
     df = df.withColumn(
-        TempColumns.without_dormancy_model_adjusted,
+        TempColumns.non_res_without_dormancy_model_adjusted,
         F.col(IndCqc.non_res_without_dormancy_model)
         * F.col(TempColumns.adjustment_ratio),
     )
@@ -175,7 +175,7 @@ def calculate_and_apply_residuals(df: DataFrame) -> DataFrame:
 
 def calculate_residuals(df: DataFrame) -> DataFrame:
     """
-    Calculates residuals between 'with_dormancy' and 'without_dormancy_model_adjusted' models at the first overlap date.
+    Calculates residuals between 'with_dormancy' and 'non_res_without_dormancy_model_adjusted' models at the first overlap date.
 
     This function filters the DataFrame at the first point in time when the 'with_dormancy_model' has values, and to locations
     who have both a 'with_dormancy' and 'without_dormancy_adjusted' model prediction.
@@ -194,12 +194,12 @@ def calculate_residuals(df: DataFrame) -> DataFrame:
             == F.col(TempColumns.first_overlap_date)
         )
         & F.col(IndCqc.non_res_with_dormancy_model).isNotNull()
-        & F.col(TempColumns.without_dormancy_model_adjusted).isNotNull()
+        & F.col(TempColumns.non_res_without_dormancy_model_adjusted).isNotNull()
     )
     residual_df = filtered_df.withColumn(
         TempColumns.residual_at_overlap,
         F.col(IndCqc.non_res_with_dormancy_model)
-        - F.col(TempColumns.without_dormancy_model_adjusted),
+        - F.col(TempColumns.non_res_without_dormancy_model_adjusted),
     )
     residual_df = residual_df.select(
         IndCqc.location_id, TempColumns.residual_at_overlap
@@ -219,17 +219,17 @@ def apply_residuals(df: DataFrame) -> DataFrame:
         DataFrame: DataFrame with smoothed predictions.
     """
     model_and_residual_are_not_null = (
-        F.col(TempColumns.without_dormancy_model_adjusted).isNotNull()
+        F.col(TempColumns.non_res_without_dormancy_model_adjusted).isNotNull()
         & F.col(TempColumns.residual_at_overlap).isNotNull()
     )
 
     df = df.withColumn(
-        TempColumns.without_dormancy_model_adjusted_and_residual_applied,
+        TempColumns.non_res_without_dormancy_model_adjusted_and_residual_applied,
         F.when(
             model_and_residual_are_not_null,
-            F.col(TempColumns.without_dormancy_model_adjusted)
+            F.col(TempColumns.non_res_without_dormancy_model_adjusted)
             + F.col(TempColumns.residual_at_overlap),
-        ).otherwise(F.col(TempColumns.without_dormancy_model_adjusted)),
+        ).otherwise(F.col(TempColumns.non_res_without_dormancy_model_adjusted)),
     )
     return df
 
@@ -237,7 +237,7 @@ def apply_residuals(df: DataFrame) -> DataFrame:
 def combine_model_predictions(df: DataFrame) -> DataFrame:
     """
     Use the 'with_dormancy' model predictions when not null. Otherwise use the
-    'without_dormancy_model_adjusted_and_residual_applied' predictions wheen not null.
+    'non_res_without_dormancy_model_adjusted_and_residual_applied' predictions wheen not null.
 
     Args:
         df (DataFrame): DataFrame with model predictions.
@@ -249,7 +249,7 @@ def combine_model_predictions(df: DataFrame) -> DataFrame:
         IndCqc.prediction,
         F.coalesce(
             IndCqc.non_res_with_dormancy_model,
-            TempColumns.without_dormancy_model_adjusted_and_residual_applied,
+            TempColumns.non_res_without_dormancy_model_adjusted_and_residual_applied,
         ),
     )
 


### PR DESCRIPTION
# Description
The 'non_res_with_dormancy_model' values are used when they are not null.
If they are null, the 'non_res_without_dormancy_model_adjusted_and_residual_applied' are used.
If both are null, the prediction will be null.

# How to test
Unit tests are passing

# Developer checklist
- [X] Unit test
- [X] Linked to [Trello ticket](https://trello.com/c/QD6b6Rry/762-epic-5-combine-models-4-combine-predictions-must)
- [X] Documentation up to date
