### PR TITLE
Update without dorm validation

### DIFF
--- a/jobs/prepare_features_non_res_ascwds_ind_cqc.py
+++ b/jobs/prepare_features_non_res_ascwds_ind_cqc.py
@@ -1,8 +1,6 @@
 import sys
 from typing import List
 
-from pyspark.sql import DataFrame
-
 from utils import utils
 from utils.column_names.ind_cqc_pipeline_columns import (
     IndCqcColumns as IndCQC,

--- a/jobs/validate_non_res_ascwds_without_dormancy_ind_cqc_features_data.py
+++ b/jobs/validate_non_res_ascwds_without_dormancy_ind_cqc_features_data.py
@@ -4,6 +4,7 @@ import sys
 # SPARK_VERSION needs to be set before pydeequ is imported
 os.environ["SPARK_VERSION"] = "3.3"
 
+from datetime import date
 from pyspark.sql.dataframe import DataFrame
 
 from utils import utils
@@ -79,6 +80,7 @@ def calculate_expected_size_of_non_res_ascwds_without_dormancy_ind_cqc_features_
     expected_size = cleaned_ind_cqc_df.where(
         (cleaned_ind_cqc_df[IndCQC.care_home] == CareHome.not_care_home)
         & (cleaned_ind_cqc_df[IndCQC.imputed_gac_service_types].isNotNull())
+        & (cleaned_ind_cqc_df[IndCQC.cqc_location_import_date] <= date(2025, 1, 1))
     ).count()
     return expected_size
 


### PR DESCRIPTION
# Description
The pipeline is failing as I missed a validation step in a recent PR (dataset filters to pre-2025 but I forgot to change the expected size of the dataset to also filter to pre-2025)

# How to test
Ran job against main data and [now passing](https://eu-west-2.console.aws.amazon.com/gluestudio/home?region=eu-west-2#/editor/job/without-dorm-validation-validate_non_res_ascwds_without_dormancy_ind_cqc_features_data_job/runs)

# Developer checklist
- [X] Unit test
- [X] Linked to Trello ticket
- [X] Documentation up to date
