### PR TITLE
Change references from 'average' in the rate of change model

### DIFF
--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -5519,32 +5519,32 @@ class ModelPrimaryServiceRateOfChange:
     ]
     # fmt: on
 
-    clean_column_to_average_rows = [
+    clean_column_with_values_rows = [
         ("1-001", 1000000001, CareHome.care_home, 10.0),
         ("1-001", 1000000002, CareHome.care_home, None),
         ("1-001", 1000000003, CareHome.care_home, 10.0),
     ]
-    expected_clean_column_to_average_rows = [
+    expected_clean_column_with_values_rows = [
         ("1-001", 1000000001, CareHome.care_home, 10.0, 1, 2),
         ("1-001", 1000000002, CareHome.care_home, None, 1, 2),
         ("1-001", 1000000003, CareHome.care_home, 10.0, 1, 2),
     ]
 
-    clean_column_to_average_one_submission_rows = [
+    clean_column_with_values_one_submission_rows = [
         ("1-001", 1000000001, CareHome.care_home, 10.0),
         ("1-001", 1000000002, CareHome.care_home, None),
     ]
-    expected_clean_column_to_average_one_submission_rows = [
+    expected_clean_column_with_values_one_submission_rows = [
         ("1-001", 1000000001, CareHome.care_home, None, 1, 1),
         ("1-001", 1000000002, CareHome.care_home, None, 1, 1),
     ]
 
-    clean_column_to_average_both_statuses_rows = [
+    clean_column_with_values_both_statuses_rows = [
         ("1-001", 1000000001, CareHome.care_home, 10.0),
         ("1-001", 1000000002, CareHome.care_home, 10.0),
         ("1-001", 1000000003, CareHome.not_care_home, 10.0),
     ]
-    expected_clean_column_to_average_both_statuses_rows = [
+    expected_clean_column_with_values_both_statuses_rows = [
         ("1-001", 1000000001, CareHome.care_home, None, 2, 2),
         ("1-001", 1000000002, CareHome.care_home, None, 2, 2),
         ("1-001", 1000000003, CareHome.not_care_home, None, 2, 1),
@@ -5591,13 +5591,13 @@ class ModelPrimaryServiceRateOfChange:
         ("1-001", CareHome.care_home, 10.0, 2),
     ]
 
-    interpolate_column_to_average_rows = [
+    interpolate_column_with_values_rows = [
         ("1-001", 1704067200, 30.0),
         ("1-001", 1704153600, None),
         ("1-001", 1704240000, 34.0),
         ("1-001", 1704326400, None),
     ]
-    expected_interpolate_column_to_average_rows = [
+    expected_interpolate_column_with_values_rows = [
         ("1-001", 1704067200, 30.0, 30.0),
         ("1-001", 1704153600, None, 32.0),
         ("1-001", 1704240000, 34.0, 34.0),

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -2751,17 +2751,17 @@ class ModelPrimaryServiceRateOfChange:
         ]
     )
 
-    clean_column_to_average_schema = StructType(
+    clean_column_with_values_schema = StructType(
         [
             StructField(IndCQC.location_id, StringType(), False),
             StructField(IndCQC.unix_time, IntegerType(), False),
             StructField(IndCQC.care_home, StringType(), False),
-            StructField(RoC_TempCol.column_to_average, DoubleType(), True),
+            StructField(RoC_TempCol.column_with_values, DoubleType(), True),
         ]
     )
-    expected_clean_column_to_average_schema = StructType(
+    expected_clean_column_with_values_schema = StructType(
         [
-            *clean_column_to_average_schema,
+            *clean_column_with_values_schema,
             StructField(RoC_TempCol.care_home_status_count, IntegerType(), True),
             StructField(RoC_TempCol.submission_count, IntegerType(), True),
         ]
@@ -2784,7 +2784,7 @@ class ModelPrimaryServiceRateOfChange:
         [
             StructField(IndCQC.location_id, StringType(), False),
             StructField(IndCQC.care_home, StringType(), False),
-            StructField(RoC_TempCol.column_to_average, DoubleType(), True),
+            StructField(RoC_TempCol.column_with_values, DoubleType(), True),
         ]
     )
     expected_calculate_submission_count_schema = StructType(
@@ -2794,17 +2794,19 @@ class ModelPrimaryServiceRateOfChange:
         ]
     )
 
-    interpolate_column_to_average_schema = StructType(
+    interpolate_column_with_values_schema = StructType(
         [
             StructField(IndCQC.location_id, StringType(), False),
             StructField(IndCQC.unix_time, IntegerType(), False),
-            StructField(RoC_TempCol.column_to_average, DoubleType(), True),
+            StructField(RoC_TempCol.column_with_values, DoubleType(), True),
         ]
     )
-    expected_interpolate_column_to_average_schema = StructType(
+    expected_interpolate_column_with_values_schema = StructType(
         [
-            *interpolate_column_to_average_schema,
-            StructField(RoC_TempCol.column_to_average_interpolated, DoubleType(), True),
+            *interpolate_column_with_values_schema,
+            StructField(
+                RoC_TempCol.column_with_values_interpolated, DoubleType(), True
+            ),
         ]
     )
 
@@ -2815,7 +2817,9 @@ class ModelPrimaryServiceRateOfChange:
             StructField(IndCQC.primary_service_type, StringType(), False),
             StructField(IndCQC.unix_time, IntegerType(), False),
             StructField(IndCQC.number_of_beds, IntegerType(), True),
-            StructField(RoC_TempCol.column_to_average_interpolated, DoubleType(), True),
+            StructField(
+                RoC_TempCol.column_with_values_interpolated, DoubleType(), True
+            ),
         ]
     )
 
@@ -2823,14 +2827,16 @@ class ModelPrimaryServiceRateOfChange:
         [
             StructField(IndCQC.location_id, StringType(), False),
             StructField(IndCQC.unix_time, IntegerType(), False),
-            StructField(RoC_TempCol.column_to_average_interpolated, DoubleType(), True),
+            StructField(
+                RoC_TempCol.column_with_values_interpolated, DoubleType(), True
+            ),
         ]
     )
     expected_add_previous_value_column_schema = StructType(
         [
             *add_previous_value_column_schema,
             StructField(
-                RoC_TempCol.previous_column_to_average_interpolated, DoubleType(), True
+                RoC_TempCol.previous_column_with_values_interpolated, DoubleType(), True
             ),
         ]
     )
@@ -2840,9 +2846,11 @@ class ModelPrimaryServiceRateOfChange:
             StructField(IndCQC.location_id, StringType(), False),
             StructField(IndCQC.primary_service_type, StringType(), False),
             StructField(IndCQC.unix_time, IntegerType(), False),
-            StructField(RoC_TempCol.column_to_average_interpolated, DoubleType(), True),
             StructField(
-                RoC_TempCol.previous_column_to_average_interpolated, DoubleType(), True
+                RoC_TempCol.column_with_values_interpolated, DoubleType(), True
+            ),
+            StructField(
+                RoC_TempCol.previous_column_with_values_interpolated, DoubleType(), True
             ),
         ]
     )

--- a/tests/unit/test_model_primary_service_rate_of_change.py
+++ b/tests/unit/test_model_primary_service_rate_of_change.py
@@ -2,11 +2,8 @@ import unittest
 from unittest.mock import patch, Mock
 import warnings
 
-from pyspark.sql import functions as F
-
 from utils import utils
 from utils.column_names.ind_cqc_pipeline_columns import IndCqcColumns as IndCqc
-from utils.column_values.categorical_column_values import CareHome
 import utils.estimate_filled_posts.models.primary_service_rate_of_change as job
 from tests.test_file_data import ModelPrimaryServiceRateOfChange as Data
 from tests.test_file_schemas import ModelPrimaryServiceRateOfChange as Schemas
@@ -72,50 +69,50 @@ class CleanColumnToAverageTests(ModelPrimaryServiceRateOfChangeTests):
         super().setUp()
 
         test_df = self.spark.createDataFrame(
-            Data.clean_column_to_average_rows,
-            Schemas.clean_column_to_average_schema,
+            Data.clean_column_with_values_rows,
+            Schemas.clean_column_with_values_schema,
         )
-        self.returned_df = job.clean_column_to_average(test_df)
+        self.returned_df = job.clean_column_with_values(test_df)
         self.expected_df = self.spark.createDataFrame(
-            Data.expected_clean_column_to_average_rows,
-            Schemas.expected_clean_column_to_average_schema,
+            Data.expected_clean_column_with_values_rows,
+            Schemas.expected_clean_column_with_values_schema,
         )
 
-    def test_clean_column_to_average_returns_expected_columns(self):
+    def test_clean_column_with_values_returns_expected_columns(self):
         self.assertEqual(self.returned_df.columns, self.expected_df.columns)
 
-    def test_clean_column_to_average_is_not_nulled_when_submitted_more_than_once_and_consistent_care_home_status(
+    def test_clean_column_with_values_is_not_nulled_when_submitted_more_than_once_and_consistent_care_home_status(
         self,
     ):
         returned_data = self.returned_df.sort(IndCqc.unix_time).collect()
         expected_data = self.expected_df.collect()
         self.assertEqual(returned_data, expected_data)
 
-    def test_clean_column_to_average_is_nulled_when_location_only_submitted_once(self):
+    def test_clean_column_with_values_is_nulled_when_location_only_submitted_once(self):
         one_submission_df = self.spark.createDataFrame(
-            Data.clean_column_to_average_one_submission_rows,
-            Schemas.clean_column_to_average_schema,
+            Data.clean_column_with_values_one_submission_rows,
+            Schemas.clean_column_with_values_schema,
         )
-        returned_df = job.clean_column_to_average(one_submission_df)
+        returned_df = job.clean_column_with_values(one_submission_df)
         expected_df = self.spark.createDataFrame(
-            Data.expected_clean_column_to_average_one_submission_rows,
-            Schemas.expected_clean_column_to_average_schema,
+            Data.expected_clean_column_with_values_one_submission_rows,
+            Schemas.expected_clean_column_with_values_schema,
         )
         returned_data = returned_df.sort(IndCqc.unix_time).collect()
         expected_data = expected_df.collect()
         self.assertEqual(returned_data, expected_data)
 
-    def test_clean_column_to_average_is_nulled_when_location_switched_between_care_home_and_non_res(
+    def test_clean_column_with_values_is_nulled_when_location_switched_between_care_home_and_non_res(
         self,
     ):
         both_statuses_df = self.spark.createDataFrame(
-            Data.clean_column_to_average_both_statuses_rows,
-            Schemas.clean_column_to_average_schema,
+            Data.clean_column_with_values_both_statuses_rows,
+            Schemas.clean_column_with_values_schema,
         )
-        returned_df = job.clean_column_to_average(both_statuses_df)
+        returned_df = job.clean_column_with_values(both_statuses_df)
         expected_df = self.spark.createDataFrame(
-            Data.expected_clean_column_to_average_both_statuses_rows,
-            Schemas.expected_clean_column_to_average_schema,
+            Data.expected_clean_column_with_values_both_statuses_rows,
+            Schemas.expected_clean_column_with_values_schema,
         )
         returned_data = returned_df.sort(IndCqc.unix_time).collect()
         expected_data = expected_df.collect()
@@ -215,30 +212,30 @@ class InterpolateColumnToAverageTests(ModelPrimaryServiceRateOfChangeTests):
         super().setUp()
 
         test_df = self.spark.createDataFrame(
-            Data.interpolate_column_to_average_rows,
-            Schemas.interpolate_column_to_average_schema,
+            Data.interpolate_column_with_values_rows,
+            Schemas.interpolate_column_with_values_schema,
         )
-        self.returned_df = job.interpolate_column_to_average(test_df)
+        self.returned_df = job.interpolate_column_with_values(test_df)
         self.expected_df = self.spark.createDataFrame(
-            Data.expected_interpolate_column_to_average_rows,
-            Schemas.expected_interpolate_column_to_average_schema,
+            Data.expected_interpolate_column_with_values_rows,
+            Schemas.expected_interpolate_column_with_values_schema,
         )
         self.returned_data = self.returned_df.sort(IndCqc.unix_time).collect()
         self.expected_data = self.expected_df.collect()
 
-    def test_interpolate_column_to_average_returns_expected_columns(self):
+    def test_interpolate_column_with_values_returns_expected_columns(self):
         self.assertEqual(
             sorted(self.returned_df.columns),
             sorted(self.expected_df.columns),
         )
 
-    def test_returned_column_to_average_interpolated_values_match_expected(
+    def test_returned_column_with_values_interpolated_values_match_expected(
         self,
     ):
         for i in range(len(self.returned_data)):
             self.assertEqual(
-                self.returned_data[i][job.TempCol.column_to_average_interpolated],
-                self.expected_data[i][job.TempCol.column_to_average_interpolated],
+                self.returned_data[i][job.TempCol.column_with_values_interpolated],
+                self.expected_data[i][job.TempCol.column_with_values_interpolated],
                 f"Returned row {i} does not match expected",
             )
 
@@ -339,10 +336,10 @@ class AddPreviousValueColumnTests(ModelPrimaryServiceRateOfChangeTests):
         for i in range(len(self.returned_data)):
             self.assertAlmostEqual(
                 self.returned_data[i][
-                    job.TempCol.previous_column_to_average_interpolated
+                    job.TempCol.previous_column_with_values_interpolated
                 ],
                 self.expected_data[i][
-                    job.TempCol.previous_column_to_average_interpolated
+                    job.TempCol.previous_column_with_values_interpolated
                 ],
                 2,
                 f"Returned row {i} does not match expected",
@@ -362,7 +359,7 @@ class AddRollingSumTests(ModelPrimaryServiceRateOfChangeTests):
         self.returned_df = job.add_rolling_sum(
             test_df,
             number_of_days,
-            job.TempCol.column_to_average_interpolated,
+            job.TempCol.column_with_values_interpolated,
             job.TempCol.rolling_current_period_sum,
         )
         self.expected_df = self.spark.createDataFrame(

--- a/utils/column_names/ind_cqc_pipeline_columns.py
+++ b/utils/column_names/ind_cqc_pipeline_columns.py
@@ -276,13 +276,13 @@ class IndCqcColumns:
 
 @dataclass
 class PrimaryServiceRateOfChangeColumns:
-    """The names of the temporary columns created during the rolling average process."""
+    """The names of the temporary columns created during the rate of change process."""
 
     care_home_status_count: str = "care_home_status_count"
-    column_to_average: str = "column_to_average"
-    column_to_average_interpolated: str = "column_to_average_interpolated"
-    previous_column_to_average_interpolated: str = (
-        "previous_column_to_average_interpolated"
+    column_with_values: str = "column_with_values"
+    column_with_values_interpolated: str = "column_with_values_interpolated"
+    previous_column_with_values_interpolated: str = (
+        "previous_column_with_values_interpolated"
     )
     rolling_current_period_sum: str = "rolling_current_period_sum"
     rolling_previous_period_sum: str = "rolling_previous_period_sum"


### PR DESCRIPTION
# Description
Straight up replace of 'column to average' with 'column_with_values'
we're not averaging anymore, and that column is already half referenced as 'column_with_values'

# How to test
[branch runs ok following name change](https://eu-west-2.console.aws.amazon.com/states/home?region=eu-west-2#/v2/executions/details/arn:aws:states:eu-west-2:344210435447:execution:remove-final-average-refs-Ind-CQC-Filled-Post-Estimates-Pipeline:3eabde28-5809-4215-9c05-b14812fad6a3)

# Developer checklist
- [X] Unit test
- [X] Linked to Trello ticket
- [X] Documentation up to date
