### PR TITLE
Refactor estimate filled posts by job role job script

### DIFF
--- a/jobs/estimate_ind_cqc_filled_posts_by_job_role.py
+++ b/jobs/estimate_ind_cqc_filled_posts_by_job_role.py
@@ -123,6 +123,10 @@ def main(
         )
     )
 
+    estimated_ind_cqc_filled_posts_by_job_role_df = model_job_role_ratio_interpolation(
+        estimated_ind_cqc_filled_posts_by_job_role_df, JRutils.list_of_job_roles_sorted
+    )
+
     estimated_ind_cqc_filled_posts_by_job_role_df = calculate_rolling_sum_of_job_roles(
         estimated_ind_cqc_filled_posts_by_job_role_df,
         NumericalValues.number_of_days_in_rolling_sum,
@@ -141,6 +145,7 @@ def main(
         estimated_ind_cqc_filled_posts_by_job_role_df,
         [
             IndCQC.ascwds_job_role_ratios,
+            IndCQC.ascwds_job_role_ratios_interpolated,
             IndCQC.ascwds_job_role_ratios_by_primary_service,
         ],
         IndCQC.ascwds_job_role_ratios_merged,
@@ -151,10 +156,6 @@ def main(
         JRutils.create_estimate_filled_posts_by_job_role_map_column(
             estimated_ind_cqc_filled_posts_by_job_role_df
         )
-    )
-
-    estimated_ind_cqc_filled_posts_by_job_role_df = model_job_role_ratio_interpolation(
-        estimated_ind_cqc_filled_posts_by_job_role_df, JRutils.list_of_job_roles_sorted
     )
 
     estimated_ind_cqc_filled_posts_by_job_role_df = JRutils.unpack_mapped_column(

--- a/tests/unit/test_estimate_ind_cqc_filled_posts_by_job_role.py
+++ b/tests/unit/test_estimate_ind_cqc_filled_posts_by_job_role.py
@@ -47,14 +47,14 @@ class MainTests(EstimateIndCQCFilledPostsByJobRoleTests):
     )
     @patch("utils.estimate_filled_posts_by_job_role_utils.utils.unpack_mapped_column")
     @patch(
-        "jobs.estimate_ind_cqc_filled_posts_by_job_role.model_job_role_ratio_interpolation"
-    )
-    @patch(
         "utils.estimate_filled_posts_by_job_role_utils.utils.create_estimate_filled_posts_by_job_role_map_column"
     )
     @patch("utils.ind_cqc_filled_posts_utils.utils.merge_columns_in_order")
     @patch(
         "jobs.estimate_ind_cqc_filled_posts_by_job_role.calculate_rolling_sum_of_job_roles"
+    )
+    @patch(
+        "jobs.estimate_ind_cqc_filled_posts_by_job_role.model_job_role_ratio_interpolation"
     )
     @patch(
         "utils.estimate_filled_posts_by_job_role_utils.utils.calculate_job_group_sum_from_job_role_map_column"
@@ -78,10 +78,10 @@ class MainTests(EstimateIndCQCFilledPostsByJobRoleTests):
         remove_ascwds_job_role_count_when_estimate_filled_posts_source_not_ascwds_mock: Mock,
         transform_job_role_count_map_to_ratios_map_mock: Mock,
         calculate_job_group_sum_from_job_role_map_column_mock: Mock,
+        model_job_role_ratio_interpolation_mock: Mock,
         calculate_rolling_sum_of_job_roles_mock: Mock,
         merge_columns_in_order_mock: Mock,
         create_estimate_filled_posts_by_job_role_map_column_mock: Mock,
-        model_job_role_ratio_interpolation_mock: Mock,
         unpack_mapped_column_mock: Mock,
         count_registered_manager_names_mock: Mock,
         calculate_difference_between_estimate_and_cqc_registered_managers_mock: Mock,
@@ -113,12 +113,12 @@ class MainTests(EstimateIndCQCFilledPostsByJobRoleTests):
         self.assertEqual(
             calculate_job_group_sum_from_job_role_map_column_mock.call_count, 2
         )
+        model_job_role_ratio_interpolation_mock.assert_called_once()
         calculate_rolling_sum_of_job_roles_mock.assert_called_once()
         merge_columns_in_order_mock.assert_called_once()
         create_estimate_filled_posts_by_job_role_map_column_mock.assert_called_once()
         unpack_mapped_column_mock.assert_called_once()
         count_registered_manager_names_mock.assert_called_once()
-        model_job_role_ratio_interpolation_mock.assert_called_once()
         calculate_difference_between_estimate_and_cqc_registered_managers_mock.assert_called_once()
         write_to_parquet_mock.assert_called_once_with(
             ANY, self.OUTPUT_DIR, "overwrite", PartitionKeys


### PR DESCRIPTION
# Description
I've moved the interpolation function further up the estimates by job role job script, and added interpolated job role ratios to the merge_columns_in_order so they now get used in the final estimates by job role.

Re-ordered the patch/mock/call checks for this job script given the new order in job.

# How to test
No new tests, but current one's passed.
[Link to successful pipeline run](https://eu-west-2.console.aws.amazon.com/states/home?region=eu-west-2#/v2/executions/details/arn:aws:states:eu-west-2:344210435447:execution:refactor-posts-by-job-role-job-Ind-CQC-Filled-Post-Estimates-Pipeline:f1f7bb38-8e31-4469-9479-5dbbd1230f12)

# Developer checklist
- [x] Unit test
- [x] Linked to Trello ticket
- [x] Documentation up to date
