### PR TITLE
Reduce filled post windows from 6 to 3 months

### DIFF
--- a/jobs/diagnostics_on_capacity_tracker.py
+++ b/jobs/diagnostics_on_capacity_tracker.py
@@ -51,7 +51,7 @@ estimate_filled_posts_columns: list = [
 absolute_value_cutoff: float = 10.0
 percentage_value_cutoff: float = 0.25
 standardised_value_cutoff: float = 1.0
-number_of_days_in_window: int = 185  # Note: using 185 as a proxy for 6 months
+number_of_days_in_window: int = 95  # Note: using 95 as a proxy for 3 months
 
 
 def main(

--- a/jobs/impute_ind_cqc_ascwds_and_pir.py
+++ b/jobs/impute_ind_cqc_ascwds_and_pir.py
@@ -32,7 +32,7 @@ PartitionKeys = [Keys.year, Keys.month, Keys.day, Keys.import_date]
 
 @dataclass
 class NumericalValues:
-    number_of_days_in_window = 185  # Note: using 185 as a proxy for 6 months
+    number_of_days_in_window = 95  # Note: using 95 as a proxy for 3 months
 
 
 def main(

--- a/tests/unit/test_diagnostics_on_capacity_tracker.py
+++ b/tests/unit/test_diagnostics_on_capacity_tracker.py
@@ -88,7 +88,7 @@ class CheckConstantsTests(DiagnosticsOnCapacityTrackerTests):
         self.assertIsInstance(job.standardised_value_cutoff, float)
 
     def test_number_of_days_in_window_is_expected_value(self):
-        self.assertEqual(job.number_of_days_in_window, 185)
+        self.assertEqual(job.number_of_days_in_window, 95)
         self.assertIsInstance(job.number_of_days_in_window, int)
 
 

--- a/tests/unit/test_impute_ind_cqc_ascwds_and_pir.py
+++ b/tests/unit/test_impute_ind_cqc_ascwds_and_pir.py
@@ -78,7 +78,7 @@ class NumericalValuesTests(ImputeIndCqcAscwdsAndPirTests):
         super().setUp()
 
     def test_number_of_days_in_window_value(self):
-        self.assertEqual(job.NumericalValues.number_of_days_in_window, 185)
+        self.assertEqual(job.NumericalValues.number_of_days_in_window, 95)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Description
Since we added a lot more datasets a few months ago that's now meant that we have sufficient data in the filled post pipeline to reduce the window periods from 6 months to 3 months, which is just as stable but is quicker to react to trends in the data

# How to test
[Branch ran ok](https://eu-west-2.console.aws.amazon.com/states/home?region=eu-west-2#/v2/executions/details/arn:aws:states:eu-west-2:344210435447:execution:reduce-window-to-95-Ind-CQC-Filled-Post-Estimates-Pipeline:4d7767f8-a0fe-4df5-8df7-1204559a4e43)

Current branch at the top - not a game changing difference but identifies the covid gap slightly better, which helps the models out too.
![image](https://github.com/user-attachments/assets/9affa65e-905d-4d3d-8297-044bde9215a1)

# Developer checklist
- [X] Unit test
- [X] Linked to [Trello ticket](https://trello.com/c/68Lr4CrZ/796-epic-5-reduce-window-time-period-from-6-months-to-3-months)
- [X] Documentation up to date
