### PR TITLE
[Epic 3] Registered Manager - MVP approach [Must]

### DIFF
--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -10329,50 +10329,62 @@ class EstimateIndCQCFilledPostsByJobRoleUtilsData:
     ]
     # fmt: on
 
+    # For a location with one registered manager:
     count_registered_manager_names_when_location_has_one_registered_manager_rows = [
         ("1-0000000001", date(2025, 1, 1), ["John Doe"])
     ]
     expected_count_registered_manager_names_when_location_has_one_registered_manager_rows = [
+        # 1 because there's at least one name
         ("1-0000000001", date(2025, 1, 1), ["John Doe"], 1)
     ]
 
+    # For a location with two registered managers:
     count_registered_manager_names_when_location_has_two_registered_managers_rows = [
         ("1-0000000001", date(2025, 1, 1), ["John Doe", "Jane Doe"])
     ]
     expected_count_registered_manager_names_when_location_has_two_registered_managers_rows = [
-        ("1-0000000001", date(2025, 1, 1), ["John Doe", "Jane Doe"], 2)
+        # Previously was 2, but now 1 to reflect "at least one manager"
+        ("1-0000000001", date(2025, 1, 1), ["John Doe", "Jane Doe"], 1)
     ]
 
+    # For a location with a null managers field:
     count_registered_manager_names_when_location_has_null_registered_manager_rows = [
         ("1-0000000001", date(2025, 1, 1), None)
     ]
     expected_count_registered_manager_names_when_location_has_null_registered_manager_rows = [
+        # No managers, so 0
         ("1-0000000001", date(2025, 1, 1), None, 0)
     ]
 
+    # For a location with an empty list:
     count_registered_manager_names_when_location_has_empty_list_rows = [
         ("1-0000000001", date(2025, 1, 1), [])
     ]
     expected_count_registered_manager_names_when_location_has_empty_list_rows = [
+        # No managers, so 0
         ("1-0000000001", date(2025, 1, 1), [], 0)
     ]
 
+    # Two locations with different numbers of managers – now both become 1 if the list has at least one name
     count_registered_manager_names_when_two_locations_have_different_number_of_registered_managers_rows = [
         ("1-0000000001", date(2025, 1, 1), ["John Doe"]),
         ("1-0000000002", date(2025, 1, 1), ["John Doe", "Jane Doe"]),
     ]
     expected_count_registered_manager_names_when_two_locations_have_different_number_of_registered_managers_rows = [
         ("1-0000000001", date(2025, 1, 1), ["John Doe"], 1),
-        ("1-0000000002", date(2025, 1, 1), ["John Doe", "Jane Doe"], 2),
+        # For the second location, even though there are two managers, the MVP approach is "1" if at least one
+        ("1-0000000002", date(2025, 1, 1), ["John Doe", "Jane Doe"], 1),
     ]
 
+    # Same location, different import dates, and different # of managers
     count_registered_manager_names_when_a_location_has_different_number_of_registered_managers_at_different_import_dates_rows = [
         ("1-0000000001", date(2025, 1, 1), ["John Doe"]),
         ("1-0000000001", date(2025, 2, 1), ["John Doe", "Jane Doe"]),
     ]
     expected_count_registered_manager_names_when_a_location_has_different_number_of_registered_managers_at_different_import_dates_rows = [
+        # In both cases, there's at least one manager, so it should be 1 for each date
         ("1-0000000001", date(2025, 1, 1), ["John Doe"], 1),
-        ("1-0000000001", date(2025, 2, 1), ["John Doe", "Jane Doe"], 2),
+        ("1-0000000001", date(2025, 2, 1), ["John Doe", "Jane Doe"], 1),
     ]
 
     unpacked_mapped_column_with_one_record_data = [

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -10329,60 +10329,48 @@ class EstimateIndCQCFilledPostsByJobRoleUtilsData:
     ]
     # fmt: on
 
-    # For a location with one registered manager:
     count_registered_manager_names_when_location_has_one_registered_manager_rows = [
         ("1-0000000001", date(2025, 1, 1), ["John Doe"])
     ]
     expected_count_registered_manager_names_when_location_has_one_registered_manager_rows = [
-        # 1 because there's at least one name
         ("1-0000000001", date(2025, 1, 1), ["John Doe"], 1)
     ]
 
-    # For a location with two registered managers:
     count_registered_manager_names_when_location_has_two_registered_managers_rows = [
         ("1-0000000001", date(2025, 1, 1), ["John Doe", "Jane Doe"])
     ]
     expected_count_registered_manager_names_when_location_has_two_registered_managers_rows = [
-        # Previously was 2, but now 1 to reflect "at least one manager"
         ("1-0000000001", date(2025, 1, 1), ["John Doe", "Jane Doe"], 1)
     ]
 
-    # For a location with a null managers field:
     count_registered_manager_names_when_location_has_null_registered_manager_rows = [
         ("1-0000000001", date(2025, 1, 1), None)
     ]
     expected_count_registered_manager_names_when_location_has_null_registered_manager_rows = [
-        # No managers, so 0
         ("1-0000000001", date(2025, 1, 1), None, 0)
     ]
 
-    # For a location with an empty list:
     count_registered_manager_names_when_location_has_empty_list_rows = [
         ("1-0000000001", date(2025, 1, 1), [])
     ]
     expected_count_registered_manager_names_when_location_has_empty_list_rows = [
-        # No managers, so 0
         ("1-0000000001", date(2025, 1, 1), [], 0)
     ]
 
-    # Two locations with different numbers of managers – now both become 1 if the list has at least one name
     count_registered_manager_names_when_two_locations_have_different_number_of_registered_managers_rows = [
         ("1-0000000001", date(2025, 1, 1), ["John Doe"]),
         ("1-0000000002", date(2025, 1, 1), ["John Doe", "Jane Doe"]),
     ]
     expected_count_registered_manager_names_when_two_locations_have_different_number_of_registered_managers_rows = [
         ("1-0000000001", date(2025, 1, 1), ["John Doe"], 1),
-        # For the second location, even though there are two managers, the MVP approach is "1" if at least one
         ("1-0000000002", date(2025, 1, 1), ["John Doe", "Jane Doe"], 1),
     ]
 
-    # Same location, different import dates, and different # of managers
     count_registered_manager_names_when_a_location_has_different_number_of_registered_managers_at_different_import_dates_rows = [
         ("1-0000000001", date(2025, 1, 1), ["John Doe"]),
         ("1-0000000001", date(2025, 2, 1), ["John Doe", "Jane Doe"]),
     ]
     expected_count_registered_manager_names_when_a_location_has_different_number_of_registered_managers_at_different_import_dates_rows = [
-        # In both cases, there's at least one manager, so it should be 1 for each date
         ("1-0000000001", date(2025, 1, 1), ["John Doe"], 1),
         ("1-0000000001", date(2025, 2, 1), ["John Doe", "Jane Doe"], 1),
     ]

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -6549,7 +6549,7 @@ class EstimateIndCQCFilledPostsByJobRoleUtilsSchemas:
             ),
         ]
     )
-    
+
     expected_count_registered_manager_names_schema = StructType(
         [
             *count_registered_manager_names_schema,

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -6549,6 +6549,7 @@ class EstimateIndCQCFilledPostsByJobRoleUtilsSchemas:
             ),
         ]
     )
+    
     expected_count_registered_manager_names_schema = StructType(
         [
             *count_registered_manager_names_schema,

--- a/utils/estimate_filled_posts_by_job_role_utils/utils.py
+++ b/utils/estimate_filled_posts_by_job_role_utils/utils.py
@@ -269,7 +269,7 @@ def count_registered_manager_names(df: DataFrame) -> DataFrame:
     """
     Updates the 'registered_manager_count' column with a binary indicator of whether
     a location has at least one registered manager name in the pre-CQC API data.
-    
+
     This MVP logic sets the count to:
       - 1 if the 'registered_manager_names' array is non-empty (i.e., has >= 1 name).
       - 0 if 'registered_manager_names' is None or an empty list.
@@ -288,9 +288,10 @@ def count_registered_manager_names(df: DataFrame) -> DataFrame:
     df = df.withColumn(
         IndCQC.registered_manager_count,
         F.when(
-            (F.col(IndCQC.registered_manager_names).isNull()) | (F.size(F.col(IndCQC.registered_manager_names)) == 0),
-            F.lit(0)
-        ).otherwise(F.lit(1))
+            (F.col(IndCQC.registered_manager_names).isNull())
+            | (F.size(F.col(IndCQC.registered_manager_names)) == 0),
+            F.lit(0),
+        ).otherwise(F.lit(1)),
     )
     return df
 

--- a/utils/estimate_filled_posts_by_job_role_utils/utils.py
+++ b/utils/estimate_filled_posts_by_job_role_utils/utils.py
@@ -268,7 +268,7 @@ def create_ratios_map_from_count_map_and_total(
 def count_registered_manager_names(df: DataFrame) -> DataFrame:
     """
     Updates the 'registered_manager_count' column with a binary indicator of whether
-    a location has at least one registered manager name in the pre-CQC API data.
+    a location has at least one registered manager name in the 'registered_manager_names' column.
 
     This MVP logic sets the count to:
       - 1 if the 'registered_manager_names' array is non-empty (i.e., has >= 1 name).


### PR DESCRIPTION
# Description

feat: Implement binary MVP logic for Registered Manager count
- Updated `count_registered_manager_names` in `estimate_filled_posts_by_job_role_utils/utils.py` to set `registered_manager_count` to 1 if there’s at least one manager, otherwise 0.
- Revised `test_file_data.py` expected values to reflect the new binary logic.

# Developer checklist

- [x] [Step function](https://eu-west-2.console.aws.amazon.com/states/home?region=eu-west-2#/v2/executions/details/arn:aws:states:eu-west-2:344210435447:execution:epic3-update-count-registered--Ind-CQC-Filled-Post-Estimates-Pipeline:f769cf45-acf3-4b4f-be6e-7196cb596aa0)
- [x] [Athena link](https://eu-west-2.console.aws.amazon.com/athena/home?region=eu-west-2#/query-editor/history/e4da1117-cbed-474a-b2b6-8e5e216d9f58)
- [x] Unit test
- [x] [Trello ticket](https://trello.com/c/fhghtpqB/785-epic-3-registered-manager-mvp-approach-must)
- [x] Documentation up to date