### PR TITLE
Apply dq rules job group perc boundaries

### DIFF
--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -11201,6 +11201,211 @@ class EstimateIndCQCFilledPostsByJobRoleUtilsData:
         ),
     ]
 
+    filter_ascwds_job_role_count_map_when_job_group_ratios_outside_percentile_boundaries_rows = [
+        (
+            "1-001",
+            {
+                JobGroupLabels.direct_care: 1.0,
+                JobGroupLabels.managers: 0.5,
+                JobGroupLabels.regulated_professions: 0.5,
+                JobGroupLabels.other: 0.5,
+            },
+            {
+                MainJobRoleLabels.care_worker: 1,
+            },
+        ),
+        (
+            "1-002",
+            {
+                JobGroupLabels.direct_care: 0.5,
+                JobGroupLabels.managers: 1.0,
+                JobGroupLabels.regulated_professions: 0.5,
+                JobGroupLabels.other: 0.5,
+            },
+            {
+                MainJobRoleLabels.care_worker: 1,
+            },
+        ),
+        (
+            "1-003",
+            {
+                JobGroupLabels.direct_care: 0.5,
+                JobGroupLabels.managers: 0.5,
+                JobGroupLabels.regulated_professions: 1.0,
+                JobGroupLabels.other: 0.5,
+            },
+            {
+                MainJobRoleLabels.care_worker: 1,
+            },
+        ),
+        (
+            "1-004",
+            {
+                JobGroupLabels.direct_care: 0.5,
+                JobGroupLabels.managers: 0.5,
+                JobGroupLabels.regulated_professions: 0.5,
+                JobGroupLabels.other: 1.0,
+            },
+            {
+                MainJobRoleLabels.care_worker: 1,
+            },
+        ),
+        (
+            "1-005",
+            {
+                JobGroupLabels.direct_care: 0.1,
+                JobGroupLabels.managers: 0.5,
+                JobGroupLabels.regulated_professions: 0.5,
+                JobGroupLabels.other: 0.5,
+            },
+            {
+                MainJobRoleLabels.care_worker: 1,
+            },
+        ),
+        (
+            "1-006",
+            {
+                JobGroupLabels.direct_care: 0.5,
+                JobGroupLabels.managers: 0.1,
+                JobGroupLabels.regulated_professions: 0.5,
+                JobGroupLabels.other: 0.5,
+            },
+            {
+                MainJobRoleLabels.care_worker: 1,
+            },
+        ),
+        (
+            "1-007",
+            {
+                JobGroupLabels.direct_care: 0.5,
+                JobGroupLabels.managers: 0.5,
+                JobGroupLabels.regulated_professions: 0.1,
+                JobGroupLabels.other: 0.5,
+            },
+            {
+                MainJobRoleLabels.care_worker: 1,
+            },
+        ),
+        (
+            "1-008",
+            {
+                JobGroupLabels.direct_care: 0.5,
+                JobGroupLabels.managers: 0.5,
+                JobGroupLabels.regulated_professions: 0.1,
+                JobGroupLabels.other: 0.5,
+            },
+            {
+                MainJobRoleLabels.care_worker: 1,
+            },
+        ),
+        (
+            "1-009",
+            {
+                JobGroupLabels.direct_care: 0.2,
+                JobGroupLabels.managers: 0.2,
+                JobGroupLabels.regulated_professions: 0.3,
+                JobGroupLabels.other: 0.3,
+            },
+            {
+                MainJobRoleLabels.care_worker: 1,
+            },
+        ),
+    ]
+    expected_filter_ascwds_job_role_count_map_when_job_group_ratios_outside_percentile_boundaries_rows = [
+        (
+            "1-001",
+            {
+                JobGroupLabels.direct_care: 1.0,
+                JobGroupLabels.managers: 0.5,
+                JobGroupLabels.regulated_professions: 0.5,
+                JobGroupLabels.other: 0.5,
+            },
+            None,
+        ),
+        (
+            "1-002",
+            {
+                JobGroupLabels.direct_care: 0.5,
+                JobGroupLabels.managers: 1.0,
+                JobGroupLabels.regulated_professions: 0.5,
+                JobGroupLabels.other: 0.5,
+            },
+            None,
+        ),
+        (
+            "1-003",
+            {
+                JobGroupLabels.direct_care: 0.5,
+                JobGroupLabels.managers: 0.5,
+                JobGroupLabels.regulated_professions: 1.0,
+                JobGroupLabels.other: 0.5,
+            },
+            None,
+        ),
+        (
+            "1-004",
+            {
+                JobGroupLabels.direct_care: 0.5,
+                JobGroupLabels.managers: 0.5,
+                JobGroupLabels.regulated_professions: 0.5,
+                JobGroupLabels.other: 1.0,
+            },
+            None,
+        ),
+        (
+            "1-005",
+            {
+                JobGroupLabels.direct_care: 0.1,
+                JobGroupLabels.managers: 0.5,
+                JobGroupLabels.regulated_professions: 0.5,
+                JobGroupLabels.other: 0.5,
+            },
+            None,
+        ),
+        (
+            "1-006",
+            {
+                JobGroupLabels.direct_care: 0.5,
+                JobGroupLabels.managers: 0.1,
+                JobGroupLabels.regulated_professions: 0.5,
+                JobGroupLabels.other: 0.5,
+            },
+            None,
+        ),
+        (
+            "1-007",
+            {
+                JobGroupLabels.direct_care: 0.5,
+                JobGroupLabels.managers: 0.5,
+                JobGroupLabels.regulated_professions: 0.1,
+                JobGroupLabels.other: 0.5,
+            },
+            None,
+        ),
+        (
+            "1-008",
+            {
+                JobGroupLabels.direct_care: 0.5,
+                JobGroupLabels.managers: 0.5,
+                JobGroupLabels.regulated_professions: 0.1,
+                JobGroupLabels.other: 0.5,
+            },
+            None,
+        ),
+        (
+            "1-009",
+            {
+                JobGroupLabels.direct_care: 0.2,
+                JobGroupLabels.managers: 0.2,
+                JobGroupLabels.regulated_professions: 0.3,
+                JobGroupLabels.other: 0.3,
+            },
+            {
+                MainJobRoleLabels.care_worker: 1,
+            },
+        ),
+    ]
+
     transform_interpolated_job_role_ratios_to_counts_rows = [
         (
             "1-001",

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -11204,11 +11204,12 @@ class EstimateIndCQCFilledPostsByJobRoleUtilsData:
     filter_ascwds_job_role_count_map_when_job_group_ratios_outside_percentile_boundaries_rows = [
         (
             "1-001",
+            PrimaryServiceType.care_home_with_nursing,
             {
-                JobGroupLabels.direct_care: 1.0,
-                JobGroupLabels.managers: 0.5,
-                JobGroupLabels.regulated_professions: 0.5,
-                JobGroupLabels.other: 0.5,
+                JobGroupLabels.direct_care: 10.0,
+                JobGroupLabels.managers: 0.9,
+                JobGroupLabels.regulated_professions: 0.9,
+                JobGroupLabels.other: 0.9,
             },
             {
                 MainJobRoleLabels.care_worker: 1,
@@ -11216,11 +11217,12 @@ class EstimateIndCQCFilledPostsByJobRoleUtilsData:
         ),
         (
             "1-002",
+            PrimaryServiceType.care_home_with_nursing,
             {
-                JobGroupLabels.direct_care: 0.5,
-                JobGroupLabels.managers: 1.0,
-                JobGroupLabels.regulated_professions: 0.5,
-                JobGroupLabels.other: 0.5,
+                JobGroupLabels.direct_care: 0.9,
+                JobGroupLabels.managers: 10.0,
+                JobGroupLabels.regulated_professions: 0.8,
+                JobGroupLabels.other: 0.8,
             },
             {
                 MainJobRoleLabels.care_worker: 1,
@@ -11228,11 +11230,12 @@ class EstimateIndCQCFilledPostsByJobRoleUtilsData:
         ),
         (
             "1-003",
+            PrimaryServiceType.care_home_with_nursing,
             {
-                JobGroupLabels.direct_care: 0.5,
-                JobGroupLabels.managers: 0.5,
-                JobGroupLabels.regulated_professions: 1.0,
-                JobGroupLabels.other: 0.5,
+                JobGroupLabels.direct_care: 0.8,
+                JobGroupLabels.managers: 0.8,
+                JobGroupLabels.regulated_professions: 10.0,
+                JobGroupLabels.other: 0.7,
             },
             {
                 MainJobRoleLabels.care_worker: 1,
@@ -11240,11 +11243,12 @@ class EstimateIndCQCFilledPostsByJobRoleUtilsData:
         ),
         (
             "1-004",
+            PrimaryServiceType.care_home_with_nursing,
             {
-                JobGroupLabels.direct_care: 0.5,
-                JobGroupLabels.managers: 0.5,
-                JobGroupLabels.regulated_professions: 0.5,
-                JobGroupLabels.other: 1.0,
+                JobGroupLabels.direct_care: 0.7,
+                JobGroupLabels.managers: 0.7,
+                JobGroupLabels.regulated_professions: 0.7,
+                JobGroupLabels.other: 10.0,
             },
             {
                 MainJobRoleLabels.care_worker: 1,
@@ -11252,11 +11256,12 @@ class EstimateIndCQCFilledPostsByJobRoleUtilsData:
         ),
         (
             "1-005",
+            PrimaryServiceType.care_home_with_nursing,
             {
-                JobGroupLabels.direct_care: 0.1,
-                JobGroupLabels.managers: 0.5,
-                JobGroupLabels.regulated_professions: 0.5,
-                JobGroupLabels.other: 0.5,
+                JobGroupLabels.direct_care: 0.0,
+                JobGroupLabels.managers: 0.6,
+                JobGroupLabels.regulated_professions: 0.6,
+                JobGroupLabels.other: 0.6,
             },
             {
                 MainJobRoleLabels.care_worker: 1,
@@ -11264,9 +11269,10 @@ class EstimateIndCQCFilledPostsByJobRoleUtilsData:
         ),
         (
             "1-006",
+            PrimaryServiceType.care_home_with_nursing,
             {
-                JobGroupLabels.direct_care: 0.5,
-                JobGroupLabels.managers: 0.1,
+                JobGroupLabels.direct_care: 0.6,
+                JobGroupLabels.managers: 0.5,
                 JobGroupLabels.regulated_professions: 0.5,
                 JobGroupLabels.other: 0.5,
             },
@@ -11276,11 +11282,12 @@ class EstimateIndCQCFilledPostsByJobRoleUtilsData:
         ),
         (
             "1-007",
+            PrimaryServiceType.care_home_only,
             {
-                JobGroupLabels.direct_care: 0.5,
-                JobGroupLabels.managers: 0.5,
-                JobGroupLabels.regulated_professions: 0.1,
-                JobGroupLabels.other: 0.5,
+                JobGroupLabels.direct_care: 10.0,
+                JobGroupLabels.managers: 0.9,
+                JobGroupLabels.regulated_professions: 0.9,
+                JobGroupLabels.other: 0.9,
             },
             {
                 MainJobRoleLabels.care_worker: 1,
@@ -11288,11 +11295,12 @@ class EstimateIndCQCFilledPostsByJobRoleUtilsData:
         ),
         (
             "1-008",
+            PrimaryServiceType.care_home_only,
             {
-                JobGroupLabels.direct_care: 0.5,
-                JobGroupLabels.managers: 0.5,
-                JobGroupLabels.regulated_professions: 0.1,
-                JobGroupLabels.other: 0.5,
+                JobGroupLabels.direct_care: 0.9,
+                JobGroupLabels.managers: 10.0,
+                JobGroupLabels.regulated_professions: 0.8,
+                JobGroupLabels.other: 0.8,
             },
             {
                 MainJobRoleLabels.care_worker: 1,
@@ -11300,11 +11308,51 @@ class EstimateIndCQCFilledPostsByJobRoleUtilsData:
         ),
         (
             "1-009",
+            PrimaryServiceType.care_home_only,
             {
-                JobGroupLabels.direct_care: 0.2,
-                JobGroupLabels.managers: 0.2,
-                JobGroupLabels.regulated_professions: 0.3,
-                JobGroupLabels.other: 0.3,
+                JobGroupLabels.direct_care: 0.8,
+                JobGroupLabels.managers: 0.8,
+                JobGroupLabels.regulated_professions: 10.0,
+                JobGroupLabels.other: 0.7,
+            },
+            {
+                MainJobRoleLabels.care_worker: 1,
+            },
+        ),
+        (
+            "1-010",
+            PrimaryServiceType.care_home_only,
+            {
+                JobGroupLabels.direct_care: 0.7,
+                JobGroupLabels.managers: 0.7,
+                JobGroupLabels.regulated_professions: 0.7,
+                JobGroupLabels.other: 10.0,
+            },
+            {
+                MainJobRoleLabels.care_worker: 1,
+            },
+        ),
+        (
+            "1-011",
+            PrimaryServiceType.care_home_only,
+            {
+                JobGroupLabels.direct_care: 0.0,
+                JobGroupLabels.managers: 0.6,
+                JobGroupLabels.regulated_professions: 0.6,
+                JobGroupLabels.other: 0.6,
+            },
+            {
+                MainJobRoleLabels.care_worker: 1,
+            },
+        ),
+        (
+            "1-012",
+            PrimaryServiceType.care_home_only,
+            {
+                JobGroupLabels.direct_care: 0.6,
+                JobGroupLabels.managers: 0.5,
+                JobGroupLabels.regulated_professions: 0.5,
+                JobGroupLabels.other: 0.5,
             },
             {
                 MainJobRoleLabels.care_worker: 1,
@@ -11314,91 +11362,135 @@ class EstimateIndCQCFilledPostsByJobRoleUtilsData:
     expected_filter_ascwds_job_role_count_map_when_job_group_ratios_outside_percentile_boundaries_rows = [
         (
             "1-001",
+            PrimaryServiceType.care_home_with_nursing,
             {
-                JobGroupLabels.direct_care: 1.0,
-                JobGroupLabels.managers: 0.5,
-                JobGroupLabels.regulated_professions: 0.5,
-                JobGroupLabels.other: 0.5,
+                JobGroupLabels.direct_care: 10.0,
+                JobGroupLabels.managers: 0.9,
+                JobGroupLabels.regulated_professions: 0.9,
+                JobGroupLabels.other: 0.9,
             },
             None,
         ),
         (
             "1-002",
+            PrimaryServiceType.care_home_with_nursing,
             {
-                JobGroupLabels.direct_care: 0.5,
-                JobGroupLabels.managers: 1.0,
-                JobGroupLabels.regulated_professions: 0.5,
-                JobGroupLabels.other: 0.5,
+                JobGroupLabels.direct_care: 0.9,
+                JobGroupLabels.managers: 10.0,
+                JobGroupLabels.regulated_professions: 0.8,
+                JobGroupLabels.other: 0.8,
             },
             None,
         ),
         (
             "1-003",
+            PrimaryServiceType.care_home_with_nursing,
             {
-                JobGroupLabels.direct_care: 0.5,
-                JobGroupLabels.managers: 0.5,
-                JobGroupLabels.regulated_professions: 1.0,
-                JobGroupLabels.other: 0.5,
+                JobGroupLabels.direct_care: 0.8,
+                JobGroupLabels.managers: 0.8,
+                JobGroupLabels.regulated_professions: 10.0,
+                JobGroupLabels.other: 0.7,
             },
             None,
         ),
         (
             "1-004",
+            PrimaryServiceType.care_home_with_nursing,
             {
-                JobGroupLabels.direct_care: 0.5,
-                JobGroupLabels.managers: 0.5,
-                JobGroupLabels.regulated_professions: 0.5,
-                JobGroupLabels.other: 1.0,
+                JobGroupLabels.direct_care: 0.7,
+                JobGroupLabels.managers: 0.7,
+                JobGroupLabels.regulated_professions: 0.7,
+                JobGroupLabels.other: 10.0,
             },
             None,
         ),
         (
             "1-005",
+            PrimaryServiceType.care_home_with_nursing,
             {
-                JobGroupLabels.direct_care: 0.1,
-                JobGroupLabels.managers: 0.5,
-                JobGroupLabels.regulated_professions: 0.5,
-                JobGroupLabels.other: 0.5,
+                JobGroupLabels.direct_care: 0.0,
+                JobGroupLabels.managers: 0.6,
+                JobGroupLabels.regulated_professions: 0.6,
+                JobGroupLabels.other: 0.6,
             },
             None,
         ),
         (
             "1-006",
+            PrimaryServiceType.care_home_with_nursing,
             {
-                JobGroupLabels.direct_care: 0.5,
-                JobGroupLabels.managers: 0.1,
+                JobGroupLabels.direct_care: 0.6,
+                JobGroupLabels.managers: 0.5,
                 JobGroupLabels.regulated_professions: 0.5,
                 JobGroupLabels.other: 0.5,
             },
-            None,
+            {
+                MainJobRoleLabels.care_worker: 1,
+            },
         ),
         (
             "1-007",
+            PrimaryServiceType.care_home_only,
             {
-                JobGroupLabels.direct_care: 0.5,
-                JobGroupLabels.managers: 0.5,
-                JobGroupLabels.regulated_professions: 0.1,
-                JobGroupLabels.other: 0.5,
+                JobGroupLabels.direct_care: 10.0,
+                JobGroupLabels.managers: 0.9,
+                JobGroupLabels.regulated_professions: 0.9,
+                JobGroupLabels.other: 0.9,
             },
             None,
         ),
         (
             "1-008",
+            PrimaryServiceType.care_home_only,
             {
-                JobGroupLabels.direct_care: 0.5,
-                JobGroupLabels.managers: 0.5,
-                JobGroupLabels.regulated_professions: 0.1,
-                JobGroupLabels.other: 0.5,
+                JobGroupLabels.direct_care: 0.9,
+                JobGroupLabels.managers: 10.0,
+                JobGroupLabels.regulated_professions: 0.8,
+                JobGroupLabels.other: 0.8,
             },
             None,
         ),
         (
             "1-009",
+            PrimaryServiceType.care_home_only,
             {
-                JobGroupLabels.direct_care: 0.2,
-                JobGroupLabels.managers: 0.2,
-                JobGroupLabels.regulated_professions: 0.3,
-                JobGroupLabels.other: 0.3,
+                JobGroupLabels.direct_care: 0.8,
+                JobGroupLabels.managers: 0.8,
+                JobGroupLabels.regulated_professions: 10.0,
+                JobGroupLabels.other: 0.7,
+            },
+            None,
+        ),
+        (
+            "1-010",
+            PrimaryServiceType.care_home_only,
+            {
+                JobGroupLabels.direct_care: 0.7,
+                JobGroupLabels.managers: 0.7,
+                JobGroupLabels.regulated_professions: 0.7,
+                JobGroupLabels.other: 10.0,
+            },
+            None,
+        ),
+        (
+            "1-011",
+            PrimaryServiceType.care_home_only,
+            {
+                JobGroupLabels.direct_care: 0.0,
+                JobGroupLabels.managers: 0.6,
+                JobGroupLabels.regulated_professions: 0.6,
+                JobGroupLabels.other: 0.6,
+            },
+            None,
+        ),
+        (
+            "1-012",
+            PrimaryServiceType.care_home_only,
+            {
+                JobGroupLabels.direct_care: 0.6,
+                JobGroupLabels.managers: 0.5,
+                JobGroupLabels.regulated_professions: 0.5,
+                JobGroupLabels.other: 0.5,
             },
             {
                 MainJobRoleLabels.care_worker: 1,

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -6764,6 +6764,22 @@ class EstimateIndCQCFilledPostsByJobRoleUtilsSchemas:
         )
     )
 
+    filter_ascwds_job_role_count_map_when_job_group_ratios_outside_percentile_boundaries_schema = StructType(
+        [
+            StructField(IndCQC.location_id, StringType(), False),
+            StructField(
+                IndCQC.ascwds_job_group_ratios,
+                MapType(StringType(), FloatType()),
+                True,
+            ),
+            StructField(
+                IndCQC.ascwds_job_role_counts_filtered,
+                MapType(StringType(), IntegerType()),
+                True,
+            ),
+        ]
+    )
+
     transform_interpolated_job_role_ratios_to_counts_schema = StructType(
         [
             StructField(IndCQC.location_id, StringType(), True),

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -6767,6 +6767,7 @@ class EstimateIndCQCFilledPostsByJobRoleUtilsSchemas:
     filter_ascwds_job_role_count_map_when_job_group_ratios_outside_percentile_boundaries_schema = StructType(
         [
             StructField(IndCQC.location_id, StringType(), False),
+            StructField(IndCQC.primary_service_type, StringType(), True),
             StructField(
                 IndCQC.ascwds_job_group_ratios,
                 MapType(StringType(), FloatType()),

--- a/tests/unit/test_estimate_ind_cqc_filled_posts_by_job_role_utils.py
+++ b/tests/unit/test_estimate_ind_cqc_filled_posts_by_job_role_utils.py
@@ -1232,11 +1232,8 @@ class ApplyQualityFiltersToAscwdsJobRoleData(
         filter_ascwds_job_role_map_when_direct_care_or_managers_plus_regulated_professions_greater_or_equal_to_one_mock: Mock,
         filter_ascwds_job_role_count_map_when_job_group_ratios_outside_percentile_boundaries_mock: Mock,
     ):
-        returned_df = job.filter_ascwds_job_role_map_when_direct_care_or_managers_plus_regulated_professions_greater_or_equal_to_one(
+        job.apply_quality_filters_to_ascwds_job_role_data(
             self.test_df,
-        )
-        job.filter_ascwds_job_role_count_map_when_job_group_ratios_outside_percentile_boundaries(
-            returned_df
         )
 
         filter_ascwds_job_role_map_when_direct_care_or_managers_plus_regulated_professions_greater_or_equal_to_one_mock.assert_called_once()
@@ -1299,7 +1296,7 @@ class FilterAscwdsJobRoleCountMapWhenJobGroupRatiosOutsidePercentileBoundaries(
             Schemas.filter_ascwds_job_role_count_map_when_job_group_ratios_outside_percentile_boundaries_schema,
         )
         self.returned_df = job.filter_ascwds_job_role_count_map_when_job_group_ratios_outside_percentile_boundaries(
-            self.test_df, 0.001, 0.999
+            self.test_df, lower_percentile_limit=0.001, upper_percentile_limit=0.999
         )
 
     def test_filter_ascwds_job_role_count_map_when_job_group_ratios_outside_percentile_boundaries_does_not_change_row_count(

--- a/tests/unit/test_estimate_ind_cqc_filled_posts_by_job_role_utils.py
+++ b/tests/unit/test_estimate_ind_cqc_filled_posts_by_job_role_utils.py
@@ -1275,6 +1275,42 @@ class FilterAscwdsByJobRoleBreakdownWhenDirectCareOrManagersPlusRegulatedProfess
         self.assertEqual(expected_data, returned_data)
 
 
+class FilterAscwdsJobRoleCountMapWhenJobGroupRatiosOutsidePercentileBoundaries(
+    EstimateIndCQCFilledPostsByJobRoleUtilsTests
+):
+    def setUp(self) -> None:
+        super().setUp()
+
+        self.test_df = self.spark.createDataFrame(
+            Data.filter_ascwds_job_role_count_map_when_job_group_ratios_outside_percentile_boundaries_rows,
+            Schemas.filter_ascwds_job_role_count_map_when_job_group_ratios_outside_percentile_boundaries_schema,
+        )
+        self.expected_df = self.spark.createDataFrame(
+            Data.expected_filter_ascwds_job_role_count_map_when_job_group_ratios_outside_percentile_boundaries_rows,
+            Schemas.filter_ascwds_job_role_count_map_when_job_group_ratios_outside_percentile_boundaries_schema,
+        )
+        self.returned_df = job.filter_ascwds_job_role_count_map_when_job_group_ratios_outside_percentile_boundaries(
+            self.test_df
+        )
+
+    def test_filter_ascwds_job_role_count_map_when_job_group_ratios_outside_percentile_boundaries_does_not_change_row_count(
+        self,
+    ):
+        self.assertEqual(self.expected_df.count(), self.returned_data.count())
+
+    def test_filter_ascwds_job_role_count_map_when_job_group_ratios_outside_percentile_boundaries_does_not_change_columns(
+        self,
+    ):
+        self.assertEqual(self.expected_df.columns, self.returned_data.columns)
+
+    def test_filter_ascwds_job_role_count_map_when_job_group_ratios_outside_percentile_boundaries_returns_expected_data(
+        self,
+    ):
+        expected_data = self.expected_df.collect()
+        returned_data = self.returned_df.collect()
+        self.assertEqual(expected_data, returned_data)
+
+
 class TransformInterpolatedJobRoleRatiosToCounts(
     EstimateIndCQCFilledPostsByJobRoleUtilsTests
 ):

--- a/tests/unit/test_estimate_ind_cqc_filled_posts_by_job_role_utils.py
+++ b/tests/unit/test_estimate_ind_cqc_filled_posts_by_job_role_utils.py
@@ -1224,14 +1224,23 @@ class ApplyQualityFiltersToAscwdsJobRoleData(
     @patch(
         f"{PATCH_PATH}.filter_ascwds_job_role_map_when_direct_care_or_managers_plus_regulated_professions_greater_or_equal_to_one"
     )
+    @patch(
+        f"{PATCH_PATH}.filter_ascwds_job_role_count_map_when_job_group_ratios_outside_percentile_boundaries"
+    )
     def test_apply_quality_filters_to_ascwds_job_role_data_calls_premade_functionality(
         self,
         filter_ascwds_job_role_map_when_direct_care_or_managers_plus_regulated_professions_greater_or_equal_to_one_mock: Mock,
+        filter_ascwds_job_role_count_map_when_job_group_ratios_outside_percentile_boundaries_mock: Mock,
     ):
-        job.filter_ascwds_job_role_map_when_direct_care_or_managers_plus_regulated_professions_greater_or_equal_to_one(
+        returned_df = job.filter_ascwds_job_role_map_when_direct_care_or_managers_plus_regulated_professions_greater_or_equal_to_one(
             self.test_df,
         )
+        job.filter_ascwds_job_role_count_map_when_job_group_ratios_outside_percentile_boundaries(
+            returned_df
+        )
+
         filter_ascwds_job_role_map_when_direct_care_or_managers_plus_regulated_professions_greater_or_equal_to_one_mock.assert_called_once()
+        filter_ascwds_job_role_count_map_when_job_group_ratios_outside_percentile_boundaries_mock.assert_called_once()
 
 
 class FilterAscwdsByJobRoleBreakdownWhenDirectCareOrManagersPlusRegulatedProfessionsGreaterOrEqualToOne(

--- a/tests/unit/test_estimate_ind_cqc_filled_posts_by_job_role_utils.py
+++ b/tests/unit/test_estimate_ind_cqc_filled_posts_by_job_role_utils.py
@@ -1299,7 +1299,7 @@ class FilterAscwdsJobRoleCountMapWhenJobGroupRatiosOutsidePercentileBoundaries(
             Schemas.filter_ascwds_job_role_count_map_when_job_group_ratios_outside_percentile_boundaries_schema,
         )
         self.returned_df = job.filter_ascwds_job_role_count_map_when_job_group_ratios_outside_percentile_boundaries(
-            self.test_df
+            self.test_df, 0.001, 0.999
         )
 
     def test_filter_ascwds_job_role_count_map_when_job_group_ratios_outside_percentile_boundaries_does_not_change_row_count(

--- a/tests/unit/test_estimate_ind_cqc_filled_posts_by_job_role_utils.py
+++ b/tests/unit/test_estimate_ind_cqc_filled_posts_by_job_role_utils.py
@@ -1296,18 +1296,19 @@ class FilterAscwdsJobRoleCountMapWhenJobGroupRatiosOutsidePercentileBoundaries(
     def test_filter_ascwds_job_role_count_map_when_job_group_ratios_outside_percentile_boundaries_does_not_change_row_count(
         self,
     ):
-        self.assertEqual(self.expected_df.count(), self.returned_data.count())
+        self.assertEqual(self.expected_df.count(), self.returned_df.count())
 
     def test_filter_ascwds_job_role_count_map_when_job_group_ratios_outside_percentile_boundaries_does_not_change_columns(
         self,
     ):
-        self.assertEqual(self.expected_df.columns, self.returned_data.columns)
+        self.assertEqual(self.expected_df.columns, self.returned_df.columns)
 
     def test_filter_ascwds_job_role_count_map_when_job_group_ratios_outside_percentile_boundaries_returns_expected_data(
         self,
     ):
-        expected_data = self.expected_df.collect()
-        returned_data = self.returned_df.collect()
+        expected_data = self.expected_df.sort(IndCQC.location_id).collect()
+        returned_data = self.returned_df.sort(IndCQC.location_id).collect()
+
         self.assertEqual(expected_data, returned_data)
 
 

--- a/utils/estimate_filled_posts_by_job_role_utils/utils.py
+++ b/utils/estimate_filled_posts_by_job_role_utils/utils.py
@@ -662,6 +662,29 @@ def filter_ascwds_job_role_map_when_direct_care_or_managers_plus_regulated_profe
     return df
 
 
+def filter_ascwds_job_role_count_map_when_job_group_ratios_outside_percentile_boundaries(
+    df: DataFrame,
+) -> DataFrame:
+    """
+    Sets ascwds_job_role_counts_filtered to null when job group ratios outside of boundaries.
+
+    The boundaires are:
+        direct_care ratio value >= 0.001 percentile and <= 0.999 percentile
+        managers ratio value <= 0.999 percentile
+        regulated_professions ratio value <= 0.999 percentile
+        other ratio value <= 0.999 percentile
+
+
+    Args:
+        df (DataFrame): A dataframe with a job role count map column and job group ratio map column.
+
+    Returns:
+        DataFrame: A dataframe with an additional column of filtered job role counts.
+    """
+
+    return df
+
+
 def transform_interpolated_job_role_ratios_to_counts(
     df: DataFrame,
 ) -> DataFrame:

--- a/utils/estimate_filled_posts_by_job_role_utils/utils.py
+++ b/utils/estimate_filled_posts_by_job_role_utils/utils.py
@@ -624,8 +624,8 @@ def apply_quality_filters_to_ascwds_job_role_data(
 
     df = filter_ascwds_job_role_count_map_when_job_group_ratios_outside_percentile_boundaries(
         df,
-        0.001,
-        0.999,
+        lower_percentile_limit=0.001,
+        upper_percentile_limit=0.999,
     )
 
     return df

--- a/utils/estimate_filled_posts_by_job_role_utils/utils.py
+++ b/utils/estimate_filled_posts_by_job_role_utils/utils.py
@@ -680,7 +680,7 @@ def filter_ascwds_job_role_count_map_when_job_group_ratios_outside_percentile_bo
     """
     Sets ascwds_job_role_counts_filtered to null when job group ratios outside of boundaries.
 
-    The boundaires are:
+    The boundaries are:
         direct_care ratio value >= 0.001 percentile and <= 0.999 percentile
         managers ratio value <= 0.999 percentile
         regulated_professions ratio value <= 0.999 percentile

--- a/utils/estimate_filled_posts_by_job_role_utils/utils.py
+++ b/utils/estimate_filled_posts_by_job_role_utils/utils.py
@@ -620,6 +620,10 @@ def apply_quality_filters_to_ascwds_job_role_data(
         df
     )
 
+    df = filter_ascwds_job_role_count_map_when_job_group_ratios_outside_percentile_boundaries(
+        df
+    )
+
     return df
 
 

--- a/utils/estimate_filled_posts_by_job_role_utils/utils.py
+++ b/utils/estimate_filled_posts_by_job_role_utils/utils.py
@@ -728,31 +728,29 @@ def filter_ascwds_job_role_count_map_when_job_group_ratios_outside_percentile_bo
 
     df = df.join(df_exploded, on=IndCQC.primary_service_type, how="left")
 
+    job_group_ratios_column = F.col(IndCQC.ascwds_job_group_ratios)
+    percentile_boundary_column = F.col(percentile_boundaries)
+    direct_care_ratio = job_group_ratios_column[JobGroupLabels.direct_care]
+    direct_care_lower_limit = percentile_boundary_column[JobGroupLabels.direct_care][0]
+    direct_care_upper_limit = percentile_boundary_column[JobGroupLabels.direct_care][1]
+    managers_ratio = job_group_ratios_column[JobGroupLabels.managers]
+    managers_upper_limit = percentile_boundary_column[JobGroupLabels.managers][1]
+    regulated_professions_ratio = job_group_ratios_column[
+        JobGroupLabels.regulated_professions
+    ]
+    regulated_professions_upper_limit = percentile_boundary_column[
+        JobGroupLabels.regulated_professions
+    ][1]
+    other_ratio = job_group_ratios_column[JobGroupLabels.other]
+    other_upper_limit = percentile_boundary_column[JobGroupLabels.other][1]
     df = df.withColumn(
         IndCQC.ascwds_job_role_counts_filtered,
         F.when(
-            (
-                F.col(IndCQC.ascwds_job_group_ratios)[JobGroupLabels.direct_care]
-                > F.col(percentile_boundaries)[JobGroupLabels.direct_care][0]
-            )
-            & (
-                F.col(IndCQC.ascwds_job_group_ratios)[JobGroupLabels.direct_care]
-                < F.col(percentile_boundaries)[JobGroupLabels.direct_care][1]
-            )
-            & (
-                F.col(IndCQC.ascwds_job_group_ratios)[JobGroupLabels.managers]
-                < F.col(percentile_boundaries)[JobGroupLabels.managers][1]
-            )
-            & (
-                F.col(IndCQC.ascwds_job_group_ratios)[
-                    JobGroupLabels.regulated_professions
-                ]
-                < F.col(percentile_boundaries)[JobGroupLabels.regulated_professions][1]
-            )
-            & (
-                F.col(IndCQC.ascwds_job_group_ratios)[JobGroupLabels.other]
-                < F.col(percentile_boundaries)[JobGroupLabels.other][1]
-            ),
+            (direct_care_ratio > direct_care_lower_limit)
+            & (direct_care_ratio < direct_care_upper_limit)
+            & (managers_ratio < managers_upper_limit)
+            & (regulated_professions_ratio < regulated_professions_upper_limit)
+            & (other_ratio < other_upper_limit),
             F.col(IndCQC.ascwds_job_role_counts_filtered),
         ).otherwise(None),
     )

--- a/utils/scale_variable_limits.py
+++ b/utils/scale_variable_limits.py
@@ -10,9 +10,3 @@ class GeneralLimits:
 class AscwdsScaleVariableLimits(GeneralLimits):
     total_staff_lower_limit = GeneralLimits.non_zero_lower_bound
     worker_records_lower_limit = GeneralLimits.non_zero_lower_bound
-
-
-@dataclass
-class AscwdsWorkerJobGroupRatioPercentileLimits:
-    lower_percentile_limit: float = 0.001
-    upper_percentile_limit: float = 0.999

--- a/utils/scale_variable_limits.py
+++ b/utils/scale_variable_limits.py
@@ -10,3 +10,9 @@ class GeneralLimits:
 class AscwdsScaleVariableLimits(GeneralLimits):
     total_staff_lower_limit = GeneralLimits.non_zero_lower_bound
     worker_records_lower_limit = GeneralLimits.non_zero_lower_bound
+
+
+@dataclass
+class AscwdsWorkerJobGroupRatioPercentileLimits:
+    lower_percentile_limit: float = 0.001
+    upper_percentile_limit: float = 0.999


### PR DESCRIPTION
# Description
I've added a utils function that:
- gets the job group ratio value at the 0.001 and 0.999 percentiles, by primary service type, as list of two elements.
- pivots those lists into four columns, one for each job group, then packages those columns into a dict, like this:
  {direct_care: [0.1, 0.9], managers: [0.2, 0.7]....}
- Joins those lists into the original job role dataframe by primary service.
- Removes values from ascwds_job_role_counts_filtered when job group ratios are outside of boundaries
  The boundaries live in utils > scale_variable_limits script (where other limit stuff is)

In the test data, there are six locations per service type (12 total but values are the same in each 6). 
The first 5 breaks the limits and the 6th is kept.
The first 4 are upper limit breaks, the 5th is lower direct care limit breaking.

# How to test
Unit tests pass.
[Branch is running](https://eu-west-2.console.aws.amazon.com/states/home?region=eu-west-2#/v2/executions/details/arn:aws:states:eu-west-2:344210435447:execution:apply-dq-rules-job-group-perc--Ind-CQC-Filled-Post-Estimates-Pipeline:2dde989c-12ab-417f-8763-5fefb8f79cdb)

# Developer checklist
- [x] Unit test
- [x] Linked to Trello ticket
- [x] Documentation up to date
