### PR TITLE
Functions required for automatic model retraining 

### DIFF
--- a/tests/unit/test_estimate_ind_cqc_filled_posts_models_utils.py
+++ b/tests/unit/test_estimate_ind_cqc_filled_posts_models_utils.py
@@ -397,18 +397,15 @@ class SaveModelToS3Tests(EstimateFilledPostsModelsUtilsTests):
         super().setUp()
 
     @patch(f"{PATCH_PATH}.get_model_s3_path")
-    @patch(f"{PATCH_PATH}.LinearRegressionModel")
-    def test_save_model_to_s3(
-        self, LinearRegressionModel_mock: Mock, get_model_s3_path_mock: Mock
-    ):
+    def test_save_model_to_s3_v2(self, get_model_s3_path_mock: Mock):
         mock_model = MagicMock()
-        get_model_s3_path_mock.return_value = f"{self.model_source}run=4/"
-
-        returned_path = job.save_model_to_s3(mock_model, self.model_source)
         expected_path = f"{self.model_source}run=4/"
+        get_model_s3_path_mock.return_value = expected_path
+
+        job.save_model_to_s3(mock_model, self.model_source)
 
         mock_model.save.assert_called_once_with(expected_path)
-        self.assertEqual(returned_path, expected_path)
+        get_model_s3_path_mock.assert_called_once_with(self.model_source, mode="save")
 
 
 class LoadLatestModelTests(EstimateFilledPostsModelsUtilsTests):

--- a/utils/estimate_filled_posts/models/utils.py
+++ b/utils/estimate_filled_posts/models/utils.py
@@ -238,20 +238,17 @@ def get_model_s3_path(model_source: str, mode: str = "load") -> str:
         raise ValueError("mode must be 'load' or 'save'")
 
 
-def save_model_to_s3(model: LinearRegressionModel, model_source: str) -> str:
+def save_model_to_s3(model: LinearRegressionModel, model_source: str) -> None:
     """
     Save model to the next available versioned S3 run path.
 
     Args:
         model (LinearRegressionModel): The trained linear regression model.
         model_source (str): Base S3 path (eg. 's3://pipeline-resources/models/prediction/1.0.0/').
-
-    Returns:
-        str: S3 path where the model was saved.
     """
     s3_path = get_model_s3_path(model_source, mode="save")
     model.save(s3_path)
-    return s3_path
+    print(f"Model saved to: {s3_path}")
 
 
 def load_latest_model_from_s3(model_source: str) -> LinearRegressionModel:

--- a/utils/estimate_filled_posts/models/utils.py
+++ b/utils/estimate_filled_posts/models/utils.py
@@ -185,7 +185,8 @@ def get_next_run_number(model_source: str) -> int:
         int: Next available run number.
     """
     existing_runs = get_existing_run_numbers(model_source)
-    return max(existing_runs) + 1 if existing_runs else 1
+    next_run_number = max(existing_runs) + 1 if existing_runs else 1
+    return next_run_number
 
 
 def get_latest_run_number(model_source: str) -> Optional[int]:
@@ -199,7 +200,8 @@ def get_latest_run_number(model_source: str) -> Optional[int]:
         Optional[int]: Latest run number if found, else None.
     """
     existing_runs = get_existing_run_numbers(model_source)
-    return max(existing_runs) if existing_runs else None
+    latest_run_number = max(existing_runs) if existing_runs else None
+    return latest_run_number
 
 
 def train_lasso_regression_model(
@@ -262,5 +264,7 @@ def load_latest_model(model_source: str) -> LinearRegressionModel:
     latest_run = get_latest_run_number(model_source)
     if latest_run is None:
         raise FileNotFoundError("No model found at the specified s3 source.")
-    model_path = f"{model_source}run_{latest_run}/"
-    return LinearRegressionModel.load(model_path)
+
+    model_path = f"{model_source}run={latest_run}/"
+    trained_model = LinearRegressionModel.load(model_path)
+    return trained_model

--- a/utils/estimate_filled_posts/models/utils.py
+++ b/utils/estimate_filled_posts/models/utils.py
@@ -152,6 +152,39 @@ def convert_care_home_ratios_to_filled_posts_and_merge_with_filled_post_values(
     return df
 
 
+def train_lasso_regression_model(
+    df: DataFrame, label_col: str
+) -> LinearRegressionModel:
+    """
+    Train a linear regression model on the given DataFrame.
+
+    elasticNetParam=1 means that the model will use only L1 regularization (Lasso).
+    Lasso regression is an algorithm that helps to identify the most important features in a
+    dataset, allowing for more effective model building.
+
+    The regulisation parameter (regParam) controls the strength of the regularisation.
+    We set this to a low value (0.001) to allow the model to have a higher degree of freedom
+    to capture more complex relationships in the data.
+
+    Args:
+        df (DataFrame): Training data.
+        label_col (str): Name of the label column.
+
+    Returns:
+        LinearRegressionModel: Trained model.
+    """
+    lasso_regression: int = 1
+    regulisation_parameter: float = 0.001
+
+    lr = LinearRegression(
+        featuresCol=IndCqc.features,
+        labelCol=label_col,
+        elasticNetParam=lasso_regression,
+        regParam=regulisation_parameter,
+    )
+    return lr.fit(df)
+
+
 def get_existing_run_numbers(model_source: str) -> List[int]:
     """
     List existing model run numbers in the specified S3 location.
@@ -233,36 +266,3 @@ def load_latest_model_from_s3(model_source: str) -> LinearRegressionModel:
     """
     s3_path = get_model_s3_path(model_source, mode="load")
     return LinearRegressionModel.load(s3_path)
-
-
-def train_lasso_regression_model(
-    df: DataFrame, label_col: str
-) -> LinearRegressionModel:
-    """
-    Train a linear regression model on the given DataFrame.
-
-    elasticNetParam=1 means that the model will use only L1 regularization (Lasso).
-    Lasso regression is an algorithm that helps to identify the most important features in a
-    dataset, allowing for more effective model building.
-
-    The regulisation parameter (regParam) controls the strength of the regularisation.
-    We set this to a low value (0.001) to allow the model to have a higher degree of freedom
-    to capture more complex relationships in the data.
-
-    Args:
-        df (DataFrame): Training data.
-        label_col (str): Name of the label column.
-
-    Returns:
-        LinearRegressionModel: Trained model.
-    """
-    lasso_regression: int = 1
-    regulisation_parameter: float = 0.001
-
-    lr = LinearRegression(
-        featuresCol=IndCqc.features,
-        labelCol=label_col,
-        elasticNetParam=lasso_regression,
-        regParam=regulisation_parameter,
-    )
-    return lr.fit(df)

--- a/utils/estimate_filled_posts/models/utils.py
+++ b/utils/estimate_filled_posts/models/utils.py
@@ -1,7 +1,13 @@
+import boto3
+import re
+
+from typing import Optional, List
 from pyspark.sql import DataFrame, functions as F
+from pyspark.ml.regression import LinearRegression, LinearRegressionModel
 
 from utils.column_names.ind_cqc_pipeline_columns import IndCqcColumns as IndCqc
 from utils.column_values.categorical_column_values import CareHome, PrimaryServiceType
+from utils import utils
 
 
 def insert_predictions_into_pipeline(
@@ -144,3 +150,117 @@ def convert_care_home_ratios_to_filled_posts_and_merge_with_filled_post_values(
         ).otherwise(F.col(posts_column)),
     )
     return df
+
+
+def get_existing_run_numbers(model_source: str) -> List[int]:
+    """
+    List existing model run numbers in the specified S3 location.
+
+    Args:
+        model_source (str): S3 path to models (e.g. 's3://pipeline-resources/models/prediction/1.0.0/').
+
+    Returns:
+        List[int]: Sorted list of detected run numbers.
+    """
+    bucket, prefix = utils.split_s3_uri(model_source)
+
+    s3 = boto3.client("s3")
+    existing = s3.list_objects_v2(Bucket=bucket, Prefix=prefix).get("Contents", [])
+    run_numbers = []
+    for obj in existing:
+        match = re.search(r"run=(\d+)/$", obj["Key"])
+        if match:
+            run_numbers.append(int(match.group(1)))
+    return sorted(set(run_numbers))
+
+
+def get_next_run_number(model_source: str) -> int:
+    """
+    Get the next model run number for a given versioned prefix.
+
+    Args:
+        model_source (str): S3 path to models (e.g. 's3://pipeline-resources/models/prediction/1.0.0/').
+
+    Returns:
+        int: Next available run number.
+    """
+    existing_runs = get_existing_run_numbers(model_source)
+    return max(existing_runs) + 1 if existing_runs else 1
+
+
+def get_latest_run_number(model_source: str) -> Optional[int]:
+    """
+    Get the latest run number for a given model version.
+
+    Args:
+        model_source (str): S3 path to models (e.g. 's3://pipeline-resources/models/prediction/1.0.0/').
+
+    Returns:
+        Optional[int]: Latest run number if found, else None.
+    """
+    existing_runs = get_existing_run_numbers(model_source)
+    return max(existing_runs) if existing_runs else None
+
+
+def train_lasso_regression_model(
+    df: DataFrame, label_col: str
+) -> LinearRegressionModel:
+    """
+    Train a linear regression model on the given DataFrame.
+
+    elasticNetParam=1 means that the model will use only L1 regularization (Lasso).
+    Lasso regression is an algorithm that helps to identify the most important features in a
+    dataset, allowing for more effective model building.
+
+    The regulisation parameter (regParam) controls the strength of the regularisation.
+    We set this to a low value (0.001) to allow the model to have a higher degree of freedom
+    to capture more complex relationships in the data.
+
+    Args:
+        df (DataFrame): Training data.
+        label_col (str): Name of the label column.
+
+    Returns:
+        LinearRegressionModel: Trained model.
+    """
+    lasso_regression: int = 1
+    regulisation_parameter: float = 0.001
+
+    lr = LinearRegression(
+        featuresCol=IndCqc.features,
+        labelCol=label_col,
+        elasticNetParam=lasso_regression,
+        regParam=regulisation_parameter,
+    )
+    return lr.fit(df)
+
+
+def save_model_to_s3(model: LinearRegressionModel, s3_destination: str) -> None:
+    """
+    Save a trained LinearRegressionModel to S3.
+
+    Args:
+        model (LinearRegressionModel): The trained model.
+        s3_destination (str): Full S3 path where model should be saved.
+    """
+    model.save(s3_destination)
+
+
+def load_latest_model(model_source: str) -> LinearRegressionModel:
+    """
+    Load the latest LinearRegressionModel from S3.
+
+    Args:
+        model_source (str): S3 path to models (e.g. 's3://pipeline-resources/models/prediction/1.0.0/').
+
+    Returns:
+        LinearRegressionModel: Loaded model.
+
+    Raises:
+        FileNotFoundError: If no model is found at the specified s3 source.
+    """
+    latest_run = get_latest_run_number(model_source)
+    if latest_run is None:
+        raise FileNotFoundError("No model found at the specified s3 source.")
+    model_path = f"{model_source}run_{latest_run}/"
+    return LinearRegressionModel.load(model_path)


### PR DESCRIPTION
# Description
There are 5 functions (and tests) in this PR which will be required for the automated model process, these can be grouped into two categories

## Run numbers
As this process will be automatic, I want to save every model it makes so I'm going to give it a run number. So the first step every time the pipeline is run will be to
- get all the model run numbers already saved - `get_existing_run_numbers`
- get_model_s3_path
     - when **saving** a new model, we want the filepath to have a run number which is one higher than the max existing model number. If one has never been saved before then set run=1
     - when **loading** a model, we want the the filepath to include the maximum run number (to get the one saved above) . If it can't find one it raises an error

## Modelling process
The modelling process can be split into 3 parts, with the first two currently happening manually in EMR scripts
- train the model
- save the model (with the latest run number from `get_model_s3_path`)
- load the model (with the latest run number from `get_model_s3_path`)

# How to test
Not incorporated into the pipeline yet so mostly relying on tests passing

# Developer checklist
- [X] Unit test
- [X] Linked to Trello ticket
- [X] Documentation up to date
