### PR TITLE
Fix ingest capacity tracker job

### DIFF
--- a/jobs/diagnostics_on_capacity_tracker.py
+++ b/jobs/diagnostics_on_capacity_tracker.py
@@ -35,6 +35,7 @@ estimate_filled_posts_columns: list = [
     IndCQC.imputed_filled_post_model,
     IndCQC.non_res_with_dormancy_model,
     IndCQC.non_res_without_dormancy_model,
+    IndCQC.non_res_combined_model,
     IndCQC.non_res_pir_linear_regression_model,
     IndCQC.imputed_posts_care_home_model,
     IndCQC.imputed_posts_non_res_combined_model,


### PR DESCRIPTION
# Description
I think the ingest capacity tracker step function failed because it's trying to find the new column "non_res_combined_model" in the estimates dataset, but the ingestion job doesn't read that column, so I've added it to the list of columns to import.

[Here's the failed run in main](https://eu-west-2.console.aws.amazon.com/states/home?region=eu-west-2#/v2/executions/details/arn:aws:states:eu-west-2:344210435447:execution:main-IngestAndCleanCapacityTrackerDataPipeline:9bf03fde-6de0-409d-93f9-29a92427291f)

[Here's my run in branch (job succeeded after re-run)](https://eu-west-2.console.aws.amazon.com/states/home?region=eu-west-2#/v2/executions/details/arn:aws:states:eu-west-2:344210435447:execution:fix-diagnostics-on-ct-job-IngestAndCleanCapacityTrackerDataPipeline:ae571bb9-2098-4fb1-b73b-3915cb76efbf)

# How to test
No new unit tests.
Linked successful run in description.

# Developer checklist
- [ ] Unit test
- [ ] Linked to Trello ticket
- [ ] Documentation up to date
