### PR TITLE
amend CircleCI to find all tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,7 @@ jobs:
       - run:
           name: run unit tests
           command: |
-            pipenv run python -m unittest discover tests/unit
+            pipenv run python -m unittest discover -s . -p "test_*.py"
 
       - run:
           name: run integration tests

--- a/projects/_01_ingest/ascwds/tests/test_clean_ascwds_workplace_data.py
+++ b/projects/_01_ingest/ascwds/tests/test_clean_ascwds_workplace_data.py
@@ -47,8 +47,8 @@ class MainTests(CleanASCWDSWorkplaceDatasetTests):
         super().setUp()
 
     @patch(f"{PATCH_PATH}.select_columns_required_for_reconciliation_df")
-    @patch(f"{PATCH_PATH}.utils.cleaning_utils.set_column_bounds")
-    @patch(f"{PATCH_PATH}.utils.cleaning_utils.apply_categorical_labels")
+    @patch(f"{PATCH_PATH}.cUtils.set_column_bounds")
+    @patch(f"{PATCH_PATH}.cUtils.apply_categorical_labels")
     @patch(f"{PATCH_PATH}.utils.format_date_fields", wraps=utils.format_date_fields)
     @patch(f"{PATCH_PATH}.utils.write_to_parquet")
     @patch(f"{PATCH_PATH}.utils.read_from_parquet")

--- a/projects/_03_independent_cqc/_05_model/tests/jobs/test_train_linear_regression_model.py
+++ b/projects/_03_independent_cqc/_05_model/tests/jobs/test_train_linear_regression_model.py
@@ -102,7 +102,7 @@ class Main(unittest.TestCase):
         create_test_and_train_datasets_mock.return_value = (self.test_df, self.test_df)
         save_model_to_s3_mock.return_value = self.model_run_number
 
-        job.train_linear_regression_model(
+        job.main(
             self.branch_name,
             self.non_res_model_name,
             self.model_version,


### PR DESCRIPTION
# Description
Currently circleci only finds tests in the tests folder. This expands it to find all files which begin with test_

Found 2 issues which are fixed in this PR too

# How to test
All tests are actually running now, and passing!

# Developer checklist
- [X] Unit test
- [X] Linked to Trello ticket
- [X] Documentation up to date
