### PR TITLE
Temporarily remove recalculate_managerial_filled_posts function

### DIFF
--- a/jobs/estimate_ind_cqc_filled_posts_by_job_role.py
+++ b/jobs/estimate_ind_cqc_filled_posts_by_job_role.py
@@ -201,11 +201,11 @@ def main(
         )
     )
 
-    estimated_ind_cqc_filled_posts_by_job_role_df = (
-        JRutils.recalculate_managerial_filled_posts(
-            estimated_ind_cqc_filled_posts_by_job_role_df
-        )
-    )
+    # estimated_ind_cqc_filled_posts_by_job_role_df = (
+    #     JRutils.recalculate_managerial_filled_posts(
+    #         estimated_ind_cqc_filled_posts_by_job_role_df
+    #     )
+    # )
 
     estimated_ind_cqc_filled_posts_by_job_role_df = (
         JRutils.recalculate_total_filled_posts(

--- a/tests/unit/test_estimate_ind_cqc_filled_posts_by_job_role.py
+++ b/tests/unit/test_estimate_ind_cqc_filled_posts_by_job_role.py
@@ -41,7 +41,7 @@ class NumericalValuesTests(EstimateIndCQCFilledPostsByJobRoleTests):
 class MainTests(EstimateIndCQCFilledPostsByJobRoleTests):
     @patch(f"{PATCH_PATH}.utils.write_to_parquet")
     @patch(f"{PATCH_PATH}.JRutils.recalculate_total_filled_posts")
-    @patch(f"{PATCH_PATH}.JRutils.recalculate_managerial_filled_posts")
+    # @patch(f"{PATCH_PATH}.JRutils.recalculate_managerial_filled_posts")
     @patch(
         f"{PATCH_PATH}.JRutils.calculate_sum_and_proportion_split_of_non_rm_managerial_estimate_posts"
     )
@@ -82,7 +82,7 @@ class MainTests(EstimateIndCQCFilledPostsByJobRoleTests):
         count_registered_manager_names_mock: Mock,
         calculate_difference_between_estimate_and_cqc_registered_managers_mock: Mock,
         calculate_sum_and_proportion_split_of_non_rm_managerial_estimate_posts_mock: Mock,
-        recalculate_managerial_filled_posts_mock: Mock,
+        # recalculate_managerial_filled_posts_mock: Mock,
         recalculate_total_filled_posts_mock: Mock,
         write_to_parquet_mock: Mock,
     ):
@@ -122,7 +122,7 @@ class MainTests(EstimateIndCQCFilledPostsByJobRoleTests):
         count_registered_manager_names_mock.assert_called_once()
         calculate_difference_between_estimate_and_cqc_registered_managers_mock.assert_called_once()
         calculate_sum_and_proportion_split_of_non_rm_managerial_estimate_posts_mock.assert_called_once()
-        recalculate_managerial_filled_posts_mock.assert_called_once()
+        # recalculate_managerial_filled_posts_mock.assert_called_once()
         recalculate_total_filled_posts_mock.assert_called_once()
         write_to_parquet_mock.assert_called_once_with(
             ANY, self.OUTPUT_DIR, "overwrite", PartitionKeys


### PR DESCRIPTION
# Description
This function isn't completing at the moment to temporarily hashing out until we find a better way of doing it