### PR TITLE
Tidy up estimate job roles

### DIFF
--- a/jobs/estimate_ind_cqc_filled_posts_by_job_role.py
+++ b/jobs/estimate_ind_cqc_filled_posts_by_job_role.py
@@ -213,6 +213,12 @@ def main(
     # )
 
     estimated_ind_cqc_filled_posts_by_job_role_df = (
+        JRutils.overwrite_registered_manager_estimate_with_cqc_count(
+            estimated_ind_cqc_filled_posts_by_job_role_df
+        )
+    )
+
+    estimated_ind_cqc_filled_posts_by_job_role_df = (
         JRutils.recalculate_total_filled_posts(
             estimated_ind_cqc_filled_posts_by_job_role_df,
             JRutils.list_of_job_roles_sorted,

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -10717,10 +10717,18 @@ class EstimateIndCQCFilledPostsByJobRoleUtilsData:
         ("1-001", 0.0, 0.0, 0.0, 0.0),
         ("1-002", 2.0, 1.0, 2.0, 1.0),
     ]
-
     expected_recalculate_total_filled_posts_rows = [
         ("1-001", 0.0, 0.0, 0.0, 0.0, 0.0),
         ("1-002", 2.0, 1.0, 2.0, 1.0, 6.0),
+    ]
+
+    overwrite_registered_manager_estimate_with_cqc_count_rows = [
+        (10.0, 1),
+        (10.0, 0),
+    ]
+    expected_overwrite_registered_manager_estimate_with_cqc_count_rows = [
+        (1.0, 1),
+        (10.0, 0),
     ]
 
 

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -5895,7 +5895,6 @@ class EstimateIndCQCFilledPostsByJobRoleUtilsSchemas:
             ),
         ]
     )
-
     expected_create_estimate_filled_posts_by_job_role_map_column_schema = StructType(
         [
             *create_estimate_filled_posts_by_job_role_map_column_schema,
@@ -5932,7 +5931,6 @@ class EstimateIndCQCFilledPostsByJobRoleUtilsSchemas:
             ),
         ]
     )
-
     expected_count_registered_manager_names_schema = StructType(
         [
             *count_registered_manager_names_schema,
@@ -5952,7 +5950,6 @@ class EstimateIndCQCFilledPostsByJobRoleUtilsSchemas:
             StructField(IndCQC.primary_service_type, StringType(), True),
         ]
     )
-
     expected_sum_job_role_split_by_service_schema = StructType(
         [
             *sum_job_role_split_by_service_schema,
@@ -5975,7 +5972,6 @@ class EstimateIndCQCFilledPostsByJobRoleUtilsSchemas:
             ),
         ]
     )
-
     expected_interpolate_job_role_ratios_schema = StructType(
         [
             *interpolate_job_role_ratios_schema,
@@ -6025,7 +6021,6 @@ class EstimateIndCQCFilledPostsByJobRoleUtilsSchemas:
             ),
         ]
     )
-
     expected_convert_map_with_all_null_values_to_null_schema = StructType(
         [
             *convert_map_with_all_null_values_to_null_schema,
@@ -6224,7 +6219,6 @@ class EstimateIndCQCFilledPostsByJobRoleUtilsSchemas:
             ),
         ]
     )
-
     expected_recalculate_managerial_filled_posts_schema = StructType(
         [*recalculate_managerial_filled_posts_schema]
     )
@@ -6238,11 +6232,12 @@ class EstimateIndCQCFilledPostsByJobRoleUtilsSchemas:
             StructField(MainJobRoleLabels.senior_management, FloatType(), False),
         ]
     )
-
     expected_recalculate_total_filled_posts_schema = StructType(
         [
             *recalculate_total_filled_posts_schema,
-            StructField(IndCQC.filled_posts, FloatType(), False),
+            StructField(
+                IndCQC.estimate_filled_posts_from_all_job_roles, FloatType(), False
+            ),
         ]
     )
 

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -6241,6 +6241,13 @@ class EstimateIndCQCFilledPostsByJobRoleUtilsSchemas:
         ]
     )
 
+    overwrite_registered_manager_estimate_with_cqc_count_schema = StructType(
+        [
+            StructField(MainJobRoleLabels.registered_manager, FloatType(), False),
+            StructField(IndCQC.registered_manager_count, IntegerType(), False),
+        ]
+    )
+
 
 @dataclass
 class EstimateJobRolesPrimaryServiceRollingSumSchemas:

--- a/tests/unit/test_estimate_ind_cqc_filled_posts_by_job_role.py
+++ b/tests/unit/test_estimate_ind_cqc_filled_posts_by_job_role.py
@@ -41,6 +41,7 @@ class NumericalValuesTests(EstimateIndCQCFilledPostsByJobRoleTests):
 class MainTests(EstimateIndCQCFilledPostsByJobRoleTests):
     @patch(f"{PATCH_PATH}.utils.write_to_parquet")
     @patch(f"{PATCH_PATH}.JRutils.recalculate_total_filled_posts")
+    @patch(f"{PATCH_PATH}.JRutils.overwrite_registered_manager_estimate_with_cqc_count")
     # @patch(f"{PATCH_PATH}.JRutils.recalculate_managerial_filled_posts")
     @patch(
         f"{PATCH_PATH}.JRutils.calculate_sum_and_proportion_split_of_non_rm_managerial_estimate_posts"
@@ -83,6 +84,7 @@ class MainTests(EstimateIndCQCFilledPostsByJobRoleTests):
         calculate_difference_between_estimate_and_cqc_registered_managers_mock: Mock,
         calculate_sum_and_proportion_split_of_non_rm_managerial_estimate_posts_mock: Mock,
         # recalculate_managerial_filled_posts_mock: Mock,
+        overwrite_registered_manager_estimate_with_cqc_count_mock: Mock,
         recalculate_total_filled_posts_mock: Mock,
         write_to_parquet_mock: Mock,
     ):
@@ -123,6 +125,7 @@ class MainTests(EstimateIndCQCFilledPostsByJobRoleTests):
         calculate_difference_between_estimate_and_cqc_registered_managers_mock.assert_called_once()
         calculate_sum_and_proportion_split_of_non_rm_managerial_estimate_posts_mock.assert_called_once()
         # recalculate_managerial_filled_posts_mock.assert_called_once()
+        overwrite_registered_manager_estimate_with_cqc_count_mock.assert_called_once()
         recalculate_total_filled_posts_mock.assert_called_once()
         write_to_parquet_mock.assert_called_once_with(
             ANY, self.OUTPUT_DIR, "overwrite", PartitionKeys

--- a/tests/unit/test_estimate_ind_cqc_filled_posts_by_job_role_utils.py
+++ b/tests/unit/test_estimate_ind_cqc_filled_posts_by_job_role_utils.py
@@ -1519,3 +1519,30 @@ class RecalculateManagerialFilledPosts(EstimateIndCQCFilledPostsByJobRoleUtilsTe
         expected_data = self.expected_df.select(expected_cols).collect()
 
         self.assertEqual(expected_data, returned_data)
+
+
+class OverwriteRegisteredManagerEstimateWithCqcCount(
+    EstimateIndCQCFilledPostsByJobRoleUtilsTests
+):
+    def setUp(self) -> None:
+        super().setUp()
+
+        test_df = self.spark.createDataFrame(
+            Data.overwrite_registered_manager_estimate_with_cqc_count_rows,
+            Schemas.overwrite_registered_manager_estimate_with_cqc_count_schema,
+        )
+        self.returned_df = job.overwrite_registered_manager_estimate_with_cqc_count(
+            test_df,
+        )
+        self.expected_df = self.spark.createDataFrame(
+            Data.expected_overwrite_registered_manager_estimate_with_cqc_count_rows,
+            Schemas.overwrite_registered_manager_estimate_with_cqc_count_schema,
+        )
+
+    def test_overwrite_registered_manager_estimate_with_cqc_count_returned_expected_values(
+        self,
+    ):
+        returned_data = self.returned_df.collect()
+        expected_data = self.expected_df.collect()
+
+        self.assertEqual(expected_data, returned_data)

--- a/tests/unit/test_estimate_ind_cqc_filled_posts_by_job_role_utils.py
+++ b/tests/unit/test_estimate_ind_cqc_filled_posts_by_job_role_utils.py
@@ -1491,6 +1491,9 @@ class RecalculateTotalFilledPosts(EstimateIndCQCFilledPostsByJobRoleUtilsTests):
         self,
     ):
         self.assertEqual(len(self.new_columns_added), 1)
+        self.assertEqual(
+            self.new_columns_added[0], IndCQC.estimate_filled_posts_from_all_job_roles
+        )
 
 
 class RecalculateManagerialFilledPosts(EstimateIndCQCFilledPostsByJobRoleUtilsTests):

--- a/utils/column_names/ind_cqc_pipeline_columns.py
+++ b/utils/column_names/ind_cqc_pipeline_columns.py
@@ -135,6 +135,9 @@ class IndCqcColumns:
     dormancy: str = CQCLClean.dormancy
     establishment_id: str = AWPClean.establishment_id
     estimate_filled_posts: str = "estimate_filled_posts"
+    estimate_filled_posts_from_all_job_roles: str = (
+        "estimate_filled_posts_from_all_job_roles"
+    )
     estimated_managerial_filled_posts_temp: str = (
         "estimated_managerial_filled_posts_temp"
     )
@@ -148,7 +151,6 @@ class IndCqcColumns:
     extrapolation_model: str = "extrapolation_model"
     extrapolation_ratio: str = "extrapolation_ratio"
     features: str = "features"
-    filled_posts: str = "filled_posts"
     filled_posts_per_bed_ratio: str = "filled_posts_per_bed_ratio"
     filled_posts_per_bed_ratio_within_std_resids: str = (
         "filled_posts_per_bed_ratio_within_std_resids"

--- a/utils/estimate_filled_posts_by_job_role_utils/utils.py
+++ b/utils/estimate_filled_posts_by_job_role_utils/utils.py
@@ -804,6 +804,28 @@ def transform_interpolated_job_role_ratios_to_counts(
     return df
 
 
+def overwrite_registered_manager_estimate_with_cqc_count(df: DataFrame) -> DataFrame:
+    """
+    This function overwrites our estimate of registered managers with the count from cqc data.
+
+    Args:
+        df (DataFrame): A dataframe with registered manager estimates from asc-wds and counts from cqc data.
+
+    Returns:
+        DataFrame: A dataframe with registered manager estimates overwritten by cqc counts.
+    """
+
+    df = df.withColumn(
+        MainJobRoleLabels.registered_manager,
+        F.when(
+            F.col(IndCQC.registered_manager_count) > 0,
+            F.col(IndCQC.registered_manager_count),
+        ).otherwise(F.col(MainJobRoleLabels.registered_manager)),
+    )
+
+    return df
+
+
 def recalculate_total_filled_posts(df: DataFrame, list_of_job_roles: list) -> DataFrame:
     """
     Created a filled_posts column which represents the total number of filled posts per location_id based on job role breakdown.

--- a/utils/estimate_filled_posts_by_job_role_utils/utils.py
+++ b/utils/estimate_filled_posts_by_job_role_utils/utils.py
@@ -818,7 +818,8 @@ def recalculate_total_filled_posts(df: DataFrame, list_of_job_roles: list) -> Da
     """
 
     df_result = df.withColumn(
-        IndCQC.filled_posts, sum([F.col(job_role) for job_role in list_of_job_roles])
+        IndCQC.estimate_filled_posts_from_all_job_roles,
+        sum([F.col(job_role) for job_role in list_of_job_roles]),
     )
 
     return df_result


### PR DESCRIPTION
# Description
This is tickets 1 and 2 of tidying up the job role breakdown.
[1st ticket ](https://trello.com/c/RAJCXFbL) - Change "filled posts column name
[2nd ticket](https://trello.com/c/TKI9Pqqh) - Function to overwrite our RM estimate with CQC count. 


# How to test
Unit tests for new function pass.
[Pipeline is running](https://eu-west-2.console.aws.amazon.com/states/home?region=eu-west-2#/v2/executions/details/arn:aws:states:eu-west-2:344210435447:execution:tidy-up-estimate-job-roles-Ind-CQC-Filled-Post-Estimates-Pipeline:1e73788e-8413-4ce5-8c34-42b9f7a65305)

# Developer checklist
- [x] Unit test
- [x] Linked to Trello ticket
- [x] Documentation up to date
