### PR TITLE
Include CT in main pipeline

### DIFF
--- a/jobs/clean_capacity_tracker_non_res_data.py
+++ b/jobs/clean_capacity_tracker_non_res_data.py
@@ -7,6 +7,7 @@ from utils.column_names.capacity_tracker_columns import (
     CapacityTrackerNonResCleanColumns as CTNRClean,
 )
 from utils.column_names.ind_cqc_pipeline_columns import PartitionKeys as Keys
+from utils.column_values.categorical_column_values import CareHome
 
 CAPACITY_TRACKER_NON_RES_COLUMNS = [
     CTNR.cqc_id,
@@ -47,6 +48,9 @@ def main(
         columns_to_bound,
         lower_limit=MIN_BOUND,
         upper_limit=MAX_BOUND,
+    )
+    capacity_tracker_non_res_df = capacity_tracker_non_res_df.withColumn(
+        CTNRClean.care_home, CareHome.not_care_home
     )
 
     print(f"Exporting as parquet to {cleaned_capacity_tracker_non_res_destination}")

--- a/jobs/clean_capacity_tracker_non_res_data.py
+++ b/jobs/clean_capacity_tracker_non_res_data.py
@@ -1,5 +1,7 @@
 import sys
 
+from pyspark.sql import functions as F
+
 from utils import utils
 import utils.cleaning_utils as cUtils
 from utils.column_names.capacity_tracker_columns import (
@@ -50,7 +52,7 @@ def main(
         upper_limit=MAX_BOUND,
     )
     capacity_tracker_non_res_df = capacity_tracker_non_res_df.withColumn(
-        CTNRClean.care_home, CareHome.not_care_home
+        CTNRClean.care_home, F.lit(CareHome.not_care_home)
     )
 
     print(f"Exporting as parquet to {cleaned_capacity_tracker_non_res_destination}")

--- a/jobs/estimate_ind_cqc_filled_posts.py
+++ b/jobs/estimate_ind_cqc_filled_posts.py
@@ -38,6 +38,8 @@ ind_cqc_columns = [
     IndCQC.related_location,
     IndCQC.time_registered,
     IndCQC.registered_manager_names,
+    IndCQC.ct_import_date,
+    IndCQC.ct_care_workers_employed,
     IndCQC.cqc_pir_import_date,
     IndCQC.pir_people_directly_employed_dedup,
     IndCQC.pir_filled_posts_model,

--- a/jobs/merge_ind_cqc_data.py
+++ b/jobs/merge_ind_cqc_data.py
@@ -180,16 +180,14 @@ def join_data_into_cqc_df(
         join_import_date_col,
     )
 
-    formatted_pir_df = join_df.withColumnRenamed(
-        join_location_id_col, CQCLClean.location_id
-    )
+    join_df = join_df.withColumnRenamed(join_location_id_col, CQCLClean.location_id)
 
     cols_to_join_on = [join_import_date_col, CQCLClean.location_id]
     if join_care_home_col:
         cols_to_join_on = cols_to_join_on + [join_care_home_col]
 
     cqc_df_with_join_data = cqc_df_with_join_import_date.join(
-        formatted_pir_df,
+        join_df,
         cols_to_join_on,
         "left",
     )

--- a/terraform/pipeline/glue.tf
+++ b/terraform/pipeline/glue.tf
@@ -449,6 +449,7 @@ module "merge_ind_cqc_data_job" {
     "--cleaned_cqc_location_source"     = "${module.datasets_bucket.bucket_uri}/domain=CQC/dataset=locations_api_cleaned/"
     "--cleaned_cqc_pir_source"          = "${module.datasets_bucket.bucket_uri}/domain=CQC/dataset=pir_cleaned/"
     "--cleaned_ascwds_workplace_source" = "${module.datasets_bucket.bucket_uri}/domain=ASCWDS/dataset=workplace_cleaned/"
+    "--cleaned_non_res_ct_source"       = "${module.datasets_bucket.bucket_uri}/domain=capacity_tracker/dataset=capacity_tracker_non_residential_cleaned/"
     "--destination"                     = "${module.datasets_bucket.bucket_uri}/domain=ind_cqc_filled_posts/dataset=ind_cqc_merged_data/"
   }
 }

--- a/terraform/pipeline/step-functions/IndCqcFilledPostEstimatePipeline-StepFunction.json
+++ b/terraform/pipeline/step-functions/IndCqcFilledPostEstimatePipeline-StepFunction.json
@@ -18,6 +18,7 @@
                   "--cleaned_cqc_location_source": "${dataset_bucket_uri}/domain=CQC/dataset=locations_api_cleaned/",
                   "--cleaned_cqc_pir_source": "${dataset_bucket_uri}/domain=CQC/dataset=pir_cleaned/",
                   "--cleaned_ascwds_workplace_source": "${dataset_bucket_uri}/domain=ASCWDS/dataset=workplace_cleaned/",
+                  "--cleaned_non_res_ct_source": "${dataset_bucket_uri}/domain=capacity_tracker/dataset=capacity_tracker_non_residential_cleaned/",
                   "--destination": "${dataset_bucket_uri}/domain=ind_cqc_filled_posts/dataset=ind_cqc_merged_data/"
                 }
               },

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -3342,55 +3342,28 @@ class CleaningUtilsData:
 
 @dataclass
 class MergeIndCQCData:
-    clean_cqc_pir_rows = [
-        ("1-000000001", "Y", date(2024, 1, 1), 10),
-        ("1-000000002", "N", date(2024, 1, 1), 20),
-        ("1-000000003", "Y", date(2024, 1, 1), 30),
-        ("1-000000001", "Y", date(2024, 2, 1), 1),
-        ("1-000000002", "N", date(2024, 2, 1), 4),
-    ]
-
-    # fmt: off
     clean_cqc_location_for_merge_rows = [
-        (date(2024, 1, 1), "1-000000001", "Independent", "Y", 10,),
-        (date(2024, 1, 1), "1-000000002", "Independent", "N", None,),
-        (date(2024, 1, 1), "1-000000003", "Independent", "N", None,),
-        (date(2024, 2, 1), "1-000000001", "Independent", "Y", 10,),
-        (date(2024, 2, 1), "1-000000002", "Independent", "N", None,),
-        (date(2024, 2, 1), "1-000000003", "Independent", "N", None,),
-        (date(2024, 3, 1), "1-000000001", "Independent", "Y", 10,),
-        (date(2024, 3, 1), "1-000000002", "Independent", "N", None,),
-        (date(2024, 3, 1), "1-000000003", "Independent", "N", None,),
+        (date(2024, 1, 1), "1-000000001", "Independent", "Y", 10),
+        (date(2024, 1, 1), "1-000000002", "Independent", "N", None),
+        (date(2024, 1, 1), "1-000000003", "Independent", "N", None),
+        (date(2024, 2, 1), "1-000000001", "Independent", "Y", 10),
+        (date(2024, 2, 1), "1-000000002", "Independent", "N", None),
+        (date(2024, 2, 1), "1-000000003", "Independent", "N", None),
+        (date(2024, 3, 1), "1-000000001", "Independent", "Y", 10),
+        (date(2024, 3, 1), "1-000000002", "Independent", "N", None),
+        (date(2024, 3, 1), "1-000000003", "Independent", "N", None),
     ]
-    # fmt: on
 
-    # fmt: off
-    clean_ascwds_workplace_for_merge_rows = [
-        (date(2024, 1, 1), "1-000000001", "1", 1,),
-        (date(2024, 1, 1), "1-000000003", "3", 2,),
-        (date(2024, 1, 5), "1-000000001", "1", 3,),
-        (date(2024, 1, 9), "1-000000001", "1", 4,),
-        (date(2024, 1, 9), "1-000000003", "3", 5,),
-        (date(2024, 3, 1), "1-000000003", "4", 6,),
+    data_to_merge_without_care_home_col_rows = [
+        (date(2024, 1, 1), "1-000000001", "1", 1),
+        (date(2024, 1, 1), "1-000000003", "3", 2),
+        (date(2024, 1, 5), "1-000000001", "1", 3),
+        (date(2024, 1, 9), "1-000000001", "1", 4),
+        (date(2024, 1, 9), "1-000000003", "3", 5),
+        (date(2024, 3, 1), "1-000000003", "4", 6),
     ]
-    # fmt: on
-
     # fmt: off
-    expected_merged_cqc_and_pir = [
-        (date(2024, 1, 1), "1-000000001", "Independent", "Y", 10, 10, date(2024, 1, 1)),
-        (date(2024, 1, 1), "1-000000002", "Independent", "N", None, 20, date(2024, 1, 1)),
-        (date(2024, 1, 1), "1-000000003", "Independent", "N", None, None, date(2024, 1, 1)),
-        (date(2024, 2, 1), "1-000000001", "Independent", "Y", 10, 1, date(2024, 2, 1)),
-        (date(2024, 2, 1), "1-000000002", "Independent", "N", None, 4, date(2024, 2, 1)),
-        (date(2024, 2, 1), "1-000000003", "Independent", "N", None, None, date(2024, 2, 1)),
-        (date(2024, 3, 1), "1-000000001", "Independent", "Y", 10, 1, date(2024, 2, 1)),
-        (date(2024, 3, 1), "1-000000002", "Independent", "N", None, 4, date(2024, 2, 1)),
-        (date(2024, 3, 1), "1-000000003", "Independent", "N", None, None, date(2024, 2, 1)),
-    ]
-    # fmt: on
-
-    # fmt: off
-    expected_cqc_and_ascwds_merged_rows = [
+    expected_merged_without_care_home_col_rows = [
         ("1-000000001", date(2024, 1, 1), date(2024, 1, 1), "Independent", "Y", 10, "1", 1,),
         ("1-000000002", date(2024, 1, 1), date(2024, 1, 1), "Independent", "N", None, None, None,),
         ("1-000000003", date(2024, 1, 1), date(2024, 1, 1), "Independent", "N", None, "3", 2,),
@@ -3403,14 +3376,24 @@ class MergeIndCQCData:
     ]
     # fmt: on
 
-    # fmt: off
-    cqc_sector_rows = [
-        ("loc-1", "Local Authority",),
-        ("loc-2", None,),
-        ("loc-3", "Independent",),
+    data_to_merge_with_care_home_col_rows = [
+        ("1-000000001", "Y", date(2024, 1, 1), 10),
+        ("1-000000002", "N", date(2024, 1, 1), 20),
+        ("1-000000003", "Y", date(2024, 1, 1), 30),
+        ("1-000000001", "Y", date(2024, 2, 1), 1),
+        ("1-000000002", "N", date(2024, 2, 1), 4),
     ]
-    expected_cqc_sector_rows = [
-        ("loc-3", "Independent",),
+    # fmt: off
+    expected_merged_with_care_home_col_rows = [
+        (date(2024, 1, 1), "1-000000001", "Independent", "Y", 10, 10, date(2024, 1, 1)),
+        (date(2024, 1, 1), "1-000000002", "Independent", "N", None, 20, date(2024, 1, 1)),
+        (date(2024, 1, 1), "1-000000003", "Independent", "N", None, None, date(2024, 1, 1)),
+        (date(2024, 2, 1), "1-000000001", "Independent", "Y", 10, 1, date(2024, 2, 1)),
+        (date(2024, 2, 1), "1-000000002", "Independent", "N", None, 4, date(2024, 2, 1)),
+        (date(2024, 2, 1), "1-000000003", "Independent", "N", None, None, date(2024, 2, 1)),
+        (date(2024, 3, 1), "1-000000001", "Independent", "Y", 10, 1, date(2024, 2, 1)),
+        (date(2024, 3, 1), "1-000000002", "Independent", "N", None, 4, date(2024, 2, 1)),
+        (date(2024, 3, 1), "1-000000003", "Independent", "N", None, None, date(2024, 2, 1)),
     ]
     # fmt: on
 

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -1599,15 +1599,6 @@ class FilterCleanedValuesSchema:
 
 @dataclass
 class MergeIndCQCData:
-    clean_cqc_pir_schema = StructType(
-        [
-            StructField(CQCPIRClean.location_id, StringType(), False),
-            StructField(CQCPIRClean.care_home, StringType(), True),
-            StructField(CQCPIRClean.cqc_pir_import_date, DateType(), True),
-            StructField(CQCPIRClean.pir_people_directly_employed, IntegerType(), True),
-        ]
-    )
-
     clean_cqc_location_for_merge_schema = StructType(
         [
             StructField(CQCLClean.cqc_location_import_date, DateType(), True),
@@ -1618,7 +1609,7 @@ class MergeIndCQCData:
         ]
     )
 
-    clean_ascwds_workplace_for_merge_schema = StructType(
+    data_to_merge_without_care_home_col_schema = StructType(
         [
             StructField(AWPClean.ascwds_workplace_import_date, DateType(), True),
             StructField(AWPClean.location_id, StringType(), True),
@@ -1626,16 +1617,7 @@ class MergeIndCQCData:
             StructField(AWPClean.total_staff, IntegerType(), True),
         ]
     )
-
-    expected_cqc_and_pir_merged_schema = StructType(
-        [
-            *clean_cqc_location_for_merge_schema,
-            StructField(CQCPIRClean.pir_people_directly_employed, IntegerType(), True),
-            StructField(CQCPIRClean.cqc_pir_import_date, DateType(), True),
-        ]
-    )
-
-    expected_cqc_and_ascwds_merged_schema = StructType(
+    expected_merged_without_care_home_col_schema = StructType(
         [
             StructField(CQCLClean.location_id, StringType(), True),
             StructField(AWPClean.ascwds_workplace_import_date, DateType(), True),
@@ -1648,10 +1630,19 @@ class MergeIndCQCData:
         ]
     )
 
-    cqc_sector_schema = StructType(
+    data_to_merge_with_care_home_col_schema = StructType(
         [
-            StructField(CQCLClean.location_id, StringType(), True),
-            StructField(CQCLClean.cqc_sector, StringType(), True),
+            StructField(CQCPIRClean.location_id, StringType(), False),
+            StructField(CQCPIRClean.care_home, StringType(), True),
+            StructField(CQCPIRClean.cqc_pir_import_date, DateType(), True),
+            StructField(CQCPIRClean.pir_people_directly_employed, IntegerType(), True),
+        ]
+    )
+    expected_merged_with_care_home_col_schema = StructType(
+        [
+            *clean_cqc_location_for_merge_schema,
+            StructField(CQCPIRClean.pir_people_directly_employed, IntegerType(), True),
+            StructField(CQCPIRClean.cqc_pir_import_date, DateType(), True),
         ]
     )
 

--- a/tests/unit/test_merge_ind_cqc_data.py
+++ b/tests/unit/test_merge_ind_cqc_data.py
@@ -1,28 +1,29 @@
 import unittest
-
 from unittest.mock import ANY, Mock, patch
 
 import jobs.merge_ind_cqc_data as job
-
 from tests.test_file_data import MergeIndCQCData as Data
 from tests.test_file_schemas import MergeIndCQCData as Schemas
-
 from utils import utils
-from utils.column_names.ind_cqc_pipeline_columns import (
-    PartitionKeys as Keys,
-)
+from utils.column_names.ind_cqc_pipeline_columns import PartitionKeys as Keys
 from utils.column_names.cleaned_data_files.cqc_location_cleaned import (
     CqcLocationCleanedColumns as CQCLClean,
 )
 from utils.column_names.cleaned_data_files.ascwds_workplace_cleaned import (
     AscwdsWorkplaceCleanedColumns as AWPClean,
 )
+from utils.column_names.cleaned_data_files.cqc_pir_cleaned import (
+    CqcPIRCleanedColumns as CQCPIRClean,
+)
+
+PATCH_PATH: str = "jobs.merge_ind_cqc_data"
 
 
 class MergeIndCQCDatasetTests(unittest.TestCase):
     TEST_CQC_LOCATION_SOURCE = "some/directory"
     TEST_CQC_PIR_SOURCE = "some/other/directory"
     TEST_ASCWDS_WORKPLACE_SOURCE = "some/other/directory"
+    TEST_CT_NON_RES_SOURCE = "yet/another/directory"
     TEST_DESTINATION = "some/other/directory"
     partition_keys = [Keys.year, Keys.month, Keys.day, Keys.import_date]
 
@@ -32,48 +33,44 @@ class MergeIndCQCDatasetTests(unittest.TestCase):
             Data.clean_cqc_location_for_merge_rows,
             Schemas.clean_cqc_location_for_merge_schema,
         )
-        self.test_clean_cqc_pir_df = self.spark.createDataFrame(
-            Data.clean_cqc_pir_rows, Schemas.clean_cqc_pir_schema
+        self.test_data_with_care_home_col = self.spark.createDataFrame(
+            Data.data_to_merge_with_care_home_col_rows,
+            Schemas.data_to_merge_with_care_home_col_schema,
         )
-        self.test_clean_ascwds_workplace_df = self.spark.createDataFrame(
-            Data.clean_ascwds_workplace_for_merge_rows,
-            Schemas.clean_ascwds_workplace_for_merge_schema,
+        self.test_data_without_care_home_col = self.spark.createDataFrame(
+            Data.data_to_merge_without_care_home_col_rows,
+            Schemas.data_to_merge_without_care_home_col_schema,
         )
 
-    @patch("jobs.merge_ind_cqc_data.join_ascwds_data_into_merged_df")
-    @patch(
-        "jobs.merge_ind_cqc_data.filter_df_to_independent_sector_only",
-        wraps=job.filter_df_to_independent_sector_only,
-    )
-    @patch("utils.utils.write_to_parquet")
-    @patch("utils.utils.read_from_parquet")
+    @patch(f"{PATCH_PATH}.utils.write_to_parquet")
+    @patch(f"{PATCH_PATH}.join_data_into_cqc_df")
+    @patch(f"{PATCH_PATH}.utils.select_rows_with_value")
+    @patch(f"{PATCH_PATH}.utils.read_from_parquet")
     def test_main_runs(
         self,
         read_from_parquet_patch: Mock,
+        select_rows_with_value_mock: Mock,
+        join_data_into_cqc_df_mock: Mock,
         write_to_parquet_patch: Mock,
-        filter_df_to_independent_sector_only: Mock,
-        join_ascwds_data_into_merged_df: Mock,
     ):
         read_from_parquet_patch.side_effect = [
             self.test_clean_cqc_location_df,
-            self.test_clean_ascwds_workplace_df,
-            self.test_clean_cqc_pir_df,
+            self.test_data_without_care_home_col,
+            self.test_data_with_care_home_col,
+            self.test_data_with_care_home_col,
         ]
 
         job.main(
             self.TEST_CQC_LOCATION_SOURCE,
             self.TEST_CQC_PIR_SOURCE,
             self.TEST_ASCWDS_WORKPLACE_SOURCE,
+            self.TEST_CT_NON_RES_SOURCE,
             self.TEST_DESTINATION,
         )
 
-        self.assertEqual(read_from_parquet_patch.call_count, 3)
-
-        filter_df_to_independent_sector_only.assert_called_once_with(
-            self.test_clean_cqc_location_df
-        )
-        join_ascwds_data_into_merged_df.assert_called_once()
-
+        self.assertEqual(read_from_parquet_patch.call_count, 4)
+        select_rows_with_value_mock.assert_called_once()
+        self.assertEqual(join_data_into_cqc_df_mock.call_count, 3)
         write_to_parquet_patch.assert_called_once_with(
             ANY,
             self.TEST_DESTINATION,
@@ -81,63 +78,48 @@ class MergeIndCQCDatasetTests(unittest.TestCase):
             partitionKeys=self.partition_keys,
         )
 
-    def test_filter_df_to_independent_sector_only_keeps_independent_locations(
+    def test_join_data_into_cqc_df_returns_expected_data_when_care_home_column_not_required(
         self,
     ):
-        test_df = self.spark.createDataFrame(
-            Data.cqc_sector_rows, Schemas.cqc_sector_schema
-        )
-
-        returned_ind_cqc_df = job.filter_df_to_independent_sector_only(test_df)
-        returned_ind_cqc_data = returned_ind_cqc_df.collect()
-
-        expected_ind_cqc_data = self.spark.createDataFrame(
-            Data.expected_cqc_sector_rows, Schemas.cqc_sector_schema
-        ).collect()
-
-        self.assertEqual(returned_ind_cqc_data, expected_ind_cqc_data)
-
-    def test_join_ascwds_data_into_merged_df(self):
-        returned_df = job.join_ascwds_data_into_merged_df(
+        returned_df = job.join_data_into_cqc_df(
             self.test_clean_cqc_location_df,
-            self.test_clean_ascwds_workplace_df,
-            CQCLClean.cqc_location_import_date,
+            self.test_data_without_care_home_col,
+            AWPClean.location_id,
             AWPClean.ascwds_workplace_import_date,
         )
 
         expected_merged_df = self.spark.createDataFrame(
-            Data.expected_cqc_and_ascwds_merged_rows,
-            Schemas.expected_cqc_and_ascwds_merged_schema,
+            Data.expected_merged_without_care_home_col_rows,
+            Schemas.expected_merged_without_care_home_col_schema,
         )
 
         returned_data = returned_df.sort(
             CQCLClean.cqc_location_import_date, CQCLClean.location_id
         ).collect()
-        expected_data = expected_merged_df.sort(
-            CQCLClean.cqc_location_import_date, CQCLClean.location_id
-        ).collect()
+        expected_data = expected_merged_df.select(returned_df.columns).collect()
 
         self.assertEqual(returned_data, expected_data)
 
-    def test_join_pir_data_into_merged_df(self):
-        returned_df = job.join_pir_data_into_merged_df(
+    def test_join_data_into_cqc_df_returns_expected_data_when_care_home_column_is_required(
+        self,
+    ):
+        returned_df = job.join_data_into_cqc_df(
             self.test_clean_cqc_location_df,
-            self.test_clean_cqc_pir_df,
+            self.test_data_with_care_home_col,
+            CQCPIRClean.location_id,
+            CQCPIRClean.cqc_pir_import_date,
+            CQCPIRClean.care_home,
         )
 
         expected_merged_df = self.spark.createDataFrame(
-            Data.expected_merged_cqc_and_pir,
-            Schemas.expected_cqc_and_pir_merged_schema,
+            Data.expected_merged_with_care_home_col_rows,
+            Schemas.expected_merged_with_care_home_col_schema,
         )
 
         returned_data = returned_df.sort(
             CQCLClean.cqc_location_import_date, CQCLClean.location_id
         ).collect()
-        expected_data = (
-            expected_merged_df.select(returned_df.columns)
-            .sort(CQCLClean.cqc_location_import_date, CQCLClean.location_id)
-            .collect()
-        )
+        expected_data = expected_merged_df.select(returned_df.columns).collect()
 
         self.assertEqual(returned_data, expected_data)
 

--- a/tests/unit/test_merge_ind_cqc_data.py
+++ b/tests/unit/test_merge_ind_cqc_data.py
@@ -55,8 +55,8 @@ class MergeIndCQCDatasetTests(unittest.TestCase):
     ):
         read_from_parquet_patch.side_effect = [
             self.test_clean_cqc_location_df,
-            self.test_data_without_care_home_col,
             self.test_data_with_care_home_col,
+            self.test_data_without_care_home_col,
             self.test_data_with_care_home_col,
         ]
 

--- a/utils/column_names/capacity_tracker_columns.py
+++ b/utils/column_names/capacity_tracker_columns.py
@@ -1,5 +1,9 @@
 from dataclasses import dataclass
 
+from utils.column_names.raw_data_files.cqc_location_api_columns import (
+    NewCqcLocationApiColumns,
+)
+
 
 @dataclass
 class CapacityTrackerCareHomeColumns:
@@ -126,3 +130,5 @@ class CapacityTrackerNonResCleanColumns(CapacityTrackerNonResColumns):
         + "_rate_of_change_trendline"
     )
     unix_timestamp: str = "unix_timestamp"
+
+    care_home: str = NewCqcLocationApiColumns.care_home

--- a/utils/column_names/ind_cqc_pipeline_columns.py
+++ b/utils/column_names/ind_cqc_pipeline_columns.py
@@ -15,6 +15,9 @@ from utils.column_names.cleaned_data_files.cqc_pir_cleaned import (
 from utils.column_names.cleaned_data_files.ons_cleaned import (
     OnsCleanedColumns as ONSClean,
 )
+from utils.column_names.capacity_tracker_columns import (
+    CapacityTrackerNonResCleanColumns as CTNRClean,
+)
 
 
 @dataclass
@@ -107,6 +110,8 @@ class IndCqcColumns:
     )
     cqc_pir_import_date: str = CQCPIRClean.cqc_pir_import_date
     cqc_sector: str = CQCLClean.cqc_sector
+    ct_import_date: str = CTNRClean.capacity_tracker_import_date
+    ct_care_workers_employed: str = "ct_" + CTNRClean.cqc_care_workers_employed
     current_ccg: str = ONSClean.current_ccg
     current_constituancy: str = ONSClean.current_constituancy
     current_cssr: str = ONSClean.current_cssr

--- a/utils/column_names/ind_cqc_pipeline_columns.py
+++ b/utils/column_names/ind_cqc_pipeline_columns.py
@@ -111,7 +111,7 @@ class IndCqcColumns:
     cqc_pir_import_date: str = CQCPIRClean.cqc_pir_import_date
     cqc_sector: str = CQCLClean.cqc_sector
     ct_import_date: str = CTNRClean.capacity_tracker_import_date
-    ct_care_workers_employed: str = "ct_" + CTNRClean.cqc_care_workers_employed
+    ct_care_workers_employed: str = CTNRClean.cqc_care_workers_employed
     current_ccg: str = ONSClean.current_ccg
     current_constituancy: str = ONSClean.current_constituancy
     current_cssr: str = ONSClean.current_cssr


### PR DESCRIPTION
# Description
Including CT data in our normal pipeline so I can see it alongside everything else!

As usual, I can talk through changes but top level

- I got rid of `filter_df_to_independent_sector_only` as we already have a function -> `utils.select_rows_with_value`

- I needed a new function alongside `join_ascwds_data_into_merged_df` and `join_pir_data_into_merged_df` in order to join CT data. However these functions were almost identical, the only difference (other than col names) was that PIR needed to join on the care home column as well - CT data also requires this. What I did was create one function which works for all 3 called `join_data_into_cqc_df`.
I haven't changed any test data as it's doing the same thing as before - the previous ASCWDS test data became the test for 'join without care home' and the previous PIR test data became the test for 'join with care home'. The ordering of the test data/schema was all over the place, so I've reordered but it's the same

# How to test
[Branch run](https://eu-west-2.console.aws.amazon.com/states/home?region=eu-west-2#/v2/executions/details/arn:aws:states:eu-west-2:344210435447:execution:include-ct-in-main-pipeline-Ind-CQC-Filled-Post-Estimates-Pipeline:4074982d-f55a-4360-8c28-f0dbff1d4941)

# Developer checklist
- [X] Unit test
- [X] Linked to [Trello ticket](https://trello.com/c/5RGjfTCh/819-include-ct-data-in-indcqc-pipeline)
- [X] Documentation up to date
