### PR TITLE
Only include large PIR places if they have multiple submissions

### DIFF
--- a/projects/_01_ingest/cqc_pir/tests/utils/test_clean_people_directly_employed_outliers.py
+++ b/projects/_01_ingest/cqc_pir/tests/utils/test_clean_people_directly_employed_outliers.py
@@ -1,4 +1,5 @@
 import unittest
+from unittest.mock import Mock, patch
 
 import projects._01_ingest.cqc_pir.utils.clean_people_directly_employed_outliers as job
 from projects._01_ingest.unittest_data.ingest_test_file_data import (
@@ -35,6 +36,15 @@ class MainTests(CleanPeopleDirectlyEmployedTests):
             [], Schemas.expected_clean_people_directly_employed_outliers_schema
         )
 
+    @patch(f"{PATCH_PATH}.null_large_single_submission_locations")
+    def test_main_calls_functions(
+        self,
+        null_large_single_submission_locations_mock: Mock,
+    ):
+        job.clean_people_directly_employed_outliers(self.test_df)
+
+        null_large_single_submission_locations_mock.assert_called_once()
+
     def test_main_adds_cleaned_column(self):
         self.assertIn(
             PIRCleanCols.pir_people_directly_employed_cleaned, self.returned_df.columns
@@ -43,3 +53,29 @@ class MainTests(CleanPeopleDirectlyEmployedTests):
 
     def test_main_returns_original_number_of_rows(self):
         self.assertEqual(self.returned_df.count(), self.test_df.count())
+
+
+class NullLargeSingleSubmissionLocationsTests(CleanPeopleDirectlyEmployedTests):
+    def setUp(self) -> None:
+        super().setUp()
+
+        test_df = self.spark.createDataFrame(
+            Data.null_large_single_submission_locations_rows,
+            Schemas.null_large_single_submission_locations_schema,
+        )
+        self.returned_df = job.null_large_single_submission_locations(test_df)
+        self.expected_df = self.spark.createDataFrame(
+            Data.expected_null_large_single_submission_locations_rows,
+            Schemas.null_large_single_submission_locations_schema,
+        )
+
+        self.returned_data = self.returned_df.sort(
+            PIRCleanCols.location_id, PIRCleanCols.cqc_pir_import_date
+        ).collect()
+        self.expected_data = self.expected_df.collect()
+
+    def test_null_large_single_submission_locations_returns_expected_data(self):
+        self.assertEqual(self.returned_data, self.expected_data)
+
+    def test_null_large_single_submission_locations_returns_expected_columns(self):
+        self.assertEqual(self.returned_df.columns, self.expected_df.columns)

--- a/projects/_01_ingest/cqc_pir/utils/clean_people_directly_employed_outliers.py
+++ b/projects/_01_ingest/cqc_pir/utils/clean_people_directly_employed_outliers.py
@@ -43,10 +43,10 @@ def null_large_single_submission_locations(df: DataFrame) -> DataFrame:
     to a data input error.
 
     Args:
-        df (DataFrame): The input DataFrame.
+        df (DataFrame): The input DataFrame containing pir_people_directly_employed_cleaned.
 
     Returns:
-        DataFrame: The input DataFrame with submission count.
+        DataFrame: The input DataFrame with large, single submission values removed.
     """
     w = Window.partitionBy(PIRCleanCols.location_id)
 

--- a/projects/_01_ingest/cqc_pir/utils/clean_people_directly_employed_outliers.py
+++ b/projects/_01_ingest/cqc_pir/utils/clean_people_directly_employed_outliers.py
@@ -1,4 +1,4 @@
-from pyspark.sql import DataFrame, functions as F
+from pyspark.sql import DataFrame, Window, functions as F
 
 from utils.column_names.raw_data_files.cqc_pir_columns import CqcPirColumns as PIRCols
 from utils.column_names.cleaned_data_files.cqc_pir_cleaned import (
@@ -26,8 +26,52 @@ def clean_people_directly_employed_outliers(df: DataFrame) -> DataFrame:
         F.col(PIRCols.pir_people_directly_employed),
     )
 
-    # TODO only include locations with 100+ posts if they have 2 submission (so we can validate them against each other)
+    df = null_large_single_submission_locations(df)
 
     # TODO remove locations with large differences (top 1% of (max-min)/avg?)
+
+    return df
+
+
+def null_large_single_submission_locations(df: DataFrame) -> DataFrame:
+    """
+    Excludes CQC PIR data for locations who submitted a large employee figure and only submitted once.
+
+    Large locations can have a big impact in localised data. In order to help identify data quality
+    issues, we only want to keep data for larger locations who have submitted more than once. This
+    is so we have multiple submissions to verify that the location are consistently large as opposed
+    to a data input error.
+
+    Args:
+        df (DataFrame): The input DataFrame.
+
+    Returns:
+        DataFrame: The input DataFrame with submission count.
+    """
+    w = Window.partitionBy(PIRCleanCols.location_id)
+
+    two_submissions: int = 2
+    submission_count: str = "submission_count"
+    max_people_employed: str = "max_value"
+    large_location_identifier: int = 100
+
+    df = df.withColumn(
+        submission_count,
+        F.count(PIRCleanCols.pir_people_directly_employed_cleaned).over(w),
+    )
+    df = df.withColumn(
+        max_people_employed,
+        F.max(PIRCleanCols.pir_people_directly_employed_cleaned).over(w),
+    )
+
+    df = df.withColumn(
+        PIRCleanCols.pir_people_directly_employed_cleaned,
+        F.when(
+            (F.col(max_people_employed) >= large_location_identifier)
+            & (F.col(submission_count) < two_submissions),
+            F.lit(None),
+        ).otherwise(F.col(PIRCleanCols.pir_people_directly_employed_cleaned)),
+    )
+    df = df.drop(max_people_employed, submission_count)
 
     return df

--- a/projects/_01_ingest/unittest_data/ingest_test_file_data.py
+++ b/projects/_01_ingest/unittest_data/ingest_test_file_data.py
@@ -658,9 +658,30 @@ class CleanCQCPIRData:
 class CleanPeopleDirectlyEmployedData:
     clean_people_directly_employed_outliers_rows = [
         ("1-0001", date(2024, 1, 1), 1),
-        ("1-0001", date(2024, 1, 1), 10),
-        ("1-0002", date(2025, 1, 1), 100),
+        ("1-0001", date(2025, 1, 1), 10),
+        ("1-0002", date(2024, 1, 1), 100),
         ("1-0002", date(2025, 1, 1), 1000),
+    ]
+
+    null_large_single_submission_locations_rows = [
+        ("1-0001", date(2024, 1, 1), None),
+        ("1-0001", date(2025, 1, 1), 99),
+        ("1-0002", date(2024, 1, 1), None),
+        ("1-0002", date(2025, 1, 1), 100),
+        ("1-0003", date(2024, 1, 1), 99),
+        ("1-0003", date(2025, 1, 1), 100),
+        ("1-0004", date(2024, 1, 1), 500),
+        ("1-0004", date(2025, 1, 1), 600),
+    ]
+    expected_null_large_single_submission_locations_rows = [
+        ("1-0001", date(2024, 1, 1), None),
+        ("1-0001", date(2025, 1, 1), 99),
+        ("1-0002", date(2024, 1, 1), None),
+        ("1-0002", date(2025, 1, 1), None),
+        ("1-0003", date(2024, 1, 1), 99),
+        ("1-0003", date(2025, 1, 1), 100),
+        ("1-0004", date(2024, 1, 1), 500),
+        ("1-0004", date(2025, 1, 1), 600),
     ]
 
 

--- a/projects/_01_ingest/unittest_data/ingest_test_file_schemas.py
+++ b/projects/_01_ingest/unittest_data/ingest_test_file_schemas.py
@@ -397,6 +397,16 @@ class CleanPeopleDirectlyEmployedSchema:
         ]
     )
 
+    null_large_single_submission_locations_schema = StructType(
+        [
+            StructField(CQCPIRClean.location_id, StringType(), True),
+            StructField(CQCPIRClean.cqc_pir_import_date, DateType(), True),
+            StructField(
+                CQCPIRClean.pir_people_directly_employed_cleaned, IntegerType(), True
+            ),
+        ]
+    )
+
 
 @dataclass
 class ValidatePIRRawData:


### PR DESCRIPTION
# Description
people just type one number into PIR so it's hard to validate it against anything.
Small places are fine as they don't really affect anything, so this is just wiping out any large places (100+) who have only submitted once.

Follow up filter will be to use those multiple submissions to validate each other - if always big then they are big, if there is a wide range between max/min then we can get rid of them

# How to test
Hard to do a proper before and after but essentially it's the same trend but takes about 5k off the most recent periods and flattens the recent upward trajectory a bit

non-res is red line, other two are CH and are unchanged

![image](https://github.com/user-attachments/assets/c65c52a9-8d9a-48a8-ab37-9f3e91101d74)

# Developer checklist
- [X] Unit test
- [X] Documentation up to date
