### PR TITLE
Include PIR in merged column if never submitted ASCWDS

### DIFF
--- a/projects/_03_independent_cqc/unittest_data/ind_cqc_test_file_data.py
+++ b/projects/_03_independent_cqc/unittest_data/ind_cqc_test_file_data.py
@@ -182,6 +182,27 @@ class ModelAndMergePirData:
     ]
     # fmt: on
 
+    include_pir_if_never_submitted_ascwds_rows = [
+        ("1-001", date(2024, 1, 1), 10.0, None),
+        ("1-001", date(2024, 2, 1), 20.0, 50.0),
+        ("1-002", date(2024, 1, 1), 30.0, None),
+        ("1-002", date(2024, 2, 1), None, 60.0),
+        ("1-003", date(2024, 1, 1), None, 70.0),
+        ("1-003", date(2024, 2, 1), 40.0, None),
+        ("1-004", date(2024, 1, 1), None, None),
+        ("1-004", date(2024, 2, 1), None, 80.0),
+    ]
+    expected_include_pir_if_never_submitted_ascwds_rows = [
+        ("1-001", date(2024, 1, 1), 10.0, None),
+        ("1-001", date(2024, 2, 1), 20.0, 50.0),
+        ("1-002", date(2024, 1, 1), 30.0, None),
+        ("1-002", date(2024, 2, 1), None, 60.0),
+        ("1-003", date(2024, 1, 1), None, 70.0),
+        ("1-003", date(2024, 2, 1), 40.0, None),
+        ("1-004", date(2024, 1, 1), None, None),
+        ("1-004", date(2024, 2, 1), 80.0, 80.0),
+    ]
+
 
 @dataclass
 class ValidateImputedIndCqcAscwdsAndPir:

--- a/projects/_03_independent_cqc/unittest_data/ind_cqc_test_file_schemas.py
+++ b/projects/_03_independent_cqc/unittest_data/ind_cqc_test_file_schemas.py
@@ -116,6 +116,15 @@ class ModelAndMergePirData:
         ]
     )
 
+    include_pir_if_never_submitted_ascwds_schema = StructType(
+        [
+            StructField(IndCQC.location_id, StringType(), False),
+            StructField(IndCQC.cqc_location_import_date, DateType(), False),
+            StructField(IndCQC.ascwds_pir_merged, FloatType(), True),
+            StructField(IndCQC.pir_filled_posts_model, FloatType(), True),
+        ]
+    )
+
     drop_temporary_columns_schema = StructType(
         [
             StructField(IndCQC.location_id, StringType(), False),

--- a/utils/column_names/ind_cqc_pipeline_columns.py
+++ b/utils/column_names/ind_cqc_pipeline_columns.py
@@ -273,6 +273,7 @@ class IndCqcColumns:
     single_period_rate_of_change = "single_period_rate_of_change"
     specialisms_offered: str = CQCLClean.specialisms_offered
     standardised_residual: str = "standardised_residual"
+    submitted_ascwds_data: str = "submitted_ascwds_data"
     sum_non_rm_managerial_estimated_filled_posts: str = (
         "sum_non_rm_managerial_estimated_filled_posts"
     )


### PR DESCRIPTION
# Description
Now we've cleaned PIR data a bit we were contemplatlating how it would look if we fully merged it in with ASCWDS data

so the rules would be
- use ASCWDS if we have it
- if we have ASCWDS but it's out of date and PIR is substantially different then incorporate PIR
- this PR is the next step, if we've never had ASCWDS data then use PIR (it will prob have merge conflicts as I've created the clean version of PIR data since I started this branch


# How to test

# Developer checklist
- [ ] Unit test
- [ ] Linked to Trello ticket
- [ ] Documentation up to date
