### PR TITLE
1st June- adding incorrect postcode

### DIFF
--- a/utils/cqc_location_dictionaries.py
+++ b/utils/cqc_location_dictionaries.py
@@ -102,6 +102,7 @@ class InvalidPostcodes:
         "PA20 3BD": "PO20 3BD",
         "PE2 5JH": "PE2 5SF",
         "PL67BF": "PL6 7FB",
+        "PL6 7BF": "PL6 7FB",
         "PL7 1RP": "PL7 1RF",
         "PO8 4PY": "PO4 8PY",
         "PR! 9HL": "PR1 9HL",


### PR DESCRIPTION
# Description
This postcode was wrong last month and it was missing a space. They've added the space into it this month, but haven't fixed the letter order, so it's unmatched again!