### PR TITLE
Specify pandas version in packages

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -17,6 +17,7 @@ openpyxl = "==3.1.2"
 pydeequ = "==1.4.0"
 pyspark = "==3.3.4"
 pydoclint = "==0.5.9"
+pandas = "==1.3.2"
 
 [dev-packages]
 pylint = "==2.17.4"


### PR DESCRIPTION
# Description
Specify pandas version in packages
Circleci started crashing as it's trying to use the most recent version 2.3.0 and keeps failing, then exiting the process