### PR TITLE
Remove populate estimate function with merge_columns_in_order

### DIFF
--- a/jobs/diagnostics_on_capacity_tracker.py
+++ b/jobs/diagnostics_on_capacity_tracker.py
@@ -20,9 +20,7 @@ from projects._03_independent_cqc._06_estimate_filled_posts.utils.models.imputat
 from projects._03_independent_cqc._06_estimate_filled_posts.utils.models.primary_service_rate_of_change_trendline import (
     model_primary_service_rate_of_change_trendline,
 )
-from utils.ind_cqc_filled_posts_utils.utils import (
-    populate_estimate_filled_posts_and_source_in_the_order_of_the_column_list,
-)
+from utils.ind_cqc_filled_posts_utils.utils import merge_columns_in_order
 
 partition_keys = [Keys.year, Keys.month, Keys.day, Keys.import_date]
 estimate_filled_posts_columns: list = [
@@ -143,7 +141,7 @@ def run_diagnostics_for_care_homes(
         CTCHClean.agency_and_non_agency_total_employed,
         number_of_days_in_window,
         CTCHClean.agency_and_non_agency_total_employed_rate_of_change_trendline,
-        max_days_between_submissions=370,
+        max_number_of_days_to_interpolate_between,
     )
     care_home_diagnostics_df = model_imputation_with_extrapolation_and_interpolation(
         care_home_diagnostics_df,
@@ -209,7 +207,7 @@ def run_diagnostics_for_non_residential(
         CTNRClean.cqc_care_workers_employed,
         number_of_days_in_window,
         CTNRClean.cqc_care_workers_employed_rate_of_change_trendline,
-        max_days_between_submissions=370,
+        max_number_of_days_to_interpolate_between,
     )
     non_res_diagnostics_df = model_imputation_with_extrapolation_and_interpolation(
         non_res_diagnostics_df,
@@ -224,16 +222,14 @@ def run_diagnostics_for_non_residential(
     non_res_diagnostics_df = convert_to_all_posts_using_ratio(
         non_res_diagnostics_df, care_worker_ratio
     )
-    non_res_diagnostics_df = (
-        populate_estimate_filled_posts_and_source_in_the_order_of_the_column_list(
-            non_res_diagnostics_df,
-            [
-                CTNRClean.capacity_tracker_all_posts,
-                IndCQC.estimate_filled_posts,
-            ],
-            CTNRClean.capacity_tracker_filled_post_estimate,
-            CTNRClean.capacity_tracker_filled_post_estimate_source,
-        )
+    non_res_diagnostics_df = merge_columns_in_order(
+        non_res_diagnostics_df,
+        [
+            CTNRClean.capacity_tracker_all_posts,
+            IndCQC.estimate_filled_posts,
+        ],
+        CTNRClean.capacity_tracker_filled_post_estimate,
+        CTNRClean.capacity_tracker_filled_post_estimate_source,
     )
     list_of_models = dUtils.create_list_of_models()
     non_res_diagnostics_df = dUtils.restructure_dataframe_to_column_wise(

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -1030,7 +1030,7 @@ class DiagnosticsOnCapacityTrackerSchemas:
             StructField(IndCQC.non_res_combined_model, FloatType(), True),
             StructField(IndCQC.imputed_pir_filled_posts_model, FloatType(), True),
             StructField(IndCQC.imputed_posts_non_res_combined_model, FloatType(), True),
-            StructField(IndCQC.estimate_filled_posts, FloatType(), True),
+            StructField(IndCQC.estimate_filled_posts, DoubleType(), True),
             StructField(IndCQC.number_of_beds, IntegerType(), True),
             StructField(IndCQC.unix_time, IntegerType(), True),
             StructField(Keys.year, StringType(), True),

--- a/tests/unit/test_diagnostics_on_capacity_tracker.py
+++ b/tests/unit/test_diagnostics_on_capacity_tracker.py
@@ -10,6 +10,8 @@ from utils.column_names.ind_cqc_pipeline_columns import (
     IndCqcColumns as IndCQC,
 )
 
+PATCH_PATH: str = "jobs.diagnostics_on_capacity_tracker"
+
 
 class DiagnosticsOnCapacityTrackerTests(unittest.TestCase):
     ESTIMATED_FILLED_POSTS_SOURCE = "some/directory"
@@ -40,14 +42,14 @@ class MainTests(DiagnosticsOnCapacityTrackerTests):
     def setUp(self) -> None:
         super().setUp()
 
-    @patch("utils.utils.write_to_parquet")
-    @patch("utils.utils.read_from_parquet")
+    @patch(f"{PATCH_PATH}.utils.write_to_parquet")
+    @patch(f"{PATCH_PATH}.utils.read_from_parquet")
     def test_main_runs(
         self,
-        read_from_parquet_patch: Mock,
-        write_to_parquet_patch: Mock,
+        read_from_parquet_mock: Mock,
+        write_to_parquet_mock: Mock,
     ):
-        read_from_parquet_patch.side_effect = [
+        read_from_parquet_mock.side_effect = [
             self.estimate_jobs_df,
             self.ct_care_home_df,
             self.ct_non_res_df,
@@ -63,8 +65,8 @@ class MainTests(DiagnosticsOnCapacityTrackerTests):
             self.NON_RES_SUMMARY_DIAGNOSTICS_DESTINATION,
         )
 
-        self.assertEqual(read_from_parquet_patch.call_count, 3)
-        self.assertEqual(write_to_parquet_patch.call_count, 4)
+        self.assertEqual(read_from_parquet_mock.call_count, 3)
+        self.assertEqual(write_to_parquet_mock.call_count, 4)
 
 
 class CheckConstantsTests(DiagnosticsOnCapacityTrackerTests):


### PR DESCRIPTION
# Description
We've replaced this function in the estimates script a while ago but didn't switch this function over.

Also spotted two magic numbers in the script, they were referenced at the top of the script but still had '370' in the script, not the reference

# How to test
[Glue job run](https://eu-west-2.console.aws.amazon.com/gluestudio/home?region=eu-west-2#/editor/job/remove-populate-estimate-func-diagnostics_on_capacity_tracker_job/runs) - set this going so hopefully it finished ok!
