### PR TITLE
Updated the specialist/generalist/other column names 

### DIFF
--- a/projects/_01_ingest/cqc_api/utils/utils.py
+++ b/projects/_01_ingest/cqc_api/utils/utils.py
@@ -26,6 +26,7 @@ def classify_specialisms(
 
     """
     new_column_name: str = f"specialist_generalist_other_{specialism}"
+    new_column_name = new_column_name.replace(" ", "_").lower()
     df = df.withColumn(
         new_column_name,
         F.when(

--- a/utils/column_names/cleaned_data_files/cqc_location_cleaned.py
+++ b/utils/column_names/cleaned_data_files/cqc_location_cleaned.py
@@ -50,7 +50,11 @@ class CqcLocationCleanedColumns(NewCqcLocationApiColumns, ONSClean):
     services_offered: str = "services_offered"
     specialisms_offered: str = "specialisms_offered"
     specialist_generalist_other_dementia: str = "specialist_generalist_other_dementia"
-    specialist_generalist_other_lda: str = "specialist_generalist_other_lda"
-    specialist_generalist_other_mh: str = "specialist_generalist_other_mh"
+    specialist_generalist_other_lda: str = (
+        "specialist_generalist_other_learning_disabilities"
+    )
+    specialist_generalist_other_mh: str = (
+        "specialist_generalist_other_mental_health_conditions"
+    )
     time_registered: str = "time_registered"
     time_since_dormant: str = "time_since_dormant"


### PR DESCRIPTION
# Description
In the last check in, the column names were created using the specific specialism offered using fstring concat. This caused an issue as the specialisms had spaces and capital letters. this PR updates the column names to lower case and replaces spaces with underscores.

Trello ticket is [here](https://trello.com/c/a72Ox7mh/881-create-individual-specialism-cols-with-specialist-generalist-from-specialismsoffered-col)

Last Glue Job run is [here ](https://eu-west-2.console.aws.amazon.com/gluestudio/home?region=eu-west-2#/editor/job/specialist-generalist-other-co-clean_cqc_location_data_job/runs)

Last step function run is [here](https://eu-west-2.console.aws.amazon.com/states/home?region=eu-west-2#/v2/executions/details/arn:aws:states:eu-west-2:344210435447:execution:specialist-generalist-other-co-Ind-CQC-Filled-Post-Estimates:26b5d891-dbb4-416e-ade7-9878aa5d2eb4)

CircleCI [test-plan-and-deploy-to-dev run](https://app.circleci.com/pipelines/github/NMDSdevopsServiceAdm/DataEngineering/7943/workflows/6ca99ff3-34cd-467a-a869-86e707e270d1)

# How to test
No extra tests added 

# Developer checklist
- [ ] Unit test
- [x] Linked to Trello ticket
- [ ] Documentation up to date
