### PR TITLE
Updated DPR file location to domain=DPR

### DIFF
--- a/terraform/pipeline/glue.tf
+++ b/terraform/pipeline/glue.tf
@@ -311,7 +311,7 @@ module "prepare_dpr_external_data_job" {
   glue_version    = "3.0"
   job_parameters = {
     "--direct_payments_source" = "${module.datasets_bucket.bucket_uri}/domain=DPR/dataset=direct_payments_external/version=2025.02/"
-    "--destination"            = "${module.datasets_bucket.bucket_uri}/domain=data_engineering/dataset=direct_payments_external_prepared/version=2025.02/"
+    "--destination"            = "${module.datasets_bucket.bucket_uri}/domain=DPR/dataset=direct_payments_external_prepared/version=2025.02/"
   }
 }
 
@@ -325,7 +325,7 @@ module "prepare_dpr_survey_data_job" {
   glue_version    = "3.0"
   job_parameters = {
     "--survey_data_source" = "${module.datasets_bucket.bucket_uri}/domain=DPR/dataset=direct_payments_survey/version=2025.02/"
-    "--destination"        = "${module.datasets_bucket.bucket_uri}/domain=data_engineering/dataset=direct_payments_survey_prepared/version=2025.02/"
+    "--destination"        = "${module.datasets_bucket.bucket_uri}/domain=DPR/dataset=direct_payments_survey_prepared/version=2025.02/"
   }
 }
 
@@ -338,9 +338,9 @@ module "merge_dpr_data_job" {
   datasets_bucket = module.datasets_bucket
   glue_version    = "3.0"
   job_parameters = {
-    "--direct_payments_external_data_source" = "${module.datasets_bucket.bucket_uri}/domain=data_engineering/dataset=direct_payments_external_prepared/version=2025.02/"
-    "--direct_payments_survey_data_source"   = "${module.datasets_bucket.bucket_uri}/domain=data_engineering/dataset=direct_payments_survey_prepared/version=2025.02/"
-    "--destination"                          = "${module.datasets_bucket.bucket_uri}/domain=data_engineering/dataset=direct_payments_merged/version=2025.02/"
+    "--direct_payments_external_data_source" = "${module.datasets_bucket.bucket_uri}/domain=DPR/dataset=direct_payments_external_prepared/version=2025.02/"
+    "--direct_payments_survey_data_source"   = "${module.datasets_bucket.bucket_uri}/domain=DPR/dataset=direct_payments_survey_prepared/version=2025.02/"
+    "--destination"                          = "${module.datasets_bucket.bucket_uri}/domain=DPR/dataset=direct_payments_merged/version=2025.02/"
   }
 }
 
@@ -353,9 +353,9 @@ module "estimate_direct_payments_job" {
   datasets_bucket = module.datasets_bucket
   glue_version    = "3.0"
   job_parameters = {
-    "--direct_payments_merged_source" = "${module.datasets_bucket.bucket_uri}/domain=data_engineering/dataset=direct_payments_merged/version=2025.02/"
-    "--destination"                   = "${module.datasets_bucket.bucket_uri}/domain=data_engineering/dataset=direct_payments_estimates/version=2025.02/"
-    "--summary_destination"           = "${module.datasets_bucket.bucket_uri}/domain=data_engineering/dataset=direct_payments_estimates_summary/version=2025.02/"
+    "--direct_payments_merged_source" = "${module.datasets_bucket.bucket_uri}/domain=DPR/dataset=direct_payments_merged/version=2025.02/"
+    "--destination"                   = "${module.datasets_bucket.bucket_uri}/domain=DPR/dataset=direct_payments_estimates/version=2025.02/"
+    "--summary_destination"           = "${module.datasets_bucket.bucket_uri}/domain=DPR/dataset=direct_payments_estimates_summary/version=2025.02/"
   }
 }
 
@@ -369,8 +369,8 @@ module "split_pa_filled_posts_into_icb_areas_job" {
   glue_version    = "3.0"
   job_parameters = {
     "--postcode_directory_source" = "${module.datasets_bucket.bucket_uri}/domain=ONS/dataset=postcode_directory_cleaned/"
-    "--pa_filled_posts_souce"     = "${module.datasets_bucket.bucket_uri}/domain=data_engineering/dataset=direct_payments_estimates/version=2025.02/"
-    "--destination"               = "${module.datasets_bucket.bucket_uri}/domain=data_engineering/dataset=direct_payments_estimates_by_icb/version=2025.02/"
+    "--pa_filled_posts_souce"     = "${module.datasets_bucket.bucket_uri}/domain=DPR/dataset=direct_payments_estimates/version=2025.02/"
+    "--destination"               = "${module.datasets_bucket.bucket_uri}/domain=DPR/dataset=direct_payments_estimates_by_icb/version=2025.02/"
   }
 }
 

--- a/terraform/pipeline/glue.tf
+++ b/terraform/pipeline/glue.tf
@@ -958,13 +958,6 @@ module "ascwds_crawler" {
   workspace_glue_database_name = "${local.workspace_prefix}-${var.glue_database_name}"
 }
 
-module "data_engineering_crawler" {
-  source                       = "../modules/glue-crawler"
-  dataset_for_crawler          = "data_engineering"
-  glue_role                    = aws_iam_role.sfc_glue_service_iam_role
-  workspace_glue_database_name = "${local.workspace_prefix}-${var.glue_database_name}"
-}
-
 module "ind_cqc_filled_posts_crawler" {
   source                       = "../modules/glue-crawler"
   dataset_for_crawler          = "ind_cqc_filled_posts"

--- a/terraform/pipeline/step-function.tf
+++ b/terraform/pipeline/step-function.tf
@@ -114,7 +114,7 @@ resource "aws_sfn_state_machine" "direct_payments_state_machine" {
     merge_dpr_data_job_name                       = module.merge_dpr_data_job.job_name
     estimate_direct_payments_job_name             = module.estimate_direct_payments_job.job_name
     split_pa_filled_posts_into_icb_areas_job_name = module.split_pa_filled_posts_into_icb_areas_job.job_name
-    data_engineering_crawler_name                 = module.data_engineering_crawler.crawler_name
+    dpr_crawler_name                              = module.dpr_crawler.crawler_name
     dataset_bucket_uri                            = module.datasets_bucket.bucket_uri
     run_crawler_state_machine_arn                 = aws_sfn_state_machine.run_crawler.arn
   })

--- a/terraform/pipeline/step-functions/DirectPaymentRecipientsPipeline-StepFunction.json
+++ b/terraform/pipeline/step-functions/DirectPaymentRecipientsPipeline-StepFunction.json
@@ -16,7 +16,7 @@
                 "JobName": "${prepare_dpr_survey_job_name}",
                 "Arguments": {
                   "--survey_data_source": "${dataset_bucket_uri}/domain=DPR/dataset=direct_payments_survey/version=2025.02/",
-                  "--destination": "${dataset_bucket_uri}/domain=data_engineering/dataset=direct_payments_survey_prepared/version=2025.02/"
+                  "--destination": "${dataset_bucket_uri}/domain=DPR/dataset=direct_payments_survey_prepared/version=2025.02/"
                 }
               },
               "End": true
@@ -33,7 +33,7 @@
                 "JobName": "${prepare_dpr_external_job_name}",
                 "Arguments": {
                   "--direct_payments_source": "${dataset_bucket_uri}/domain=DPR/dataset=direct_payments_external/version=2025.02/",
-                  "--destination": "${dataset_bucket_uri}/domain=data_engineering/dataset=direct_payments_external_prepared/version=2025.02/"
+                  "--destination": "${dataset_bucket_uri}/domain=DPR/dataset=direct_payments_external_prepared/version=2025.02/"
                 }
               },
               "End": true
@@ -48,9 +48,9 @@
       "Parameters": {
         "JobName": "${merge_dpr_data_job_name}",
         "Arguments": {
-          "--direct_payments_external_data_source": "${dataset_bucket_uri}/domain=data_engineering/dataset=direct_payments_external_prepared/version=2025.02/",
-          "--direct_payments_survey_data_source": "${dataset_bucket_uri}/domain=data_engineering/dataset=direct_payments_survey_prepared/version=2025.02/",
-          "--destination": "${dataset_bucket_uri}/domain=data_engineering/dataset=direct_payments_merged/version=2025.02/"
+          "--direct_payments_external_data_source": "${dataset_bucket_uri}/domain=DPR/dataset=direct_payments_external_prepared/version=2025.02/",
+          "--direct_payments_survey_data_source": "${dataset_bucket_uri}/domain=DPR/dataset=direct_payments_survey_prepared/version=2025.02/",
+          "--destination": "${dataset_bucket_uri}/domain=DPR/dataset=direct_payments_merged/version=2025.02/"
         }
       },
       "Next": "estimate direct payments"
@@ -61,9 +61,9 @@
       "Parameters": {
         "JobName": "${estimate_direct_payments_job_name}",
         "Arguments": {
-          "--direct_payments_merged_source": "${dataset_bucket_uri}/domain=data_engineering/dataset=direct_payments_merged/version=2025.02/",
-          "--destination": "${dataset_bucket_uri}/domain=data_engineering/dataset=direct_payments_estimates/version=2025.02/",
-          "--summary_destination": "${dataset_bucket_uri}/domain=data_engineering/dataset=direct_payments_estimates_summary/version=2025.02/"
+          "--direct_payments_merged_source": "${dataset_bucket_uri}/domain=DPR/dataset=direct_payments_merged/version=2025.02/",
+          "--destination": "${dataset_bucket_uri}/domain=DPR/dataset=direct_payments_estimates/version=2025.02/",
+          "--summary_destination": "${dataset_bucket_uri}/domain=DPR/dataset=direct_payments_estimates_summary/version=2025.02/"
         }
       },
       "Next": "Split pa estimates into hybrid areas"
@@ -75,8 +75,8 @@
         "JobName": "${split_pa_filled_posts_into_icb_areas_job_name}",
         "Arguments":{
           "--postcode_directory_source": "${dataset_bucket_uri}/domain=ONS/dataset=postcode_directory_cleaned/",
-          "--pa_filled_posts_souce": "${dataset_bucket_uri}/domain=data_engineering/dataset=direct_payments_estimates/version=2025.02/",
-          "--destination": "${dataset_bucket_uri}/domain=data_engineering/dataset=direct_payments_estimates_by_icb/version=2025.02/"
+          "--pa_filled_posts_souce": "${dataset_bucket_uri}/domain=DPR/dataset=direct_payments_estimates/version=2025.02/",
+          "--destination": "${dataset_bucket_uri}/domain=DPR/dataset=direct_payments_estimates_by_icb/version=2025.02/"
         }
       },
       "Next": "Run data engineering crawler"

--- a/terraform/pipeline/step-functions/DirectPaymentRecipientsPipeline-StepFunction.json
+++ b/terraform/pipeline/step-functions/DirectPaymentRecipientsPipeline-StepFunction.json
@@ -81,15 +81,11 @@
       },
       "Next": "Run data engineering crawler"
     },
-    "Run data engineering crawler": {
+    "Run DPR crawler": {
       "Type": "Task",
-      "Resource": "arn:aws:states:::states:startExecution.sync:2",
+      "Resource": "arn:aws:states:::aws-sdk:glue:startCrawler",
       "Parameters": {
-        "StateMachineArn": "arn:aws:states:eu-west-2:344210435447:stateMachine:main-RunCrawler",
-        "Input": {
-          "crawler_name": "${data_engineering_crawler_name}",
-          "AWS_STEP_FUNCTIONS_STARTED_BY_EXECUTION_ID.$": "$$.Execution.Id"
-        }
+        "Name": "${dpr_crawler_name}"
       },
       "End": true
     }

--- a/terraform/pipeline/step-functions/DirectPaymentRecipientsPipeline-StepFunction.json
+++ b/terraform/pipeline/step-functions/DirectPaymentRecipientsPipeline-StepFunction.json
@@ -79,7 +79,7 @@
           "--destination": "${dataset_bucket_uri}/domain=DPR/dataset=direct_payments_estimates_by_icb/version=2025.02/"
         }
       },
-      "Next": "Run data engineering crawler"
+      "Next": "Run DPR crawler"
     },
     "Run DPR crawler": {
       "Type": "Task",


### PR DESCRIPTION
# Description
Trello ticket [#899](https://trello.com/c/Jm1zbJMz/899-change-dpr-domain-from-dataengineering-to-dpr)

When we first started this project everything went into the data_engineering folder. We've changed this so each dataset/project has it's own partition. Currently half of the DPR work uses `domain=data_engineering` and half uses `domain=DPR`

In the PR I've
- Used 'domain=DPR' for all DPR jobs
- Replaced the crawler in the Step function with the DPR crawler
- Removed the data engineering crawler altogether (that domain no longer exists following this PR)

# How to test
[Branch run successful](https://eu-west-2.console.aws.amazon.com/states/home?region=eu-west-2#/v2/executions/details/arn:aws:states:eu-west-2:344210435447:execution:change-dpr-s3-path-Direct-Payment-Recipients:dae3efc4-5f7f-4a18-8abc-0d6119c05899)

Outputs appear in expected place
<img width="645" height="510" alt="image" src="https://github.com/user-attachments/assets/264c3ac3-7746-49ea-9a97-eb9ddc62e8ee" />

I've manually moved all of the DPR files in [s3-main-datasets](https://eu-west-2.console.aws.amazon.com/s3/buckets/sfc-main-datasets?region=eu-west-2&tab=objects&bucketType=general) from the `domain=data_engineering` to be in the `domain=DPR` folder.

The `domain=data_engineering` bucket no longer exists
