### PR TITLE
T879A - Dataset Rebuild ECR creation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,8 +45,8 @@ jobs:
               docker login -u AWS -p $(aws ecr get-login-password --region eu-west-2) ${AWS_ACCOUNT_ID}.dkr.ecr.eu-west-2.amazonaws.com
               
               # Push the image
-              docker tag latest ${AWS_ACCOUNT_ID}.dkr.ecr.eu-west-2.amazonaws.com/create-snapshot-lambda-repo:${CIRCLE_BRANCH}
-              docker push ${AWS_ACCOUNT_ID}.dkr.ecr.eu-west-2.amazonaws.com/create-snapshot-lambda-repo:${CIRCLE_BRANCH}
+              docker tag latest ${AWS_ACCOUNT_ID}.dkr.ecr.eu-west-2.amazonaws.com/lambda/create-snapshot:${CIRCLE_BRANCH}
+              docker push ${AWS_ACCOUNT_ID}.dkr.ecr.eu-west-2.amazonaws.com/lambda/create-snapshot:${CIRCLE_BRANCH}
             else
               echo "There are no changes in the create dataset snapshot container. Skipping."
             fi
@@ -59,8 +59,8 @@ jobs:
               docker login -u AWS -p $(aws ecr get-login-password --region eu-west-2) ${AWS_ACCOUNT_ID}.dkr.ecr.eu-west-2.amazonaws.com
 
               # Push the image
-              docker tag latest ${AWS_ACCOUNT_ID}.dkr.ecr.eu-west-2.amazonaws.com/check-datasets-equal-repo:${CIRCLE_BRANCH}
-              docker push ${AWS_ACCOUNT_ID}.dkr.ecr.eu-west-2.amazonaws.com/check-datasets-equal-repo:${CIRCLE_BRANCH}
+              docker tag latest ${AWS_ACCOUNT_ID}.dkr.ecr.eu-west-2.amazonaws.com/lambda/check-datasets-equal:${CIRCLE_BRANCH}
+              docker push ${AWS_ACCOUNT_ID}.dkr.ecr.eu-west-2.amazonaws.com/lambda/check-datasets-equal:${CIRCLE_BRANCH}
             else
               echo "There are no changes in the check dataset equality container. Skipping."
             fi
@@ -289,10 +289,10 @@ workflows:
   test-plan-approve-and-deploy-to-main:
     unless: << pipeline.parameters.GHA_Action >>
     jobs:
-#      - lambda-function-containerisation:
-#          filters:
-#            branches:
-#              only: main
+      - lambda-function-containerisation:
+          filters:
+            branches:
+              only: main
       - test:
           filters:
             branches:
@@ -300,7 +300,7 @@ workflows:
       - terraform-plan:
           requires:
             - test
-#            - lambda-function-containerisation
+            - lambda-function-containerisation
       - plan-approval:
           type: approval
           requires:
@@ -316,10 +316,10 @@ workflows:
   test-plan-and-deploy-to-dev:
     unless: << pipeline.parameters.GHA_Action >>
     jobs:
-#      - lambda-function-containerisation:
-#          filters:
-#            branches:
-#              ignore: main
+      - lambda-function-containerisation:
+          filters:
+            branches:
+              ignore: main
       - test:
           filters:
             branches:
@@ -339,7 +339,7 @@ workflows:
       - terraform-plan:
           requires:
             - test
-#            - lambda-function-containerisation
+            - lambda-function-containerisation
             - lint-terraform
       - terraform-apply:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -289,10 +289,10 @@ workflows:
   test-plan-approve-and-deploy-to-main:
     unless: << pipeline.parameters.GHA_Action >>
     jobs:
-      - lambda-function-containerisation:
-          filters:
-            branches:
-              only: main
+#      - lambda-function-containerisation:
+#          filters:
+#            branches:
+#              only: main
       - test:
           filters:
             branches:
@@ -300,7 +300,7 @@ workflows:
       - terraform-plan:
           requires:
             - test
-            - lambda-function-containerisation
+#            - lambda-function-containerisation
       - plan-approval:
           type: approval
           requires:
@@ -316,10 +316,10 @@ workflows:
   test-plan-and-deploy-to-dev:
     unless: << pipeline.parameters.GHA_Action >>
     jobs:
-      - lambda-function-containerisation:
-          filters:
-            branches:
-              ignore: main
+#      - lambda-function-containerisation:
+#          filters:
+#            branches:
+#              ignore: main
       - test:
           filters:
             branches:
@@ -339,7 +339,7 @@ workflows:
       - terraform-plan:
           requires:
             - test
-            - lambda-function-containerisation
+#            - lambda-function-containerisation
             - lint-terraform
       - terraform-apply:
           requires:

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -6,6 +6,12 @@ AWS CLI is a prerequisite of Terraform.
 2. Request access to the AWS Console
 3. Once this access is granted, follow the steps here to [setup your access and secret key](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html)
 
+## Resource Dependencies
+Some resources have been created outside of terraform. The extra resources you would need to create are:
+- An ECR repository called "lambda/create-snapshot"
+- An ECR repository called "lambda/check-datasets-equal"
+
+
 ## Deploying Terraform
 
 1. Set up your AWS crendentials as terraform variables

--- a/lambdas/check_dataset_equality/lambda_function.py
+++ b/lambdas/check_dataset_equality/lambda_function.py
@@ -13,7 +13,7 @@ logger.setLevel(logging.INFO)
 
 
 def lambda_handler(event, context):
-    logger.info("Received event: " + json.dumps(event, indent=2))
+    logger.info("Received event: \n" + json.dumps(event, indent=2))
     left_df = pl.read_parquet(event["left"])
     right_df = pl.read_parquet(event["right"])
 

--- a/lambdas/create_dataset_snapshot/lambda_function.py
+++ b/lambdas/create_dataset_snapshot/lambda_function.py
@@ -17,6 +17,8 @@ logger.setLevel(logging.INFO)
 
 
 def lambda_handler(event, context):
+    logger.info("Received event: \n" + json.dumps(event, indent=2))
+
     input_parse = match(
         "s3://(?P<bucket>[\w\-=.]+)/(?P<read_folder>[\w/-=.]+)", event["input_uri"]
     )

--- a/terraform/pipeline/ecr.tf
+++ b/terraform/pipeline/ecr.tf
@@ -17,13 +17,13 @@ resource "aws_ecr_repository" "check_datasets_equal" {
   }
 }
 
-# Get the latest image digests for this branch
-data "aws_ecr_image" "create_dataset_snapshot" {
-  repository_name = aws_ecr_repository.create_dataset_snapshot.name
-  image_tag       = local.workspace_prefix
-}
-
-data "aws_ecr_image" "check_datasets_equal" {
-  repository_name = aws_ecr_repository.check_datasets_equal.name
-  image_tag       = local.workspace_prefix
-}
+# # Get the latest image digests for this branch
+# data "aws_ecr_image" "create_dataset_snapshot" {
+#   repository_name = aws_ecr_repository.create_dataset_snapshot.name
+#   image_tag       = local.workspace_prefix
+# }
+#
+# data "aws_ecr_image" "check_datasets_equal" {
+#   repository_name = aws_ecr_repository.check_datasets_equal.name
+#   image_tag       = local.workspace_prefix
+# }

--- a/terraform/pipeline/ecr.tf
+++ b/terraform/pipeline/ecr.tf
@@ -1,5 +1,6 @@
 # ECR Repositories to store the Docker images
 resource "aws_ecr_repository" "create_dataset_snapshot" {
+  count                = terraform.workspace == "main" ? 1 : 0
   name                 = "create-snapshot-lambda-repo"
   image_tag_mutability = "MUTABLE"
   force_delete         = true
@@ -9,6 +10,7 @@ resource "aws_ecr_repository" "create_dataset_snapshot" {
 }
 
 resource "aws_ecr_repository" "check_datasets_equal" {
+  count                = terraform.workspace == "main" ? 1 : 0
   name                 = "check-datasets-equal-repo"
   image_tag_mutability = "MUTABLE"
   force_delete         = true

--- a/terraform/pipeline/ecr.tf
+++ b/terraform/pipeline/ecr.tf
@@ -1,31 +1,16 @@
-# ECR Repositories to store the Docker images
-resource "aws_ecr_repository" "create_dataset_snapshot" {
-  count                = terraform.workspace == "main" ? 1 : 0
-  name                 = "create-snapshot-lambda-repo"
-  image_tag_mutability = "MUTABLE"
-  force_delete         = true
-  image_scanning_configuration {
-    scan_on_push = true
-  }
+#####################################################################################################
+# The ECR repositories are created outside of terraform please see:                                 #
+# https://skillsforcare.atlassian.net/wiki/spaces/DE/pages/1493762050/Lambda+deployment+via+Docker  #
+# for more information on how to create one                                                         #
+#####################################################################################################
+
+# Get the latest image digests for this branch
+data "aws_ecr_image" "create_dataset_snapshot" {
+  repository_name = "lambda/create-snapshot"
+  image_tag       = local.workspace_prefix
 }
 
-resource "aws_ecr_repository" "check_datasets_equal" {
-  count                = terraform.workspace == "main" ? 1 : 0
-  name                 = "check-datasets-equal-repo"
-  image_tag_mutability = "MUTABLE"
-  force_delete         = true
-  image_scanning_configuration {
-    scan_on_push = true
-  }
+data "aws_ecr_image" "check_datasets_equal" {
+  repository_name = "lambda/check-datasets-equal"
+  image_tag       = local.workspace_prefix
 }
-
-# # Get the latest image digests for this branch
-# data "aws_ecr_image" "create_dataset_snapshot" {
-#   repository_name = aws_ecr_repository.create_dataset_snapshot.name
-#   image_tag       = local.workspace_prefix
-# }
-#
-# data "aws_ecr_image" "check_datasets_equal" {
-#   repository_name = aws_ecr_repository.check_datasets_equal.name
-#   image_tag       = local.workspace_prefix
-# }

--- a/terraform/pipeline/lambda.tf
+++ b/terraform/pipeline/lambda.tf
@@ -28,23 +28,23 @@ resource "aws_lambda_function" "error_notification_lambda" {
   }
 }
 
-# resource "aws_lambda_function" "create_snapshot_lambda" {
-#   role          = aws_iam_role.create_snapshot_lambda.arn
-#   function_name = "${local.workspace_prefix}-create-full-snapshot"
-#   package_type  = "Image"
-#   image_uri     = "${aws_ecr_repository.create_dataset_snapshot.repository_url}@${data.aws_ecr_image.create_dataset_snapshot.image_digest}"
-#   memory_size   = 3072
-#   timeout       = 60
-# }
-#
-# resource "aws_lambda_function" "check_datasets_equal" {
-#   role          = aws_iam_role.check_datasets_equal.arn
-#   function_name = "${local.workspace_prefix}-check-datasets-equal"
-#   package_type  = "Image"
-#   image_uri     = "${aws_ecr_repository.check_datasets_equal.repository_url}@${data.aws_ecr_image.check_datasets_equal.image_digest}"
-#   memory_size   = 2048
-#   timeout       = 60
-# }
+resource "aws_lambda_function" "create_snapshot_lambda" {
+  role          = aws_iam_role.create_snapshot_lambda.arn
+  function_name = "${local.workspace_prefix}-create-full-snapshot"
+  package_type  = "Image"
+  image_uri     = "${data.aws_caller_identity.current.account_id}.dkr.ecr.eu-west-2.amazonaws.com/lambda/create-snapshot@${data.aws_ecr_image.create_dataset_snapshot.image_digest}"
+  memory_size   = 3072
+  timeout       = 60
+}
+
+resource "aws_lambda_function" "check_datasets_equal" {
+  role          = aws_iam_role.check_datasets_equal.arn
+  function_name = "${local.workspace_prefix}-check-datasets-equal"
+  package_type  = "Image"
+  image_uri     = "${data.aws_caller_identity.current.account_id}.dkr.ecr.eu-west-2.amazonaws.com/lambda/check-datasets-equal@${data.aws_ecr_image.check_datasets_equal.image_digest}"
+  memory_size   = 2048
+  timeout       = 60
+}
 
 data "aws_iam_policy_document" "error_notification_lambda_assume_role" {
   statement {

--- a/terraform/pipeline/lambda.tf
+++ b/terraform/pipeline/lambda.tf
@@ -28,23 +28,23 @@ resource "aws_lambda_function" "error_notification_lambda" {
   }
 }
 
-resource "aws_lambda_function" "create_snapshot_lambda" {
-  role          = aws_iam_role.create_snapshot_lambda.arn
-  function_name = "${local.workspace_prefix}-create-full-snapshot"
-  package_type  = "Image"
-  image_uri     = "${aws_ecr_repository.create_dataset_snapshot.repository_url}@${data.aws_ecr_image.create_dataset_snapshot.image_digest}"
-  memory_size   = 3072
-  timeout       = 60
-}
-
-resource "aws_lambda_function" "check_datasets_equal" {
-  role          = aws_iam_role.check_datasets_equal.arn
-  function_name = "${local.workspace_prefix}-check-datasets-equal"
-  package_type  = "Image"
-  image_uri     = "${aws_ecr_repository.check_datasets_equal.repository_url}@${data.aws_ecr_image.check_datasets_equal.image_digest}"
-  memory_size   = 2048
-  timeout       = 60
-}
+# resource "aws_lambda_function" "create_snapshot_lambda" {
+#   role          = aws_iam_role.create_snapshot_lambda.arn
+#   function_name = "${local.workspace_prefix}-create-full-snapshot"
+#   package_type  = "Image"
+#   image_uri     = "${aws_ecr_repository.create_dataset_snapshot.repository_url}@${data.aws_ecr_image.create_dataset_snapshot.image_digest}"
+#   memory_size   = 3072
+#   timeout       = 60
+# }
+#
+# resource "aws_lambda_function" "check_datasets_equal" {
+#   role          = aws_iam_role.check_datasets_equal.arn
+#   function_name = "${local.workspace_prefix}-check-datasets-equal"
+#   package_type  = "Image"
+#   image_uri     = "${aws_ecr_repository.check_datasets_equal.repository_url}@${data.aws_ecr_image.check_datasets_equal.image_digest}"
+#   memory_size   = 2048
+#   timeout       = 60
+# }
 
 data "aws_iam_policy_document" "error_notification_lambda_assume_role" {
   statement {

--- a/terraform/pipeline/step-function.tf
+++ b/terraform/pipeline/step-function.tf
@@ -129,28 +129,28 @@ resource "aws_sfn_state_machine" "delta_download_cqc_api_state_machine" {
   ]
 }
 
-# resource "aws_sfn_state_machine" "build_full_cqc_state_machine" {
-#   name     = "${local.workspace_prefix}-Build-Full-CQC-Dataset"
-#   role_arn = aws_iam_role.step_function_iam_role.arn
-#   type     = "STANDARD"
-#   definition = templatefile("step-functions/BuildCQCDataset-StepFunction.json", {
-#     dataset_bucket_uri         = module.datasets_bucket.bucket_uri
-#     dataset_bucket_name        = module.datasets_bucket.bucket_name
-#     create_snapshot_lambda_arn = aws_lambda_function.create_snapshot_lambda.arn
-#     check_equal_lambda_arn     = aws_lambda_function.check_datasets_equal.arn
-#   })
-#
-#   logging_configuration {
-#     log_destination        = "${aws_cloudwatch_log_group.state_machines.arn}:*"
-#     include_execution_data = true
-#     level                  = "ERROR"
-#   }
-#
-#   depends_on = [
-#     aws_iam_policy.step_function_iam_policy,
-#     module.datasets_bucket
-#   ]
-# }
+resource "aws_sfn_state_machine" "build_full_cqc_state_machine" {
+  name     = "${local.workspace_prefix}-Build-Full-CQC-Dataset"
+  role_arn = aws_iam_role.step_function_iam_role.arn
+  type     = "STANDARD"
+  definition = templatefile("step-functions/BuildCQCDataset-StepFunction.json", {
+    dataset_bucket_uri         = module.datasets_bucket.bucket_uri
+    dataset_bucket_name        = module.datasets_bucket.bucket_name
+    create_snapshot_lambda_arn = aws_lambda_function.create_snapshot_lambda.arn
+    check_equal_lambda_arn     = aws_lambda_function.check_datasets_equal.arn
+  })
+
+  logging_configuration {
+    log_destination        = "${aws_cloudwatch_log_group.state_machines.arn}:*"
+    include_execution_data = true
+    level                  = "ERROR"
+  }
+
+  depends_on = [
+    aws_iam_policy.step_function_iam_policy,
+    module.datasets_bucket
+  ]
+}
 
 resource "aws_sfn_state_machine" "direct_payments_state_machine" {
   name     = "${local.workspace_prefix}-Direct-Payment-Recipients"
@@ -529,8 +529,8 @@ resource "aws_iam_policy" "step_function_iam_policy" {
         ],
         "Resource" : [
           "${aws_lambda_function.error_notification_lambda.arn}*",
-          # "${aws_lambda_function.create_snapshot_lambda.arn}*",
-          # "${aws_lambda_function.check_datasets_equal.arn}*"
+          "${aws_lambda_function.create_snapshot_lambda.arn}*",
+          "${aws_lambda_function.check_datasets_equal.arn}*"
         ]
       },
       {

--- a/terraform/pipeline/step-function.tf
+++ b/terraform/pipeline/step-function.tf
@@ -129,28 +129,28 @@ resource "aws_sfn_state_machine" "delta_download_cqc_api_state_machine" {
   ]
 }
 
-resource "aws_sfn_state_machine" "build_full_cqc_state_machine" {
-  name     = "${local.workspace_prefix}-Build-Full-CQC-Dataset"
-  role_arn = aws_iam_role.step_function_iam_role.arn
-  type     = "STANDARD"
-  definition = templatefile("step-functions/BuildCQCDataset-StepFunction.json", {
-    dataset_bucket_uri         = module.datasets_bucket.bucket_uri
-    dataset_bucket_name        = module.datasets_bucket.bucket_name
-    create_snapshot_lambda_arn = aws_lambda_function.create_snapshot_lambda.arn
-    check_equal_lambda_arn     = aws_lambda_function.check_datasets_equal.arn
-  })
-
-  logging_configuration {
-    log_destination        = "${aws_cloudwatch_log_group.state_machines.arn}:*"
-    include_execution_data = true
-    level                  = "ERROR"
-  }
-
-  depends_on = [
-    aws_iam_policy.step_function_iam_policy,
-    module.datasets_bucket
-  ]
-}
+# resource "aws_sfn_state_machine" "build_full_cqc_state_machine" {
+#   name     = "${local.workspace_prefix}-Build-Full-CQC-Dataset"
+#   role_arn = aws_iam_role.step_function_iam_role.arn
+#   type     = "STANDARD"
+#   definition = templatefile("step-functions/BuildCQCDataset-StepFunction.json", {
+#     dataset_bucket_uri         = module.datasets_bucket.bucket_uri
+#     dataset_bucket_name        = module.datasets_bucket.bucket_name
+#     create_snapshot_lambda_arn = aws_lambda_function.create_snapshot_lambda.arn
+#     check_equal_lambda_arn     = aws_lambda_function.check_datasets_equal.arn
+#   })
+#
+#   logging_configuration {
+#     log_destination        = "${aws_cloudwatch_log_group.state_machines.arn}:*"
+#     include_execution_data = true
+#     level                  = "ERROR"
+#   }
+#
+#   depends_on = [
+#     aws_iam_policy.step_function_iam_policy,
+#     module.datasets_bucket
+#   ]
+# }
 
 resource "aws_sfn_state_machine" "direct_payments_state_machine" {
   name     = "${local.workspace_prefix}-Direct-Payment-Recipients"
@@ -529,8 +529,8 @@ resource "aws_iam_policy" "step_function_iam_policy" {
         ],
         "Resource" : [
           "${aws_lambda_function.error_notification_lambda.arn}*",
-          "${aws_lambda_function.create_snapshot_lambda.arn}*",
-          "${aws_lambda_function.check_datasets_equal.arn}*"
+          # "${aws_lambda_function.create_snapshot_lambda.arn}*",
+          # "${aws_lambda_function.check_datasets_equal.arn}*"
         ]
       },
       {


### PR DESCRIPTION
## Description
Trello ticket [#879](https://trello.com/c/ekNXYRr5)

In order to merge [T879 - Data Structure - New Import Process of providers dataset](https://github.com/NMDSdevopsServiceAdm/DataEngineering/pull/927) we need to create the ECR repositories manually, so that the docker images can be pushed to them. 

## Testing
- [x] Unit tests passing

This ticket is a sub-item of T879 - Data Structure - New Import Process of providers dataset](https://github.com/NMDSdevopsServiceAdm/DataEngineering/pull/927) - all testing is reported there