### PR TITLE
942 Fix delta locations validation failure for missing CQC sector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ All notable changes to this project will be documented in this file.
 
 - Updated the CQC locations schema to include a new assessment field for storing the latest CQC ratings. Modified the function that builds the full locations dataset from the delta dataset to use this updated schema, ensuring the newly added column is included.
 
+- Moved evaluation of CQC Sector into Location cleaning script to remove unnecessary dependency.
+
 ### Improved
 - Deduplicated Capacity Tracker data so it's more in line with the ASC-WDS and PIR process
 

--- a/projects/_01_ingest/cqc_api/jobs/delta_clean_cqc_location_data.py
+++ b/projects/_01_ingest/cqc_api/jobs/delta_clean_cqc_location_data.py
@@ -1,0 +1,841 @@
+import sys
+import warnings
+
+from pyspark.sql import DataFrame, Window, functions as F
+from pyspark.sql.types import (
+    StringType,
+)
+
+from utils import utils
+import utils.cleaning_utils as cUtils
+from utils.cqc_local_authority_provider_ids import LocalAuthorityProviderIds
+from utils.column_names.ind_cqc_pipeline_columns import (
+    PartitionKeys as Keys,
+)
+from utils.column_names.raw_data_files.cqc_location_api_columns import (
+    NewCqcLocationApiColumns as CQCL,
+)
+from utils.column_names.cleaned_data_files.cqc_provider_cleaned import (
+    CqcProviderCleanedColumns as CQCPClean,
+)
+from utils.column_names.cleaned_data_files.cqc_location_cleaned import (
+    CqcLocationCleanedColumns as CQCLClean,
+)
+from utils.column_values.categorical_column_values import (
+    CareHome,
+    Dormancy,
+    LocationType,
+    PrimaryServiceType,
+    RegistrationStatus,
+    RelatedLocation,
+    Services,
+    Specialisms,
+)
+from utils.column_names.cleaned_data_files.ons_cleaned import (
+    OnsCleanedColumns as ONSClean,
+    contemporary_geography_columns,
+    current_geography_columns,
+)
+from projects._01_ingest.cqc_api.utils.extract_registered_manager_names import (
+    extract_registered_manager_names,
+)
+from utils.raw_data_adjustments import remove_records_from_locations_data
+from projects._01_ingest.cqc_api.utils.postcode_matcher import run_postcode_matching
+
+from projects._01_ingest.cqc_api.utils.utils import (
+    classify_specialisms,
+)
+from utils.column_values.categorical_column_values import (
+    Sector,
+)
+
+cqcPartitionKeys = [Keys.year, Keys.month, Keys.day, Keys.import_date]
+
+cqc_location_api_cols_to_import = [
+    CQCL.location_id,
+    CQCL.provider_id,
+    CQCL.name,
+    CQCL.postal_address_line1,
+    CQCL.postal_code,
+    CQCL.registration_status,
+    CQCL.registration_date,
+    CQCL.deregistration_date,
+    CQCL.type,
+    CQCL.relationships,
+    CQCL.care_home,
+    CQCL.number_of_beds,
+    CQCL.dormancy,
+    CQCL.gac_service_types,
+    CQCL.regulated_activities,
+    CQCL.specialisms,
+    Keys.import_date,
+    Keys.year,
+    Keys.month,
+    Keys.day,
+]
+ons_cols_to_import = [
+    ONSClean.postcode,
+    *contemporary_geography_columns,
+    *current_geography_columns,
+]
+cqc_provider_cols_to_import = [
+    CQCPClean.provider_id,
+    CQCPClean.name,
+    CQCPClean.cqc_sector,
+    CQCPClean.cqc_provider_import_date,
+]
+
+
+def main(
+    cqc_location_source: str,
+    cleaned_cqc_provider_source: str,
+    cleaned_ons_postcode_directory_source: str,
+    cleaned_cqc_location_destination: str,
+):
+    cqc_location_df = utils.read_from_parquet(
+        cqc_location_source, selected_columns=cqc_location_api_cols_to_import
+    )
+    cqc_provider_df = utils.read_from_parquet(
+        cleaned_cqc_provider_source, selected_columns=cqc_provider_cols_to_import
+    )
+    ons_postcode_directory_df = utils.read_from_parquet(
+        cleaned_ons_postcode_directory_source, selected_columns=ons_cols_to_import
+    )
+
+    cqc_location_df = create_cleaned_registration_date_column(cqc_location_df)
+    cqc_location_df = cUtils.column_to_date(
+        cqc_location_df, CQCLClean.imputed_registration_date, string_format="yyyy-MM-dd"
+    )
+
+    cqc_location_df = clean_provider_id_column(cqc_location_df)
+    cqc_location_df = utils.select_rows_with_non_null_value(
+        cqc_location_df, CQCL.provider_id
+    )
+
+    cqc_location_df = remove_non_social_care_locations(cqc_location_df)
+    cqc_location_df = remove_records_from_locations_data(cqc_location_df)
+    cqc_location_df = utils.format_date_fields(
+        cqc_location_df,
+        date_column_identifier=CQCLClean.registration_date,  # This will format both registration date and deregistration date
+        raw_date_format="yyyy-MM-dd",
+    )
+    cqc_location_df = cUtils.column_to_date(
+        cqc_location_df, Keys.import_date, CQCLClean.cqc_location_import_date
+    )
+    cqc_location_df = calculate_time_registered_for(cqc_location_df)
+    cqc_location_df = calculate_time_since_dormant(cqc_location_df)
+
+    cqc_location_df = impute_historic_relationships(cqc_location_df)
+    registered_locations_df = select_registered_locations_only(cqc_location_df)
+
+    registered_locations_df = impute_missing_struct_column(
+        registered_locations_df, CQCL.gac_service_types
+    )
+    registered_locations_df = impute_missing_struct_column(
+        registered_locations_df, CQCL.regulated_activities
+    )
+    registered_locations_df = impute_missing_struct_column(
+        registered_locations_df, CQCL.specialisms
+    )
+    registered_locations_df = remove_locations_that_never_had_regulated_activities(
+        registered_locations_df
+    )
+    registered_locations_df = extract_from_struct(
+        registered_locations_df,
+        registered_locations_df[CQCLClean.imputed_gac_service_types][CQCL.description],
+        CQCLClean.services_offered,
+    )
+    registered_locations_df = extract_from_struct(
+        registered_locations_df,
+        registered_locations_df[CQCLClean.imputed_specialisms][CQCL.name],
+        CQCLClean.specialisms_offered,
+    )
+    registered_locations_df = classify_specialisms(
+        registered_locations_df,
+        Specialisms.dementia,
+    )
+    registered_locations_df = classify_specialisms(
+        registered_locations_df,
+        Specialisms.learning_disabilities,
+    )
+    registered_locations_df = classify_specialisms(
+        registered_locations_df,
+        Specialisms.mental_health,
+    )
+    registered_locations_df = remove_specialist_colleges(registered_locations_df)
+    registered_locations_df = allocate_primary_service_type(registered_locations_df)
+    registered_locations_df = realign_carehome_column_with_primary_service(
+        registered_locations_df
+    )
+    registered_locations_df = extract_registered_manager_names(registered_locations_df)
+
+    registered_locations_df = add_related_location_column(registered_locations_df)
+
+    # registered_locations_df = join_cqc_provider_data(
+    #     registered_locations_df, cqc_provider_df
+    # )
+
+    known_la_providerids = LocalAuthorityProviderIds.known_ids
+    registered_locations_df = add_cqc_sector_column_to_cqc_locations_dataframe(
+        registered_locations_df, known_la_providerids
+    )
+
+    registered_locations_df = impute_missing_data_from_provider_dataset(
+        registered_locations_df, CQCLClean.provider_name
+    )
+    registered_locations_df = impute_missing_data_from_provider_dataset(
+        registered_locations_df, CQCLClean.cqc_sector
+    )
+
+    registered_locations_df = run_postcode_matching(
+        registered_locations_df, ons_postcode_directory_df
+    )
+
+    utils.write_to_parquet(
+        registered_locations_df,
+        cleaned_cqc_location_destination,
+        mode="overwrite",
+        partitionKeys=cqcPartitionKeys,
+    )
+
+
+def clean_provider_id_column(cqc_df: DataFrame) -> DataFrame:
+    cqc_df = remove_provider_ids_with_too_many_characters(cqc_df)
+    cqc_df = fill_missing_provider_ids_from_other_rows(cqc_df)
+    return cqc_df
+
+
+def remove_provider_ids_with_too_many_characters(cqc_df: DataFrame) -> DataFrame:
+    cqc_df = cqc_df.withColumn(
+        CQCL.provider_id,
+        F.when(F.length(CQCL.provider_id) <= 14, cqc_df[CQCL.provider_id]),
+    )
+    return cqc_df
+
+
+def fill_missing_provider_ids_from_other_rows(cqc_df: DataFrame) -> DataFrame:
+    cqc_df = cqc_df.withColumn(
+        CQCL.provider_id,
+        F.when(
+            cqc_df[CQCL.provider_id].isNull(),
+            F.first(CQCL.provider_id, ignorenulls=True).over(
+                Window.partitionBy(CQCL.location_id)
+            ),
+        ).otherwise(cqc_df[CQCL.provider_id]),
+    )
+    return cqc_df
+
+
+def create_cleaned_registration_date_column(cqc_df: DataFrame) -> DataFrame:
+    """
+    Adds a new column which is a cleaned and imputed copy of registrationdate.
+
+    This function handles the steps for creating, cleaning and filling the blanks in the column imputed_registration_date.
+
+    Args:
+        cqc_df (DataFrame): A dataframe of CQC locations data with the column location_id, import_date, and registrationdate.
+
+    Returns:
+        DataFrame: A dataframe of CQC locations data with the additional column imputed_registration_date.
+    """
+    cqc_df = cqc_df.withColumn(
+        CQCLClean.imputed_registration_date, cqc_df[CQCL.registration_date]
+    )
+    cqc_df = remove_time_from_date_column(cqc_df, CQCLClean.imputed_registration_date)
+    cqc_df = remove_registration_dates_that_are_later_than_import_date(cqc_df)
+    cqc_df = impute_missing_registration_dates(cqc_df)
+    return cqc_df
+
+
+def remove_time_from_date_column(df: DataFrame, column_name: str) -> DataFrame:
+    """
+    Converts a timestamp-as-string to a date-as-string.
+
+    This function takes a column of string type containing mixed date and timestamp data and removes the time portion of the timestamp data.
+
+    Args:
+        df (DataFrame): A dataframe with the named column.
+        column_name (str): A string with the name of the column to remove time data from.
+
+    Returns:
+        DataFrame: A dataframe with the named column without time data.
+    """
+    df = df.withColumn(column_name, F.substring(column_name, 1, 10))
+    return df
+
+
+def remove_registration_dates_that_are_later_than_import_date(
+    df: DataFrame,
+) -> DataFrame:
+    """
+    Nullifies registration dates from the imupted_registration_date column which are after the import date.
+
+    This function changes registration dates from the imupted_registration_date column to None when they are greater than the import date.
+
+    Args:
+        df (DataFrame): A dataframe of CQC locations data with the column imputed_registration_date containing cleaned registration dates.
+
+    Returns:
+        DataFrame: A dataframe of CQC locations data with the column imputed_registration_date containing registration dates that are less than or equal to than the import date.
+    """
+    min_import_date = "min_import_date"
+    df = df.withColumn(
+        min_import_date,
+        F.regexp_replace(
+            F.min(Keys.import_date).over(Window.partitionBy(CQCL.location_id)),
+            "(\d{4})(\d{2})(\d{2})",
+            "$1-$2-$3",
+        ),
+    )
+    df = df.withColumn(
+        CQCLClean.imputed_registration_date,
+        F.when(
+            df[CQCLClean.imputed_registration_date] <= df[min_import_date],
+            df[CQCLClean.imputed_registration_date],
+        ),
+    ).drop(min_import_date)
+    return df
+
+
+def impute_missing_registration_dates(df: DataFrame) -> DataFrame:
+    """
+    Fills missing dates in the imputed_registration_date_column.
+
+    This function fills missing dates in the imputed_registration_date_column. Where there is a value in
+    imputed_registation_date for that location at a later point in time, the minimum registration date for
+    that location is used. Where there is no value for that location at any point in time, the minimum
+    import date is used.
+
+    Args:
+        df (DataFrame): A dataframe with the columns imputed_registration_date, location_id, and import_date.
+
+    Returns:
+        DataFrame: A dataframe with the imputed_registration_date filled.
+    """
+    df = df.withColumn(
+        CQCLClean.imputed_registration_date,
+        F.when(
+            df[CQCLClean.imputed_registration_date].isNull(),
+            F.min(CQCLClean.imputed_registration_date).over(
+                Window.partitionBy(CQCL.location_id)
+            ),
+        ).otherwise(df[CQCLClean.imputed_registration_date]),
+    )
+    df = df.withColumn(
+        CQCLClean.imputed_registration_date,
+        F.when(
+            df[CQCLClean.imputed_registration_date].isNull(),
+            F.regexp_replace(
+                F.min(Keys.import_date).over(Window.partitionBy(CQCL.location_id)),
+                "(\d{4})(\d{2})(\d{2})",
+                "$1-$2-$3",
+            ),
+        ).otherwise(df[CQCLClean.imputed_registration_date]),
+    )
+    return df
+
+
+def calculate_time_registered_for(df: DataFrame) -> DataFrame:
+    """
+    Adds a new column called time_registered which is the number of months the location has been registered with CQC for (rounded up).
+
+    This function adds a new integer column to the given data frame which represents the number of months (rounded up) between the
+    imputed registration date and the cqc location import date.
+
+    Args:
+        df (DataFrame): A dataframe containing the columns: imputed_registration_date and cqc_location_import_date.
+
+    Returns:
+        DataFrame: A dataframe with the new time_registered column added.
+    """
+    df = df.withColumn(
+        CQCLClean.time_registered,
+        F.floor(
+            F.months_between(
+                F.col(CQCLClean.cqc_location_import_date),
+                F.col(CQCLClean.imputed_registration_date),
+            )
+        )
+        + 1,
+    )
+
+    return df
+
+
+def remove_non_social_care_locations(df: DataFrame) -> DataFrame:
+    return df.where(df[CQCL.type] == LocationType.social_care_identifier)
+
+
+def impute_historic_relationships(df: DataFrame) -> DataFrame:
+    """
+    Imputes historic relationships for locations in the given DataFrame.
+
+    If a location is 'Deregistered' it can have both Predecessors (a previous linked location) and
+    Successors (the location it was linked to after closing). A 'Registered' location can only have
+    Predecessors. As we are backdating data, locations which were Deregistered when the 'relationship'
+    data was first added will need any references to Successors removing when they were previously
+    Registered. In order to do this, the function performs the following steps:
+    1. Creates a window specification to partition by location_id and order by cqc_location_import_date.
+    2. Adds a column 'first_known_relationships' with the first non-null relationship for each location.
+    3. Filters the relationships to include only those of type 'HSCA Predecessor'.
+    4. Adds a column 'imputed_relationships' based on the following conditions:
+       - If 'relationships' is not null, use 'relationships'.
+       - If 'registration_status' is 'deregistered', use 'first_known_relationships'.
+       - If 'registration_status' is 'registered', use 'relationships_predecessors_only'.
+    5. Drops the intermediate columns 'first_known_relationships' and 'relationships_predecessors_only'.
+
+    Args:
+        df (DataFrame): Input DataFrame containing location data and relationships.
+
+    Returns:
+        DataFrame: DataFrame with imputed historic relationships.
+    """
+    w = (
+        Window.partitionBy(CQCL.location_id)
+        .orderBy(CQCLClean.cqc_location_import_date)
+        .rowsBetween(Window.unboundedPreceding, Window.unboundedFollowing)
+    )
+    df = df.withColumn(
+        CQCLClean.first_known_relationships,
+        F.first(CQCL.relationships, ignorenulls=True).over(w),
+    )
+    df = get_relationships_where_type_is_predecessor(df)
+
+    df = df.withColumn(
+        CQCLClean.imputed_relationships,
+        F.when(F.col(CQCL.relationships).isNotNull(), F.col(CQCL.relationships))
+        .when(
+            (F.col(CQCL.registration_status) == RegistrationStatus.deregistered),
+            F.col(CQCLClean.first_known_relationships),
+        )
+        .when(
+            (F.col(CQCL.registration_status) == RegistrationStatus.registered),
+            F.col(CQCLClean.relationships_predecessors_only),
+        ),
+    )
+    df = df.drop(
+        CQCLClean.first_known_relationships,
+        CQCLClean.relationships_predecessors_only,
+    )
+
+    return df
+
+
+def get_relationships_where_type_is_predecessor(df: DataFrame) -> DataFrame:
+    """
+    Filters and aggregates relationships of type 'HSCA Predecessor' for each location.
+
+    This function performs the following steps:
+    1. Selects distinct location_id and first_known_relationships columns.
+    2. Explodes the first_known_relationships column to create a row for each relationship.
+    3. Filters the exploded relationships to include only those of type 'HSCA Predecessor'.
+    4. Groups by location_id and collects the set of 'HSCA Predecessor' relationships.
+    5. Joins the original DataFrame with the aggregated DataFrame on location_id.
+
+    Args:
+        df (DataFrame): Input DataFrame containing location data and relationships.
+
+    Returns:
+        DataFrame: DataFrame with an additional column for 'HSCA Predecessor' relationships.
+    """
+    distinct_df = df.select(
+        CQCL.location_id, CQCLClean.first_known_relationships
+    ).distinct()
+
+    exploded_df = distinct_df.withColumn(
+        CQCLClean.relationships_exploded,
+        F.explode(CQCLClean.first_known_relationships),
+    )
+    predecessors_df = exploded_df.filter(
+        F.col(f"{CQCLClean.relationships_exploded}.{CQCL.type}") == "HSCA Predecessor"
+    )
+    aggregated_predecessors_df = predecessors_df.groupby(CQCL.location_id).agg(
+        F.collect_set(CQCLClean.relationships_exploded).alias(
+            CQCLClean.relationships_predecessors_only
+        )
+    )
+
+    df = df.join(aggregated_predecessors_df, CQCL.location_id, "left")
+
+    return df
+
+
+def impute_missing_struct_column(df: DataFrame, column_name: str) -> DataFrame:
+    """
+    Imputes missing rows in a struct col in the DataFrame by filling with known values from other import_dates.
+
+    The function performs the following steps:
+    1. Creates a new column with the prefix 'imputed_' which copies the column if it contains data,
+       and sets it to None if the array is empty.
+    2. Fills the missing values in 'imputed_' with the previous known value within the partition.
+    3. Fills any remaining missing values in 'imputed_' with the future known value within the partition.
+
+    Args:
+        df (DataFrame): Input DataFrame containing 'location_id', 'cqc_location_import_date', and a struct column to impute.
+        column_name (str): Name of struct column to impute
+
+    Returns:
+        DataFrame: DataFrame with the struct column containing imputed values.
+    """
+    new_column_name = "imputed_" + column_name
+    w_future = Window.partitionBy(CQCL.location_id).orderBy(
+        CQCLClean.cqc_location_import_date
+    )
+    w_historic = w_future.rowsBetween(
+        Window.unboundedPreceding, Window.unboundedFollowing
+    )
+
+    df = df.withColumn(
+        new_column_name,
+        F.when(
+            F.size(F.col(column_name)) > 0,
+            F.col(column_name),
+        ).otherwise(F.lit(None)),
+    )
+
+    df = df.withColumn(
+        new_column_name,
+        F.coalesce(
+            F.col(new_column_name),
+            F.last(new_column_name, ignorenulls=True).over(w_future),
+        ),
+    )
+
+    df = df.withColumn(
+        new_column_name,
+        F.coalesce(
+            F.col(new_column_name),
+            F.first(new_column_name, ignorenulls=True).over(w_historic),
+        ),
+    )
+
+    return df
+
+
+def remove_locations_that_never_had_regulated_activities(df: DataFrame) -> DataFrame:
+    """
+    Removes locations who have never submitted regulated activities data.
+
+    Removes locations who have never submitted regulated activities data as it is
+    the activities that are regulated and not the location. This function removes any blank rows
+    from the imputed_regulatedactivities column, which are locations that have no data at any time point.
+
+    Args:
+        df (DataFrame): A dataframe with imputed_regulatedactivities
+
+    Returns:
+        DataFrame: A dataframe where blank imputed rows are removed.
+    """
+    df = df.where(df[CQCLClean.imputed_regulated_activities].isNotNull())
+    return df
+
+
+def extract_from_struct(
+    df: DataFrame, source_struct_column_name: str, new_column_name: str
+) -> DataFrame:
+    """
+    Extracts data from a specified struct column and stores it in a new column as an array.
+
+    Args:
+        df (DataFrame): The input DataFrame.
+        source_struct_column_name (str): The name of the column to extract data from.
+        new_column_name (str): The name of the new column where extracted data will be stored.
+
+    Returns:
+        DataFrame: A new DataFrame with the extracted data stored in the specified column.
+    """
+    df = df.withColumn(new_column_name, source_struct_column_name)
+    return df
+
+
+def allocate_primary_service_type(df: DataFrame) -> DataFrame:
+    """
+    Allocates the primary service type for each row in the DataFrame based on the descriptions in the 'imputed_gac_service_types' field.
+
+    primary_service_type is allocated in the following order:
+    1) Firstly identify all locations who offer "Care home service with nursing"
+    2) Of those who don't, identify all locations who offer "Care home service without nursing"
+    3) All other locations are identified as being non residential
+
+    Args:
+        df (DataFrame): The input DataFrame containing the 'imputed_gac_service_types' column.
+
+    Returns:
+        DataFrame: The DataFrame with the new 'primary_service_type' column added.
+    """
+    df = df.withColumn(
+        CQCLClean.primary_service_type,
+        F.when(
+            F.array_contains(
+                df[CQCLClean.imputed_gac_service_types][CQCL.description],
+                "Care home service with nursing",
+            ),
+            PrimaryServiceType.care_home_with_nursing,
+        )
+        .when(
+            F.array_contains(
+                df[CQCLClean.imputed_gac_service_types][CQCL.description],
+                "Care home service without nursing",
+            ),
+            PrimaryServiceType.care_home_only,
+        )
+        .otherwise(PrimaryServiceType.non_residential),
+    )
+    return df
+
+
+def realign_carehome_column_with_primary_service(df: DataFrame) -> DataFrame:
+    """
+    Allocates the location as a care_home if primary_service_type is a care home.
+
+    Following some missing values in CQC data, the services were imputed. The care_home column is automatically given
+    'N' if service is missing. Therefore if imputed service values implied the location was a care home then the
+    care_home column needs assigning 'Y'.
+
+    Args:
+        df (DataFrame): The input DataFrame containing the 'primary_service_type' column.
+
+    Returns:
+        DataFrame: The DataFrame with the 'care_home' column realigned with the 'primary_service_type' column.
+    """
+    df = df.withColumn(
+        CQCLClean.care_home,
+        F.when(
+            (
+                F.col(CQCLClean.primary_service_type)
+                == PrimaryServiceType.care_home_with_nursing
+            )
+            | (
+                F.col(CQCLClean.primary_service_type)
+                == PrimaryServiceType.care_home_only
+            ),
+            CareHome.care_home,
+        ).otherwise(CareHome.not_care_home),
+    )
+    return df
+
+
+def add_related_location_column(df: DataFrame) -> DataFrame:
+    """
+    Adds a column which flags whether the location was related to a previous location or not
+
+    Args:
+        df(DataFrame): A dataframe with the imputed_relationships column.
+
+    Returns:
+        DataFrame: A dataframe with a column stating whether the location was related to a previous location or not.
+    """
+    df = df.withColumn(
+        CQCLClean.related_location,
+        F.when(
+            F.size(F.col(CQCLClean.imputed_relationships)) > 0,
+            F.lit(RelatedLocation.has_related_location),
+        ).otherwise(
+            F.lit(RelatedLocation.no_related_location),
+        ),
+    )
+    return df
+
+
+def remove_specialist_colleges(df: DataFrame) -> DataFrame:
+    """
+    Removes rows where 'Specialist college service' is the only service listed in 'services_offered'.
+
+    We do not include locations which are only specialist colleges in our
+    estimates. This function identifies and removes the ones listed in the locations dataset.
+
+    Args:
+        df (DataFrame): A cleaned locations dataframe with the services_offered column already created.
+
+    Returns:
+        DataFrame: A cleaned locations dataframe with locations which are only specialist colleges removed.
+    """
+    df = df.where(
+        (df[CQCLClean.services_offered][0] != Services.specialist_college_service)
+        | (F.size(df[CQCLClean.services_offered]) != 1)
+        | (df[CQCLClean.services_offered].isNull())
+    )
+    return df
+
+
+def impute_missing_data_from_provider_dataset(
+    locations_df: DataFrame, column_name: str
+) -> DataFrame:
+    w = (
+        Window.partitionBy(CQCL.provider_id)
+        .orderBy(CQCLClean.cqc_location_import_date)
+        .rowsBetween(Window.unboundedPreceding, Window.unboundedFollowing)
+    )
+    locations_df = locations_df.withColumn(
+        column_name,
+        F.when(
+            locations_df[column_name].isNull(),
+            F.first(column_name, ignorenulls=True).over(w),
+        ).otherwise(locations_df[column_name]),
+    )
+    return locations_df
+
+
+def join_cqc_provider_data(locations_df: DataFrame, provider_df: DataFrame):
+    locations_df = cUtils.add_aligned_date_column(
+        locations_df,
+        provider_df,
+        CQCLClean.cqc_location_import_date,
+        CQCPClean.cqc_provider_import_date,
+    )
+
+    provider_data_to_join_df = provider_df.withColumnRenamed(
+        CQCPClean.provider_id, CQCLClean.provider_id
+    )
+    provider_data_to_join_df = provider_data_to_join_df.withColumnRenamed(
+        CQCPClean.name, CQCLClean.provider_name
+    )
+
+    joined_df = locations_df.join(
+        provider_data_to_join_df,
+        [CQCLClean.provider_id, CQCPClean.cqc_provider_import_date],
+        how="left",
+    )
+    return joined_df
+
+
+def select_registered_locations_only(locations_df: DataFrame) -> DataFrame:
+    invalid_rows = locations_df.where(
+        (locations_df[CQCL.registration_status] != RegistrationStatus.registered)
+        & (locations_df[CQCL.registration_status] != RegistrationStatus.deregistered)
+    ).count()
+
+    if invalid_rows != 0:
+        warnings.warn(
+            f"{invalid_rows} row(s) has/have an invalid registration status and have been dropped."
+        )
+
+    locations_df = locations_df.where(
+        locations_df[CQCL.registration_status] == RegistrationStatus.registered
+    )
+    return locations_df
+
+
+def calculate_time_since_dormant(df: DataFrame) -> DataFrame:
+    """
+    Adds a column to show the number of months since the location was last dormant.
+
+    This function calculates the number of months since the last time a location was marked as dormant.
+    It uses a window function to track the most recent date when dormancy was marked as "Y" and calculates
+    the number of months since that date for each location.
+
+    'time_since_dormant' values before the first instance of dormancy are null.
+    If the location has never been dormant then 'time_since_dormant' is null.
+
+    Args:
+        df (DataFrame): A dataframe with columns: cqc_location_import_date, dormancy, and location_id.
+
+    Returns:
+        DataFrame: A dataframe with an additional column 'time_since_dormant'.
+    """
+    w = Window.partitionBy(CQCLClean.location_id).orderBy(
+        CQCLClean.cqc_location_import_date
+    )
+
+    df = df.withColumn(
+        CQCLClean.dormant_date,
+        F.when(
+            F.col(CQCLClean.dormancy) == Dormancy.dormant,
+            F.col(CQCLClean.cqc_location_import_date),
+        ),
+    )
+
+    df = df.withColumn(
+        CQCLClean.last_dormant_date,
+        F.last(CQCLClean.dormant_date, ignorenulls=True).over(w),
+    )
+
+    df = df.withColumn(
+        CQCLClean.time_since_dormant,
+        F.when(
+            F.col(CQCLClean.last_dormant_date).isNotNull(),
+            F.when(F.col(CQCLClean.dormancy) == Dormancy.dormant, 1).otherwise(
+                F.floor(
+                    F.months_between(
+                        F.col(CQCLClean.cqc_location_import_date),
+                        F.col(CQCLClean.last_dormant_date),
+                    )
+                )
+                + 1,
+            ),
+        ),
+    )
+
+    df = df.drop(
+        CQCLClean.dormant_date,
+        CQCLClean.last_dormant_date,
+    )
+
+    return df
+
+
+if __name__ == "__main__":
+    print("Spark job 'clean_cqc_location_data' starting...")
+    print(f"Job parameters: {sys.argv}")
+
+    (
+        cqc_location_source,
+        cleaned_cqc_provider_source,
+        cleaned_ons_postcode_directory_source,
+        cleaned_cqc_location_destination,
+    ) = utils.collect_arguments(
+        (
+            "--cqc_location_source",
+            "Source s3 directory for parquet CQC locations dataset",
+        ),
+        (
+            "--cleaned_cqc_provider_source",
+            "Source s3 directory for cleaned parquet CQC provider dataset",
+        ),
+        (
+            "--cleaned_ons_postcode_directory_source",
+            "Source s3 directory for parquet ONS postcode directory dataset",
+        ),
+        (
+            "--cleaned_cqc_location_destination",
+            "Destination s3 directory for cleaned parquet CQC locations dataset",
+        ),
+    )
+    main(
+        cqc_location_source,
+        cleaned_cqc_provider_source,
+        cleaned_ons_postcode_directory_source,
+        cleaned_cqc_location_destination,
+    )
+
+    print("Spark job 'clean_cqc_location_data' complete")
+
+
+def add_cqc_sector_column_to_cqc_locations_dataframe(
+    cqc_location_df: DataFrame, la_providerids: list
+):
+    cqc_location_with_sector_column = cqc_location_df.join(
+        create_dataframe_from_la_cqc_location_list(la_providerids),
+        CQCL.provider_id,
+        "left",
+    )
+
+    cqc_location_with_sector_column = cqc_location_with_sector_column.fillna(
+        Sector.independent, subset=CQCPClean.cqc_sector
+    )
+
+    return cqc_location_with_sector_column
+
+
+def create_dataframe_from_la_cqc_location_list(la_providerids: list) -> DataFrame:
+    spark = utils.get_spark()
+
+    la_locations_dataframe = spark.createDataFrame(
+        la_providerids, StringType()
+    ).withColumnRenamed("value", CQCL.provider_id)
+
+    la_providers_dataframe = la_locations_dataframe.withColumn(
+        CQCPClean.cqc_sector, F.lit(Sector.local_authority).cast(StringType())
+    )
+
+    return la_providers_dataframe

--- a/projects/_01_ingest/cqc_api/jobs/delta_clean_cqc_location_data.py
+++ b/projects/_01_ingest/cqc_api/jobs/delta_clean_cqc_location_data.py
@@ -171,7 +171,7 @@ def main(
             registered_locations_df, known_la_providerids
         )
         .withColumn(CQCLClean.provider_name, F.lit(""))
-        .withColumn(CQCLClean.cqc_provider_import_date, F.lit(None))
+        .withColumn(CQCLClean.cqc_provider_import_date, F.lit(""))
     )
 
     registered_locations_df = impute_missing_data_from_provider_dataset(

--- a/projects/_01_ingest/cqc_api/jobs/delta_clean_cqc_location_data.py
+++ b/projects/_01_ingest/cqc_api/jobs/delta_clean_cqc_location_data.py
@@ -168,7 +168,7 @@ def main(
     known_la_providerids = LocalAuthorityProviderIds.known_ids
     registered_locations_df = add_cqc_sector_column_to_cqc_locations_dataframe(
         registered_locations_df, known_la_providerids
-    )
+    ).withColumn(CQCLClean.provider_name, F.lit(""))
 
     registered_locations_df = impute_missing_data_from_provider_dataset(
         registered_locations_df, CQCLClean.provider_name

--- a/projects/_01_ingest/cqc_api/jobs/validate_delta_locations_api_cleaned_data.py
+++ b/projects/_01_ingest/cqc_api/jobs/validate_delta_locations_api_cleaned_data.py
@@ -57,6 +57,7 @@ def main(
     )
     rules = Rules.rules_to_check
     rules["complete_columns"].remove(CQCLClean.provider_name)
+    rules["complete_columns"].remove(CQCLClean.cqc_provider_import_date)
 
     rules[
         RuleName.size_of_dataset

--- a/projects/_01_ingest/cqc_api/jobs/validate_delta_locations_api_cleaned_data.py
+++ b/projects/_01_ingest/cqc_api/jobs/validate_delta_locations_api_cleaned_data.py
@@ -1,0 +1,194 @@
+import os
+import sys
+
+os.environ["SPARK_VERSION"] = "3.3"
+
+from pyspark.sql import DataFrame, functions as F, Window
+from pyspark.sql.types import ArrayType
+
+from utils import utils
+from utils.column_names.cleaned_data_files.cqc_location_cleaned import (
+    NewCqcLocationApiColumns as CQCL,
+    CqcLocationCleanedColumns as CQCLClean,
+)
+from utils.column_names.ind_cqc_pipeline_columns import (
+    PartitionKeys as Keys,
+)
+from utils.column_values.categorical_column_values import (
+    LocationType,
+    RegistrationStatus,
+    Services,
+)
+from utils.raw_data_adjustments import RecordsToRemoveInLocationsData
+from utils.validation.validation_rules.locations_api_cleaned_validation_rules import (
+    LocationsAPICleanedValidationRules as Rules,
+)
+from utils.validation.validation_utils import (
+    validate_dataset,
+    add_column_with_length_of_string,
+    raise_exception_if_any_checks_failed,
+)
+from utils.validation.validation_rule_names import RuleNames as RuleName
+
+PartitionKeys = [Keys.year, Keys.month, Keys.day, Keys.import_date]
+
+raw_cqc_locations_columns_to_import = [
+    Keys.import_date,
+    CQCL.location_id,
+    CQCL.provider_id,
+    CQCL.type,
+    CQCL.registration_status,
+    CQCL.gac_service_types,
+    CQCL.regulated_activities,
+]
+
+
+def main(
+    raw_cqc_location_source: str,
+    cleaned_cqc_locations_source: str,
+    report_destination: str,
+):
+    raw_location_df = utils.read_from_parquet(
+        raw_cqc_location_source,
+        selected_columns=raw_cqc_locations_columns_to_import,
+    )
+    cleaned_cqc_locations_df = utils.read_from_parquet(
+        cleaned_cqc_locations_source,
+    )
+    rules = Rules.rules_to_check
+    rules["complete_columns"].remove(CQCLClean.provider_name)
+
+    rules[
+        RuleName.size_of_dataset
+    ] = calculate_expected_size_of_cleaned_cqc_locations_dataset(raw_location_df)
+
+    cleaned_cqc_locations_df = add_column_with_length_of_string(
+        cleaned_cqc_locations_df, [CQCL.location_id, CQCL.provider_id]
+    )
+
+    check_result_df = validate_dataset(cleaned_cqc_locations_df, rules)
+
+    utils.write_to_parquet(check_result_df, report_destination, mode="overwrite")
+
+    if isinstance(check_result_df, DataFrame):
+        raise_exception_if_any_checks_failed(check_result_df)
+
+
+def calculate_expected_size_of_cleaned_cqc_locations_dataset(
+    raw_location_df: DataFrame,
+) -> int:
+    has_a_known_regulated_activity: str = "has_a_known_regulated_activity"
+    has_a_known_provider_id: str = "has_a_known_provider_id"
+
+    raw_location_df = identify_if_location_has_a_known_value(
+        raw_location_df, CQCL.regulated_activities, has_a_known_regulated_activity
+    )
+    raw_location_df = identify_if_location_has_a_known_value(
+        raw_location_df, CQCL.provider_id, has_a_known_provider_id
+    )
+
+    expected_size = raw_location_df.where(
+        (raw_location_df[CQCL.type] == LocationType.social_care_identifier)
+        & (raw_location_df[CQCL.registration_status] == RegistrationStatus.registered)
+        & (
+            raw_location_df[CQCL.location_id]
+            != RecordsToRemoveInLocationsData.dental_practice
+        )
+        & (
+            raw_location_df[CQCL.location_id]
+            != RecordsToRemoveInLocationsData.temp_registration
+        )
+        & (
+            (
+                raw_location_df[CQCL.gac_service_types][0][CQCL.description]
+                != Services.specialist_college_service
+            )
+            | (F.size(raw_location_df[CQCL.gac_service_types]) != 1)
+            | (raw_location_df[CQCL.gac_service_types].isNull())
+        )
+        & (raw_location_df[has_a_known_regulated_activity] == True)
+        & (raw_location_df[has_a_known_provider_id] == True)
+    ).count()
+    return expected_size
+
+
+def identify_if_location_has_a_known_value(
+    df: DataFrame, col_to_check: str, new_col_name: str
+) -> DataFrame:
+    """
+    Identifies if a location has ever had a known valid response and adds a new column to the DataFrame.
+
+    This function partitions the DataFrame by location ID and checks if there are any known values within each location.
+    If the column is an array type, the 'known value' is defined as the array being of size greater than zero.
+    Otherwise, a known value is identified as a non-null value.
+    If any valid responses are found, it sets the value of the new column to True; otherwise, it sets it to False.
+
+    Args:
+        df (DataFrame): The input DataFrame containing location data.
+        col_to_check (str): The name of the column to check.
+        new_col_name (str): The name of the new column to be added to the DataFrame.
+
+    Returns:
+        DataFrame: The DataFrame with the new column indicating the presence of valid responses.
+    """
+    window_spec = Window.partitionBy(
+        CQCL.location_id,
+    ).rowsBetween(Window.unboundedPreceding, Window.unboundedFollowing)
+
+    col_to_check_is_array = isinstance(df.schema[col_to_check].dataType, ArrayType)
+
+    has_known_array_expr = F.max(F.size(df[col_to_check])).over(window_spec) > 0
+
+    has_non_null_value_expr = (
+        F.max(F.when(df[col_to_check].isNotNull(), 1)).over(window_spec) > 0
+    )
+
+    if col_to_check_is_array:
+        df = df.withColumn(
+            new_col_name,
+            F.when(has_known_array_expr, True).otherwise(False),
+        )
+    else:
+        df = df.withColumn(
+            new_col_name,
+            F.when(has_non_null_value_expr, True).otherwise(False),
+        )
+
+    return df
+
+
+if __name__ == "__main__":
+    print("Spark job 'validate_locations_api_cleaned_data' starting...")
+    print(f"Job parameters: {sys.argv}")
+
+    (
+        raw_cqc_location_source,
+        cleaned_cqc_locations_source,
+        report_destination,
+    ) = utils.collect_arguments(
+        (
+            "--raw_cqc_location_source",
+            "Source s3 directory for parquet locations api dataset",
+        ),
+        (
+            "--cleaned_cqc_locations_source",
+            "Source s3 directory for parquet locations api cleaned dataset",
+        ),
+        (
+            "--report_destination",
+            "Destination s3 directory for validation report parquet",
+        ),
+    )
+    try:
+        main(
+            raw_cqc_location_source,
+            cleaned_cqc_locations_source,
+            report_destination,
+        )
+    finally:
+        spark = utils.get_spark()
+        if spark.sparkContext._gateway:
+            spark.sparkContext._gateway.shutdown_callback_server()
+        spark.stop()
+
+    print("Spark job 'validate_locations_api_cleaned_data' complete")

--- a/projects/_01_ingest/cqc_api/tests/jobs/test_delta_clean_cqc_location_data.py
+++ b/projects/_01_ingest/cqc_api/tests/jobs/test_delta_clean_cqc_location_data.py
@@ -714,45 +714,6 @@ class RemoveSpecialistCollegesTests(CleanCQCLocationDatasetTests):
         self.assertEqual(returned_df.collect(), expected_df.collect())
 
 
-class JoinCqcProviderDataTests(CleanCQCLocationDatasetTests):
-    def setUp(self) -> None:
-        super().setUp()
-        self.test_location_df = cUtils.column_to_date(
-            self.test_location_df,
-            Keys.import_date,
-            CQCLCleaned.cqc_location_import_date,
-        ).drop(CQCLCleaned.import_date)
-
-    def test_join_cqc_provider_data_adds_three_columns(self):
-        returned_df = job.join_cqc_provider_data(
-            self.test_location_df, self.test_provider_df
-        )
-        new_columns = 3
-        expected_columns = len(self.test_location_df.columns) + new_columns
-
-        self.assertEqual(len(returned_df.columns), expected_columns)
-
-    def test_join_cqc_provider_data_correctly_joins_data(self):
-        returned_df = job.join_cqc_provider_data(
-            self.test_location_df, self.test_provider_df
-        )
-        returned_data = (
-            returned_df.select(sorted(returned_df.columns))
-            .sort(CQCL.location_id)
-            .collect()
-        )
-        expected_df = self.spark.createDataFrame(
-            Data.expected_joined_rows, Schemas.expected_joined_schema
-        )
-        expected_data = (
-            expected_df.select(sorted(expected_df.columns))
-            .sort(CQCL.location_id)
-            .collect()
-        )
-
-        self.assertCountEqual(returned_data, expected_data)
-
-
 class SelectRegisteredLocationsOnlyTest(CleanCQCLocationDatasetTests):
     def setUp(self) -> None:
         return super().setUp()

--- a/projects/_01_ingest/cqc_api/tests/jobs/test_delta_clean_cqc_location_data.py
+++ b/projects/_01_ingest/cqc_api/tests/jobs/test_delta_clean_cqc_location_data.py
@@ -1,0 +1,1005 @@
+import unittest
+import warnings
+from dataclasses import asdict
+from unittest.mock import ANY, Mock, patch
+
+from pyspark.sql import DataFrame, functions as F
+
+import projects._01_ingest.cqc_api.jobs.delta_clean_cqc_location_data as job
+from projects._01_ingest.unittest_data.ingest_test_file_data import (
+    CQCLocationsData as Data,
+)
+from projects._01_ingest.unittest_data.ingest_test_file_schemas import (
+    CQCLocationsSchema as Schemas,
+)
+from utils import utils
+import utils.cleaning_utils as cUtils
+from utils.column_names.ind_cqc_pipeline_columns import (
+    PartitionKeys as Keys,
+)
+from utils.column_names.raw_data_files.cqc_location_api_columns import (
+    NewCqcLocationApiColumns as CQCL,
+)
+from utils.column_names.cleaned_data_files.cqc_location_cleaned import (
+    CqcLocationCleanedColumns as CQCLCleaned,
+)
+from utils.column_values.categorical_column_values import (
+    Sector,
+)
+
+
+PATCH_PATH = "projects._01_ingest.cqc_api.jobs.delta_clean_cqc_location_data"
+
+
+class CleanCQCLocationDatasetTests(unittest.TestCase):
+    TEST_LOC_SOURCE = "some/directory"
+    TEST_PROV_SOURCE = "some/other/directory"
+    TEST_DESTINATION = "some/other/directory"
+    TEST_ONS_POSTCODE_DIRECTORY_SOURCE = "some/other/directory"
+    partition_keys = [Keys.year, Keys.month, Keys.day, Keys.import_date]
+
+    def setUp(self) -> None:
+        self.spark = utils.get_spark()
+        self.test_clean_cqc_location_df = self.spark.createDataFrame(
+            Data.sample_rows, schema=Schemas.detailed_schema
+        )
+        self.test_location_df = self.spark.createDataFrame(
+            Data.small_location_rows, Schemas.small_location_schema
+        )
+        self.test_provider_df = self.spark.createDataFrame(
+            Data.join_provider_rows, Schemas.join_provider_schema
+        )
+        self.test_ons_postcode_directory_df = self.spark.createDataFrame(
+            Data.ons_postcode_directory_rows, Schemas.ons_postcode_directory_schema
+        )
+
+
+class MainTests(CleanCQCLocationDatasetTests):
+    def setUp(self) -> None:
+        super().setUp()
+
+    @patch(f"{PATCH_PATH}.utils.write_to_parquet")
+    @patch(f"{PATCH_PATH}.run_postcode_matching")
+    @patch(f"{PATCH_PATH}.impute_missing_data_from_provider_dataset")
+    # @patch(f"{PATCH_PATH}.join_cqc_provider_data")
+    @patch(f"{PATCH_PATH}.add_cqc_sector_column_to_cqc_locations_dataframe")
+    @patch(f"{PATCH_PATH}.add_related_location_column")
+    @patch(f"{PATCH_PATH}.extract_registered_manager_names")
+    @patch(f"{PATCH_PATH}.realign_carehome_column_with_primary_service")
+    @patch(f"{PATCH_PATH}.allocate_primary_service_type")
+    @patch(f"{PATCH_PATH}.remove_specialist_colleges")
+    @patch(f"{PATCH_PATH}.classify_specialisms")
+    @patch(f"{PATCH_PATH}.extract_from_struct")
+    @patch(f"{PATCH_PATH}.remove_locations_that_never_had_regulated_activities")
+    @patch(f"{PATCH_PATH}.impute_missing_struct_column")
+    @patch(f"{PATCH_PATH}.select_registered_locations_only")
+    @patch(f"{PATCH_PATH}.impute_historic_relationships")
+    @patch(f"{PATCH_PATH}.calculate_time_registered_for")
+    @patch(f"{PATCH_PATH}.utils.format_date_fields", wraps=utils.format_date_fields)
+    @patch(f"{PATCH_PATH}.remove_records_from_locations_data")
+    @patch(f"{PATCH_PATH}.remove_non_social_care_locations")
+    @patch(f"{PATCH_PATH}.utils.select_rows_with_non_null_value")
+    @patch(f"{PATCH_PATH}.clean_provider_id_column")
+    @patch(f"{PATCH_PATH}.cUtils.column_to_date", wraps=cUtils.column_to_date)
+    @patch(f"{PATCH_PATH}.create_cleaned_registration_date_column")
+    @patch(f"{PATCH_PATH}.utils.read_from_parquet")
+    def test_main_runs(
+        self,
+        read_from_parquet_mock: Mock,
+        create_cleaned_registration_date_column_mock: Mock,
+        column_to_date_mock: Mock,
+        clean_provider_id_column_mock: Mock,
+        select_rows_with_non_null_value_mock: Mock,
+        remove_non_social_care_locations_mock: Mock,
+        remove_records_from_locations_data_mock: Mock,
+        format_date_fields_mock: Mock,
+        calculate_time_registered_for_mock: Mock,
+        impute_historic_relationships_mock: Mock,
+        select_registered_locations_only_mock: Mock,
+        impute_missing_struct_column_mock: Mock,
+        remove_locations_that_never_had_regulated_activities_mock: Mock,
+        extract_from_struct_mock: Mock,
+        classify_specialisms_mock: Mock,
+        remove_specialist_colleges_mock: Mock,
+        allocate_primary_service_type_mock: Mock,
+        realign_carehome_column_with_primary_service_mock: Mock,
+        extract_registered_manager_names_mock: Mock,
+        add_related_location_column_mock: Mock,
+        # join_cqc_provider_data_mock: Mock,
+        add_cqc_sector_column_to_cqc_locations_dataframe: Mock,
+        impute_missing_data_from_provider_dataset_mock: Mock,
+        run_postcode_matching_mock: Mock,
+        write_to_parquet_mock: Mock,
+    ):
+        read_from_parquet_mock.side_effect = [
+            self.test_clean_cqc_location_df,
+            self.test_provider_df,
+            self.test_ons_postcode_directory_df,
+        ]
+
+        job.main(
+            self.TEST_LOC_SOURCE,
+            self.TEST_PROV_SOURCE,
+            self.TEST_ONS_POSTCODE_DIRECTORY_SOURCE,
+            self.TEST_DESTINATION,
+        )
+
+        self.assertEqual(read_from_parquet_mock.call_count, 3)
+        create_cleaned_registration_date_column_mock.assert_called_once()
+        self.assertEqual(column_to_date_mock.call_count, 2)
+        clean_provider_id_column_mock.assert_called_once()
+        select_rows_with_non_null_value_mock.assert_called_once()
+        remove_non_social_care_locations_mock.assert_called_once()
+        remove_records_from_locations_data_mock.assert_called_once()
+        format_date_fields_mock.assert_called_once()
+        calculate_time_registered_for_mock.assert_called_once()
+        impute_historic_relationships_mock.assert_called_once()
+        select_registered_locations_only_mock.assert_called_once()
+        self.assertEqual(impute_missing_struct_column_mock.call_count, 3)
+        remove_locations_that_never_had_regulated_activities_mock.assert_called_once()
+        self.assertEqual(extract_from_struct_mock.call_count, 2)
+        self.assertEqual(classify_specialisms_mock.call_count, 3)
+        remove_specialist_colleges_mock.assert_called_once()
+        allocate_primary_service_type_mock.assert_called_once()
+        realign_carehome_column_with_primary_service_mock.assert_called_once()
+        extract_registered_manager_names_mock.assert_called_once()
+        add_related_location_column_mock.assert_called_once()
+        # join_cqc_provider_data_mock.assert_called_once()
+        add_cqc_sector_column_to_cqc_locations_dataframe.assert_called_once()
+        self.assertEqual(impute_missing_data_from_provider_dataset_mock.call_count, 2)
+        run_postcode_matching_mock.assert_called_once()
+        write_to_parquet_mock.assert_called_once_with(
+            ANY,
+            self.TEST_DESTINATION,
+            mode="overwrite",
+            partitionKeys=self.partition_keys,
+        )
+
+        final_df: DataFrame = write_to_parquet_mock.call_args[0][0]
+        expected_cols = list(asdict(CQCLCleaned()).values())
+        for col in final_df.columns:
+            self.assertIn(col, expected_cols)
+
+
+class CleanRegistrationDateTests(CleanCQCLocationDatasetTests):
+    def setUp(self) -> None:
+        super().setUp()
+
+    def test_create_cleaned_registration_date_column(self):
+        test_df = self.spark.createDataFrame(
+            Data.clean_registration_date_column_rows,
+            Schemas.clean_registration_column_schema,
+        )
+        expected_df = self.spark.createDataFrame(
+            Data.expected_clean_registration_date_column_rows,
+            Schemas.expected_clean_registration_column_schema,
+        )
+        returned_df = job.create_cleaned_registration_date_column(test_df)
+        self.assertEqual(expected_df.collect(), returned_df.collect())
+
+    def test_remove_time_from_date_column(self):
+        test_df = self.spark.createDataFrame(
+            Data.remove_time_from_date_column_rows,
+            Schemas.expected_clean_registration_column_schema,
+        )
+        expected_df = self.spark.createDataFrame(
+            Data.expected_remove_time_from_date_column_rows,
+            Schemas.expected_clean_registration_column_schema,
+        )
+        returned_df = job.remove_time_from_date_column(
+            test_df, CQCLCleaned.imputed_registration_date
+        )
+        self.assertEqual(expected_df.collect(), returned_df.collect())
+
+    def test_remove_registration_dates_that_are_later_than_import_date(self):
+        test_df = self.spark.createDataFrame(
+            Data.remove_late_registration_dates_rows,
+            Schemas.remove_late_registration_dates_schema,
+        )
+        expected_df = self.spark.createDataFrame(
+            Data.expected_remove_late_registration_dates_rows,
+            Schemas.remove_late_registration_dates_schema,
+        )
+        returned_df = job.remove_registration_dates_that_are_later_than_import_date(
+            test_df
+        )
+        self.assertEqual(expected_df.collect(), returned_df.collect())
+
+    def test_impute_missing_registration_dates_where_dates_are_the_same(self):
+        test_df = self.spark.createDataFrame(
+            Data.impute_missing_registration_dates_rows,
+            Schemas.expected_clean_registration_column_schema,
+        )
+        expected_df = self.spark.createDataFrame(
+            Data.expected_impute_missing_registration_dates_rows,
+            Schemas.expected_clean_registration_column_schema,
+        )
+        returned_df = job.impute_missing_registration_dates(test_df)
+        self.assertEqual(expected_df.collect(), returned_df.collect())
+
+    def test_impute_missing_registration_dates_where_dates_are_different_return_min_registration_date(
+        self,
+    ):
+        test_df = self.spark.createDataFrame(
+            Data.impute_missing_registration_dates_different_rows,
+            Schemas.expected_clean_registration_column_schema,
+        )
+        expected_df = self.spark.createDataFrame(
+            Data.expected_impute_missing_registration_dates_different_rows,
+            Schemas.expected_clean_registration_column_schema,
+        )
+        returned_df = job.impute_missing_registration_dates(test_df)
+        self.assertEqual(expected_df.collect(), returned_df.collect())
+
+    def test_impute_missing_registration_dates_where_dates_are_all_missing_returns_min_import_date(
+        self,
+    ):
+        test_df = self.spark.createDataFrame(
+            Data.impute_missing_registration_dates_missing_rows,
+            Schemas.expected_clean_registration_column_schema,
+        )
+        expected_df = self.spark.createDataFrame(
+            Data.expected_impute_missing_registration_dates_missing_rows,
+            Schemas.expected_clean_registration_column_schema,
+        )
+        returned_df = job.impute_missing_registration_dates(test_df)
+        self.assertEqual(expected_df.collect(), returned_df.collect())
+
+
+class CalculateTimeRegisteredForTests(CleanCQCLocationDatasetTests):
+    def setUp(self) -> None:
+        super().setUp()
+
+    def test_calculate_time_registered_returns_one_when_dates_are_on_the_same_day(
+        self,
+    ):
+        test_df = self.spark.createDataFrame(
+            Data.calculate_time_registered_same_day_rows,
+            Schemas.calculate_time_registered_for_schema,
+        )
+        returned_df = job.calculate_time_registered_for(test_df)
+
+        expected_df = self.spark.createDataFrame(
+            Data.expected_calculate_time_registered_same_day_rows,
+            Schemas.expected_calculate_time_registered_for_schema,
+        )
+        returned_data = returned_df.collect()
+        expected_data = expected_df.collect()
+
+        self.assertEqual(returned_data, expected_data)
+
+    def test_calculate_time_registered_returns_expected_values_when_dates_are_exact_months_apart(
+        self,
+    ):
+        test_df = self.spark.createDataFrame(
+            Data.calculate_time_registered_exact_months_apart_rows,
+            Schemas.calculate_time_registered_for_schema,
+        )
+        returned_df = job.calculate_time_registered_for(test_df)
+
+        expected_df = self.spark.createDataFrame(
+            Data.expected_calculate_time_registered_exact_months_apart_rows,
+            Schemas.expected_calculate_time_registered_for_schema,
+        )
+        returned_data = returned_df.sort(CQCLCleaned.location_id).collect()
+        expected_data = expected_df.collect()
+
+        self.assertEqual(returned_data, expected_data)
+
+    def test_calculate_time_registered_returns_expected_values_when_dates_are_one_day_less_than_a_full_month_apart(
+        self,
+    ):
+        test_df = self.spark.createDataFrame(
+            Data.calculate_time_registered_one_day_less_than_a_full_month_apart_rows,
+            Schemas.calculate_time_registered_for_schema,
+        )
+        returned_df = job.calculate_time_registered_for(test_df)
+
+        expected_df = self.spark.createDataFrame(
+            Data.expected_calculate_time_registered_one_day_less_than_a_full_month_apart_rows,
+            Schemas.expected_calculate_time_registered_for_schema,
+        )
+        returned_data = returned_df.sort(CQCLCleaned.location_id).collect()
+        expected_data = expected_df.collect()
+
+        self.assertEqual(returned_data, expected_data)
+
+    def test_calculate_time_registered_returns_expected_values_when_dates_are_one_day_more_than_a_full_month_apart(
+        self,
+    ):
+        test_df = self.spark.createDataFrame(
+            Data.calculate_time_registered_one_day_more_than_a_full_month_apart_rows,
+            Schemas.calculate_time_registered_for_schema,
+        )
+        returned_df = job.calculate_time_registered_for(test_df)
+
+        expected_df = self.spark.createDataFrame(
+            Data.expected_calculate_time_registered_one_day_more_than_a_full_month_apart_rows,
+            Schemas.expected_calculate_time_registered_for_schema,
+        )
+        returned_data = returned_df.sort(CQCLCleaned.location_id).collect()
+        expected_data = expected_df.collect()
+
+        self.assertEqual(returned_data, expected_data)
+
+
+class RemovedNonSocialCareLocationsTests(CleanCQCLocationDatasetTests):
+    def setUp(self) -> None:
+        super().setUp()
+
+    def test_remove_non_social_care_locations_only_keeps_social_care_orgs(
+        self,
+    ):
+        test_df = self.spark.createDataFrame(
+            Data.social_care_org_rows, Schemas.social_care_org_schema
+        )
+
+        returned_social_care_df = job.remove_non_social_care_locations(test_df)
+        returned_social_care_data = returned_social_care_df.collect()
+
+        expected_social_care_data = self.spark.createDataFrame(
+            Data.expected_social_care_org_rows, Schemas.social_care_org_schema
+        ).collect()
+
+        self.assertEqual(returned_social_care_data, expected_social_care_data)
+
+
+class ImputeHistoricRelationshipsTests(CleanCQCLocationDatasetTests):
+    def setUp(self) -> None:
+        super().setUp()
+
+    def test_impute_historic_relationships_when_type_is_none_returns_none(self):
+        test_df = self.spark.createDataFrame(
+            Data.impute_historic_relationships_when_type_is_none_returns_none_rows,
+            Schemas.impute_historic_relationships_schema,
+        )
+        returned_df = job.impute_historic_relationships(test_df)
+        expected_df = self.spark.createDataFrame(
+            Data.expected_impute_historic_relationships_when_type_is_none_returns_none_rows,
+            Schemas.expected_impute_historic_relationships_schema,
+        )
+        self.assertEqual(returned_df.collect(), expected_df.collect())
+
+    def test_impute_historic_relationships_when_type_is_predecessor_returns_predecessor(
+        self,
+    ):
+        test_df = self.spark.createDataFrame(
+            Data.impute_historic_relationships_when_type_is_predecessor_returns_predecessor_rows,
+            Schemas.impute_historic_relationships_schema,
+        )
+        returned_df = job.impute_historic_relationships(test_df)
+        expected_df = self.spark.createDataFrame(
+            Data.expected_impute_historic_relationships_when_type_is_predecessor_returns_predecessor_rows,
+            Schemas.expected_impute_historic_relationships_schema,
+        )
+        self.assertEqual(returned_df.collect(), expected_df.collect())
+
+    def test_impute_historic_relationships_when_type_is_successor_returns_none_when_registered(
+        self,
+    ):
+        test_df = self.spark.createDataFrame(
+            Data.impute_historic_relationships_when_type_is_successor_returns_none_when_registered_rows,
+            Schemas.impute_historic_relationships_schema,
+        )
+        returned_df = job.impute_historic_relationships(test_df)
+        expected_df = self.spark.createDataFrame(
+            Data.expected_impute_historic_relationships_when_type_is_successor_returns_none_when_registered_rows,
+            Schemas.expected_impute_historic_relationships_schema,
+        )
+        self.assertEqual(returned_df.collect(), expected_df.collect())
+
+    def test_impute_historic_relationships_when_type_is_successor_returns_successor_when_deregistered(
+        self,
+    ):
+        test_df = self.spark.createDataFrame(
+            Data.impute_historic_relationships_when_type_is_successor_returns_successor_when_deregistered_rows,
+            Schemas.impute_historic_relationships_schema,
+        )
+        returned_df = job.impute_historic_relationships(test_df)
+        expected_df = self.spark.createDataFrame(
+            Data.expected_impute_historic_relationships_when_type_is_successor_returns_successor_when_deregistered_rows,
+            Schemas.expected_impute_historic_relationships_schema,
+        )
+        self.assertEqual(returned_df.collect(), expected_df.collect())
+
+    def test_impute_historic_relationships_when_type_has_both_types_only_returns_predecessors_when_registered(
+        self,
+    ):
+        test_df = self.spark.createDataFrame(
+            Data.impute_historic_relationships_when_type_has_both_types_only_returns_predecessors_when_registered_rows,
+            Schemas.impute_historic_relationships_schema,
+        )
+        returned_df = job.impute_historic_relationships(test_df)
+        expected_df = self.spark.createDataFrame(
+            Data.expected_impute_historic_relationships_when_type_has_both_types_only_returns_predecessors_when_registered_rows,
+            Schemas.expected_impute_historic_relationships_schema,
+        )
+        self.assertEqual(returned_df.collect(), expected_df.collect())
+
+    def test_impute_historic_relationships_when_type_has_both_types_returns_original_values_when_deregistered(
+        self,
+    ):
+        test_df = self.spark.createDataFrame(
+            Data.impute_historic_relationships_when_type_has_both_types_returns_original_values_when_deregistered_rows,
+            Schemas.impute_historic_relationships_schema,
+        )
+        returned_df = job.impute_historic_relationships(test_df)
+        expected_df = self.spark.createDataFrame(
+            Data.expected_impute_historic_relationships_when_type_has_both_types_returns_original_values_when_deregistered_rows,
+            Schemas.expected_impute_historic_relationships_schema,
+        )
+        self.assertEqual(returned_df.collect(), expected_df.collect())
+
+    def test_impute_historic_relationships_where_different_relationships_over_time_returns_first_found(
+        self,
+    ):
+        test_df = self.spark.createDataFrame(
+            Data.impute_historic_relationships_where_different_relationships_over_time_returns_first_found_rows,
+            Schemas.impute_historic_relationships_schema,
+        )
+        returned_df = job.impute_historic_relationships(test_df)
+        expected_df = self.spark.createDataFrame(
+            Data.expected_impute_historic_relationships_where_different_relationships_over_time_returns_first_found_rows,
+            Schemas.expected_impute_historic_relationships_schema,
+        )
+        self.assertEqual(returned_df.collect(), expected_df.collect())
+
+
+class GetRelationshipsWhereTypeIsPredecessorTests(CleanCQCLocationDatasetTests):
+    def setUp(self) -> None:
+        super().setUp()
+
+    def test_get_relationships_where_type_is_none_returns_none(self):
+        test_df = self.spark.createDataFrame(
+            Data.get_relationships_where_type_is_none_returns_none_rows,
+            Schemas.get_relationships_where_type_is_predecessor_schema,
+        )
+        returned_df = job.get_relationships_where_type_is_predecessor(test_df)
+        expected_df = self.spark.createDataFrame(
+            Data.expected_get_relationships_where_type_is_none_returns_none_rows,
+            Schemas.expected_get_relationships_where_type_is_predecessor_schema,
+        )
+        self.assertEqual(returned_df.collect(), expected_df.collect())
+
+    def test_get_relationships_where_type_is_successor_returns_none(self):
+        test_df = self.spark.createDataFrame(
+            Data.get_relationships_where_type_is_successor_returns_none_rows,
+            Schemas.get_relationships_where_type_is_predecessor_schema,
+        )
+        returned_df = job.get_relationships_where_type_is_predecessor(test_df)
+        expected_df = self.spark.createDataFrame(
+            Data.expected_get_relationships_where_type_is_successor_returns_none_rows,
+            Schemas.expected_get_relationships_where_type_is_predecessor_schema,
+        )
+        self.assertEqual(returned_df.collect(), expected_df.collect())
+
+    def test_get_relationships_where_type_is_predecessor_returns_predecessor(self):
+        test_df = self.spark.createDataFrame(
+            Data.get_relationships_where_type_is_predecessor_returns_predecessor_rows,
+            Schemas.get_relationships_where_type_is_predecessor_schema,
+        )
+        returned_df = job.get_relationships_where_type_is_predecessor(test_df)
+        expected_df = self.spark.createDataFrame(
+            Data.expected_get_relationships_where_type_is_predecessor_returns_predecessor_rows,
+            Schemas.expected_get_relationships_where_type_is_predecessor_schema,
+        )
+        self.assertEqual(returned_df.collect(), expected_df.collect())
+
+    def test_get_relationships_where_type_has_both_types_only_returns_predecessor(self):
+        test_df = self.spark.createDataFrame(
+            Data.get_relationships_where_type_has_both_types_only_returns_predecessor_rows,
+            Schemas.get_relationships_where_type_is_predecessor_schema,
+        )
+        returned_df = job.get_relationships_where_type_is_predecessor(test_df)
+        expected_df = self.spark.createDataFrame(
+            Data.expected_get_relationships_where_type_has_both_types_only_returns_predecessor_rows,
+            Schemas.expected_get_relationships_where_type_is_predecessor_schema,
+        )
+        self.assertEqual(returned_df.collect(), expected_df.collect())
+
+
+class ImputeMissingStructColumnTests(CleanCQCLocationDatasetTests):
+    def setUp(self) -> None:
+        super().setUp()
+        self.test_impute_missing_struct_column_df = self.spark.createDataFrame(
+            Data.impute_missing_struct_column_rows,
+            Schemas.impute_missing_struct_column_schema,
+        )
+        self.returned_df = job.impute_missing_struct_column(
+            self.test_impute_missing_struct_column_df, CQCLCleaned.gac_service_types
+        )
+        self.expected_df = self.spark.createDataFrame(
+            Data.expected_impute_missing_struct_column_rows,
+            Schemas.expected_impute_missing_struct_column_schema,
+        )
+
+        self.returned_data = self.returned_df.sort(
+            CQCL.location_id, CQCLCleaned.cqc_location_import_date
+        ).collect()
+        self.expected_data = self.expected_df.collect()
+
+    def test_impute_missing_struct_column_returns_expected_columns(self):
+        self.assertTrue(self.returned_df.columns, self.expected_df.columns)
+
+    def test_original_column_remains_unchanged(self):
+        for i in range(len(self.returned_data)):
+            self.assertEqual(
+                self.returned_data[i][CQCL.gac_service_types],
+                self.expected_data[i][CQCL.gac_service_types],
+                f"Returned value in row {i} does not match original",
+            )
+
+    def test_impute_missing_struct_column_returns_expected_imputed_data(self):
+        for i in range(len(self.returned_data)):
+            self.assertEqual(
+                self.returned_data[i][CQCLCleaned.imputed_gac_service_types],
+                self.expected_data[i][CQCLCleaned.imputed_gac_service_types],
+                f"Returned value in row {i} does not match expected",
+            )
+
+
+class RemoveLocationsThatNeverHadRegulatedActivitesTests(CleanCQCLocationDatasetTests):
+    def setUp(self) -> None:
+        super().setUp()
+        self.test_df = self.spark.createDataFrame(
+            Data.remove_locations_that_never_had_regulated_activities_rows,
+            Schemas.remove_locations_that_never_had_regulated_activities_schema,
+        )
+        self.returned_df = job.remove_locations_that_never_had_regulated_activities(
+            self.test_df
+        )
+        self.expected_df = self.spark.createDataFrame(
+            Data.expected_remove_locations_that_never_had_regulated_activities_rows,
+            Schemas.remove_locations_that_never_had_regulated_activities_schema,
+        )
+
+        self.returned_data = self.returned_df.sort(CQCL.location_id).collect()
+        self.expected_data = self.expected_df.collect()
+
+    def test_remove_locations_that_never_had_regulated_activities_returns_expected_data(
+        self,
+    ):
+        self.assertEqual(self.returned_data, self.expected_data)
+
+
+class ExtractFromStructTests(CleanCQCLocationDatasetTests):
+    def setUp(self) -> None:
+        super().setUp()
+        test_df = self.spark.createDataFrame(
+            Data.extract_from_struct_rows,
+            schema=Schemas.extract_from_struct_schema,
+        )
+        self.returned_df = job.extract_from_struct(
+            test_df,
+            test_df[CQCL.gac_service_types][CQCL.description],
+            CQCLCleaned.services_offered,
+        )
+
+    def test_extract_from_struct_adds_column(self):
+        self.assertTrue(CQCLCleaned.services_offered in self.returned_df.columns)
+
+    def test_extract_from_struct_returns_correct_data(self):
+        expected_df = self.spark.createDataFrame(
+            Data.expected_extract_from_struct_rows,
+            Schemas.expected_extract_from_struct_schema,
+        )
+        returned_data = self.returned_df.sort(CQCLCleaned.location_id).collect()
+        expected_data = expected_df.collect()
+        self.assertEqual(returned_data, expected_data)
+
+
+class AllocatePrimaryServiceTests(CleanCQCLocationDatasetTests):
+    def setUp(self) -> None:
+        super().setUp()
+
+    def test_allocate_primary_service_type(self):
+        PRIMARY_SERVICE_TYPE_COLUMN_NAME = "primary_service_type"
+
+        test_primary_service_df = self.spark.createDataFrame(
+            Data.primary_service_type_rows,
+            schema=Schemas.primary_service_type_schema,
+        )
+        expected_df = self.spark.createDataFrame(
+            Data.expected_primary_service_type_rows,
+            schema=Schemas.expected_primary_service_type_schema,
+        )
+
+        output_df = job.allocate_primary_service_type(test_primary_service_df)
+
+        self.assertTrue(PRIMARY_SERVICE_TYPE_COLUMN_NAME in output_df.columns)
+
+        primary_service_values = output_df.select(
+            F.collect_list(PRIMARY_SERVICE_TYPE_COLUMN_NAME)
+        ).first()[0]
+
+        self.assertEqual(len(primary_service_values), 10)
+
+        self.assertEqual(output_df.collect(), expected_df.collect())
+
+
+class RealignCareHomeColumnWthPrimaryServiceTests(CleanCQCLocationDatasetTests):
+    def setUp(self) -> None:
+        super().setUp()
+        test_realign_carehome_column_df = self.spark.createDataFrame(
+            Data.realign_carehome_column_rows,
+            Schemas.realign_carehome_column_schema,
+        )
+        returned_df = job.realign_carehome_column_with_primary_service(
+            test_realign_carehome_column_df
+        )
+        expected_df = self.spark.createDataFrame(
+            Data.expected_realign_carehome_column_rows,
+            Schemas.realign_carehome_column_schema,
+        )
+
+        self.returned_data = returned_df.sort(CQCL.location_id).collect()
+        self.expected_data = expected_df.collect()
+
+    def test_care_home_values_match_expected_data(self):
+        self.assertEqual(self.returned_data, self.expected_data)
+
+
+class RemoveSpecialistCollegesTests(CleanCQCLocationDatasetTests):
+    def setUp(self) -> None:
+        super().setUp()
+
+    def test_remove_specialist_colleges_removes_rows_where_specialist_college_is_only_service(
+        self,
+    ):
+        test_df = self.spark.createDataFrame(
+            Data.test_only_service_specialist_colleges_rows,
+            Schemas.remove_specialist_colleges_schema,
+        )
+        returned_df = job.remove_specialist_colleges(test_df)
+        expected_df = self.spark.createDataFrame(
+            Data.expected_only_service_specialist_colleges_rows,
+            Schemas.remove_specialist_colleges_schema,
+        )
+        self.assertEqual(returned_df.collect(), expected_df.collect())
+
+    def test_remove_specialist_colleges_does_not_remove_rows_where_specialist_college_is_one_of_multiple_services(
+        self,
+    ):
+        test_df = self.spark.createDataFrame(
+            Data.test_multiple_services_specialist_colleges_rows,
+            Schemas.remove_specialist_colleges_schema,
+        )
+        returned_df = job.remove_specialist_colleges(test_df)
+        expected_df = self.spark.createDataFrame(
+            Data.test_multiple_services_specialist_colleges_rows,
+            Schemas.remove_specialist_colleges_schema,
+        )
+        self.assertEqual(returned_df.collect(), expected_df.collect())
+
+    def test_remove_specialist_colleges_does_not_remove_rows_where_specialist_college_is_not_listed_in_services(
+        self,
+    ):
+        test_df = self.spark.createDataFrame(
+            Data.test_without_specialist_colleges_rows,
+            Schemas.remove_specialist_colleges_schema,
+        )
+        returned_df = job.remove_specialist_colleges(test_df)
+        expected_df = self.spark.createDataFrame(
+            Data.expected_without_specialist_colleges_rows,
+            Schemas.remove_specialist_colleges_schema,
+        )
+        self.assertEqual(returned_df.collect(), expected_df.collect())
+
+    def test_remove_specialist_colleges_does_not_remove_rows_where_gac_service_type_struct_is_empty(
+        self,
+    ):
+        test_df = self.spark.createDataFrame(
+            Data.test_empty_array_specialist_colleges_rows,
+            Schemas.remove_specialist_colleges_schema,
+        )
+        returned_df = job.remove_specialist_colleges(test_df)
+        expected_df = self.spark.createDataFrame(
+            Data.expected_empty_array_specialist_colleges_rows,
+            Schemas.remove_specialist_colleges_schema,
+        )
+        self.assertEqual(returned_df.collect(), expected_df.collect())
+
+    def test_remove_specialist_colleges_does_not_remove_rows_where_gac_service_type_column_is_null(
+        self,
+    ):
+        test_df = self.spark.createDataFrame(
+            Data.test_null_row_specialist_colleges_rows,
+            Schemas.remove_specialist_colleges_schema,
+        )
+        returned_df = job.remove_specialist_colleges(test_df)
+        expected_df = self.spark.createDataFrame(
+            Data.expected_null_row_specialist_colleges_rows,
+            Schemas.remove_specialist_colleges_schema,
+        )
+        self.assertEqual(returned_df.collect(), expected_df.collect())
+
+
+class JoinCqcProviderDataTests(CleanCQCLocationDatasetTests):
+    def setUp(self) -> None:
+        super().setUp()
+        self.test_location_df = cUtils.column_to_date(
+            self.test_location_df,
+            Keys.import_date,
+            CQCLCleaned.cqc_location_import_date,
+        ).drop(CQCLCleaned.import_date)
+
+    def test_join_cqc_provider_data_adds_three_columns(self):
+        returned_df = job.join_cqc_provider_data(
+            self.test_location_df, self.test_provider_df
+        )
+        new_columns = 3
+        expected_columns = len(self.test_location_df.columns) + new_columns
+
+        self.assertEqual(len(returned_df.columns), expected_columns)
+
+    def test_join_cqc_provider_data_correctly_joins_data(self):
+        returned_df = job.join_cqc_provider_data(
+            self.test_location_df, self.test_provider_df
+        )
+        returned_data = (
+            returned_df.select(sorted(returned_df.columns))
+            .sort(CQCL.location_id)
+            .collect()
+        )
+        expected_df = self.spark.createDataFrame(
+            Data.expected_joined_rows, Schemas.expected_joined_schema
+        )
+        expected_data = (
+            expected_df.select(sorted(expected_df.columns))
+            .sort(CQCL.location_id)
+            .collect()
+        )
+
+        self.assertCountEqual(returned_data, expected_data)
+
+
+class SelectRegisteredLocationsOnlyTest(CleanCQCLocationDatasetTests):
+    def setUp(self) -> None:
+        return super().setUp()
+
+    def test_select_registered_locations_only_splits_data_correctly(
+        self,
+    ):
+        test_df = self.spark.createDataFrame(
+            Data.registration_status_rows, Schemas.registration_status_schema
+        )
+
+        returned_registered_df = job.select_registered_locations_only(test_df)
+        returned_registered_data = returned_registered_df.collect()
+
+        expected_registered_data = self.spark.createDataFrame(
+            Data.expected_registered_rows, Schemas.registration_status_schema
+        ).collect()
+
+        self.assertEqual(returned_registered_data, expected_registered_data)
+
+    def test_select_registered_locations_only_raises_a_warning_if_any_rows_are_invalid(
+        self,
+    ):
+        test_df = self.spark.createDataFrame(
+            Data.registration_status_with_missing_data_rows,
+            Schemas.registration_status_schema,
+        )
+        returned_registered_df = job.select_registered_locations_only(test_df)
+        returned_registered_data = returned_registered_df.collect()
+
+        expected_registered_data = self.spark.createDataFrame(
+            Data.expected_registered_rows, Schemas.registration_status_schema
+        ).collect()
+
+        self.assertEqual(returned_registered_data, expected_registered_data)
+
+        self.assertWarns(Warning)
+
+    def test_select_registered_locations_only_does_not_raise_a_warning_if_all_rows_are_valid(
+        self,
+    ):
+        test_df = self.spark.createDataFrame(
+            Data.registration_status_rows, Schemas.registration_status_schema
+        )
+        with warnings.catch_warnings(record=True) as warnings_log:
+            returned_registered_df = job.select_registered_locations_only(test_df)
+
+            self.assertEqual(warnings_log, [])
+
+
+class CleanProviderIdColumn(CleanCQCLocationDatasetTests):
+    def setUp(self) -> None:
+        super().setUp()
+
+    def test_clean_provider_id_column(self):
+        test_df = self.spark.createDataFrame(
+            Data.clean_provider_id_column_rows, Schemas.clean_provider_id_column_schema
+        )
+        expected_df = self.spark.createDataFrame(
+            Data.expected_clean_provider_id_column_rows,
+            Schemas.clean_provider_id_column_schema,
+        )
+        returned_df = job.clean_provider_id_column(test_df)
+        self.assertEqual(expected_df.collect(), returned_df.collect())
+
+    def test_remove_values_with_too_many_characters(self):
+        test_df = self.spark.createDataFrame(
+            Data.long_provider_id_column_rows, Schemas.clean_provider_id_column_schema
+        )
+        expected_df = self.spark.createDataFrame(
+            Data.expected_long_provider_id_column_rows,
+            Schemas.clean_provider_id_column_schema,
+        )
+        returned_df = job.remove_provider_ids_with_too_many_characters(test_df)
+        self.assertEqual(expected_df.collect(), returned_df.collect())
+
+    def test_fill_missing_values_if_present_in_other_rows(self):
+        test_df = self.spark.createDataFrame(
+            Data.fill_missing_provider_id_column_rows,
+            Schemas.clean_provider_id_column_schema,
+        )
+        expected_df = self.spark.createDataFrame(
+            Data.expected_fill_missing_provider_id_column_rows,
+            Schemas.clean_provider_id_column_schema,
+        )
+        returned_df = job.fill_missing_provider_ids_from_other_rows(test_df)
+        self.assertEqual(expected_df.collect(), returned_df.collect())
+
+
+class ImputeMissingDataFromProviderDataset(CleanCQCLocationDatasetTests):
+    def setUp(self) -> None:
+        super().setUp()
+        self.column_to_impute = CQCLCleaned.cqc_sector
+
+    def test_impute_missing_data_from_provider_dataset_returns_correct_values_when_column_has_the_same_values(
+        self,
+    ):
+        test_df = self.spark.createDataFrame(
+            Data.impute_missing_data_from_provider_dataset_single_value_rows,
+            Schemas.impute_missing_data_from_provider_dataset_schema,
+        )
+        expected_df = self.spark.createDataFrame(
+            Data.expected_impute_missing_data_from_provider_dataset_rows,
+            Schemas.impute_missing_data_from_provider_dataset_schema,
+        )
+        returned_df = job.impute_missing_data_from_provider_dataset(
+            test_df, self.column_to_impute
+        )
+        self.assertEqual(expected_df.collect(), returned_df.collect())
+
+    def test_impute_missing_data_from_provider_dataset_returns_correct_values_when_column_values_change_over_time(
+        self,
+    ):
+        test_df = self.spark.createDataFrame(
+            Data.impute_missing_data_from_provider_dataset_multiple_values_rows,
+            Schemas.impute_missing_data_from_provider_dataset_schema,
+        )
+        expected_df = self.spark.createDataFrame(
+            Data.expected_impute_missing_data_from_provider_dataset_multiple_values_rows,
+            Schemas.impute_missing_data_from_provider_dataset_schema,
+        ).sort(CQCLCleaned.cqc_location_import_date)
+        returned_df = job.impute_missing_data_from_provider_dataset(
+            test_df, self.column_to_impute
+        ).sort(CQCLCleaned.cqc_location_import_date)
+        self.assertEqual(expected_df.collect(), returned_df.collect())
+
+
+class AddColumnRelatedLocation(CleanCQCLocationDatasetTests):
+    def setUp(self) -> None:
+        super().setUp()
+
+    def test_add_related_location_column_returns_correct_values(self):
+        test_df = self.spark.createDataFrame(
+            Data.add_related_location_column_rows,
+            Schemas.add_related_location_column_schema,
+        )
+        expected_df = self.spark.createDataFrame(
+            Data.expected_add_related_location_column_rows,
+            Schemas.expected_add_related_location_column_schema,
+        )
+        returned_df = job.add_related_location_column(test_df)
+        self.assertEqual(
+            expected_df.collect(), returned_df.sort(CQCL.location_id).collect()
+        )
+
+
+class CalculateTimeSinceDormant(CleanCQCLocationDatasetTests):
+    def setUp(self):
+        super().setUp()
+
+        self.test_df = self.spark.createDataFrame(
+            Data.calculate_time_since_dormant_rows,
+            Schemas.calculate_time_since_dormant_schema,
+        )
+        self.returned_df = job.calculate_time_since_dormant(self.test_df)
+        self.expected_df = self.spark.createDataFrame(
+            Data.expected_calculate_time_since_dormant_rows,
+            Schemas.expected_calculate_time_since_dormant_schema,
+        )
+
+        self.columns_added_by_function = [
+            column
+            for column in self.returned_df.columns
+            if column not in self.test_df.columns
+        ]
+
+    def test_calculate_time_since_dormant_returns_new_column(self):
+        self.assertEqual(len(self.columns_added_by_function), 1)
+        self.assertEqual(
+            self.columns_added_by_function[0], CQCLCleaned.time_since_dormant
+        )
+
+    def test_calculate_time_since_dormant_returns_expected_values(self):
+        returned_data = self.returned_df.sort(
+            CQCLCleaned.cqc_location_import_date
+        ).collect()
+        expected_data = self.expected_df.collect()
+
+        self.assertEqual(returned_data, expected_data)
+
+
+class CreateLaCqcProviderDataframeTests(CleanCQCLocationDatasetTests):
+    def setUp(self) -> None:
+        super().setUp()
+
+    def test_create_dataframe_from_la_cqc_provider_list_creates_a_dataframe_with_a_column_of_providerids_and_a_column_of_strings(
+        self,
+    ):
+        test_la_cqc_dataframe = job.create_dataframe_from_la_cqc_location_list(
+            Data.sector_rows
+        )
+        self.assertEqual(
+            test_la_cqc_dataframe.columns, [CQCL.provider_id, CQCLCleaned.cqc_sector]
+        )
+
+        test_cqc_sector_list = test_la_cqc_dataframe.select(
+            F.collect_list(CQCLCleaned.cqc_sector)
+        ).first()[0]
+        self.assertEqual(
+            test_cqc_sector_list,
+            [
+                Sector.local_authority,
+                Sector.local_authority,
+                Sector.local_authority,
+                Sector.local_authority,
+            ],
+        )
+
+
+class AddCqcSectorColumnTests(CleanCQCLocationDatasetTests):
+    def setUp(self) -> None:
+        super().setUp()
+
+        test_cqc_provider_df = self.spark.createDataFrame(
+            Data.rows_without_cqc_sector,
+            Schemas.rows_without_cqc_sector_schema,
+        )
+        self.test_cqc_provider_with_sector = (
+            job.add_cqc_sector_column_to_cqc_locations_dataframe(
+                test_cqc_provider_df, Data.sector_rows
+            )
+        )
+        self.test_expected_dataframe = self.spark.createDataFrame(
+            Data.expected_rows_with_cqc_sector,
+            Schemas.expected_rows_with_cqc_sector_schema,
+        )
+
+    def test_add_cqc_sector_column_to_cqc_provider_dataframe_adds_cqc_sector_column(
+        self,
+    ):
+        self.assertTrue(
+            CQCLCleaned.cqc_sector in self.test_cqc_provider_with_sector.columns
+        )
+
+    def test_add_cqc_sector_column_to_cqc_provider_dataframe_returns_expected_df(
+        self,
+    ):
+        expected_data = self.test_expected_dataframe.sort(CQCL.provider_id).collect()
+        returned_data = self.test_cqc_provider_with_sector.sort(
+            CQCL.provider_id
+        ).collect()
+
+        self.assertEqual(
+            returned_data,
+            expected_data,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main(warnings="ignore")

--- a/projects/_01_ingest/cqc_api/tests/jobs/test_delta_clean_cqc_location_data.py
+++ b/projects/_01_ingest/cqc_api/tests/jobs/test_delta_clean_cqc_location_data.py
@@ -124,7 +124,7 @@ class MainTests(CleanCQCLocationDatasetTests):
             self.TEST_DESTINATION,
         )
 
-        self.assertEqual(read_from_parquet_mock.call_count, 3)
+        self.assertEqual(read_from_parquet_mock.call_count, 2)
         create_cleaned_registration_date_column_mock.assert_called_once()
         self.assertEqual(column_to_date_mock.call_count, 2)
         clean_provider_id_column_mock.assert_called_once()

--- a/projects/_01_ingest/unittest_data/ingest_test_file_data.py
+++ b/projects/_01_ingest/unittest_data/ingest_test_file_data.py
@@ -3628,6 +3628,25 @@ class CQCLocationsData:
         ),
     ]
 
+    sector_rows = [
+        "1-10000000002",
+        "1-10000000003",
+        "1-10000000004",
+        "1-10000000005",
+    ]
+
+    rows_without_cqc_sector = [
+        ("1-10000000001", "data"),
+        ("1-10000000002", None),
+        ("1-10000000003", "data"),
+    ]
+
+    expected_rows_with_cqc_sector = [
+        ("1-10000000001", "data", Sector.independent),
+        ("1-10000000002", None, Sector.local_authority),
+        ("1-10000000003", "data", Sector.local_authority),
+    ]
+
 
 @dataclass
 class CQCProviderData:

--- a/projects/_01_ingest/unittest_data/ingest_test_file_schemas.py
+++ b/projects/_01_ingest/unittest_data/ingest_test_file_schemas.py
@@ -1914,6 +1914,20 @@ class CQCLocationsSchema:
         ]
     )
 
+    rows_without_cqc_sector_schema = StructType(
+        [
+            StructField(CQCP.provider_id, StringType(), True),
+            StructField("some_data", StringType(), True),
+        ]
+    )
+    expected_rows_with_cqc_sector_schema = StructType(
+        [
+            StructField(CQCP.provider_id, StringType(), True),
+            StructField("some_data", StringType(), True),
+            StructField(CQCPClean.cqc_sector, StringType(), True),
+        ]
+    )
+
 
 @dataclass
 class CQCProviderSchema:

--- a/terraform/pipeline/eventbridge.tf
+++ b/terraform/pipeline/eventbridge.tf
@@ -320,7 +320,7 @@ resource "aws_scheduler_schedule" "bulk_download_cqc_api_schedule" {
 
 resource "aws_scheduler_schedule" "delta_download_cqc_api_schedule" {
   name        = "${local.workspace_prefix}-CqcApiSchedule-Delta"
-  state       = "ENABLED"
+  state       = terraform.workspace == "main" ? "ENABLED" : "DISABLED"
   description = "Regular scheduling of the CQC API delta download pipeline on the first, eighth, fifteenth and twenty third of each month."
 
   flexible_time_window {

--- a/terraform/pipeline/glue.tf
+++ b/terraform/pipeline/glue.tf
@@ -458,6 +458,24 @@ module "clean_cqc_location_data_job" {
   }
 }
 
+module "delta_clean_cqc_location_data_job" {
+  source            = "../modules/glue-job"
+  script_dir        = "projects/_01_ingest/cqc_api/jobs"
+  script_name       = "delta_clean_cqc_location_data.py"
+  glue_role         = aws_iam_role.sfc_glue_service_iam_role
+  resource_bucket   = module.pipeline_resources
+  datasets_bucket   = module.datasets_bucket
+  worker_type       = "G.2X"
+  number_of_workers = 5
+
+  job_parameters = {
+    "--cqc_location_source"                   = "${module.datasets_bucket.bucket_uri}/domain=CQC/dataset=locations_api/version=2.1.1/"
+    "--cleaned_cqc_provider_source"           = "${module.datasets_bucket.bucket_uri}/domain=CQC/dataset=providers_api_cleaned/"
+    "--cleaned_ons_postcode_directory_source" = "${module.datasets_bucket.bucket_uri}/domain=ONS/dataset=postcode_directory_cleaned/"
+    "--cleaned_cqc_location_destination"      = "${module.datasets_bucket.bucket_uri}/domain=CQC/dataset=locations_api_cleaned/"
+  }
+}
+
 module "reconciliation_job" {
   source          = "../modules/glue-job"
   script_dir      = "projects/_02_sfc_internal/reconciliation/jobs"

--- a/terraform/pipeline/glue.tf
+++ b/terraform/pipeline/glue.tf
@@ -547,6 +547,22 @@ module "validate_locations_api_cleaned_data_job" {
   }
 }
 
+module "validate_delta_locations_api_cleaned_data_job" {
+  source          = "../modules/glue-job"
+  script_dir      = "projects/_01_ingest/cqc_api/jobs"
+  script_name     = "validate_delta_locations_api_cleaned_data.py"
+  glue_role       = aws_iam_role.sfc_glue_service_iam_role
+  resource_bucket = module.pipeline_resources
+  datasets_bucket = module.datasets_bucket
+  glue_version    = "4.0"
+
+  job_parameters = {
+    "--raw_cqc_location_source"      = "${module.datasets_bucket.bucket_uri}/domain=CQC_delta/dataset=full_locations_api/version=3.0.0/"
+    "--cleaned_cqc_locations_source" = "${module.datasets_bucket.bucket_uri}/domain=CQC_delta/dataset=full_locations_api_cleaned/"
+    "--report_destination"           = "${module.datasets_bucket.bucket_uri}/domain=data_validation_reports/dataset=data_quality_report_delta_locations_api_cleaned/"
+  }
+}
+
 module "validate_providers_api_cleaned_data_job" {
   source          = "../modules/glue-job"
   script_dir      = "projects/_01_ingest/cqc_api/jobs"

--- a/terraform/pipeline/step-function.tf
+++ b/terraform/pipeline/step-function.tf
@@ -173,7 +173,7 @@ resource "aws_sfn_state_machine" "cqc_api_pipeline_state_machine" {
     validate_locations_api_raw_delta_data_job_name = module.validate_locations_api_raw_delta_data_job.job_name
     create_snapshot_lambda_lambda_arn              = aws_lambda_function.create_snapshot_lambda.arn
     clean_cqc_provider_data_job_name               = module.clean_cqc_provider_data_job.job_name
-    clean_cqc_location_data_job_name               = module.clean_cqc_location_data_job.job_name
+    clean_cqc_location_data_job_name               = module.delta_clean_cqc_location_data_job.job_name
     validate_locations_api_cleaned_data_job_name   = module.validate_locations_api_cleaned_data_job.job_name
     validate_providers_api_cleaned_data_job_name   = module.validate_providers_api_cleaned_data_job.job_name
     cqc_crawler_name                               = module.cqc_crawler_delta.crawler_name # TODO: point back to main crawler

--- a/terraform/pipeline/step-function.tf
+++ b/terraform/pipeline/step-function.tf
@@ -174,7 +174,7 @@ resource "aws_sfn_state_machine" "cqc_api_pipeline_state_machine" {
     create_snapshot_lambda_lambda_arn              = aws_lambda_function.create_snapshot_lambda.arn
     clean_cqc_provider_data_job_name               = module.clean_cqc_provider_data_job.job_name
     clean_cqc_location_data_job_name               = module.delta_clean_cqc_location_data_job.job_name
-    validate_locations_api_cleaned_data_job_name   = module.validate_locations_api_cleaned_data_job.job_name
+    validate_locations_api_cleaned_data_job_name   = module.validate_delta_locations_api_cleaned_data_job.job_name
     validate_providers_api_cleaned_data_job_name   = module.validate_providers_api_cleaned_data_job.job_name
     cqc_crawler_name                               = module.cqc_crawler_delta.crawler_name # TODO: point back to main crawler
     data_validation_reports_crawler_name           = module.data_validation_reports_crawler.crawler_name


### PR DESCRIPTION
## Description
Trello ticket [#942](https://trello.com/c/nmqHM6y1)

Refactored locations cleaning to assign CQC Sector directly using the Provider Id from the Locations API, rather than joining with the Providers dataset. There are dummy columns for Provider Name and Provider Import date to keep the schema consistent for downstream processes. 

## Testing
- [x] Unit tests passing
- [x] Successful [Step Function run](https://eu-west-2.console.aws.amazon.com/states/home?region=eu-west-2#/v2/executions/details/arn:aws:states:eu-west-2:344210435447:execution:942-assign-cqc-sector-CQC-API-Pipeline:38d54620-c937-411e-90b3-ef2c213bd82c)
- [x] Outputs checked in Athena

Also ran the [function on the data in main](https://eu-west-2.console.aws.amazon.com/states/home?region=eu-west-2#/v2/executions/details/arn:aws:states:eu-west-2:344210435447:execution:mt-testNewCleanLocs:06662b69-fc1f-46a8-bc61-9f4faf4c5fa7) to ensure the data is equal. Removing the columns that we know are dummies (provider_name, cqc,provider_import_date) and the specific location data (longitude and latitude primarily - this is because for locations which get their location data from the group sharing most of their details the specific row selected by spark within the group is random) the data validates.
<img width="1282" height="203" alt="Screenshot 2025-08-13 at 17 24 42" src="https://github.com/user-attachments/assets/235a8901-e4b1-4b13-88d2-899be275675a" />

## Checklist (delete if not relevant)
- [x] Unit tests added/amended
- [x] Updated CHANGELOG
- [x] Moved Trello ticket to PR column
