### PR TITLE
Fix clean_cqc_location_data_job raise error issue

### DIFF
--- a/projects/_01_ingest/cqc_api/jobs/clean_cqc_location_data.py
+++ b/projects/_01_ingest/cqc_api/jobs/clean_cqc_location_data.py
@@ -72,12 +72,6 @@ ons_cols_to_import = [
     *contemporary_geography_columns,
     *current_geography_columns,
 ]
-cqc_provider_cols_to_import = [
-    CQCPClean.provider_id,
-    CQCPClean.name,
-    CQCPClean.cqc_sector,
-    CQCPClean.cqc_provider_import_date,
-]
 
 
 def main(

--- a/projects/_01_ingest/cqc_api/utils/postcode_matcher.py
+++ b/projects/_01_ingest/cqc_api/utils/postcode_matcher.py
@@ -319,7 +319,7 @@ def raise_error_if_unmatched(unmatched_df: DataFrame) -> None:
     Raises:
         TypeError: If unmatched postcodes exist.
     """
-    if not unmatched_df.rdd.isEmpty():
+    if not unmatched_df.head(1):
         rows = (
             unmatched_df.select(
                 CQCL.location_id,

--- a/projects/_01_ingest/cqc_api/utils/postcode_matcher.py
+++ b/projects/_01_ingest/cqc_api/utils/postcode_matcher.py
@@ -319,28 +319,30 @@ def raise_error_if_unmatched(unmatched_df: DataFrame) -> None:
     Raises:
         TypeError: If unmatched postcodes exist.
     """
-    if unmatched_df.head(1):
-        rows = (
-            unmatched_df.select(
-                CQCL.location_id,
-                CQCL.name,
-                CQCL.postal_address_line1,
-                CQCLClean.postcode_cleaned,
-            )
-            .distinct()
-            .sort(CQCLClean.postcode_cleaned)
-            .collect()
+    if unmatched_df.limit(1).count() == 0:
+        return
+
+    rows = (
+        unmatched_df.select(
+            CQCL.location_id,
+            CQCL.name,
+            CQCL.postal_address_line1,
+            CQCLClean.postcode_cleaned,
         )
-        errors = [
-            (
-                r[CQCL.location_id],
-                r[CQCL.name],
-                r[CQCL.postal_address_line1],
-                r[CQCLClean.postcode_cleaned],
-            )
-            for r in rows
-        ]
-        raise TypeError(f"Unmatched postcodes found: {errors}")
+        .distinct()
+        .orderBy(CQCLClean.postcode_cleaned)
+        .collect()
+    )
+    errors = [
+        (
+            r[CQCL.location_id],
+            r[CQCL.name],
+            r[CQCL.postal_address_line1],
+            r[CQCLClean.postcode_cleaned],
+        )
+        for r in rows
+    ]
+    raise TypeError(f"Unmatched postcodes found: {errors}")
 
 
 def combine_matched_dataframes(dataframes: List[DataFrame]) -> DataFrame:

--- a/projects/_01_ingest/cqc_api/utils/postcode_matcher.py
+++ b/projects/_01_ingest/cqc_api/utils/postcode_matcher.py
@@ -319,7 +319,7 @@ def raise_error_if_unmatched(unmatched_df: DataFrame) -> None:
     Raises:
         TypeError: If unmatched postcodes exist.
     """
-    if not unmatched_df.head(1):
+    if unmatched_df.head(1):
         rows = (
             unmatched_df.select(
                 CQCL.location_id,


### PR DESCRIPTION
## Description
Trello ticket [#965](https://trello.com/c/YN6ytdbj/965-fix-error-in-cleancqclocationdatajob)

We have started [getting errors](https://eu-west-2.console.aws.amazon.com/gluestudio/home?region=eu-west-2#/editor/job/main-clean_cqc_location_data_job/runs) in the CQC clean location job (`IllegalArgumentException: Self-suppression not permitted` and then `An error occurred while calling o970.javaToPython. Could not execute broadcast in 300 secs`)

Both errors look to be caused by the `.rdd.isEmpty()` part of the postcode checker which raises an error if there are unmatched postcodes. Not entirely sure why it's stopped working as we haven't (knowingly) changed anything.

## Testing
- [X] Unit tests passing
- [X] Successful Step Function
[Failed runs in main](https://eu-west-2.console.aws.amazon.com/gluestudio/home?region=eu-west-2#/editor/job/main-clean_cqc_location_data_job/runs)
[Successful branch run (on main data)](https://eu-west-2.console.aws.amazon.com/gluestudio/home?region=eu-west-2#/editor/job/fix-cqc-loc-self-illegal-arg-clean_cqc_location_data_job/runs)

## Checklist (delete if not relevant)
- [X] Moved Trello ticket to PR column
