### PR TITLE
Added extra_conf broadcast join option to clean CQC locations

### DIFF
--- a/terraform/pipeline/glue.tf
+++ b/terraform/pipeline/glue.tf
@@ -455,6 +455,7 @@ module "clean_cqc_location_data_job" {
     "--cleaned_ons_postcode_directory_source" = "${module.datasets_bucket.bucket_uri}/domain=ONS/dataset=postcode_directory_cleaned/"
     "--cleaned_cqc_location_destination"      = "${module.datasets_bucket.bucket_uri}/domain=CQC/dataset=locations_api_cleaned/"
   }
+  extra_conf = " --conf spark.sql.autoBroadcastJoinThreshold=-1"
 }
 
 module "delta_clean_cqc_location_data_job" {


### PR DESCRIPTION
## Description
Trello ticket [#965](https://trello.com/c/YN6ytdbj/965-fix-error-in-cleancqclocationdatajob)

Job is failing on the broadcast join so added this line from the delta version of the job 

## Testing
- [X] [Glue job run on main data](https://eu-west-2.console.aws.amazon.com/gluestudio/home?region=eu-west-2#/editor/job/cqc-loc-broadcastjoin-clean_cqc_location_data_job/runs)

## Checklist (delete if not relevant)
- [X] Moved Trello ticket to PR column
