### PR TITLE
Increase capacity of coverage job

### DIFF
--- a/terraform/pipeline/glue.tf
+++ b/terraform/pipeline/glue.tf
@@ -514,13 +514,15 @@ module "merge_ind_cqc_data_job" {
 }
 
 module "merge_coverage_data_job" {
-  source          = "../modules/glue-job"
-  script_dir      = "projects/_02_sfc_internal/cqc_coverage/jobs"
-  script_name     = "merge_coverage_data.py"
-  glue_role       = aws_iam_role.sfc_glue_service_iam_role
-  resource_bucket = module.pipeline_resources
-  datasets_bucket = module.datasets_bucket
-  glue_version    = "3.0"
+  source            = "../modules/glue-job"
+  script_dir        = "projects/_02_sfc_internal/cqc_coverage/jobs"
+  script_name       = "merge_coverage_data.py"
+  glue_role         = aws_iam_role.sfc_glue_service_iam_role
+  resource_bucket   = module.pipeline_resources
+  datasets_bucket   = module.datasets_bucket
+  glue_version      = "3.0"
+  worker_type       = "G.2X"
+  number_of_workers = 5
 
   job_parameters = {
     "--cleaned_cqc_location_source"         = "${module.datasets_bucket.bucket_uri}/domain=CQC/dataset=locations_api_cleaned/"


### PR DESCRIPTION
## Description
Spotted whilst testing that merge coverage runs on the default settings and takes nearly 25 minutes to complete.

I've increased the worker_type and number_of_workers to match the IND CQC merge job as they are really similar, and that job only takes 5-6 minutes to complete