### PR TITLE
[970] Refactor: repoint all jobs to delta built CQC datasets

### DIFF
--- a/terraform/pipeline/glue.tf
+++ b/terraform/pipeline/glue.tf
@@ -417,7 +417,7 @@ module "flatten_cqc_ratings_job" {
   datasets_bucket = module.datasets_bucket
 
   job_parameters = {
-    "--cqc_location_source"           = "${module.datasets_bucket.bucket_uri}/domain=CQC/dataset=locations_api/version=2.1.1/"
+    "--cqc_location_source"           = "${module.datasets_bucket.bucket_uri}/domain=CQC_delta/dataset=full_locations_api/version=3.0.0/"
     "--ascwds_workplace_source"       = "${module.datasets_bucket.bucket_uri}/domain=ASCWDS/dataset=workplace/"
     "--cqc_ratings_destination"       = "${module.datasets_bucket.bucket_uri}/domain=SfC/dataset=sfc_cqc_ratings_for_data_requests/version=2.0.0/"
     "--benchmark_ratings_destination" = "${module.datasets_bucket.bucket_uri}/domain=SfC/dataset=sfc_cqc_ratings_for_benchmarks/version=2.0.0/"
@@ -435,8 +435,8 @@ module "clean_cqc_provider_data_job" {
   number_of_workers = 4
 
   job_parameters = {
-    "--cqc_provider_source"  = "${module.datasets_bucket.bucket_uri}/domain=CQC/dataset=providers_api/version=2.0.0/"
-    "--cqc_provider_cleaned" = "${module.datasets_bucket.bucket_uri}/domain=CQC/dataset=providers_api_cleaned/"
+    "--cqc_provider_source"  = "${module.datasets_bucket.bucket_uri}/domain=CQC_delta/dataset=full_providers_api/version=3.0.0/"
+    "--cqc_provider_cleaned" = "${module.datasets_bucket.bucket_uri}/domain=CQC_delta/dataset=full_providers_api_cleaned/"
   }
 }
 
@@ -469,9 +469,9 @@ module "delta_clean_cqc_location_data_job" {
   number_of_workers = 5
 
   job_parameters = {
-    "--cqc_location_source"                   = "${module.datasets_bucket.bucket_uri}/domain=CQC/dataset=locations_api/version=2.1.1/"
+    "--cqc_location_source"                   = "${module.datasets_bucket.bucket_uri}/domain=CQC_delta/dataset=full_locations_api/version=2.1.1/"
     "--cleaned_ons_postcode_directory_source" = "${module.datasets_bucket.bucket_uri}/domain=ONS/dataset=postcode_directory_cleaned/"
-    "--cleaned_cqc_location_destination"      = "${module.datasets_bucket.bucket_uri}/domain=CQC/dataset=locations_api_cleaned/"
+    "--cleaned_cqc_location_destination"      = "${module.datasets_bucket.bucket_uri}/domain=CQC_delta/dataset=full_locations_api_cleaned/"
   }
   extra_conf = " --conf spark.sql.autoBroadcastJoinThreshold=-1"
 }
@@ -485,7 +485,7 @@ module "reconciliation_job" {
   datasets_bucket = module.datasets_bucket
 
   job_parameters = {
-    "--cqc_location_api_source"                    = "${module.datasets_bucket.bucket_uri}/domain=CQC/dataset=locations_api/version=2.1.1/"
+    "--cqc_location_api_source"                    = "${module.datasets_bucket.bucket_uri}/domain=CQC_delta/dataset=full_locations_api/version=2.1.1/"
     "--ascwds_reconciliation_source"               = "${module.datasets_bucket.bucket_uri}/domain=SfC/dataset=sfc_workplace_for_reconciliation/"
     "--reconciliation_single_and_subs_destination" = "${module.datasets_bucket.bucket_uri}/domain=SfC/dataset=sfc_reconciliation_singles_and_subs"
     "--reconciliation_parents_destination"         = "${module.datasets_bucket.bucket_uri}/domain=SfC/dataset=sfc_reconciliation_parents"
@@ -504,7 +504,7 @@ module "merge_ind_cqc_data_job" {
   number_of_workers = 5
 
   job_parameters = {
-    "--cleaned_cqc_location_source"     = "${module.datasets_bucket.bucket_uri}/domain=CQC/dataset=locations_api_cleaned/"
+    "--cleaned_cqc_location_source"     = "${module.datasets_bucket.bucket_uri}/domain=CQC_delta/dataset=full_locations_api_cleaned/"
     "--cleaned_cqc_pir_source"          = "${module.datasets_bucket.bucket_uri}/domain=CQC/dataset=pir_cleaned/"
     "--cleaned_ascwds_workplace_source" = "${module.datasets_bucket.bucket_uri}/domain=ASCWDS/dataset=workplace_cleaned/"
     "--cleaned_ct_non_res_source"       = "${module.datasets_bucket.bucket_uri}/domain=capacity_tracker/dataset=capacity_tracker_non_residential_cleaned/"
@@ -523,7 +523,7 @@ module "merge_coverage_data_job" {
   glue_version    = "3.0"
 
   job_parameters = {
-    "--cleaned_cqc_location_source"         = "${module.datasets_bucket.bucket_uri}/domain=CQC/dataset=locations_api_cleaned/"
+    "--cleaned_cqc_location_source"         = "${module.datasets_bucket.bucket_uri}/domain=CQC_delta/dataset=full_locations_api_cleaned/"
     "--workplace_for_reconciliation_source" = "${module.datasets_bucket.bucket_uri}/domain=SfC/dataset=sfc_workplace_for_reconciliation/"
     "--cqc_ratings_source"                  = "${module.datasets_bucket.bucket_uri}/domain=SfC/dataset=sfc_cqc_ratings_for_data_requests/version=2.0.0/"
     "--merged_coverage_destination"         = "${module.datasets_bucket.bucket_uri}/domain=SfC/dataset=sfc_merged_coverage_data/"
@@ -573,8 +573,8 @@ module "validate_providers_api_cleaned_data_job" {
   glue_version    = "4.0"
 
   job_parameters = {
-    "--raw_cqc_provider_source"      = "${module.datasets_bucket.bucket_uri}/domain=CQC/dataset=providers_api/version=2.0.0/"
-    "--cleaned_cqc_providers_source" = "${module.datasets_bucket.bucket_uri}/domain=CQC/dataset=providers_api_cleaned/"
+    "--raw_cqc_provider_source"      = "${module.datasets_bucket.bucket_uri}/domain=CQC_delta/dataset=full_providers_api/version=3.0.0/"
+    "--cleaned_cqc_providers_source" = "${module.datasets_bucket.bucket_uri}/domain=CQC_delta/dataset=full_providers_api_cleaned/"
     "--report_destination"           = "${module.datasets_bucket.bucket_uri}/domain=data_validation_reports/dataset=data_quality_report_providers_api_cleaned/"
   }
 }
@@ -652,7 +652,7 @@ module "validate_merged_ind_cqc_data_job" {
   number_of_workers = 4
 
   job_parameters = {
-    "--cleaned_cqc_location_source" = "${module.datasets_bucket.bucket_uri}/domain=CQC/dataset=locations_api_cleaned/"
+    "--cleaned_cqc_location_source" = "${module.datasets_bucket.bucket_uri}/domain=CQC_delta/dataset=full_locations_api_cleaned/"
     "--merged_ind_cqc_source"       = "${module.datasets_bucket.bucket_uri}/domain=ind_cqc_filled_posts/dataset=ind_cqc_merged_data/"
     "--report_destination"          = "${module.datasets_bucket.bucket_uri}/domain=data_validation_reports/dataset=data_quality_report_ind_cqc_merged_data/"
   }
@@ -668,7 +668,7 @@ module "validate_merge_coverage_data_job" {
   glue_version    = "4.0"
 
   job_parameters = {
-    "--cleaned_cqc_location_source" = "${module.datasets_bucket.bucket_uri}/domain=CQC/dataset=locations_api_cleaned/"
+    "--cleaned_cqc_location_source" = "${module.datasets_bucket.bucket_uri}/domain=CQC_delta/dataset=full_locations_api_cleaned/"
     "--merged_coverage_data_source" = "${module.datasets_bucket.bucket_uri}/domain=SfC/dataset=sfc_merged_coverage_data/"
     "--report_destination"          = "${module.datasets_bucket.bucket_uri}/domain=data_validation_reports/dataset=data_quality_report_sfc_merged_coverage_data/"
   }
@@ -829,7 +829,7 @@ module "validate_locations_api_raw_data_job" {
   glue_version    = "4.0"
 
   job_parameters = {
-    "--raw_cqc_location_source" = "${module.datasets_bucket.bucket_uri}/domain=CQC/dataset=locations_api/version=2.1.1/"
+    "--raw_cqc_location_source" = "${module.datasets_bucket.bucket_uri}/domain=CQC_delta/dataset=full_locations_api/version=3.0.0/"
     "--report_destination"      = "${module.datasets_bucket.bucket_uri}/domain=data_validation_reports/dataset=data_quality_report_locations_api_raw/"
   }
 }
@@ -859,7 +859,7 @@ module "validate_providers_api_raw_data_job" {
   glue_version    = "4.0"
 
   job_parameters = {
-    "--raw_cqc_provider_source" = "${module.datasets_bucket.bucket_uri}/domain=CQC/dataset=providers_api/version=2.0.0/"
+    "--raw_cqc_provider_source" = "${module.datasets_bucket.bucket_uri}/domain=CQC_delta/dataset=full_providers_api/version=3.0.0/"
     "--report_destination"      = "${module.datasets_bucket.bucket_uri}/domain=data_validation_reports/dataset=data_quality_report_providers_api_raw/"
   }
 }

--- a/terraform/pipeline/step-function.tf
+++ b/terraform/pipeline/step-function.tf
@@ -59,11 +59,11 @@ resource "aws_sfn_state_machine" "clean_and_validate_state_machine" {
     clean_ascwds_workplace_job_name                                  = module.clean_ascwds_workplace_job.job_name
     clean_ascwds_worker_job_name                                     = module.clean_ascwds_worker_job.job_name
     clean_cqc_provider_data_job_name                                 = module.clean_cqc_provider_data_job.job_name
-    clean_cqc_location_data_job_name                                 = module.clean_cqc_location_data_job.job_name
+    clean_cqc_location_data_job_name                                 = module.delta_clean_cqc_location_data_job.job_name
     clean_ons_data_job_name                                          = module.clean_ons_data_job.job_name
     reconciliation_job_name                                          = module.reconciliation_job.job_name
     ascwds_crawler_name                                              = module.ascwds_crawler.crawler_name
-    cqc_crawler_name                                                 = module.cqc_crawler.crawler_name
+    cqc_crawler_name                                                 = module.cqc_crawler_delta.crawler_name
     ons_crawler_name                                                 = module.ons_crawler.crawler_name
     trigger_coverage_state_machine_arn                               = aws_sfn_state_machine.coverage_state_machine.arn
     trigger_ind_cqc_filled_post_estimates_pipeline_state_machine_arn = aws_sfn_state_machine.ind_cqc_filled_post_estimates_pipeline_state_machine.arn
@@ -434,7 +434,7 @@ resource "aws_sfn_state_machine" "silver_validation_state_machine" {
     dataset_bucket_uri                              = module.datasets_bucket.bucket_uri
     validate_ascwds_worker_cleaned_data_job_name    = module.validate_ascwds_worker_cleaned_data_job.job_name
     validate_ascwds_workplace_cleaned_data_job_name = module.validate_ascwds_workplace_cleaned_data_job.job_name
-    validate_locations_api_cleaned_data_job_name    = module.validate_locations_api_cleaned_data_job.job_name
+    validate_locations_api_cleaned_data_job_name    = module.validate_delta_locations_api_cleaned_data_job.job_name
     validate_providers_api_cleaned_data_job_name    = module.validate_providers_api_cleaned_data_job.job_name
     data_validation_reports_crawler_name            = module.data_validation_reports_crawler.crawler_name
     pipeline_failure_lambda_function_arn            = aws_lambda_function.error_notification_lambda.arn

--- a/terraform/pipeline/step-functions/CleanAndValidate-StepFunction.json
+++ b/terraform/pipeline/step-functions/CleanAndValidate-StepFunction.json
@@ -51,7 +51,7 @@
                         "Parameters": {
                           "JobName": "${reconciliation_job_name}",
                           "Arguments": {
-                            "--cqc_location_api_source": "${dataset_bucket_uri}/domain=CQC/dataset=locations_api/version=2.1.1/",
+                            "--cqc_location_api_source": "${dataset_bucket_uri}/domain=CQC_delta/dataset=full_locations_api/version=3.0.0/",
                             "--ascwds_reconciliation_source": "${dataset_bucket_uri}/domain=SfC/dataset=sfc_workplace_for_reconciliation/",
                             "--reconciliation_single_and_subs_destination": "${dataset_bucket_uri}/domain=SfC/dataset=sfc_reconciliation_singles_and_subs",
                             "--reconciliation_parents_destination": "${dataset_bucket_uri}/domain=SfC/dataset=sfc_reconciliation_parents"
@@ -114,8 +114,8 @@
                         "Parameters": {
                           "JobName": "${clean_cqc_provider_data_job_name}",
                           "Arguments": {
-                            "--cqc_provider_source": "${dataset_bucket_uri}/domain=CQC/dataset=providers_api/version=2.0.0/",
-                            "--cqc_provider_cleaned": "${dataset_bucket_uri}/domain=CQC/dataset=providers_api_cleaned/"
+                            "--cqc_provider_source": "${dataset_bucket_uri}/domain=CQC_delta/dataset=full_providers_api/version=3.0.0/",
+                            "--cqc_provider_cleaned": "${dataset_bucket_uri}/domain=CQC_delta/dataset=full_providers_api_cleaned/"
                           }
                         },
                         "End": true
@@ -131,9 +131,9 @@
                 "Parameters": {
                   "JobName": "${clean_cqc_location_data_job_name}",
                   "Arguments": {
-                    "--cqc_location_source": "${dataset_bucket_uri}/domain=CQC/dataset=locations_api/version=2.1.1",
+                    "--cqc_location_source": "${dataset_bucket_uri}/domain=CQC_delta/dataset=full_locations_api/version=3.0.0",
                     "--cleaned_ons_postcode_directory_source": "${dataset_bucket_uri}/domain=ONS/dataset=postcode_directory_cleaned/",
-                    "--cleaned_cqc_location_destination": "${dataset_bucket_uri}/domain=CQC/dataset=locations_api_cleaned/"
+                    "--cleaned_cqc_location_destination": "${dataset_bucket_uri}/domain=CQC_delta/dataset=full_locations_api_cleaned/"
                   }
                 },
                 "Next": "Run CQC crawler"

--- a/terraform/pipeline/step-functions/IngestCQCAPI-StepFunction.json
+++ b/terraform/pipeline/step-functions/IngestCQCAPI-StepFunction.json
@@ -64,7 +64,7 @@
                         "Parameters": {
                           "JobName": "${flatten_cqc_ratings_job_name}",
                           "Arguments": {
-                            "--cqc_location_source": "${dataset_bucket_uri}/domain=CQC/dataset=locations_api/version=2.1.1/",
+                            "--cqc_location_source": "${dataset_bucket_uri}/domain=CQC_delta/dataset=full_locations_api/version=3.0.0/",
                             "--ascwds_workplace_source": "${dataset_bucket_uri}/domain=ASCWDS/dataset=workplace/",
                             "--cqc_ratings_destination": "${dataset_bucket_uri}/domain=SfC/dataset=sfc_cqc_ratings_for_data_requests/version=2.0.0/",
                             "--benchmark_ratings_destination": "${dataset_bucket_uri}/domain=SfC/dataset=sfc_cqc_ratings_for_benchmarks/version=2.0.0/"

--- a/terraform/pipeline/step-functions/ValidationSilver-StepFunction.json
+++ b/terraform/pipeline/step-functions/ValidationSilver-StepFunction.json
@@ -49,9 +49,9 @@
                 "Parameters": {
                   "JobName": "${validate_locations_api_cleaned_data_job_name}",
                   "Arguments": {
-                    "--raw_cqc_location_source": "${dataset_bucket_uri}/domain=CQC/dataset=locations_api/version=2.1.1/",
-                    "--cleaned_cqc_locations_source": "${dataset_bucket_uri}/domain=CQC/dataset=locations_api_cleaned/",
-                    "--report_destination": "${dataset_bucket_uri}/domain=data_validation_reports/dataset=data_quality_report_locations_api_cleaned/"
+                    "--raw_cqc_location_source": "${dataset_bucket_uri}/domain=CQC_delta/dataset=full_locations_api/version=3.0.0",
+                    "--cleaned_cqc_locations_source": "${dataset_bucket_uri}/domain=CQC_delta/dataset=full_locations_api_cleaned/",
+                    "--report_destination": "${dataset_bucket_uri}/domain=data_validation_reports/dataset=data_quality_report_full_locations_api_cleaned/"
                   }
                 },
                 "End": true
@@ -67,9 +67,9 @@
                 "Parameters": {
                   "JobName": "${validate_providers_api_cleaned_data_job_name}",
                   "Arguments": {
-                    "--raw_cqc_provider_source": "${dataset_bucket_uri}/domain=CQC/dataset=providers_api/version=2.0.0/",
-                    "--cleaned_cqc_providers_source": "${dataset_bucket_uri}/domain=CQC/dataset=providers_api_cleaned/",
-                    "--report_destination": "${dataset_bucket_uri}/domain=data_validation_reports/dataset=data_quality_report_providers_api_cleaned/"
+                    "--raw_cqc_provider_source": "${dataset_bucket_uri}/domain=CQC_delta/dataset=full_providers_api/version=3.0.0/",
+                    "--cleaned_cqc_providers_source": "${dataset_bucket_uri}/domain=CQC_delta/dataset=full_providers_api_cleaned/",
+                    "--report_destination": "${dataset_bucket_uri}/domain=data_validation_reports/dataset=data_quality_report_full_providers_api_cleaned/"
                   }
                 },
                 "End": true


### PR DESCRIPTION
## Description
Trello ticket [#970](https://trello.com/c/gZZge1h1)

Pointed clean and validate jobs to datasets built by delta pipeline (ie full datasets rebuilt from the delta data). Without this change the downstream processes would clean and validate the data created by the legacy process. As the delta process starts earlier and is much faster, the current week of data would not be there for the downstream processing.

## Testing
- [x] Unit tests passing
- [x] Successful run of:
             [CQC-And-ASCWDS-Orchestrator](https://eu-west-2.console.aws.amazon.com/states/home?region=eu-west-2#/statemachines/view/arn:aws:states:eu-west-2:344210435447:stateMachine:970-repoint-at-delta-CQC-And-ASCWDS-Orchestrator)]
             [Workforce-Intelligence-Pipeline](https://eu-west-2.console.aws.amazon.com/states/home?region=eu-west-2#/statemachines/view/arn:aws:states:eu-west-2:344210435447:stateMachine:970-repoint-at-delta-Workforce-Intelligence-Pipeline)
             [Ind-CQC-Filled-Post-Estimates](https://eu-west-2.console.aws.amazon.com/states/home?region=eu-west-2#/statemachines/view/arn:aws:states:eu-west-2:344210435447:stateMachine:970-repoint-at-delta-Ind-CQC-Filled-Post-Estimates)
             [SfC-Internal](https://eu-west-2.console.aws.amazon.com/states/home?region=eu-west-2#/statemachines/view/arn:aws:states:eu-west-2:344210435447:stateMachine:970-repoint-at-delta-SfC-Internal)
- [x] Outputs checked in Athena

## Checklist (delete if not relevant)
~- [ ] Unit tests added/amended~
~- [ ] Docstrings added/updated~
~- [ ] Migration to polars - added comment to pyspark functions which have been migrated~
~- [ ] Updated CHANGELOG~
- [x] Moved Trello ticket to PR column
