### PR TITLE
[968] Switch CQC delta download to append mode

### DIFF
--- a/polars_utils/utils.py
+++ b/polars_utils/utils.py
@@ -40,7 +40,7 @@ def write_to_parquet(
         logger.info("The provided dataframe was empty. No data was written.")
     else:
         if append:
-            output_path += f"/{uuid.uuid4()}.parquet"
+            output_path += f"{uuid.uuid4()}.parquet"
         df.write_parquet(output_path)
         logger.info("Parquet written to {}".format(output_path))
 

--- a/polars_utils/utils.py
+++ b/polars_utils/utils.py
@@ -16,7 +16,7 @@ def write_to_parquet(
     df: pl.DataFrame,
     output_path: str,
     logger: logging.Logger = util_logger,
-    append: bool = False,
+    append: bool = True,
 ) -> None:
     """Writes a Polars DataFrame to a Parquet file.
 

--- a/projects/_01_ingest/cqc_api/fargate/delta_download_cqc_locations.py
+++ b/projects/_01_ingest/cqc_api/fargate/delta_download_cqc_locations.py
@@ -95,8 +95,7 @@ def main(destination: str, start_timestamp: str, end_timestamp: str) -> None:
         df: pl.DataFrame = pl.DataFrame(generator, POLARS_LOCATION_SCHEMA)
         df_unique: pl.DataFrame = df.unique(subset=[ColNames.location_id])
 
-        output_file_path = f"{destination}data.parquet"
-        utils.write_to_parquet(df_unique, output_file_path, logger=logger)
+        utils.write_to_parquet(df_unique, destination, logger=logger)
         return None
 
     except InvalidTimestampArgumentError as e:

--- a/projects/_01_ingest/cqc_api/fargate/delta_download_cqc_providers.py
+++ b/projects/_01_ingest/cqc_api/fargate/delta_download_cqc_providers.py
@@ -98,8 +98,7 @@ def main(destination: str, start_timestamp: str, end_timestamp: str) -> None:
         logger.info("Creating dataframe and writing to Parquet")
         df: pl.DataFrame = pl.DataFrame(generator, POLARS_PROVIDER_SCHEMA)
         df_unique: pl.DataFrame = df.unique(subset=[ColNames.provider_id])
-        output_file_path = f"{destination}data.parquet"
-        utils.write_to_parquet(df_unique, output_file_path, logger=logger)
+        utils.write_to_parquet(df_unique, destination, logger=logger)
         return None
     except InvalidTimestampArgumentError as e:
         logger.error(f"Start timestamp is after end timestamp: Args: {sys.argv}")

--- a/projects/_01_ingest/cqc_api/tests/fargate/test_delta_download_cqc_locations.py
+++ b/projects/_01_ingest/cqc_api/tests/fargate/test_delta_download_cqc_locations.py
@@ -51,18 +51,21 @@ class TestDeltaDownloadCQCLocations(unittest.TestCase):
         with self.assertRaises(InvalidTimestampArgumentError):
             main(dest, start, end)
 
+    @patch(f"{PATCH_PATH}.utils.uuid")
     @patch(f"{PATCH_PATH}.get_secret")
     @patch(f"{PATCH_PATH}.cqc.get_updated_objects")
     @patch(f"{PATCH_PATH}.SECRET_ID", new="cqc-secret-name")
     @patch(f"{PATCH_PATH}.AWS_REGION", new="us-east-1")
-    def test_main_writes_parquet(self, mock_objects, mock_get_secret):
+    def test_main_writes_parquet(self, mock_objects, mock_get_secret, mock_uuid):
         mock_get_secret.return_value = '{"Ocp-Apim-Subscription-Key": "abc1"}'
         mock_objects.return_value = [
             {"locationId": 1},
             {"locationId": 2},
             {"locationId": 3},
         ]
-        dest = f"{self.temp_dir}/data.parquet"
+        file_name = "abc"
+        mock_uuid.uuid4.return_value = file_name
+        dest = f"{self.temp_dir}/{file_name}.parquet"
         start = "2025-07-20T15:40:23Z"
         end = "2025-07-25T14:23:40Z"
         main(self.temp_dir + "/", start, end)
@@ -73,18 +76,24 @@ class TestDeltaDownloadCQCLocations(unittest.TestCase):
         result = pl.read_parquet(dest)
         self.assertEqual(result.height, 3)
 
+    @patch(f"{PATCH_PATH}.utils.uuid")
     @patch(f"{PATCH_PATH}.get_secret")
     @patch(f"{PATCH_PATH}.cqc.get_updated_objects")
     @patch(f"{PATCH_PATH}.SECRET_ID", new="cqc-secret-name")
     @patch(f"{PATCH_PATH}.AWS_REGION", new="us-east-1")
-    def test_main_copes_with_malformed_destination(self, mock_objects, mock_get_secret):
+    def test_main_copes_with_malformed_destination(
+        self, mock_objects, mock_get_secret, mock_uuid
+    ):
         mock_get_secret.return_value = '{"Ocp-Apim-Subscription-Key": "abc1"}'
         mock_objects.return_value = [
             {"locationId": 1},
             {"locationId": 2},
             {"locationId": 3},
         ]
-        dest = f"{self.temp_dir}/new_path/data.parquet"
+        file_name = "abc"
+        mock_uuid.uuid4.return_value = file_name
+
+        dest = f"{self.temp_dir}/new_path/{file_name}.parquet"
         start = "2025-07-20T15:40:23Z"
         end = "2025-07-25T14:23:40Z"
         new_path = f"{self.temp_dir}/new_path"
@@ -95,3 +104,47 @@ class TestDeltaDownloadCQCLocations(unittest.TestCase):
         self.assertTrue(pathlib.Path(dest).suffix == ".parquet")
         result = pl.read_parquet(dest)
         self.assertEqual(result.height, 3)
+
+    @patch(f"{PATCH_PATH}.utils.uuid")
+    @patch(f"{PATCH_PATH}.get_secret")
+    @patch(f"{PATCH_PATH}.cqc.get_updated_objects")
+    @patch(f"{PATCH_PATH}.SECRET_ID", new="cqc-secret-name")
+    @patch(f"{PATCH_PATH}.AWS_REGION", new="us-east-1")
+    def test_main_writes_copes_with_multiple_runs(
+        self, mock_objects, mock_get_secret, mock_uuid
+    ):
+        mock_get_secret.return_value = '{"Ocp-Apim-Subscription-Key": "abc1"}'
+        mock_objects.side_effect = [
+            [
+                {"locationId": 1},
+                {"locationId": 2},
+                {"locationId": 3},
+            ],
+            [
+                {"locationId": 4},
+                {"locationId": 5},
+                {"locationId": 6},
+            ],
+        ]
+        uuids = ["abc", "def"]
+        mock_uuid.uuid4.side_effect = uuids
+        start = "2025-07-20T09:40:23Z"
+        middle = "2025-07-20T12:23:40Z"
+        end = "2025-07-20T19:40:23Z"
+
+        expected_paths = [f"{self.temp_dir}/{uuid}.parquet" for uuid in uuids]
+
+        main(self.temp_dir + "/", start, middle)
+        main(self.temp_dir + "/", middle, end)
+
+        self.assertTrue(pathlib.Path(expected_paths[0]).exists())
+        self.assertTrue(pathlib.Path(expected_paths[1]).exists())
+        self.assertTrue(pathlib.Path(expected_paths[0]).is_file())
+        self.assertTrue(pathlib.Path(expected_paths[1]).is_file())
+        self.assertTrue(pathlib.Path(expected_paths[0]).suffix == ".parquet")
+        self.assertTrue(pathlib.Path(expected_paths[1]).suffix == ".parquet")
+
+        result_a = pl.read_parquet(expected_paths[0])
+        self.assertEqual(result_a["locationId"].str.to_integer().sum(), 6)
+        result_b = pl.read_parquet(expected_paths[1])
+        self.assertEqual(result_b["locationId"].str.to_integer().sum(), 15)

--- a/projects/_01_ingest/cqc_api/tests/fargate/test_delta_download_cqc_locations.py
+++ b/projects/_01_ingest/cqc_api/tests/fargate/test_delta_download_cqc_locations.py
@@ -113,7 +113,9 @@ class TestDeltaDownloadCQCLocations(unittest.TestCase):
     def test_main_writes_copes_with_multiple_runs(
         self, mock_objects, mock_get_secret, mock_uuid
     ):
+        # GIVEN
         mock_get_secret.return_value = '{"Ocp-Apim-Subscription-Key": "abc1"}'
+        #   that we yield two distinct objects
         mock_objects.side_effect = [
             [
                 {"locationId": 1},
@@ -128,23 +130,25 @@ class TestDeltaDownloadCQCLocations(unittest.TestCase):
         ]
         uuids = ["abc", "def"]
         mock_uuid.uuid4.side_effect = uuids
+
+        # WHEN
+        #   we run main twice with timepoints on the same day
         start = "2025-07-20T09:40:23Z"
         middle = "2025-07-20T12:23:40Z"
         end = "2025-07-20T19:40:23Z"
 
-        expected_paths = [f"{self.temp_dir}/{uuid}.parquet" for uuid in uuids]
-
         main(self.temp_dir + "/", start, middle)
         main(self.temp_dir + "/", middle, end)
 
+        # THEN
+        expected_paths = [f"{self.temp_dir}/{uuid}.parquet" for uuid in uuids]
+        #   both runs should have resulted in a parquet file being written
         self.assertTrue(pathlib.Path(expected_paths[0]).exists())
         self.assertTrue(pathlib.Path(expected_paths[1]).exists())
         self.assertTrue(pathlib.Path(expected_paths[0]).is_file())
         self.assertTrue(pathlib.Path(expected_paths[1]).is_file())
         self.assertTrue(pathlib.Path(expected_paths[0]).suffix == ".parquet")
         self.assertTrue(pathlib.Path(expected_paths[1]).suffix == ".parquet")
-
-        result_a = pl.read_parquet(expected_paths[0])
-        self.assertEqual(result_a["locationId"].str.to_integer().sum(), 6)
-        result_b = pl.read_parquet(expected_paths[1])
-        self.assertEqual(result_b["locationId"].str.to_integer().sum(), 15)
+        #   and reading the directory should give us one dataframe with both timepoints
+        result = pl.read_parquet(self.temp_dir)
+        self.assertEqual(result["locationId"].str.to_integer().sum(), 21)

--- a/projects/_01_ingest/cqc_api/tests/fargate/test_delta_download_cqc_providers.py
+++ b/projects/_01_ingest/cqc_api/tests/fargate/test_delta_download_cqc_providers.py
@@ -51,18 +51,21 @@ class TestDeltaDownloadCQCProviders(unittest.TestCase):
         with self.assertRaises(InvalidTimestampArgumentError):
             main(dest, start, end)
 
+    @patch(f"{PATCH_PATH}.utils.uuid")
     @patch(f"{PATCH_PATH}.get_secret")
     @patch(f"{PATCH_PATH}.cqc.get_updated_objects")
     @patch(f"{PATCH_PATH}.SECRET_ID", new="cqc-secret-name")
     @patch(f"{PATCH_PATH}.AWS_REGION", new="us-east-1")
-    def test_main_writes_parquet(self, mock_objects, mock_get_secret):
+    def test_main_writes_parquet(self, mock_objects, mock_get_secret, mock_uuid):
         mock_get_secret.return_value = '{"Ocp-Apim-Subscription-Key": "abc1"}'
         mock_objects.return_value = [
             {"providerId": 1},
             {"providerId": 2},
             {"providerId": 3},
         ]
-        dest = f"{self.temp_dir}/data.parquet"
+        file_name = "abc"
+        mock_uuid.uuid4.return_value = file_name
+        dest = f"{self.temp_dir}/{file_name}.parquet"
         start = "2025-07-20T15:40:23Z"
         end = "2025-07-25T14:23:40Z"
         main(self.temp_dir + "/", start, end)
@@ -72,18 +75,23 @@ class TestDeltaDownloadCQCProviders(unittest.TestCase):
         result = pl.read_parquet(dest)
         self.assertEqual(result.height, 3)
 
+    @patch(f"{PATCH_PATH}.utils.uuid")
     @patch(f"{PATCH_PATH}.get_secret")
     @patch(f"{PATCH_PATH}.cqc.get_updated_objects")
     @patch(f"{PATCH_PATH}.SECRET_ID", new="cqc-secret-name")
     @patch(f"{PATCH_PATH}.AWS_REGION", new="us-east-1")
-    def test_main_copes_with_malformed_destination(self, mock_objects, mock_get_secret):
+    def test_main_copes_with_malformed_destination(
+        self, mock_objects, mock_get_secret, mock_uuid
+    ):
         mock_get_secret.return_value = '{"Ocp-Apim-Subscription-Key": "abc1"}'
         mock_objects.return_value = [
             {"providerId": 1},
             {"providerId": 2},
             {"providerId": 3},
         ]
-        dest = f"{self.temp_dir}/new_path/data.parquet"
+        file_name = "abc"
+        mock_uuid.uuid4.return_value = file_name
+        dest = f"{self.temp_dir}/new_path/{file_name}.parquet"
         start = "2025-07-20T15:40:23Z"
         end = "2025-07-25T14:23:40Z"
         new_path = f"{self.temp_dir}/new_path"
@@ -94,3 +102,47 @@ class TestDeltaDownloadCQCProviders(unittest.TestCase):
         self.assertTrue(pathlib.Path(dest).suffix == ".parquet")
         result = pl.read_parquet(dest)
         self.assertEqual(result.height, 3)
+
+    @patch(f"{PATCH_PATH}.utils.uuid")
+    @patch(f"{PATCH_PATH}.get_secret")
+    @patch(f"{PATCH_PATH}.cqc.get_updated_objects")
+    @patch(f"{PATCH_PATH}.SECRET_ID", new="cqc-secret-name")
+    @patch(f"{PATCH_PATH}.AWS_REGION", new="us-east-1")
+    def test_main_writes_copes_with_multiple_runs(
+        self, mock_objects, mock_get_secret, mock_uuid
+    ):
+        mock_get_secret.return_value = '{"Ocp-Apim-Subscription-Key": "abc1"}'
+        mock_objects.side_effect = [
+            [
+                {"providerId": 1},
+                {"providerId": 2},
+                {"providerId": 3},
+            ],
+            [
+                {"providerId": 4},
+                {"providerId": 5},
+                {"providerId": 6},
+            ],
+        ]
+        uuids = ["abc", "def"]
+        mock_uuid.uuid4.side_effect = uuids
+        start = "2025-07-20T09:40:23Z"
+        middle = "2025-07-20T12:23:40Z"
+        end = "2025-07-20T19:40:23Z"
+
+        expected_paths = [f"{self.temp_dir}/{uuid}.parquet" for uuid in uuids]
+
+        main(self.temp_dir + "/", start, middle)
+        main(self.temp_dir + "/", middle, end)
+
+        self.assertTrue(pathlib.Path(expected_paths[0]).exists())
+        self.assertTrue(pathlib.Path(expected_paths[1]).exists())
+        self.assertTrue(pathlib.Path(expected_paths[0]).is_file())
+        self.assertTrue(pathlib.Path(expected_paths[1]).is_file())
+        self.assertTrue(pathlib.Path(expected_paths[0]).suffix == ".parquet")
+        self.assertTrue(pathlib.Path(expected_paths[1]).suffix == ".parquet")
+
+        result_a = pl.read_parquet(expected_paths[0])
+        self.assertEqual(result_a["providerId"].str.to_integer().sum(), 6)
+        result_b = pl.read_parquet(expected_paths[1])
+        self.assertEqual(result_b["providerId"].str.to_integer().sum(), 15)

--- a/tests/test_polars_utils/test_utils.py
+++ b/tests/test_polars_utils/test_utils.py
@@ -26,7 +26,7 @@ class TestUtils(unittest.TestCase):
         df: pl.DataFrame = pl.DataFrame({})
         destination: str = os.path.join(self.temp_dir, "test.parquet")
         with self.assertLogs(self.logger) as cm:
-            utils.write_to_parquet(df, destination, self.logger)
+            utils.write_to_parquet(df, destination, self.logger, append=False)
         self.assertFalse(Path(destination).exists())
         self.assertTrue(
             "The provided dataframe was empty. No data was written." in cm.output[0]
@@ -36,15 +36,15 @@ class TestUtils(unittest.TestCase):
         df: pl.DataFrame = pl.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
         destination: str = os.path.join(self.temp_dir, "test.parquet")
         with self.assertLogs(self.logger) as cm:
-            utils.write_to_parquet(df, destination, self.logger)
+            utils.write_to_parquet(df, destination, self.logger, append=False)
         self.assertTrue(Path(destination).exists())
         self.assertTrue(f"Parquet written to {destination}" in cm.output[0])
 
     def test_write_parquet_writes_with_append(self):
         df: pl.DataFrame = pl.DataFrame({"a": [1, 2, 1], "b": [4, 5, 6]})
         destination: str = self.temp_dir
-        write_to_parquet(df, destination, self.logger, append=True)
-        write_to_parquet(df, destination, self.logger, append=True)
+        write_to_parquet(df, destination, self.logger)
+        write_to_parquet(df, destination, self.logger)
         self.assertEqual(len(glob(destination + "/**", recursive=True)), 3)
 
     def test_write_parquet_writes_with_overwrite(self):

--- a/tests/test_polars_utils/test_utils.py
+++ b/tests/test_polars_utils/test_utils.py
@@ -42,7 +42,7 @@ class TestUtils(unittest.TestCase):
 
     def test_write_parquet_writes_with_append(self):
         df: pl.DataFrame = pl.DataFrame({"a": [1, 2, 1], "b": [4, 5, 6]})
-        destination: str = self.temp_dir
+        destination: str = self.temp_dir + "/"
         write_to_parquet(df, destination, self.logger)
         write_to_parquet(df, destination, self.logger)
         self.assertEqual(len(glob(destination + "/**", recursive=True)), 3)


### PR DESCRIPTION
## Description
Trello ticket [#968](https://trello.com/c/PAc9xN05)

The Polars function for writing to parquet now defaults to appending, rather than overwriting, in line with Spark functionality. This affects the import jobs, which now both append data, rather than overwriting it - this means that if the import job is run multiple times on the same day, the data will all be available in the same folder.

## Testing
- [x] Unit tests passing
- [x] Successful [Step Function run 1](https://eu-west-2.console.aws.amazon.com/states/home?region=eu-west-2#/v2/executions/details/arn:aws:states:eu-west-2:344210435447:execution:968-delta-append-Ingest-CQC-API-Delta:c0ddc2df-6298-4e17-a1e4-efce1909a90c), followed by [run 2](https://eu-west-2.console.aws.amazon.com/states/home?region=eu-west-2#/v2/executions/details/arn:aws:states:eu-west-2:344210435447:execution:968-delta-append-Ingest-CQC-API-Delta:aa223599-2190-484c-a9bf-42941a7e12f7) (to prove that it can be run multiple times on the same day), followed by [run 3](https://eu-west-2.console.aws.amazon.com/states/home?region=eu-west-2#/v2/executions/details/arn:aws:states:eu-west-2:344210435447:execution:968-delta-append-Ingest-CQC-API-Delta:bd1cccf3-1007-410a-8917-e1ae4e01cd48) (to prove that if there are no changes it will still work). 
- [x] Outputs checked in Athena (including checking that the changes from the second run are present)

## Checklist (delete if not relevant)
- [x] Unit tests added/amended
~- [ ] Docstrings added/updated~
~- [ ] Migration to polars - added comment to pyspark functions which have been migrated~
~- [ ] Updated CHANGELOG~
- [x] Moved Trello ticket to PR column
