### PR TITLE
Amended CT ingestion crawlers

### DIFF
--- a/terraform/pipeline/step-functions/IngestCapacityTrackerCareHome-StepFunction.json
+++ b/terraform/pipeline/step-functions/IngestCapacityTrackerCareHome-StepFunction.json
@@ -28,7 +28,6 @@
                 "Arguments": {
                   "--capacity_tracker_care_home_source": "${dataset_bucket_uri}/domain=capacity_tracker/dataset=capacity_tracker_care_home/",
                   "--cleaned_capacity_tracker_care_home_destination": "${dataset_bucket_uri}/domain=capacity_tracker/dataset=capacity_tracker_care_home_cleaned/"
-
                 }
               },
               "Next": "Validate cleaned CT Care Home data"
@@ -94,6 +93,9 @@
               ],
               "Default": "No Error"
             },
+            "No Error": {
+              "Type": "Succeed"
+            },
             "Publish Error Notification": {
               "Type": "Task",
               "Resource": "arn:aws:states:::lambda:invoke.waitForTaskToken",
@@ -110,15 +112,16 @@
               },
               "Next": "Fail"
             },
-            "No Error": {
-              "Type": "Succeed"
-            },
             "Fail": {
               "Type": "Fail"
             }
           }
         }
-      ]
+      ],
+      "Next": "Success"
+    },
+    "Success": {
+      "Type": "Succeed"
     }
   }
 }

--- a/terraform/pipeline/step-functions/IngestCapacityTrackerCareHome-StepFunction.json
+++ b/terraform/pipeline/step-functions/IngestCapacityTrackerCareHome-StepFunction.json
@@ -4,7 +4,6 @@
   "States": {
     "Capacity Tracker Care Home pipeline": {
       "Type": "Parallel",
-      "Next": "Run validation crawler when success",
       "Branches": [
         {
           "StartAt": "Ingest Capacity Tracker Care Home",
@@ -50,69 +49,76 @@
           }
         }
       ],
+      "Next": "Run Crawler and Handle Error",
       "Catch": [
         {
           "ErrorEquals": [
             "States.ALL"
           ],
-          "Next": "Publish error notification",
+          "Next": "Run Crawler and Handle Error",
           "ResultPath": "$.error"
         }
       ]
     },
-    "Run validation crawler when success": {
-      "Type": "Task",
-      "Parameters": {
-        "Name": "${data_validation_reports_crawler_name}"
-      },
-      "Resource": "arn:aws:states:::aws-sdk:glue:startCrawler",
-      "Next": "Run CT crawler when success"
-    },
-    "Run CT crawler when success": {
-      "Type": "Task",
-      "Parameters": {
-        "Name": "${ct_crawler_name}"
-      },
-      "Resource": "arn:aws:states:::aws-sdk:glue:startCrawler",
-      "Next": "Success"
-    },
-    "Publish error notification": {
-      "Type": "Task",
-      "Resource": "arn:aws:states:::lambda:invoke.waitForTaskToken",
-      "Parameters": {
-        "FunctionName": "${pipeline_failure_lambda_function_arn}:$LATEST",
-        "Payload": {
-          "Error.$": "$.error.Cause",
-          "ExecutionId.$": "$$.Execution.Id",
-          "StateMachineName.$": "$$.StateMachine.Name",
-          "StateMachineId.$": "$$.StateMachine.Id",
-          "ExecutionStartTime.$": "$$.Execution.StartTime",
-          "CallbackToken.$": "$$.Task.Token"
+    "Run Crawler and Handle Error": {
+      "Type": "Parallel",
+      "Branches": [
+        {
+          "StartAt": "Run CT Crawler",
+          "States": {
+            "Run CT Crawler": {
+              "Type": "Task",
+              "Resource": "arn:aws:states:::aws-sdk:glue:startCrawler",
+              "Parameters": {
+                "StateMachineArn": "${run_crawler_state_machine_arn}",
+                "Input": {
+                  "crawler_name": "${ct_crawler_name}",
+                  "AWS_STEP_FUNCTIONS_STARTED_BY_EXECUTION_ID.$": "$$.Execution.Id"
+                }
+              },
+              "End": true
+            }
+          }
+        },
+        {
+          "StartAt": "Check if Error Exists",
+          "States": {
+            "Check if Error Exists": {
+              "Type": "Choice",
+              "Choices": [
+                {
+                  "Variable": "$.error",
+                  "IsPresent": true,
+                  "Next": "Publish Error Notification"
+                }
+              ],
+              "Default": "No Error"
+            },
+            "Publish Error Notification": {
+              "Type": "Task",
+              "Resource": "arn:aws:states:::lambda:invoke.waitForTaskToken",
+              "Parameters": {
+                "FunctionName": "${pipeline_failure_lambda_function_arn}:$LATEST",
+                "Payload": {
+                  "Error.$": "$.error.Cause",
+                  "ExecutionId.$": "$$.Execution.Id",
+                  "StateMachineName.$": "$$.StateMachine.Name",
+                  "StateMachineId.$": "$$.StateMachine.Id",
+                  "ExecutionStartTime.$": "$$.Execution.StartTime",
+                  "CallbackToken.$": "$$.Task.Token"
+                }
+              },
+              "Next": "Fail"
+            },
+            "No Error": {
+              "Type": "Succeed"
+            },
+            "Fail": {
+              "Type": "Fail"
+            }
+          }
         }
-      },
-      "Next": "Run validation crawler when failed"
-    },
-    "Run validation crawler when failed": {
-      "Type": "Task",
-      "Parameters": {
-        "Name": "${data_validation_reports_crawler_name}"
-      },
-      "Resource": "arn:aws:states:::aws-sdk:glue:startCrawler",
-      "Next": "Run CT crawler when failed"
-    },
-    "Run CT crawler when failed": {
-      "Type": "Task",
-      "Parameters": {
-        "Name": "${ct_crawler_name}"
-      },
-      "Resource": "arn:aws:states:::aws-sdk:glue:startCrawler",
-      "Next": "Fail"
-    },
-    "Fail": {
-      "Type": "Fail"
-    },
-    "Success": {
-      "Type": "Succeed"
+      ]
     }
   }
 }

--- a/terraform/pipeline/step-functions/IngestCapacityTrackerCareHome-StepFunction.json
+++ b/terraform/pipeline/step-functions/IngestCapacityTrackerCareHome-StepFunction.json
@@ -68,7 +68,7 @@
           "States": {
             "Run CT Crawler": {
               "Type": "Task",
-              "Resource": "arn:aws:states:::aws-sdk:glue:startCrawler",
+              "Resource": "arn:aws:states:::states:startExecution.sync:2",
               "Parameters": {
                 "StateMachineArn": "${run_crawler_state_machine_arn}",
                 "Input": {

--- a/terraform/pipeline/step-functions/IngestCapacityTrackerNonRes-StepFunction.json
+++ b/terraform/pipeline/step-functions/IngestCapacityTrackerNonRes-StepFunction.json
@@ -4,7 +4,6 @@
   "States": {
     "Capacity Tracker Non Residential pipeline": {
       "Type": "Parallel",
-      "Next": "Run validation crawler when success",
       "Branches": [
         {
           "StartAt": "Ingest Capacity Tracker Non Res",
@@ -50,69 +49,76 @@
           }
         }
       ],
+      "Next": "Run Crawler and Handle Error",
       "Catch": [
         {
           "ErrorEquals": [
             "States.ALL"
           ],
-          "Next": "Publish error notification",
+          "Next": "Run Crawler and Handle Error",
           "ResultPath": "$.error"
         }
       ]
     },
-    "Run validation crawler when success": {
-      "Type": "Task",
-      "Parameters": {
-        "Name": "${data_validation_reports_crawler_name}"
-      },
-      "Resource": "arn:aws:states:::aws-sdk:glue:startCrawler",
-      "Next": "Run CT crawler when success"
-    },
-    "Run CT crawler when success": {
-      "Type": "Task",
-      "Parameters": {
-        "Name": "${ct_crawler_name}"
-      },
-      "Resource": "arn:aws:states:::aws-sdk:glue:startCrawler",
-      "Next": "Success"
-    },
-    "Publish error notification": {
-      "Type": "Task",
-      "Resource": "arn:aws:states:::lambda:invoke.waitForTaskToken",
-      "Parameters": {
-        "FunctionName": "${pipeline_failure_lambda_function_arn}:$LATEST",
-        "Payload": {
-          "Error.$": "$.error.Cause",
-          "ExecutionId.$": "$$.Execution.Id",
-          "StateMachineName.$": "$$.StateMachine.Name",
-          "StateMachineId.$": "$$.StateMachine.Id",
-          "ExecutionStartTime.$": "$$.Execution.StartTime",
-          "CallbackToken.$": "$$.Task.Token"
+    "Run Crawler and Handle Error": {
+      "Type": "Parallel",
+      "Branches": [
+        {
+          "StartAt": "Run CT Crawler",
+          "States": {
+            "Run CT Crawler": {
+              "Type": "Task",
+              "Resource": "arn:aws:states:::aws-sdk:glue:startCrawler",
+              "Parameters": {
+                "StateMachineArn": "${run_crawler_state_machine_arn}",
+                "Input": {
+                  "crawler_name": "${ct_crawler_name}",
+                  "AWS_STEP_FUNCTIONS_STARTED_BY_EXECUTION_ID.$": "$$.Execution.Id"
+                }
+              },
+              "End": true
+            }
+          }
+        },
+        {
+          "StartAt": "Check if Error Exists",
+          "States": {
+            "Check if Error Exists": {
+              "Type": "Choice",
+              "Choices": [
+                {
+                  "Variable": "$.error",
+                  "IsPresent": true,
+                  "Next": "Publish Error Notification"
+                }
+              ],
+              "Default": "No Error"
+            },
+            "Publish Error Notification": {
+              "Type": "Task",
+              "Resource": "arn:aws:states:::lambda:invoke.waitForTaskToken",
+              "Parameters": {
+                "FunctionName": "${pipeline_failure_lambda_function_arn}:$LATEST",
+                "Payload": {
+                  "Error.$": "$.error.Cause",
+                  "ExecutionId.$": "$$.Execution.Id",
+                  "StateMachineName.$": "$$.StateMachine.Name",
+                  "StateMachineId.$": "$$.StateMachine.Id",
+                  "ExecutionStartTime.$": "$$.Execution.StartTime",
+                  "CallbackToken.$": "$$.Task.Token"
+                }
+              },
+              "Next": "Fail"
+            },
+            "No Error": {
+              "Type": "Succeed"
+            },
+            "Fail": {
+              "Type": "Fail"
+            }
+          }
         }
-      },
-      "Next": "Run validation crawler when failed"
-    },
-    "Run validation crawler when failed": {
-      "Type": "Task",
-      "Parameters": {
-        "Name": "${data_validation_reports_crawler_name}"
-      },
-      "Resource": "arn:aws:states:::aws-sdk:glue:startCrawler",
-      "Next": "Run CT crawler when failed"
-    },
-    "Run CT crawler when failed": {
-      "Type": "Task",
-      "Parameters": {
-        "Name": "${ct_crawler_name}"
-      },
-      "Resource": "arn:aws:states:::aws-sdk:glue:startCrawler",
-      "Next": "Fail"
-    },
-    "Fail": {
-      "Type": "Fail"
-    },
-    "Success": {
-      "Type": "Succeed"
+      ]
     }
   }
 }

--- a/terraform/pipeline/step-functions/IngestCapacityTrackerNonRes-StepFunction.json
+++ b/terraform/pipeline/step-functions/IngestCapacityTrackerNonRes-StepFunction.json
@@ -28,7 +28,6 @@
                 "Arguments": {
                   "--capacity_tracker_non_res_source": "${dataset_bucket_uri}/domain=capacity_tracker/dataset=capacity_tracker_non_residential/",
                   "--cleaned_capacity_tracker_non_res_destination": "${dataset_bucket_uri}/domain=capacity_tracker/dataset=capacity_tracker_non_residential_cleaned/"
-
                 }
               },
               "Next": "Validate cleaned CT Non Res data"
@@ -94,6 +93,9 @@
               ],
               "Default": "No Error"
             },
+            "No Error": {
+              "Type": "Succeed"
+            },
             "Publish Error Notification": {
               "Type": "Task",
               "Resource": "arn:aws:states:::lambda:invoke.waitForTaskToken",
@@ -110,15 +112,16 @@
               },
               "Next": "Fail"
             },
-            "No Error": {
-              "Type": "Succeed"
-            },
             "Fail": {
               "Type": "Fail"
             }
           }
         }
-      ]
+      ],
+      "Next": "Success"
+    },
+    "Success": {
+      "Type": "Succeed"
     }
   }
 }

--- a/terraform/pipeline/step-functions/IngestCapacityTrackerNonRes-StepFunction.json
+++ b/terraform/pipeline/step-functions/IngestCapacityTrackerNonRes-StepFunction.json
@@ -68,7 +68,7 @@
           "States": {
             "Run CT Crawler": {
               "Type": "Task",
-              "Resource": "arn:aws:states:::aws-sdk:glue:startCrawler",
+              "Resource": "arn:aws:states:::states:startExecution.sync:2",
               "Parameters": {
                 "StateMachineArn": "${run_crawler_state_machine_arn}",
                 "Input": {

--- a/terraform/pipeline/step-functions/RunCrawler-StepFunction.json
+++ b/terraform/pipeline/step-functions/RunCrawler-StepFunction.json
@@ -13,7 +13,7 @@
             "ErrorEquals": [
               "Glue.CrawlerRunningException"
             ],
-            "Next": "Wait for 1 minute",
+            "Next": "Wait for 10 seconds",
             "Comment": "Crawler already running",
             "ResultPath": "$.response.start_crawler"
           }
@@ -33,9 +33,9 @@
         ],
         "End": true
       },
-      "Wait for 1 minute": {
+      "Wait for 10 seconds": {
         "Type": "Wait",
-        "Seconds": 60,
+        "Seconds": 10,
         "Next": "StartCrawler"
       }
     }

--- a/terraform/pipeline/step-functions/RunCrawler-StepFunction.json
+++ b/terraform/pipeline/step-functions/RunCrawler-StepFunction.json
@@ -13,7 +13,7 @@
             "ErrorEquals": [
               "Glue.CrawlerRunningException"
             ],
-            "Next": "Wait for 2 minutes",
+            "Next": "Wait for 1 minute",
             "Comment": "Crawler already running",
             "ResultPath": "$.response.start_crawler"
           }
@@ -33,9 +33,9 @@
         ],
         "End": true
       },
-      "Wait for 2 minutes": {
+      "Wait for 1 minute": {
         "Type": "Wait",
-        "Seconds": 120,
+        "Seconds": 60,
         "Next": "StartCrawler"
       }
     }


### PR DESCRIPTION
## Description
Trello ticket [#975](https://trello.com/c/1UEpgTE7/975-amend-ct-ingestion-crawlers)

We ingest CT files every month but one of them always breaks as the crawler is already running.
The validation crawler won't need rerunning as the partitions won't change, so I've removed that.
I'd added a retry loop to the CT crawler, so if it's already running, it will wait 10 seconds then try again (repeated loop).

## Testing
- [X] Unit tests passing

## Checklist (delete if not relevant)
- [X] Moved Trello ticket to PR column
