### PR TITLE
Remove recode_unknown_codes_to_null function call for assessment data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,9 @@ All notable changes to this project will be documented in this file.
   - upgrading to PySpark 3.5
   - upgrading Glue jobs to 5.0 (default Python version is 3.11)
 
+- Removed recode_unknown_codes_to_null function call at preperation step of assessment data within flatten_cqc_ratings job.
+
+
 ### Improved
 
 

--- a/projects/_02_sfc_internal/cqc_ratings/jobs/flatten_cqc_ratings.py
+++ b/projects/_02_sfc_internal/cqc_ratings/jobs/flatten_cqc_ratings.py
@@ -151,7 +151,6 @@ def prepare_historic_ratings(cqc_location_df: DataFrame) -> DataFrame:
 
 def prepare_assessment_ratings(cqc_location_df: DataFrame) -> DataFrame:
     ratings_df = flatten_assessment_ratings(cqc_location_df)
-    ratings_df = recode_unknown_codes_to_null(ratings_df)
     return ratings_df
 
 


### PR DESCRIPTION
## Description
Trello ticket [#996](https://trello.com/c/m5IfO3b3/996-remove-recodeunknowncodestonull-function-call-for-assessment-data)

The execution of the step function main-Ingest-CQC-API has failed at the flatten_cqc_ratings job because of recode_unknown_codes_to_null function call for assessment data.

Not sure why this did not fail at the merge process but this function needs some columns in specific format which assessment data does not have. This PR is to remove that function call for assessment data as the merge job takes care of the column names.

## Testing
- [x] Unit tests passing
- [x] Successful [Step Glue Job run](https://eu-west-2.console.aws.amazon.com/gluestudio/home?region=eu-west-2#/editor/job/996-remove-recode-flatten_cqc_ratings_job/runs)
- [x] [Outputs checked in Athena](https://eu-west-2.console.aws.amazon.com/athena/home?region=eu-west-2#/query-editor/history/bb5d2d12-19d4-47a8-81ef-6c104e98aa3f)

[Add any additional testing information here - add screenshot if relevant]

## Checklist (delete if not relevant)
- [x] Updated CHANGELOG
- [x] Moved Trello ticket to PR column
