### PR TITLE
Add provider Name to CQC Coverage job

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 - New function added within flatten_cqc_ratings_job to flatten the new assessment column which is now used by CQC to publish the ratings data. 
 - Added current_lsoa21 column to the IND CQC pipeline. This column is now included across all jobs, ensuring it is present the Archive outputs.
+- Added provider name into the merged dataframe within the CQC Coverage job.
 
 
 ### Changed

--- a/projects/_02_sfc_internal/cqc_coverage/jobs/merge_coverage_data.py
+++ b/projects/_02_sfc_internal/cqc_coverage/jobs/merge_coverage_data.py
@@ -22,6 +22,9 @@ from utils.column_names.cleaned_data_files.ascwds_workplace_cleaned import (
 from utils.column_names.ind_cqc_pipeline_columns import (
     PartitionKeys as Keys,
 )
+from utils.column_names.raw_data_files.cqc_provider_api_columns import (
+    CqcProviderApiColumns as CQCP,
+)
 from utils.column_names.coverage_columns import CoverageColumns
 from utils.column_names.cqc_ratings_columns import CQCRatingsColumns
 from utils.column_values.categorical_column_values import (
@@ -84,12 +87,18 @@ cqc_ratings_columns_to_import = [
     CQCRatingsColumns.latest_rating_flag,
     CQCRatingsColumns.current_or_historic,
 ]
+cleaned_cqc_providers_columns_to_import = [
+    CQCP.provider_id,
+    CQCP.name,
+    Keys.import_date,
+]
 
 
 def main(
     cleaned_cqc_location_source: str,
     workplace_for_reconciliation_source: str,
     cqc_ratings_source: str,
+    cqc_providers_source: str,
     merged_coverage_destination: str,
     reduced_coverage_destination: str,
 ):
@@ -112,7 +121,10 @@ def main(
         cqc_ratings_source,
         selected_columns=cqc_ratings_columns_to_import,
     )
-
+    cqc_providers_df = utils.read_from_parquet(
+        cqc_providers_source,
+        selected_columns=cleaned_cqc_providers_columns_to_import,
+    )
     cqc_location_df = cUtils.reduce_dataset_to_earliest_file_per_month(cqc_location_df)
 
     ascwds_workplace_df = cUtils.remove_duplicates_based_on_column_order(
@@ -152,7 +164,9 @@ def main(
     )
 
     merged_coverage_df = add_columns_for_locality_manager_dashboard(merged_coverage_df)
-
+    merged_coverage_df = join_provider_name_into_merged_covergae_df(
+        merged_coverage_df, cqc_providers_df
+    )
     utils.write_to_parquet(
         merged_coverage_df,
         merged_coverage_destination,
@@ -313,6 +327,39 @@ def join_latest_cqc_rating_into_coverage_df(
     return merged_coverage_with_latest_rating_df
 
 
+def join_provider_name_into_merged_covergae_df(
+    merged_coverage_df: DataFrame,
+    cqc_providers_df: DataFrame,
+) -> DataFrame:
+    """
+    Join clean providers df to coverage dataframe using providerid as key.
+
+    Requirements that are not arguments: CQC providerid.
+    Columns (providerid and provider name) from the CQC providers dataframe are joined to the coverage dataframe using provideris.
+
+    Args:
+        merged_coverage_df (DataFrame): A dataframe of CQC locations with ASC-WDS columns joined via locationid.
+        cqc_providers_df (DataFrame): A dataframe of cqc providers cleaned.
+
+    Returns:
+        DataFrame: The coverage dataframe with the provider name added to it.
+    """
+    cqc_providers_df = cUtils.remove_duplicates_based_on_column_order(
+        cqc_providers_df,
+        [CQCP.provider_id, CQCP.name],
+        Keys.import_date,
+        sort_ascending=False,
+    )
+    merged_coverage_with_provider_name_df = merged_coverage_df.join(
+        cqc_providers_df.select(
+            CQCP.provider_id, F.col(CQCP.name).alias("providerName")
+        ),
+        on=CQCP.provider_id,
+        how="left",
+    )
+    return merged_coverage_with_provider_name_df
+
+
 if __name__ == "__main__":
     print("Spark job 'merge_coverage_data' starting...")
     print(f"Job parameters: {sys.argv}")
@@ -321,6 +368,7 @@ if __name__ == "__main__":
         cleaned_cqc_location_source,
         workplace_for_reconciliation_source,
         cqc_ratings_source,
+        cqc_providers_source,
         merged_coverage_destination,
         reduced_coverage_destination,
     ) = utils.collect_arguments(
@@ -333,6 +381,10 @@ if __name__ == "__main__":
             "Source s3 directory for parquet ASCWDS workplace for reconciliation dataset",
         ),
         ("--cqc_ratings_source", "Source s3 directory for parquet CQC ratings dataset"),
+        (
+            "--cqc_providers_source",
+            "Source s3 directory for parquet CQC providers dataset",
+        ),
         (
             "--merged_coverage_destination",
             "Destination s3 directory for full parquet",

--- a/projects/_02_sfc_internal/cqc_coverage/jobs/merge_coverage_data.py
+++ b/projects/_02_sfc_internal/cqc_coverage/jobs/merge_coverage_data.py
@@ -350,12 +350,12 @@ def join_provider_name_into_merged_covergae_df(
         Keys.import_date,
         sort_ascending=False,
     ).select(CQCP.provider_id, F.col(CQCP.name).alias(CQCLClean.provider_name))
-
+    merged_coverage_cols = merged_coverage_df.columns
     merged_coverage_with_provider_name_df = merged_coverage_df.join(
         cqc_providers_df,
         on=CQCP.provider_id,
         how="left",
-    )
+    ).select(*merged_coverage_cols, CQCLClean.provider_name)
     return merged_coverage_with_provider_name_df
 
 

--- a/projects/_02_sfc_internal/cqc_coverage/jobs/merge_coverage_data.py
+++ b/projects/_02_sfc_internal/cqc_coverage/jobs/merge_coverage_data.py
@@ -346,14 +346,13 @@ def join_provider_name_into_merged_covergae_df(
     """
     cqc_providers_df = cUtils.remove_duplicates_based_on_column_order(
         cqc_providers_df,
-        [CQCP.provider_id, CQCP.name],
+        [CQCP.provider_id],
         Keys.import_date,
         sort_ascending=False,
-    )
+    ).select(CQCP.provider_id, F.col(CQCP.name).alias(CQCLClean.provider_name))
+
     merged_coverage_with_provider_name_df = merged_coverage_df.join(
-        cqc_providers_df.select(
-            CQCP.provider_id, F.col(CQCP.name).alias("providerName")
-        ),
+        cqc_providers_df,
         on=CQCP.provider_id,
         how="left",
     )

--- a/projects/_02_sfc_internal/cqc_coverage/jobs/merge_coverage_data.py
+++ b/projects/_02_sfc_internal/cqc_coverage/jobs/merge_coverage_data.py
@@ -397,6 +397,7 @@ if __name__ == "__main__":
         cleaned_cqc_location_source,
         workplace_for_reconciliation_source,
         cqc_ratings_source,
+        cqc_providers_source,
         merged_coverage_destination,
         reduced_coverage_destination,
     )

--- a/projects/_02_sfc_internal/cqc_coverage/tests/jobs/test_merge_coverage_data.py
+++ b/projects/_02_sfc_internal/cqc_coverage/tests/jobs/test_merge_coverage_data.py
@@ -269,26 +269,21 @@ class JoinProviderNameIntoMergedCovergae(SetupForTests):
             Schemas.sample_merged_coverage_schema,
         )
 
-        self.returned_df = job.join_latest_cqc_rating_into_coverage_df(
+        self.returned_df = job.join_provider_name_into_merged_covergae_df(
             self.sample_merged_coverage_df, self.test_cqc_providers_df
         )
-
         self.expected_df = self.spark.createDataFrame(
             Data.expected_merged_covergae_and_provider_name_joined_rows,
             Schemas.expected_merged_covergae_and_provider_name_joined_schema,
         )
 
-    def test_join_provider_name_into_merged_covergae_df_adds_expected_columns(self):
-        self.assertEqual(len(self.returned_df.columns), len(self.expected_df.columns))
+    def test_join_provider_name_into_merged_coverage_df_adds_expected_columns(self):
+        returned_columns = self.returned_df.columns
+        expected_columns = self.expected_df.columns
+        self.assertEqual(sorted(returned_columns), sorted(expected_columns))
 
     def test_join_provider_name_into_merged_covergae_df_does_not_add_any_rows(self):
         self.assertEqual(self.returned_df.count(), self.expected_df.count())
-
-    def test_join_provider_name_into_merged_covergae_df_has_no_duplicate_columns(self):
-        self.assertEqual(
-            sorted(self.returned_df.columns),
-            sorted(list(set(self.returned_df.columns))),
-        )
 
     def test_join_provider_name_into_merged_covergae_df_has_expected_values(self):
         self.assertEqual(self.returned_df.collect(), self.expected_df.collect())

--- a/projects/_02_sfc_internal/unittest_data/sfc_test_file_data.py
+++ b/projects/_02_sfc_internal/unittest_data/sfc_test_file_data.py
@@ -388,12 +388,12 @@ class MergeCoverageData:
         ("loc_6", "provider_2"),
     ]
     expected_merged_covergae_and_provider_name_joined_rows = [
-        ("loc_1", "provider_1", "Provider Name A"),
-        ("loc_2", "provider_1", "Provider Name A"),
-        ("loc_3", "provider_1", "Provider Name A"),
-        ("loc_4", "provider_2", "Provider Name C"),
-        ("loc_5", "provider_2", "Provider Name C"),
-        ("loc_6", "provider_2", "Provider Name C"),
+        ("provider_1", "loc_1", "Provider Name A"),
+        ("provider_1", "loc_2", "Provider Name A"),
+        ("provider_1", "loc_3", "Provider Name A"),
+        ("provider_2", "loc_4","Provider Name C"),
+        ("provider_2", "loc_5", "Provider Name C"),
+        ("provider_2", "loc_6", "Provider Name C"),
     ]
 
 

--- a/projects/_02_sfc_internal/unittest_data/sfc_test_file_data.py
+++ b/projects/_02_sfc_internal/unittest_data/sfc_test_file_data.py
@@ -374,6 +374,28 @@ class MergeCoverageData:
     ]
     # fmt: on
 
+    sample_cqc_providers_for_merge_rows = [
+        ("provider_1", "Provider Name A", "20250908"),
+        ("provider_1", "Provider Name B", "20250901"),
+        ("provider_2", "Provider Name C", "20250908"),
+    ]
+    sample_merged_coverage_rows = [
+        ("loc_1", "provider_1"),
+        ("loc_2", "provider_1"),
+        ("loc_3", "provider_1"),
+        ("loc_4", "provider_2"),
+        ("loc_5", "provider_2"),
+        ("loc_6", "provider_2"),
+    ]
+    expected_merged_covergae_and_provider_name_joined_rows = [
+        ("loc_1", "provider_1", "Provider Name A"),
+        ("loc_2", "provider_1", "Provider Name A"),
+        ("loc_3", "provider_1", "Provider Name A"),
+        ("loc_4", "provider_2", "Provider Name C"),
+        ("loc_5", "provider_2", "Provider Name C"),
+        ("loc_6", "provider_2", "Provider Name C"),
+    ]
+
 
 @dataclass
 class ValidateMergedCoverageData:

--- a/projects/_02_sfc_internal/unittest_data/sfc_test_file_data.py
+++ b/projects/_02_sfc_internal/unittest_data/sfc_test_file_data.py
@@ -388,12 +388,12 @@ class MergeCoverageData:
         ("loc_6", "provider_2"),
     ]
     expected_merged_covergae_and_provider_name_joined_rows = [
-        ("provider_1", "loc_1", "Provider Name A"),
-        ("provider_1", "loc_2", "Provider Name A"),
-        ("provider_1", "loc_3", "Provider Name A"),
-        ("provider_2", "loc_4", "Provider Name C"),
-        ("provider_2", "loc_5", "Provider Name C"),
-        ("provider_2", "loc_6", "Provider Name C"),
+        ("loc_1", "provider_1", "Provider Name A"),
+        ("loc_2", "provider_1", "Provider Name A"),
+        ("loc_3", "provider_1", "Provider Name A"),
+        ("loc_4", "provider_2", "Provider Name C"),
+        ("loc_5", "provider_2", "Provider Name C"),
+        ("loc_6", "provider_2", "Provider Name C"),
     ]
 
 

--- a/projects/_02_sfc_internal/unittest_data/sfc_test_file_data.py
+++ b/projects/_02_sfc_internal/unittest_data/sfc_test_file_data.py
@@ -391,7 +391,7 @@ class MergeCoverageData:
         ("provider_1", "loc_1", "Provider Name A"),
         ("provider_1", "loc_2", "Provider Name A"),
         ("provider_1", "loc_3", "Provider Name A"),
-        ("provider_2", "loc_4","Provider Name C"),
+        ("provider_2", "loc_4", "Provider Name C"),
         ("provider_2", "loc_5", "Provider Name C"),
         ("provider_2", "loc_6", "Provider Name C"),
     ]

--- a/projects/_02_sfc_internal/unittest_data/sfc_test_file_schemas.py
+++ b/projects/_02_sfc_internal/unittest_data/sfc_test_file_schemas.py
@@ -428,7 +428,6 @@ class MergeCoverageData:
         [
             StructField(CQCLClean.location_id, StringType(), True),
             StructField(CQCP.provider_id, StringType(), True),
-            
         ]
     )
     expected_merged_covergae_and_provider_name_joined_schema = StructType(

--- a/projects/_02_sfc_internal/unittest_data/sfc_test_file_schemas.py
+++ b/projects/_02_sfc_internal/unittest_data/sfc_test_file_schemas.py
@@ -424,14 +424,20 @@ class MergeCoverageData:
             StructField(Keys.import_date, StringType(), True),
         ]
     )
-    sample_merged_coverage_schema = [
-        StructField(CQCLClean.location_id, StringType(), True),
-        StructField(CQCP.provider_id, StringType(), True),
-    ]
-    expected_merged_covergae_and_provider_name_joined_schema = [
-        *sample_merged_coverage_schema,
-        StructField("providerName", StringType(), True),
-    ]
+    sample_merged_coverage_schema = StructType(
+        [
+            StructField(CQCLClean.location_id, StringType(), True),
+            StructField(CQCP.provider_id, StringType(), True),
+            
+        ]
+    )
+    expected_merged_covergae_and_provider_name_joined_schema = StructType(
+        [
+            StructField(CQCP.provider_id, StringType(), True),
+            StructField(CQCLClean.location_id, StringType(), True),
+            StructField(CQCLClean.provider_name, StringType(), True),
+        ]
+    )
 
 
 @dataclass

--- a/projects/_02_sfc_internal/unittest_data/sfc_test_file_schemas.py
+++ b/projects/_02_sfc_internal/unittest_data/sfc_test_file_schemas.py
@@ -432,8 +432,7 @@ class MergeCoverageData:
     )
     expected_merged_covergae_and_provider_name_joined_schema = StructType(
         [
-            StructField(CQCP.provider_id, StringType(), True),
-            StructField(CQCLClean.location_id, StringType(), True),
+            *sample_merged_coverage_schema,
             StructField(CQCLClean.provider_name, StringType(), True),
         ]
     )

--- a/projects/_02_sfc_internal/unittest_data/sfc_test_file_schemas.py
+++ b/projects/_02_sfc_internal/unittest_data/sfc_test_file_schemas.py
@@ -30,6 +30,9 @@ from utils.column_names.raw_data_files.ascwds_workplace_columns import (
 from utils.column_names.raw_data_files.cqc_location_api_columns import (
     NewCqcLocationApiColumns as CQCL,
 )
+from utils.column_names.raw_data_files.cqc_provider_api_columns import (
+    CqcProviderApiColumns as CQCP,
+)
 from utils.column_names.reconciliation_columns import (
     ReconciliationColumns as ReconColumn,
 )
@@ -414,6 +417,21 @@ class MergeCoverageData:
             StructField(CQCRatings.overall_rating, StringType(), True),
         ]
     )
+    sample_cqc_providers_for_merge_schema = StructType(
+        [
+            StructField(CQCP.provider_id, StringType(), True),
+            StructField(CQCP.name, StringType(), True),
+            StructField(Keys.import_date, StringType(), True),
+        ]
+    )
+    sample_merged_coverage_schema = [
+        StructField(CQCLClean.location_id, StringType(), True),
+        StructField(CQCP.provider_id, StringType(), True),
+    ]
+    expected_merged_covergae_and_provider_name_joined_schema = [
+        *sample_merged_coverage_schema,
+        StructField("providerName", StringType(), True),
+    ]
 
 
 @dataclass

--- a/terraform/pipeline/glue.tf
+++ b/terraform/pipeline/glue.tf
@@ -529,6 +529,7 @@ module "merge_coverage_data_job" {
     "--cleaned_cqc_location_source"         = "${module.datasets_bucket.bucket_uri}/domain=CQC/dataset=locations_api_cleaned/"
     "--workplace_for_reconciliation_source" = "${module.datasets_bucket.bucket_uri}/domain=SfC/dataset=sfc_workplace_for_reconciliation/"
     "--cqc_ratings_source"                  = "${module.datasets_bucket.bucket_uri}/domain=SfC/dataset=sfc_cqc_ratings_for_data_requests/version=2.0.0/"
+    "--cqc_providers_source"                = "${module.datasets_bucket.bucket_uri}/domain=CQC/dataset=providers_api/"
     "--merged_coverage_destination"         = "${module.datasets_bucket.bucket_uri}/domain=SfC/dataset=sfc_merged_coverage_data/"
     "--reduced_coverage_destination"        = "${module.datasets_bucket.bucket_uri}/domain=SfC/dataset=sfc_monthly_coverage_data/"
   }

--- a/terraform/pipeline/glue.tf
+++ b/terraform/pipeline/glue.tf
@@ -528,7 +528,7 @@ module "merge_coverage_data_job" {
   job_parameters = {
     "--cleaned_cqc_location_source"         = "${module.datasets_bucket.bucket_uri}/domain=CQC/dataset=locations_api_cleaned/"
     "--workplace_for_reconciliation_source" = "${module.datasets_bucket.bucket_uri}/domain=SfC/dataset=sfc_workplace_for_reconciliation/"
-    "--cqc_ratings_source"                  = "${module.datasets_bucket.bucket_uri}/domain=SfC/dataset=sfc_cqc_ratings_for_data_requests/version=2.0.0/"
+    "--cqc_ratings_source"                  = "${module.datasets_bucket.bucket_uri}/domain=SfC/dataset=sfc_cqc_ratings_for_data_requests/"
     "--cqc_providers_source"                = "${module.datasets_bucket.bucket_uri}/domain=CQC/dataset=providers_api/"
     "--merged_coverage_destination"         = "${module.datasets_bucket.bucket_uri}/domain=SfC/dataset=sfc_merged_coverage_data/"
     "--reduced_coverage_destination"        = "${module.datasets_bucket.bucket_uri}/domain=SfC/dataset=sfc_monthly_coverage_data/"

--- a/terraform/pipeline/step-functions/SfCCoverage-StepFunction.json
+++ b/terraform/pipeline/step-functions/SfCCoverage-StepFunction.json
@@ -11,6 +11,7 @@
           "--cleaned_cqc_location_source": "${dataset_bucket_uri}/domain=CQC_delta/dataset=full_locations_api_cleaned/",
           "--workplace_for_reconciliation_source": "${dataset_bucket_uri}/domain=SfC/dataset=sfc_workplace_for_reconciliation/",
           "--cqc_ratings_source": "${dataset_bucket_uri}/domain=SfC/dataset=sfc_cqc_ratings_for_data_requests/version=2.0.0/",
+          "--cqc_providers_source": "${dataset_bucket_uri}/domain=CQC_delta/dataset=providers_api/",
           "--merged_coverage_destination": "${dataset_bucket_uri}/domain=SfC/dataset=sfc_merged_coverage_data/",
           "--reduced_coverage_destination": "${dataset_bucket_uri}/domain=SfC/dataset=sfc_monthly_coverage_data/"
         }

--- a/terraform/pipeline/step-functions/SfCCoverage-StepFunction.json
+++ b/terraform/pipeline/step-functions/SfCCoverage-StepFunction.json
@@ -10,7 +10,7 @@
         "Arguments": {
           "--cleaned_cqc_location_source": "${dataset_bucket_uri}/domain=CQC_delta/dataset=full_locations_api_cleaned/",
           "--workplace_for_reconciliation_source": "${dataset_bucket_uri}/domain=SfC/dataset=sfc_workplace_for_reconciliation/",
-          "--cqc_ratings_source": "${dataset_bucket_uri}/domain=SfC/dataset=sfc_cqc_ratings_for_data_requests/version=2.0.0/",
+          "--cqc_ratings_source": "${dataset_bucket_uri}/domain=SfC/dataset=sfc_cqc_ratings_for_data_requests/",
           "--cqc_providers_source": "${dataset_bucket_uri}/domain=CQC_delta/dataset=providers_api/",
           "--merged_coverage_destination": "${dataset_bucket_uri}/domain=SfC/dataset=sfc_merged_coverage_data/",
           "--reduced_coverage_destination": "${dataset_bucket_uri}/domain=SfC/dataset=sfc_monthly_coverage_data/"

--- a/terraform/pipeline/step-functions/SfCInternal-StepFunction.json
+++ b/terraform/pipeline/step-functions/SfCInternal-StepFunction.json
@@ -30,7 +30,7 @@
                 "Arguments": {
                   "--cleaned_cqc_location_source": "${dataset_bucket_uri}/domain=CQC_delta/dataset=full_locations_api_cleaned/",
                   "--workplace_for_reconciliation_source": "${dataset_bucket_uri}/domain=SfC/dataset=sfc_workplace_for_reconciliation/",
-                  "--cqc_ratings_source": "${dataset_bucket_uri}/domain=SfC/dataset=sfc_cqc_ratings_for_data_requests/version=2.0.0/",
+                  "--cqc_ratings_source": "${dataset_bucket_uri}/domain=SfC/dataset=sfc_cqc_ratings_for_data_requests/",
                   "--cqc_providers_source": "${dataset_bucket_uri}/domain=CQC_delta/dataset=providers_api/",
                   "--merged_coverage_destination": "${dataset_bucket_uri}/domain=SfC/dataset=sfc_merged_coverage_data/",
                   "--reduced_coverage_destination": "${dataset_bucket_uri}/domain=SfC/dataset=sfc_monthly_coverage_data/"

--- a/terraform/pipeline/step-functions/SfCInternal-StepFunction.json
+++ b/terraform/pipeline/step-functions/SfCInternal-StepFunction.json
@@ -31,6 +31,7 @@
                   "--cleaned_cqc_location_source": "${dataset_bucket_uri}/domain=CQC_delta/dataset=full_locations_api_cleaned/",
                   "--workplace_for_reconciliation_source": "${dataset_bucket_uri}/domain=SfC/dataset=sfc_workplace_for_reconciliation/",
                   "--cqc_ratings_source": "${dataset_bucket_uri}/domain=SfC/dataset=sfc_cqc_ratings_for_data_requests/version=2.0.0/",
+                  "--cqc_providers_source": "${dataset_bucket_uri}/domain=CQC_delta/dataset=providers_api/",
                   "--merged_coverage_destination": "${dataset_bucket_uri}/domain=SfC/dataset=sfc_merged_coverage_data/",
                   "--reduced_coverage_destination": "${dataset_bucket_uri}/domain=SfC/dataset=sfc_monthly_coverage_data/"
                 }


### PR DESCRIPTION
## Description
Trello ticket [#992](https://trello.com/c/QdeMtQFQ/992-must-provider-name-need-this-for-coverage)

Updated the CQC coverage job by including the provider name. This PR has following changes:
- Load the CQC providers dataset.
- Select only providerId and providerName.
- Deduplicate providers on providerId, keeping the most recent record.
- Join providerName into the coverage DataFrame using providerId as the key.

## Testing
- [x] Unit tests passing
- [x] Successful [Step Glue Job run](https://eu-west-2.console.aws.amazon.com/gluestudio/home?region=eu-west-2#/editor/job/add-prov-to-cvrg-merge_coverage_data_job/runs)
- [x] Outputs checked in [Athena](https://eu-west-2.console.aws.amazon.com/athena/home?region=eu-west-2#/query-editor/history/55169d27-1808-4ee7-94f7-e8ea566f93e1)

## Checklist (delete if not relevant)
- [x] Unit tests added/amended
- [x] Docstrings added/updated
- [x] Updated CHANGELOG
- [x] Moved Trello ticket to PR column
