### PR TITLE
1013 - Change the datasource parameters for internal SfC glue jobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file.
 - Migrated Polars validation scripts over to use PointBlank (compatible with >= Python 3.11), so far:
   - locations_raw
 - Updated glue script and step function parameters for flatten_cqc_ratings job with CQC_delta datastes.
+- Updated reconciliation job parameters in glue script to be consistent with SFC-Internal step function.
 
 ### Improved
 

--- a/terraform/pipeline/glue.tf
+++ b/terraform/pipeline/glue.tf
@@ -485,7 +485,7 @@ module "reconciliation_job" {
   datasets_bucket = module.datasets_bucket
 
   job_parameters = {
-    "--cqc_location_api_source"                    = "${module.datasets_bucket.bucket_uri}/domain=CQC/dataset=locations_api/version=2.1.1/"
+    "--cqc_location_api_source"                    = "${module.datasets_bucket.bucket_uri}domain=CQC_delta/dataset=delta_locations_api/version=3.0.0/"
     "--ascwds_reconciliation_source"               = "${module.datasets_bucket.bucket_uri}/domain=SfC/dataset=sfc_workplace_for_reconciliation/"
     "--reconciliation_single_and_subs_destination" = "${module.datasets_bucket.bucket_uri}/domain=SfC/dataset=sfc_reconciliation_singles_and_subs"
     "--reconciliation_parents_destination"         = "${module.datasets_bucket.bucket_uri}/domain=SfC/dataset=sfc_reconciliation_parents"


### PR DESCRIPTION
## Description
[Trello ticket 1013 - Change the datasource parameters for internal SfC glue jobs](https://trello.com/c/q7jM1tbQ)

Spotted that the job parameters in terraform > glue were inconsistent with SFC-Internal step function.

## Testing
No tests, just copy pasted the reconciliation source from step function into glue script.

## Checklist (delete if not relevant)
- [x] Updated CHANGELOG
- [x] Moved Trello ticket to PR column
