### PR TITLE
[FIX] Remove hardcoded account reference

### DIFF
--- a/terraform/modules/fargate-task/iam.tf
+++ b/terraform/modules/fargate-task/iam.tf
@@ -79,7 +79,7 @@ resource "aws_iam_policy" "secretsmanager_read_policy" {
         Action = [
           "secretsmanager:GetSecretValue"
         ],
-        Resource = var.secret_arn,
+        Resource = "arn:aws:secretsmanager:${var.region}:${local.account_id}:secret:${var.secret_arn_label}",
       }
     ]
   })

--- a/terraform/modules/fargate-task/variables.tf
+++ b/terraform/modules/fargate-task/variables.tf
@@ -13,9 +13,9 @@ variable "ecr_repo_name" {
   default = "fargate/cqc"
 }
 
-variable "secret_arn" {
+variable "secret_arn_label" {
   type    = string
-  default = "arn:aws:secretsmanager:eu-west-2:344210435447:secret:cqc_api_primary_key-mK4hzZ"
+  default = "cqc_api_primary_key-mK4hzZ"
 }
 
 variable "secret_name" {


### PR DESCRIPTION
## Description
Trello ticket [1008](https://trello.com/c/7kNl4HhT/1008-check-over-application-code-for-anything-account-specific)

Checked repo for hardcoded references and refactored one instance of a hardcoded account id.

## Testing
- [x] Unit tests passing (no Python changes)
- [x] Successful [Step Function run](https://eu-west-2.console.aws.amazon.com/states/home?region=eu-west-2#/v2/executions/details/arn:aws:states:eu-west-2:344210435447:execution:fix-remove-hardcoded-parameter-Ingest-CQC-API-Delta:eded18a5-ee83-439b-9d0f-8093751c276a) * run failed but passed the Secrets retrieval stage
- [ ] Outputs checked in Athena N/A

No Python code change - account reference removed from Terraform.

## Checklist (delete if not relevant)
- [ ] Updated CHANGELOG - minor fix, undocumented
- [x] Moved Trello ticket to PR column
