### PR TITLE
WIP - 1025 - Ct posts to beds

### DIFF
--- a/projects/_03_independent_cqc/_02_clean/jobs/clean_ind_cqc_filled_posts.py
+++ b/projects/_03_independent_cqc/_02_clean/jobs/clean_ind_cqc_filled_posts.py
@@ -14,6 +14,9 @@ from projects._03_independent_cqc._02_clean.utils.ascwds_filled_posts_calculator
 from projects._03_independent_cqc._02_clean.utils.clean_ascwds_filled_post_outliers.clean_ascwds_filled_post_outliers import (
     clean_ascwds_filled_post_outliers,
 )
+from projects._03_independent_cqc._02_clean.utils.clean_ct_care_home_outliers.clean_ct_care_home_outliers import (
+    null_ct_posts_to_beds_outliers,
+)
 from utils import utils
 from utils.column_names.ind_cqc_pipeline_columns import IndCqcColumns as IndCQC
 from utils.column_names.ind_cqc_pipeline_columns import PartitionKeys as Keys
@@ -95,6 +98,8 @@ def main(
         IndCQC.ct_care_home_total_employed_dedup,
         IndCQC.ct_care_home_posts_per_bed_ratio,
     )
+
+    locations_df = null_ct_posts_to_beds_outliers(locations_df)
 
     print(f"Exporting as parquet to {cleaned_ind_cqc_destination}")
 

--- a/projects/_03_independent_cqc/_02_clean/jobs/clean_ind_cqc_filled_posts.py
+++ b/projects/_03_independent_cqc/_02_clean/jobs/clean_ind_cqc_filled_posts.py
@@ -90,6 +90,12 @@ def main(
         IndCQC.filled_posts_per_bed_ratio,
     )
 
+    locations_df = cUtils.calculate_filled_posts_per_bed_ratio(
+        locations_df,
+        IndCQC.ct_care_home_total_employed_dedup,
+        IndCQC.ct_care_home_posts_per_bed_ratio,
+    )
+
     print(f"Exporting as parquet to {cleaned_ind_cqc_destination}")
 
     utils.write_to_parquet(

--- a/projects/_03_independent_cqc/_02_clean/tests/jobs/test_clean_ind_cqc_filled_posts.py
+++ b/projects/_03_independent_cqc/_02_clean/tests/jobs/test_clean_ind_cqc_filled_posts.py
@@ -3,13 +3,7 @@ import warnings
 from datetime import date
 from unittest.mock import ANY, Mock, patch
 
-from pyspark.sql.types import (
-    IntegerType,
-    StringType,
-    StructField,
-    StructType,
-    DateType,
-)
+from pyspark.sql.types import DateType, IntegerType, StringType, StructField, StructType
 
 import projects._03_independent_cqc._02_clean.jobs.clean_ind_cqc_filled_posts as job
 from projects._03_independent_cqc.unittest_data.ind_cqc_test_file_data import (
@@ -19,11 +13,8 @@ from projects._03_independent_cqc.unittest_data.ind_cqc_test_file_schemas import
     CleanIndCQCData as Schemas,
 )
 from utils import utils
-from utils.column_names.ind_cqc_pipeline_columns import (
-    PartitionKeys as Keys,
-    IndCqcColumns as IndCQC,
-)
-
+from utils.column_names.ind_cqc_pipeline_columns import IndCqcColumns as IndCQC
+from utils.column_names.ind_cqc_pipeline_columns import PartitionKeys as Keys
 
 PATCH_PATH = "projects._03_independent_cqc._02_clean.jobs.clean_ind_cqc_filled_posts"
 
@@ -95,7 +86,7 @@ class MainTests(CleanIndFilledPostsTests):
         populate_missing_care_home_number_of_beds_mock.assert_called_once()
         calculate_ascwds_filled_posts_mock.assert_called_once()
         self.assertEqual(create_column_with_repeated_values_removed_mock.call_count, 4)
-        self.assertEqual(calculate_filled_posts_per_bed_ratio_mock.call_count, 2)
+        self.assertEqual(calculate_filled_posts_per_bed_ratio_mock.call_count, 3)
         create_banded_bed_count_column_mock.assert_called_once()
         clean_ascwds_filled_post_outliers_mock.assert_called_once()
 

--- a/projects/_03_independent_cqc/_02_clean/tests/jobs/test_clean_ind_cqc_filled_posts.py
+++ b/projects/_03_independent_cqc/_02_clean/tests/jobs/test_clean_ind_cqc_filled_posts.py
@@ -43,6 +43,7 @@ class MainTests(CleanIndFilledPostsTests):
         super().setUp()
 
     @patch(f"{PATCH_PATH}.utils.write_to_parquet")
+    @patch(f"{PATCH_PATH}.null_ct_posts_to_beds_outliers")
     @patch(f"{PATCH_PATH}.clean_ascwds_filled_post_outliers")
     @patch(f"{PATCH_PATH}.cUtils.create_banded_bed_count_column")
     @patch(f"{PATCH_PATH}.cUtils.calculate_filled_posts_per_bed_ratio")
@@ -69,6 +70,7 @@ class MainTests(CleanIndFilledPostsTests):
         calculate_filled_posts_per_bed_ratio_mock: Mock,
         create_banded_bed_count_column_mock: Mock,
         clean_ascwds_filled_post_outliers_mock: Mock,
+        null_ct_posts_to_beds_outliers_mock: Mock,
         write_to_parquet_mock: Mock,
     ):
         read_from_parquet_mock.return_value = self.merge_ind_cqc_test_df
@@ -89,6 +91,7 @@ class MainTests(CleanIndFilledPostsTests):
         self.assertEqual(calculate_filled_posts_per_bed_ratio_mock.call_count, 3)
         create_banded_bed_count_column_mock.assert_called_once()
         clean_ascwds_filled_post_outliers_mock.assert_called_once()
+        null_ct_posts_to_beds_outliers_mock.assert_called_once()
 
         write_to_parquet_mock.assert_called_once_with(
             ANY,

--- a/projects/_03_independent_cqc/_02_clean/tests/utils/clean_ct_care_home_outliers/test_clean_ct_care_home_outliers.py
+++ b/projects/_03_independent_cqc/_02_clean/tests/utils/clean_ct_care_home_outliers/test_clean_ct_care_home_outliers.py
@@ -1,0 +1,49 @@
+import unittest
+
+import projects._03_independent_cqc._02_clean.utils.clean_ct_care_home_outliers.clean_ct_care_home_outliers as job
+from projects._03_independent_cqc.unittest_data.ind_cqc_test_file_data import (
+    NullCtPostsToBedsOutliers as Data,
+)
+from projects._03_independent_cqc.unittest_data.ind_cqc_test_file_schemas import (
+    NullCtPostsToBedsOutliers as Schemas,
+)
+from utils import utils
+from utils.column_names.ind_cqc_pipeline_columns import IndCqcColumns as IndCQC
+
+
+class TestCleanCtCareHomeOutliers(unittest.TestCase):
+    def setUp(self):
+        self.spark = utils.get_spark()
+
+
+class TestNullCtPostsToBedsOutliers(TestCleanCtCareHomeOutliers):
+    def setUp(self) -> None:
+        super().setUp()
+
+        test_df = self.spark.createDataFrame(
+            Data.null_ct_posts_to_beds_outliers_rows,
+            Schemas.null_ct_posts_to_beds_outliers_schema,
+        )
+        self.returned_df = job.null_ct_posts_to_beds_outliers(test_df)
+        self.expected_df = self.spark.createDataFrame(
+            Data.expected_null_ct_posts_to_beds_outliers_rows,
+            Schemas.expected_null_ct_posts_to_beds_outliers_schema,
+        )
+        self.new_columns_added = [
+            column
+            for column in self.returned_df.columns
+            if column not in test_df.columns
+        ]
+
+    def test_null_ct_posts_to_beds_outliers_adds_1_expected_column(
+        self,
+    ):
+        self.assertEqual(len(self.new_columns_added), 1)
+        self.assertEqual(
+            self.new_columns_added[0], IndCQC.ct_care_home_total_employed_dedup_cleaned
+        )
+
+    def test_null_ct_posts_to_beds_outliers_returns_expected_values(
+        self,
+    ):
+        self.assertEqual(self.returned_df.collect(), self.expected_df.collect())

--- a/projects/_03_independent_cqc/_02_clean/utils/clean_ascwds_filled_post_outliers/null_grouped_providers.py
+++ b/projects/_03_independent_cqc/_02_clean/utils/clean_ascwds_filled_post_outliers/null_grouped_providers.py
@@ -1,17 +1,18 @@
 from dataclasses import dataclass, fields
 
-from pyspark.sql import DataFrame, functions as F, Window
+from pyspark.sql import DataFrame, Window
+from pyspark.sql import functions as F
 
 import utils.cleaning_utils as cUtils
-from utils.column_names.ind_cqc_pipeline_columns import (
-    IndCqcColumns as IndCQC,
-    NullGroupedProviderColumns as NGPcol,
-)
-from utils.column_values.categorical_column_values import AscwdsFilteringRule, CareHome
 from projects._03_independent_cqc._02_clean.utils.clean_ascwds_filled_post_outliers.ascwds_filtering_utils import (
     update_filtering_rule,
 )
 from projects.utils.utils.utils import calculate_windowed_column
+from utils.column_names.ind_cqc_pipeline_columns import IndCqcColumns as IndCQC
+from utils.column_names.ind_cqc_pipeline_columns import (
+    NullGroupedProviderColumns as NGPcol,
+)
+from utils.column_values.categorical_column_values import AscwdsFilteringRule, CareHome
 
 
 @dataclass
@@ -196,7 +197,7 @@ def null_care_home_grouped_providers(df: DataFrame) -> DataFrame:
     )
 
     df = cUtils.calculate_filled_posts_per_bed_ratio(
-        df, IndCQC.ascwds_filled_posts_dedup_clean
+        df, IndCQC.ascwds_filled_posts_dedup_clean, IndCQC.filled_posts_per_bed_ratio
     )
 
     df = update_filtering_rule(

--- a/projects/_03_independent_cqc/_02_clean/utils/clean_ascwds_filled_post_outliers/winsorize_care_home_filled_posts_per_bed_ratio_outliers.py
+++ b/projects/_03_independent_cqc/_02_clean/utils/clean_ascwds_filled_post_outliers/winsorize_care_home_filled_posts_per_bed_ratio_outliers.py
@@ -1,13 +1,14 @@
 from dataclasses import dataclass
 
-from pyspark.sql import DataFrame, functions as F
+from pyspark.sql import DataFrame
+from pyspark.sql import functions as F
 
 import utils.cleaning_utils as cUtils
-from utils.column_names.ind_cqc_pipeline_columns import IndCqcColumns as IndCQC
-from utils.column_values.categorical_column_values import CareHome, AscwdsFilteringRule
 from projects._03_independent_cqc._02_clean.utils.clean_ascwds_filled_post_outliers.ascwds_filtering_utils import (
     update_filtering_rule,
 )
+from utils.column_names.ind_cqc_pipeline_columns import IndCqcColumns as IndCQC
+from utils.column_values.categorical_column_values import AscwdsFilteringRule, CareHome
 
 
 @dataclass
@@ -404,7 +405,9 @@ def winsorize_outliers(
     )
 
     winsorized_df = cUtils.calculate_filled_posts_per_bed_ratio(
-        winsorized_df, IndCQC.ascwds_filled_posts_dedup_clean
+        winsorized_df,
+        IndCQC.ascwds_filled_posts_dedup_clean,
+        IndCQC.filled_posts_per_bed_ratio,
     )
 
     return winsorized_df
@@ -432,4 +435,6 @@ def combine_dataframes(
 
     all_locations_df = original_non_care_home_df.unionByName(care_home_df)
 
+    return all_locations_df
+    return all_locations_df
     return all_locations_df

--- a/projects/_03_independent_cqc/_02_clean/utils/clean_ct_care_home_outliers/clean_ct_care_home_outliers.py
+++ b/projects/_03_independent_cqc/_02_clean/utils/clean_ct_care_home_outliers/clean_ct_care_home_outliers.py
@@ -1,0 +1,42 @@
+from pyspark.sql import DataFrame
+from pyspark.sql import functions as F
+
+from utils.column_names.ind_cqc_pipeline_columns import IndCqcColumns as IndCQC
+
+MINIMUM_RATIO_CUTOFF: float = 0.66
+MAXIMUM_RATIO_CUTOFF: float = 6.0
+
+
+def null_ct_posts_to_beds_outliers(df: DataFrame) -> DataFrame:
+    """
+    Nulls capacity tracker values where posts to bed ratio is out of bounds.
+
+    Analysis of Capacity Tracker posts to bed ratio between April 2024 and September 2025 showed
+    95% of locations per month have a ratio between 0.66 and 6.00.
+
+    This function copies ct_care_home_total_employed_dedup into ct_care_home_total_employed_dedup_cleaned
+    when the locations posts to bed ratio is inside 0.66 to 6.00 or ratio is null.
+
+    Args:
+        df(DataFrame): A dataframe with ct_care_home_posts_per_bed_ratio column.
+
+    Returns:
+        DataFrame: The same dataframe with ct_care_home_total_employed_dedup_cleaned.
+    """
+
+    df = df.withColumn(
+        IndCQC.ct_care_home_total_employed_dedup_cleaned,
+        F.when(
+            (F.col(IndCQC.ct_care_home_posts_per_bed_ratio).isNull())
+            | (
+                (F.col(IndCQC.ct_care_home_posts_per_bed_ratio) > MINIMUM_RATIO_CUTOFF)
+                & (
+                    F.col(IndCQC.ct_care_home_posts_per_bed_ratio)
+                    < MAXIMUM_RATIO_CUTOFF
+                )
+            ),
+            F.col(IndCQC.ct_care_home_total_employed_dedup),
+        ).otherwise(None),
+    )
+
+    return df

--- a/projects/_03_independent_cqc/_03_impute/jobs/impute_ind_cqc_ascwds_and_pir.py
+++ b/projects/_03_independent_cqc/_03_impute/jobs/impute_ind_cqc_ascwds_and_pir.py
@@ -1,22 +1,24 @@
-from dataclasses import dataclass
 import os
 import sys
+from dataclasses import dataclass
 
 os.environ["SPARK_VERSION"] = "3.5"
 
 from pyspark.sql import DataFrame
 
-from utils import utils
 import utils.cleaning_utils as cUtils
-from utils.column_names.ind_cqc_pipeline_columns import (
-    IndCqcColumns as IndCQC,
-    PartitionKeys as Keys,
+from projects._03_independent_cqc._03_impute.utils.model_and_merge_pir_filled_posts import (
+    merge_ascwds_and_pir_filled_post_submissions,
+    model_pir_filled_posts,
 )
-from projects._03_independent_cqc._06_estimate_filled_posts.utils.models.primary_service_rate_of_change_trendline import (
-    model_primary_service_rate_of_change_trendline,
+from projects._03_independent_cqc._03_impute.utils.utils import (
+    combine_care_home_and_non_res_values_into_single_column,
 )
 from projects._03_independent_cqc._06_estimate_filled_posts.utils.models.imputation_with_extrapolation_and_interpolation import (
     model_imputation_with_extrapolation_and_interpolation,
+)
+from projects._03_independent_cqc._06_estimate_filled_posts.utils.models.primary_service_rate_of_change_trendline import (
+    model_primary_service_rate_of_change_trendline,
 )
 from projects._03_independent_cqc._06_estimate_filled_posts.utils.models.rolling_average import (
     model_calculate_rolling_average,
@@ -24,13 +26,9 @@ from projects._03_independent_cqc._06_estimate_filled_posts.utils.models.rolling
 from projects._03_independent_cqc._06_estimate_filled_posts.utils.models.utils import (
     convert_care_home_ratios_to_filled_posts_and_merge_with_filled_post_values,
 )
-from projects._03_independent_cqc._03_impute.utils.model_and_merge_pir_filled_posts import (
-    model_pir_filled_posts,
-    merge_ascwds_and_pir_filled_post_submissions,
-)
-from projects._03_independent_cqc._03_impute.utils.utils import (
-    combine_care_home_and_non_res_values_into_single_column,
-)
+from utils import utils
+from utils.column_names.ind_cqc_pipeline_columns import IndCqcColumns as IndCQC
+from utils.column_names.ind_cqc_pipeline_columns import PartitionKeys as Keys
 
 PartitionKeys = [Keys.year, Keys.month, Keys.day, Keys.import_date]
 
@@ -124,7 +122,7 @@ def main(
 
     df = combine_care_home_and_non_res_values_into_single_column(
         df,
-        IndCQC.ct_care_home_total_employed_dedup,
+        IndCQC.ct_care_home_total_employed_dedup_cleaned,
         IndCQC.ct_non_res_care_workers_employed_dedup,
         IndCQC.ct_combined_care_home_and_non_res_dedup,
     )
@@ -139,7 +137,7 @@ def main(
 
     df = model_imputation_with_extrapolation_and_interpolation(
         df,
-        IndCQC.ct_care_home_total_employed_dedup,
+        IndCQC.ct_care_home_total_employed_dedup_cleaned,
         IndCQC.ct_combined_care_home_and_non_res_rate_of_change_trendline,
         IndCQC.ct_care_home_total_employed_imputed,
         care_home=True,

--- a/projects/_03_independent_cqc/_06_estimate_filled_posts/jobs/estimate_ind_cqc_filled_posts.py
+++ b/projects/_03_independent_cqc/_06_estimate_filled_posts/jobs/estimate_ind_cqc_filled_posts.py
@@ -5,13 +5,14 @@ os.environ["SPARK_VERSION"] = "3.5"
 
 from pyspark.sql import DataFrame
 
-from utils import utils
-from utils.column_names.ind_cqc_pipeline_columns import (
-    PartitionKeys as Keys,
-    IndCqcColumns as IndCQC,
-)
 from projects._03_independent_cqc._06_estimate_filled_posts.utils.models.care_homes import (
     model_care_homes,
+)
+from projects._03_independent_cqc._06_estimate_filled_posts.utils.models.imputation_with_extrapolation_and_interpolation import (
+    model_imputation_with_extrapolation_and_interpolation,
+)
+from projects._03_independent_cqc._06_estimate_filled_posts.utils.models.non_res_with_and_without_dormancy_combined import (
+    combine_non_res_with_and_without_dormancy_models,
 )
 from projects._03_independent_cqc._06_estimate_filled_posts.utils.models.non_res_with_dormancy import (
     model_non_res_with_dormancy,
@@ -19,16 +20,13 @@ from projects._03_independent_cqc._06_estimate_filled_posts.utils.models.non_res
 from projects._03_independent_cqc._06_estimate_filled_posts.utils.models.non_res_without_dormancy import (
     model_non_res_without_dormancy,
 )
-from projects._03_independent_cqc._06_estimate_filled_posts.utils.models.non_res_with_and_without_dormancy_combined import (
-    combine_non_res_with_and_without_dormancy_models,
-)
-from projects._03_independent_cqc._06_estimate_filled_posts.utils.models.imputation_with_extrapolation_and_interpolation import (
-    model_imputation_with_extrapolation_and_interpolation,
-)
 from projects._03_independent_cqc.utils.utils.utils import (
-    merge_columns_in_order,
     allocate_primary_service_type_second_level,
+    merge_columns_in_order,
 )
+from utils import utils
+from utils.column_names.ind_cqc_pipeline_columns import IndCqcColumns as IndCQC
+from utils.column_names.ind_cqc_pipeline_columns import PartitionKeys as Keys
 
 ind_cqc_columns = [
     IndCQC.cqc_location_import_date,
@@ -58,6 +56,7 @@ ind_cqc_columns = [
     IndCQC.ct_care_home_import_date,
     IndCQC.ct_care_home_total_employed,
     IndCQC.ct_care_home_total_employed_dedup,
+    IndCQC.ct_care_home_total_employed_dedup_cleaned,
     IndCQC.ct_care_home_total_employed_imputed,
     IndCQC.cqc_pir_import_date,
     IndCQC.pir_people_directly_employed_dedup,

--- a/projects/_03_independent_cqc/unittest_data/ind_cqc_test_file_data.py
+++ b/projects/_03_independent_cqc/unittest_data/ind_cqc_test_file_data.py
@@ -9,16 +9,12 @@ from projects._03_independent_cqc._02_clean.utils.ascwds_filled_posts_calculator
 from projects._03_independent_cqc._02_clean.utils.ascwds_filled_posts_calculator.total_staff_equals_worker_records import (
     ascwds_filled_posts_totalstaff_equal_wkrrecs_source_description,
 )
-from utils.column_names.ind_cqc_pipeline_columns import (
-    IndCqcColumns as IndCQC,
-)
+from utils.column_names.ind_cqc_pipeline_columns import IndCqcColumns as IndCQC
 from utils.column_names.raw_data_files.cqc_location_api_columns import (
     NewCqcLocationApiColumns as CQCL,
 )
-from utils.column_values.categorical_columns_by_dataset import (
-    DiagnosticOnKnownFilledPostsCategoricalValues as CatValues,
-)
 from utils.column_values.categorical_column_values import (
+    RUI,
     AscwdsFilteringRule,
     CareHome,
     Dormancy,
@@ -30,10 +26,12 @@ from utils.column_values.categorical_column_values import (
     Region,
     RegistrationStatus,
     RelatedLocation,
-    RUI,
     Sector,
     Services,
     Specialisms,
+)
+from utils.column_values.categorical_columns_by_dataset import (
+    DiagnosticOnKnownFilledPostsCategoricalValues as CatValues,
 )
 
 
@@ -6255,4 +6253,24 @@ class IndCQCDataUtils:
             ],
             PrimaryServiceTypeSecondLevel.other_non_residential,
         ),
+    ]
+
+
+@dataclass
+class NullCtPostsToBedsOutliers:
+    null_ct_posts_to_beds_outliers_rows = [
+        ("1-001", 1, 1.00),
+        ("1-002", 1, None),
+        ("1-003", None, 1.00),
+        ("1-004", None, None),
+        ("1-005", 1, 0.65),
+        ("1-006", 1, 6.01),
+    ]
+    expected_null_ct_posts_to_beds_outliers_rows = [
+        ("1-001", 1, 1.00, 1),
+        ("1-002", 1, None, 1),
+        ("1-003", None, 1.00, None),
+        ("1-004", None, None, None),
+        ("1-005", 1, 0.65, None),
+        ("1-006", 1, 6.01, None),
     ]

--- a/projects/_03_independent_cqc/unittest_data/ind_cqc_test_file_schemas.py
+++ b/projects/_03_independent_cqc/unittest_data/ind_cqc_test_file_schemas.py
@@ -3357,3 +3357,22 @@ class IndCQCDataUtils:
             StructField(IndCQC.primary_service_type_second_level, StringType(), True),
         ]
     )
+
+
+@dataclass
+class NullCtPostsToBedsOutliers:
+    null_ct_posts_to_beds_outliers_schema = StructType(
+        [
+            StructField(IndCQC.location_id, StringType(), True),
+            StructField(IndCQC.ct_care_home_total_employed_dedup, IntegerType(), True),
+            StructField(IndCQC.ct_care_home_posts_per_bed_ratio, FloatType(), True),
+        ]
+    )
+    expected_null_ct_posts_to_beds_outliers_schema = StructType(
+        [
+            *null_ct_posts_to_beds_outliers_schema,
+            StructField(
+                IndCQC.ct_care_home_total_employed_dedup_cleaned, IntegerType(), True
+            ),
+        ]
+    )

--- a/tests/unit/test_cleaning_utils.py
+++ b/tests/unit/test_cleaning_utils.py
@@ -648,7 +648,7 @@ class CalculateFilledPostsPerBedRatioTests(unittest.TestCase):
             Schemas.filled_posts_per_bed_ratio_schema,
         )
         returned_df = job.calculate_filled_posts_per_bed_ratio(
-            test_df, IndCQC.ascwds_filled_posts_dedup
+            test_df, IndCQC.ascwds_filled_posts_dedup, IndCQC.filled_posts_per_bed_ratio
         )
         expected_df = self.spark.createDataFrame(
             Data.expected_filled_posts_per_bed_ratio_rows,

--- a/utils/cleaning_utils.py
+++ b/utils/cleaning_utils.py
@@ -1,13 +1,12 @@
-from typing import Optional, Union, List
+from typing import List, Optional, Union
 
 from pyspark.ml.feature import Bucketizer
-from pyspark.sql import DataFrame, Window, functions as F
+from pyspark.sql import DataFrame, Window
+from pyspark.sql import functions as F
 from pyspark.sql.types import IntegerType
 
-from utils.column_names.ind_cqc_pipeline_columns import (
-    PartitionKeys as Keys,
-    IndCqcColumns as IndCQC,
-)
+from utils.column_names.ind_cqc_pipeline_columns import IndCqcColumns as IndCQC
+from utils.column_names.ind_cqc_pipeline_columns import PartitionKeys as Keys
 from utils.column_values.categorical_column_values import CareHome
 
 key: str = "key"
@@ -211,7 +210,7 @@ def cast_to_int(df: DataFrame, column_names: list) -> DataFrame:
 
 
 def calculate_filled_posts_per_bed_ratio(
-    input_df: DataFrame, filled_posts_column: str
+    input_df: DataFrame, filled_posts_column: str, new_column_name: str
 ) -> DataFrame:
     """
     Add a column with the filled post per bed ratio for care homes.
@@ -219,12 +218,13 @@ def calculate_filled_posts_per_bed_ratio(
     Args:
         input_df (DataFrame): A dataframe containing the given column, care_home and numberofbeds.
         filled_posts_column (str): The name of the column to use for calculating the ratio.
+        new_column_name (str): The name to give the new column.
 
     Returns:
         DataFrame: The same dataframe with an additional column contianing the filled posts per bed ratio for care homes.
     """
     input_df = input_df.withColumn(
-        IndCQC.filled_posts_per_bed_ratio,
+        new_column_name,
         F.when(
             F.col(IndCQC.care_home) == CareHome.care_home,
             F.col(filled_posts_column) / F.col(IndCQC.number_of_beds),

--- a/utils/column_names/ind_cqc_pipeline_columns.py
+++ b/utils/column_names/ind_cqc_pipeline_columns.py
@@ -125,6 +125,9 @@ class IndCqcColumns:
     ct_care_home_total_employed_dedup: str = (
         ct_care_home_total_employed + "_deduplicated"
     )
+    ct_care_home_total_employed_dedup_cleaned: str = (
+        ct_care_home_total_employed_dedup + "_cleaned"
+    )
     ct_care_home_total_employed_imputed: str = ct_care_home_total_employed + "_imputed"
     ct_combined_care_home_and_non_res_dedup: str = (
         "ct_combined_care_home_and_non_res_deduplicated"

--- a/utils/column_names/ind_cqc_pipeline_columns.py
+++ b/utils/column_names/ind_cqc_pipeline_columns.py
@@ -1,5 +1,11 @@
 from dataclasses import dataclass
 
+from utils.column_names.capacity_tracker_columns import (
+    CapacityTrackerCareHomeCleanColumns as CTCHClean,
+)
+from utils.column_names.capacity_tracker_columns import (
+    CapacityTrackerNonResCleanColumns as CTNRClean,
+)
 from utils.column_names.cleaned_data_files.ascwds_worker_cleaned import (
     AscwdsWorkerCleanedColumns as AWKClean,
 )
@@ -14,10 +20,6 @@ from utils.column_names.cleaned_data_files.cqc_pir_cleaned import (
 )
 from utils.column_names.cleaned_data_files.ons_cleaned import (
     OnsCleanedColumns as ONSClean,
-)
-from utils.column_names.capacity_tracker_columns import (
-    CapacityTrackerCareHomeCleanColumns as CTCHClean,
-    CapacityTrackerNonResCleanColumns as CTNRClean,
 )
 
 
@@ -118,6 +120,7 @@ class IndCqcColumns:
     cqc_pir_import_date: str = CQCPIRClean.cqc_pir_import_date
     cqc_sector: str = CQCLClean.cqc_sector
     ct_care_home_import_date: str = CTCHClean.ct_care_home_import_date
+    ct_care_home_posts_per_bed_ratio: str = "ct_care_home_posts_per_bed_ratio"
     ct_care_home_total_employed: str = CTCHClean.ct_care_home_total_employed
     ct_care_home_total_employed_dedup: str = (
         ct_care_home_total_employed + "_deduplicated"


### PR DESCRIPTION
## Description
[1025 - Ct posts to beds](https://trello.com/c/bnn4xtAA)

Added a function to clean Capacity Tracker care home posts. If posts to beds ratio is outside 0.66 and 6.00 then it gets nulled in a new cleaned column.
The boundary was determined from the posts to beds ratio for all locations from months April 2024 to September 2025. I took the top and bottom 2.5 percentiles from all locations over each of those months, then took the average of those percentiles.

Added this function into the ind cqc cleaning script.

Changed the imputation of CT care home figures to use this cleaned column.

Added the cleaned column to list of imports in estimate filled posts script.

## Testing
- [ ] Unit tests passing
- [ ] Successful [Step Function run](add link)
- [ ] Outputs checked in Athena

[Add any additional testing information here - add screenshot if relevant]

## Checklist (delete if not relevant)
- [ ] Unit tests added/amended
- [ ] Docstrings added/updated
- [ ] Migration to polars - added comment to pyspark functions which have been migrated
- [ ] Updated CHANGELOG
- [ ] Moved Trello ticket to PR column
