### PR TITLE
1004 Fix/deploy dependencies in prod

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,6 +44,9 @@ jobs:
             aws ecr get-login-password --region eu-west-2 | docker login -u AWS --password-stdin ${<< parameters.aws_account_id >>}.dkr.ecr.eu-west-2.amazonaws.com
             echo "Rebuilding lambdas and pushing to ECR."
             export AWS_ACCOUNT_ID=${<< parameters.aws_account_id >>}
+            # This transformation should match the workspace_prefix set in terraform/pipeline/main.tf locals block
+            export SANITISED_CIRCLE_BRANCH=$(echo ${CIRCLE_BRANCH:0:30} | tr -c '[:alnum:]\n' '-' | tr '[:upper:]' '[:lower:]')
+
             docker buildx bake all --push
 
   test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -140,12 +140,14 @@ jobs:
       - run:
           name: terraform plan
           command: |
+            # This transformation should match the workspace_prefix set in terraform/pipeline/main.tf locals block
+            export SANITISED_CIRCLE_BRANCH=$(echo ${CIRCLE_BRANCH:0:30} | tr -c '[:alnum:]\n' '-' | tr '[:upper:]' '[:lower:]')
             export AWS_ACCESS_KEY_ID=${<< parameters.access_key >>}
             export AWS_SECRET_ACCESS_KEY=${<< parameters.secret_key >>}
             cd terraform/pipeline
             export AWS_ACCOUNT_ID=${AWS_ACCOUNT_ID_<< parameters.aws_account >>}
             terraform init -input=false -backend-config=../<< parameters.aws_account >>.s3.tfbackend
-            terraform workspace select ${CIRCLE_BRANCH} || terraform workspace new ${CIRCLE_BRANCH}
+            terraform workspace select ${SANITISED_CIRCLE_BRANCH} || terraform workspace new ${SANITISED_CIRCLE_BRANCH}
             terraform plan -out tfapply
       - store_artifacts:
           path: terraform/pipeline/tfapply

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -212,8 +212,8 @@ jobs:
       - run:
           name: Setup Environment Variables
           command: |
-            echo 'export AWS_ACCESS_KEY_ID="${AWS_ACCESS_KEY_ID_non_prod}"' >> "$BASH_ENV"
-            echo 'export AWS_SECRET_ACCESS_KEY="${AWS_SECRET_ACCESS_KEY_non_prod}"' >> "$BASH_ENV"
+            echo 'export AWS_ACCESS_KEY_ID="${<< parameters.access_key >>}"' >> "$BASH_ENV"
+            echo 'export AWS_SECRET_ACCESS_KEY="${<< parameters.secret_key >>}"' >> "$BASH_ENV"
       - run:
           name: package utils, schemas, projects and environment
           command: |

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -6,7 +6,7 @@ variable "AWS_ACCOUNT_ID" {
   type = string
 }
 
-variable "CIRCLE_BRANCH" {
+variable "SANITISED_CIRCLE_BRANCH" {
   type = string
 }
 
@@ -21,7 +21,7 @@ group "all" {
 target "create_dataset_snapshot" {
   context = "."
   dockerfile = "./lambdas/create_dataset_snapshot/Dockerfile"
-  tags = ["${AWS_ACCOUNT_ID}.dkr.ecr.eu-west-2.amazonaws.com/lambda/create-snapshot:${CIRCLE_BRANCH}"]
+  tags = ["${AWS_ACCOUNT_ID}.dkr.ecr.eu-west-2.amazonaws.com/lambda/create-snapshot:${SANITISED_CIRCLE_BRANCH}"]
   platforms = ["linux/amd64"]
   no-cache = true
 }
@@ -29,7 +29,7 @@ target "create_dataset_snapshot" {
 target "check_dataset_equality" {
   context = "."
   dockerfile = "./lambdas/check_dataset_equality/Dockerfile"
-  tags = ["${AWS_ACCOUNT_ID}.dkr.ecr.eu-west-2.amazonaws.com/lambda/check-datasets-equal:${CIRCLE_BRANCH}"]
+  tags = ["${AWS_ACCOUNT_ID}.dkr.ecr.eu-west-2.amazonaws.com/lambda/check-datasets-equal:${SANITISED_CIRCLE_BRANCH}"]
   platforms = ["linux/amd64"]
   no-cache = true
 }
@@ -37,7 +37,7 @@ target "check_dataset_equality" {
 target "delta_cqc" {
   context = "."
   dockerfile = "./projects/_01_ingest/cqc_api/fargate/Dockerfile"
-  tags = ["${AWS_ACCOUNT_ID}.dkr.ecr.eu-west-2.amazonaws.com/fargate/cqc:${CIRCLE_BRANCH}"]
+  tags = ["${AWS_ACCOUNT_ID}.dkr.ecr.eu-west-2.amazonaws.com/fargate/cqc:${SANITISED_CIRCLE_BRANCH}"]
   platforms = ["linux/amd64"]
   no-cache = true
 }
@@ -45,7 +45,7 @@ target "delta_cqc" {
 target "model_retrain" {
   context = "."
   dockerfile = "./projects/_03_independent_cqc/_05_model/fargate/retraining/Dockerfile"
-  tags = ["${AWS_ACCOUNT_ID}.dkr.ecr.eu-west-2.amazonaws.com/fargate/model-retrain:${CIRCLE_BRANCH}"]
+  tags = ["${AWS_ACCOUNT_ID}.dkr.ecr.eu-west-2.amazonaws.com/fargate/model-retrain:${SANITISED_CIRCLE_BRANCH}"]
   platforms = ["linux/amd64"]
   no-cache = true
 }
@@ -53,7 +53,7 @@ target "model_retrain" {
 target "model_preprocess" {
   context = "."
   dockerfile = "./projects/_03_independent_cqc/_05_model/fargate/preprocessing/Dockerfile"
-  tags = ["${AWS_ACCOUNT_ID}.dkr.ecr.eu-west-2.amazonaws.com/fargate/preprocessing:${CIRCLE_BRANCH}"]
+  tags = ["${AWS_ACCOUNT_ID}.dkr.ecr.eu-west-2.amazonaws.com/fargate/preprocessing:${SANITISED_CIRCLE_BRANCH}"]
   platforms = ["linux/amd64"]
   no-cache = true
 }
@@ -61,7 +61,7 @@ target "model_preprocess" {
 target "_03_independent_cqc" {
   context = "."
   dockerfile = "./projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/Dockerfile"
-  tags = ["${AWS_ACCOUNT_ID}.dkr.ecr.eu-west-2.amazonaws.com/fargate/03_independent_cqc:${CIRCLE_BRANCH}"]
+  tags = ["${AWS_ACCOUNT_ID}.dkr.ecr.eu-west-2.amazonaws.com/fargate/03_independent_cqc:${SANITISED_CIRCLE_BRANCH}"]
   platforms = ["linux/amd64"]
   no-cache = true
 }


### PR DESCRIPTION
## Description
Trello ticket [1004](https://trello.com/c/wBpAMI9A/1004-move-circleci-feature-branch-spin-up-to-new-non-prod-environment?filter=label%3AToby)

Above ticket introduced a bug whereby `deploy-dependencies` would always assume it was running against non-prod account.
Also fixed an issue relating to non alphanumeric characters in branch names causing issues when that name is used in terrform workspace/ECR image URI. It implements the same logic used to generate the `workspace_prefix` in terraform, but implemented through different means

## Testing
- [ ] Unit tests passing
- [ ] Successful [Step Function run](add link)
- [ ] Outputs checked in Athena

[Add any additional testing information here - add screenshot if relevant]

## Checklist (delete if not relevant)
- [ ] Unit tests added/amended
- [ ] Docstrings added/updated
- [ ] Updated CHANGELOG
- [x] Moved Trello ticket to PR column
