### PR TITLE
Fix environment variable population for terraform-destroy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -263,13 +263,10 @@ jobs:
     steps:
       - checkout
       - run:
-          name: Setup Environment Variables
-          command: |
-            echo 'export AWS_ACCESS_KEY_ID="${AWS_ACCESS_KEY_ID_non_prod}"' >> "$BASH_ENV"
-            echo 'export AWS_SECRET_ACCESS_KEY="${AWS_SECRET_ACCESS_KEY_non_prod}"' >> "$BASH_ENV"
-      - run:
           name: terraform destroy
           command: |
+            export AWS_ACCESS_KEY_ID="${AWS_ACCESS_KEY_ID_non_prod}"
+            export AWS_SECRET_ACCESS_KEY="${AWS_SECRET_ACCESS_KEY_non_prod}"
             cd terraform/pipeline
             terraform init -input=false -backend-config=../non_prod.s3.tfbackend
             terraform workspace select << pipeline.parameters.GHA_Meta >>


### PR DESCRIPTION


## Description
Trello ticket [1035](https://trello.com/c/wSOn9237/1035-test-feature-branch-deletion-from-new-account?filter=label%3AToby)

Fix to allow for the terraform-destroy job to successfully destroy branches in the new non-prod environment. I've tested this in the context of a CircleCI SSH debug session, but it can't be fully exercised until merged to main

I'm not sure why the previous approach didn't work here, as it seems to work fine in other jobs

## Testing
- [ ] Unit tests passing
- [ ] Successful [Step Function run](add link)
- [ ] Outputs checked in Athena

[Add any additional testing information here - add screenshot if relevant]

## Checklist (delete if not relevant)
- [ ] Unit tests added/amended
- [ ] Docstrings added/updated
- [ ] Updated CHANGELOG
- [x] Moved Trello ticket to PR column
