### PR TITLE
Add admin role, with AdministratorAccess permission, and a CanAssumeAdminRole group with permissions to switch to admin role

### DIFF
--- a/terraform/pipeline/iam.tf
+++ b/terraform/pipeline/iam.tf
@@ -170,6 +170,10 @@ resource "aws_iam_role" "admin_role" {
   count              = local.workspace_prefix == "main" ? 1 : 0
   name               = "Admin"
   assume_role_policy = data.aws_iam_policy_document.admin_role_assume_role_policy[0].json
+
+  tags = {
+    HasProductionAccess = true
+  }
 }
 
 resource "aws_iam_role_policy_attachment" "admin_role_administrator_access_policy_attach" {

--- a/terraform/pipeline/iam.tf
+++ b/terraform/pipeline/iam.tf
@@ -133,3 +133,46 @@ resource "aws_iam_policy" "retrieve_cqc_api_primary_key_secret" {
 
   policy = templatefile("policy-documents/retrieve-specific-secret.json", { secret_arn = data.aws_secretsmanager_secret.cqc_api_primary_key.arn })
 }
+
+resource "aws_iam_group" "can_assume_admin_role" {
+  count = local.workspace_prefix == "main" ? 1 : 0
+  name  = "CanAssumeAdminRole"
+}
+
+resource "aws_iam_group_policy" "can_assume_admin_role_access_policy" {
+  count  = local.workspace_prefix == "main" ? 1 : 0
+  group  = aws_iam_group.can_assume_admin_role[0].name
+  policy = data.aws_iam_policy_document.admin_role_access_policy[0].json
+}
+
+data "aws_iam_policy_document" "admin_role_access_policy" {
+  count = local.workspace_prefix == "main" ? 1 : 0
+  statement {
+    actions   = ["sts:AssumeRole"]
+    resources = [aws_iam_role.admin_role[0].arn]
+  }
+}
+
+data "aws_iam_policy_document" "admin_role_assume_role_policy" {
+  count = local.workspace_prefix == "main" ? 1 : 0
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    # This is a trust policy against the root user, it does not allow every user access to the role, they still need the `sts:AssumeRole` permission against their user
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::344210435447:root"]
+    }
+  }
+}
+
+resource "aws_iam_role" "admin_role" {
+  count              = local.workspace_prefix == "main" ? 1 : 0
+  name               = "Admin"
+  assume_role_policy = data.aws_iam_policy_document.admin_role_assume_role_policy[0].json
+}
+
+resource "aws_iam_role_policy_attachment" "admin_role_administrator_access_policy_attach" {
+  role       = aws_iam_role.admin_role.arn
+  policy_arn = "arn:aws:iam::aws:policy/AdministratorAccess"
+}

--- a/terraform/pipeline/iam.tf
+++ b/terraform/pipeline/iam.tf
@@ -177,6 +177,6 @@ resource "aws_iam_role" "admin_role" {
 }
 
 resource "aws_iam_role_policy_attachment" "admin_role_administrator_access_policy_attach" {
-  role       = aws_iam_role.admin_role.arn
+  role       = aws_iam_role.admin_role[0].arn
   policy_arn = "arn:aws:iam::aws:policy/AdministratorAccess"
 }

--- a/terraform/pipeline/iam.tf
+++ b/terraform/pipeline/iam.tf
@@ -177,6 +177,7 @@ resource "aws_iam_role" "admin_role" {
 }
 
 resource "aws_iam_role_policy_attachment" "admin_role_administrator_access_policy_attach" {
+  count      = local.workspace_prefix == "main" ? 1 : 0
   role       = aws_iam_role.admin_role[0].arn
   policy_arn = "arn:aws:iam::aws:policy/AdministratorAccess"
 }


### PR DESCRIPTION
## Description
Trello ticket [1034](https://trello.com/c/2ddyqfaR/1034-move-elevated-permissions-over-to-roles?filter=label%3AToby)

This PR:
* adds `Admin` role
* associates `AdministratorAccess` permission
* adds `CanAssumeAdminRole` group 
* associates permissions to assume `admin` role with `CanAssumeAdminRole` groupwith permissions to switch to `Admin` role

## Testing
- [ ] Unit tests passing
- [ ] Successful [Step Function run](add link)
- [ ] Outputs checked in Athena

[Add any additional testing information here - add screenshot if relevant]

## Checklist (delete if not relevant)
- [ ] Unit tests added/amended
- [ ] Docstrings added/updated
- [ ] Updated CHANGELOG
- [ ] Moved Trello ticket to PR column
