### PR TITLE
Add cross-account access to non-prod on read only basis for circleci and cross-account user

### DIFF
--- a/terraform/pipeline/policy-documents/sfc-main-datasets.cross-account-access.json
+++ b/terraform/pipeline/policy-documents/sfc-main-datasets.cross-account-access.json
@@ -1,0 +1,34 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "ObjectLevel",
+            "Effect": "Allow",
+            "Principal": {
+                "AWS": [
+					"arn:aws:iam::856699698263:user/circleci",
+					"arn:aws:iam::856699698263:role/CrossAccountAccessRole"
+				]
+            },
+            "Action": [
+                "s3:GetObject",
+                "s3:GetObjectAttributes",
+                "s3:GetObjectVersion",
+                "s3:GetObjectTagging"
+            ],
+            "Resource": "arn:aws:s3:::sfc-main-datasets/*"
+        },
+        {
+            "Sid": "BucketLevel",
+            "Effect": "Allow",
+            "Principal": {
+                "AWS": [
+					"arn:aws:iam::856699698263:user/circleci",
+					"arn:aws:iam::856699698263:role/CrossAccountAccessRole"
+				]
+            },
+            "Action": "s3:ListBucket",
+            "Resource": "arn:aws:s3:::sfc-main-datasets"
+        }
+    ]
+}

--- a/terraform/pipeline/s3.tf
+++ b/terraform/pipeline/s3.tf
@@ -9,3 +9,10 @@ module "datasets_bucket" {
   bucket_name             = "${local.workspace_prefix}-datasets"
   empty_bucket_on_destroy = local.is_development_environment
 }
+
+resource "aws_s3_bucket_policy" "cross_account_access_read_only" {
+  count = local.workspace_prefix == "main" ? 1 : 0
+
+  bucket = module.datasets_bucket.bucket_name
+  policy = file("policy-documents/sfc-main-datasets.cross-account-access.json")
+}


### PR DESCRIPTION
## Description
Trello ticket [1038](https://trello.com/c/Bu7WwHXr/1038-add-policy-against-sfc-main-datasets-that-allows-the-madetech-user-group-and-circleci-user-read-only-access-from-non-prod-accoun)

Add cross-account access to non-prod on read only basis for circleci and cross-account user

## Testing
- [ ] Unit tests passing
- [ ] Successful [Step Function run](add link)
- [ ] Outputs checked in Athena

[Add any additional testing information here - add screenshot if relevant]

## Checklist (delete if not relevant)
- [ ] Unit tests added/amended
- [ ] Docstrings added/updated
- [ ] Updated CHANGELOG
- [x] Moved Trello ticket to PR column
