### PR TITLE
Fix role to point at role name instead of ARN to fix issue on terraform apply

### DIFF
--- a/terraform/pipeline/iam.tf
+++ b/terraform/pipeline/iam.tf
@@ -178,6 +178,6 @@ resource "aws_iam_role" "admin_role" {
 
 resource "aws_iam_role_policy_attachment" "admin_role_administrator_access_policy_attach" {
   count      = local.workspace_prefix == "main" ? 1 : 0
-  role       = aws_iam_role.admin_role[0].arn
+  role       = aws_iam_role.admin_role[0].name
   policy_arn = "arn:aws:iam::aws:policy/AdministratorAccess"
 }


### PR DESCRIPTION

## Description
Trello ticket [1034](https://trello.com/c/2ddyqfaR/1034-move-elevated-permissions-over-to-roles)

Fix bad parameter in `aws_iam_role_policy_attachment` resource definition

## Testing
- [ ] Unit tests passing
- [ ] Successful [Step Function run](add link)
- [ ] Outputs checked in Athena

[Add any additional testing information here - add screenshot if relevant]

## Checklist (delete if not relevant)
- [ ] Unit tests added/amended
- [ ] Docstrings added/updated
- [ ] Updated CHANGELOG
- [ ] Moved Trello ticket to PR column
