### PR TITLE
WIP - 1311 - Remove versioning to fix terraform destroy in branches

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -308,31 +308,6 @@ jobs:
             cd terraform/pipeline
             terraform init -input=false -backend-config=../non_prod.s3.tfbackend
             terraform workspace select ${SANITISED_CIRCLE_BRANCH}
-            # --- Force-empty dataset bucket for this branch ---
-            echo "Emptying dataset bucket: s3://sfc-${SANITISED_CIRCLE_BRANCH}-datasets"
-            NB_OBJECTS=$(aws s3api list-object-versions --bucket "sfc-${SANITISED_CIRCLE_BRANCH}-datasets" --query='length(Versions[*] || `[]` )' | awk '{ print $1 }')
-            echo "      '${NB_OBJECTS}' objects to remove"
-            if [[ "$NB_OBJECTS" != "0" ]]; then
-              start=$SECONDS
-              while [[ $NB_OBJECTS -gt 0 ]]
-              do
-                aws s3api delete-objects --bucket "sfc-${SANITISED_CIRCLE_BRANCH}-datasets" --delete "$(aws s3api list-object-versions --bucket "sfc-${SANITISED_CIRCLE_BRANCH}-datasets" --max-items 100 --query='{Objects: Versions[0:100].{Key:Key,VersionId:VersionId}}')" --query 'length(Deleted[*] || `[]` )' > /dev/null
-                NB_OBJECTS=$((NB_OBJECTS  > 100 ? NB_OBJECTS - 100 : 0))
-                echo "      Removed batch of Objects... Remaining : $NB_OBJECTS ($(( SECONDS - start ))s)"
-              done
-            fi
-
-            NB_OBJECTS=$(aws s3api list-object-versions --bucket "sfc-${SANITISED_CIRCLE_BRANCH}-datasets" --query='length(DeleteMarkers[*] || `[]` )' | awk '{ print $1 }')
-            echo "      '${NB_OBJECTS}' markers to remove"
-            if [[ "$NB_OBJECTS" != "0" ]]; then
-              start=$SECONDS
-              while [[ $NB_OBJECTS -gt 0 ]]
-              do
-                aws s3api delete-objects --bucket "sfc-${SANITISED_CIRCLE_BRANCH}-datasets" --delete "$(aws s3api list-object-versions --bucket "sfc-${SANITISED_CIRCLE_BRANCH}-datasets" --max-items 100 --query='{Objects: DeleteMarkers[0:100].{Key:Key,VersionId:VersionId}}')" --query 'length(Deleted[*] || `[]` )' > /dev/null
-                NB_OBJECTS=$((NB_OBJECTS  > 100 ? NB_OBJECTS - 100 : 0))
-                echo "      Removed batch of Markers... Remaining : $NB_OBJECTS (took $(( SECONDS - start ))s)"
-              done
-            fi
             # --- Run destroy ---
             terraform destroy -auto-approve
       - run:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 - Added a new test account in ASC-WDS to the list of test_accounts in [clean_ascwds_workplace_data](projects\_01_ingest\ascwds\jobs\clean_ascwds_workplace_data.py)
+- Versioning in s3 removed from feature branches to enable terraform destroy to work correctly.
 
 
 ## [v2025.12.0] - 06/01/2026

--- a/terraform/modules/s3-bucket/inputs.tf
+++ b/terraform/modules/s3-bucket/inputs.tf
@@ -6,5 +6,5 @@ variable "bucket_name" {
 variable "empty_bucket_on_destroy" {
   description = "Should the bucket be emptied before destroying?"
   type        = bool
-  default     = false
+  default     = true
 }

--- a/terraform/modules/s3-bucket/s3.tf
+++ b/terraform/modules/s3-bucket/s3.tf
@@ -12,7 +12,7 @@ resource "aws_s3_bucket_acl" "s3_bucket_acl" {
 resource "aws_s3_bucket_versioning" "s3_bucket_versioning" {
   bucket = aws_s3_bucket.s3_bucket.id
   versioning_configuration {
-    status = var.enable_versioning ? "Enabled" : "Suspended"
+    status = var.enable_versioning ? "Enabled" : "Disabled"
   }
 }
 


### PR DESCRIPTION
## Description
Trello ticket [#1311](https://trello.com/c/sQs1RSoq/1311-l-terraform-destroy-timing-out)

- Remove scripting in Circle CI to empty s3 buckets before calling terraform destroy (no longer needed)
- Disable versioning on feature branches to prevent terraform destroy failures from versioning issues
- Set empty buckets on destroy to true

## Testing
- [x] Unit tests passing

I've run terraform destroy locally to check this works. I can't test in CircleCI because terraform destroy runs on main, so it will need merging before testing there.

When this is merged any branches that currently have versioning enabled or suspended (except main) will need the s3 buckets deleting and then redeploying. This is because versioning cannot be disabled on a bucket that previously had versioning enabled or suspended. 

## Checklist (delete if not relevant)
- [x] Updated CHANGELOG
- [x] Moved Trello ticket to PR column
