### PR TITLE
1560 Change cqc api so start date is 30 days earlier

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -257,6 +257,8 @@ jobs:
             aws s3 sync "s3://sfc-main-datasets/domain=capacity_tracker/dataset=capacity_tracker_non_residential_cleaned/" "s3://$BRANCH_DATASET_BUCKET/domain=capacity_tracker/dataset=capacity_tracker_non_residential_cleaned/"
             aws s3 sync "s3://sfc-main-datasets/domain=CQC/dataset=pir_cleaned/" "s3://$BRANCH_DATASET_BUCKET/domain=CQC/dataset=pir_cleaned/"
             aws s3 sync "s3://sfc-main-datasets/domain=ind_cqc_filled_posts/dataset=ind_cqc_06_estimated_filled_posts/" "s3://$BRANCH_DATASET_BUCKET/domain=ind_cqc_filled_posts/dataset=main_ind_cqc_06_estimated_filled_posts/"
+            aws s3 sync "s3://sfc-main-datasets/domain=CQC/dataset=delta_locations_api/version=3.1.0/" "s3://$BRANCH_DATASET_BUCKET/domain=CQC/dataset=delta_locations_api/version=3.1.0/"
+            aws s3 sync "s3://sfc-main-datasets/domain=CQC/dataset=delta_providers_api/" "s3://$BRANCH_DATASET_BUCKET/domain=CQC/dataset=delta_providers_api/"
       - run:
           name: Copy models to non-prod dataset
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -257,8 +257,8 @@ jobs:
             aws s3 sync "s3://sfc-main-datasets/domain=capacity_tracker/dataset=capacity_tracker_non_residential_cleaned/" "s3://$BRANCH_DATASET_BUCKET/domain=capacity_tracker/dataset=capacity_tracker_non_residential_cleaned/"
             aws s3 sync "s3://sfc-main-datasets/domain=CQC/dataset=pir_cleaned/" "s3://$BRANCH_DATASET_BUCKET/domain=CQC/dataset=pir_cleaned/"
             aws s3 sync "s3://sfc-main-datasets/domain=ind_cqc_filled_posts/dataset=ind_cqc_06_estimated_filled_posts/" "s3://$BRANCH_DATASET_BUCKET/domain=ind_cqc_filled_posts/dataset=main_ind_cqc_06_estimated_filled_posts/"
-            aws s3 sync "s3://sfc-main-datasets/domain=CQC/dataset=delta_locations_api/version=3.1.0/" "s3://$BRANCH_DATASET_BUCKET/domain=CQC/dataset=delta_locations_api/version=3.1.0/"
-            aws s3 sync "s3://sfc-main-datasets/domain=CQC/dataset=delta_providers_api/" "s3://$BRANCH_DATASET_BUCKET/domain=CQC/dataset=delta_providers_api/"
+            aws s3 sync "s3://sfc-main-datasets/domain=CQC/dataset=cqc_locations_01_delta_api/version=3.1.0/" "s3://$BRANCH_DATASET_BUCKET/domain=CQC/dataset=cqc_locations_01_delta_api/version=3.1.0/"
+            aws s3 sync "s3://sfc-main-datasets/domain=CQC/dataset=cqc_providers_01_delta_api/" "s3://$BRANCH_DATASET_BUCKET/domain=CQC/dataset=cqc_providers_01_delta_api/"
       - run:
           name: Copy models to non-prod dataset
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -257,8 +257,6 @@ jobs:
             aws s3 sync "s3://sfc-main-datasets/domain=capacity_tracker/dataset=capacity_tracker_non_residential_cleaned/" "s3://$BRANCH_DATASET_BUCKET/domain=capacity_tracker/dataset=capacity_tracker_non_residential_cleaned/"
             aws s3 sync "s3://sfc-main-datasets/domain=CQC/dataset=pir_cleaned/" "s3://$BRANCH_DATASET_BUCKET/domain=CQC/dataset=pir_cleaned/"
             aws s3 sync "s3://sfc-main-datasets/domain=ind_cqc_filled_posts/dataset=ind_cqc_06_estimated_filled_posts/" "s3://$BRANCH_DATASET_BUCKET/domain=ind_cqc_filled_posts/dataset=main_ind_cqc_06_estimated_filled_posts/"
-            aws s3 sync "s3://sfc-main-datasets/domain=CQC/dataset=cqc_locations_01_delta_api/version=3.1.0/" "s3://$BRANCH_DATASET_BUCKET/domain=CQC/dataset=cqc_locations_01_delta_api/version=3.1.0/"
-            aws s3 sync "s3://sfc-main-datasets/domain=CQC/dataset=cqc_providers_01_delta_api/" "s3://$BRANCH_DATASET_BUCKET/domain=CQC/dataset=cqc_providers_01_delta_api/"
       - run:
           name: Copy models to non-prod dataset
           command: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ All notable changes to this project will be documented in this file.
 
 - Removed partitioning from direct payments pipeline outputs.
 
+- Changed cqc api delta download to get changes from 15 days prior to start time up to end time.
+
 ### Fixed
 - Update setup instructions with pre-commit hooks setup
 

--- a/projects/_01_ingest/cqc_api/fargate/cqc_locations_1_delta_api_download.py
+++ b/projects/_01_ingest/cqc_api/fargate/cqc_locations_1_delta_api_download.py
@@ -26,7 +26,7 @@ CQC_ORG_TYPE = "location"
 
 def main(
     destination: str,
-    end_timestamp: str = None,
+    end_timestamp: str,
     previous_days_to_capture: int = cqc.days_to_rollback_start_timestamp,
 ) -> None:
     """

--- a/projects/_01_ingest/cqc_api/fargate/cqc_locations_1_delta_api_download.py
+++ b/projects/_01_ingest/cqc_api/fargate/cqc_locations_1_delta_api_download.py
@@ -27,7 +27,7 @@ CQC_ORG_TYPE = "location"
 def main(
     destination: str,
     end_timestamp: str,
-    previous_days_to_capture: int = cqc.days_to_rollback_start_timestamp,
+    previous_days_to_capture: str = cqc.days_to_rollback_start_timestamp,
 ) -> None:
     """
     This function performs the following steps:
@@ -46,7 +46,8 @@ def main(
             Parquet file will be written.
         end_timestamp (str): The ISO 8601 formatted string representing the
             end of the data retrieval period (e.g., '2023-01-31T23:59:59Z').
-        previous_days_to_capture (int): Number of days before end_timestamp (default 15).
+        previous_days_to_capture (str): Number of days before end_timestamp as a
+            string (default "15").
 
     Return:
         None
@@ -61,7 +62,7 @@ def main(
         destination = destination if destination[-1] == "/" else f"{destination}/"
 
         end_dt = dt.fromisoformat(end_timestamp.replace("Z", ""))
-        start_dt = end_dt - timedelta(days=previous_days_to_capture)
+        start_dt = end_dt - timedelta(days=float(previous_days_to_capture))
 
         print(f'Getting SecretID "{SECRET_ID}"')
         secret = get_secret(secret_name=SECRET_ID, region_name=AWS_REGION)
@@ -119,6 +120,10 @@ if __name__ == "__main__":
         (
             "--end_timestamp",
             "End timestamp for location changes",
+        ),
+        (
+            "--previous_days_to_capture",
+            "Number of days prior to end timestamp as a string",
         ),
     )
     print(f"Running cqc locations delta api download job")

--- a/projects/_01_ingest/cqc_api/fargate/cqc_locations_1_delta_api_download.py
+++ b/projects/_01_ingest/cqc_api/fargate/cqc_locations_1_delta_api_download.py
@@ -32,8 +32,8 @@ CQC_ORG_TYPE = "location"
 def main(destination: str, start_timestamp: str, end_timestamp: str) -> None:
     """
     This function performs the following steps:
-    1. Validates the provided start and end timestamps.
-    2. Subtracts 15 days from input start_timestamp.
+    1. Subtracts 15 days from input start_timestamp.
+    2. Validates the provided start and end timestamps.
     3. Retrieves the CQC API subscription key from AWS Secrets Manager.
     4. Calls the CQC API to fetch updated location objects within the specified
        time range.
@@ -64,7 +64,9 @@ def main(destination: str, start_timestamp: str, end_timestamp: str) -> None:
     try:
         destination = destination if destination[-1] == "/" else f"{destination}/"
 
-        start_dt = dt.fromisoformat(start_timestamp.replace("Z", ""))
+        start_dt = dt.fromisoformat(start_timestamp.replace("Z", "")) - timedelta(
+            days=15
+        )
         end_dt = dt.fromisoformat(end_timestamp.replace("Z", ""))
 
         if start_dt > end_dt:
@@ -72,13 +74,13 @@ def main(destination: str, start_timestamp: str, end_timestamp: str) -> None:
                 "start_timestamp is after end_timestamp"
             )
 
-        start_dt = start_dt - timedelta(days=15)
-
         print(f'Getting SecretID "{SECRET_ID}"')
         secret = get_secret(secret_name=SECRET_ID, region_name=AWS_REGION)
         cqc_api_primary_key_value: str = json.loads(secret)["Ocp-Apim-Subscription-Key"]
 
-        print("Collecting locations with changes from API")
+        print(
+            f"Collecting locations with changes from API between {start_dt} and {end_dt}"
+        )
 
         api_generator: Generator[dict, None, None] = cqc.get_updated_objects(
             object_type=CQC_OBJECT_TYPE,
@@ -132,7 +134,9 @@ if __name__ == "__main__":
         ("--start_timestamp", "Start timestamp for location changes"),
         ("--end_timestamp", "End timestamp for location changes"),
     )
-    print(f"Running job from {args.start_timestamp} to {args.end_timestamp}")
+    print(
+        f"Running job from 15 days prior to {args.start_timestamp} to {args.end_timestamp}"
+    )
 
     date_today = date.today()
     destination = utils.generate_s3_dir(

--- a/projects/_01_ingest/cqc_api/fargate/cqc_locations_1_delta_api_download.py
+++ b/projects/_01_ingest/cqc_api/fargate/cqc_locations_1_delta_api_download.py
@@ -18,18 +18,17 @@ from utils.column_names.raw_data_files.cqc_location_api_columns import (
     NewCqcLocationApiColumns as ColNames,
 )
 
-
-class InvalidTimestampArgumentError(Exception):
-    pass
-
-
 SECRET_ID = os.environ.get("CQC_SECRET_NAME", "")
 AWS_REGION = os.environ.get("AWS_REGION", "")
 CQC_OBJECT_TYPE = "locations"
 CQC_ORG_TYPE = "location"
 
 
-def main(destination: str, start_timestamp: str, end_timestamp: str) -> None:
+def main(
+    destination: str,
+    end_timestamp: str = None,
+    previous_days_to_capture: int = cqc.days_to_rollback_start_timestamp,
+) -> None:
     """
     This function performs the following steps:
     1. Subtracts set number of days from input start_timestamp.
@@ -46,16 +45,14 @@ def main(destination: str, start_timestamp: str, end_timestamp: str) -> None:
     Args:
         destination (str): The S3 path or local file path where the processed
             Parquet file will be written.
-        start_timestamp (str): The ISO 8601 formatted string representing the
-            start of the data retrieval period (e.g., '2023-01-01T00:00:00Z').
         end_timestamp (str): The ISO 8601 formatted string representing the
             end of the data retrieval period (e.g., '2023-01-31T23:59:59Z').
+        previous_days_to_capture (int): Number of days before end_timestamp (default 15).
 
     Return:
         None
 
     Raises:
-        InvalidTimestampArgumentError: If `start_timestamp` is after `end_timestamp`.
         FileNotFoundError: If the function is unable to write the Parquet
             file to the specified `destination`.
         Exception: For any other unspecified errors that occur during API
@@ -64,15 +61,8 @@ def main(destination: str, start_timestamp: str, end_timestamp: str) -> None:
     try:
         destination = destination if destination[-1] == "/" else f"{destination}/"
 
-        start_dt = dt.fromisoformat(start_timestamp.replace("Z", "")) - timedelta(
-            days=cqc.days_to_rollback_start_timestamp
-        )
         end_dt = dt.fromisoformat(end_timestamp.replace("Z", ""))
-
-        if start_dt > end_dt:
-            raise InvalidTimestampArgumentError(
-                "start_timestamp is after end_timestamp"
-            )
+        start_dt = end_dt - timedelta(days=previous_days_to_capture)
 
         print(f'Getting SecretID "{SECRET_ID}"')
         secret = get_secret(secret_name=SECRET_ID, region_name=AWS_REGION)
@@ -112,10 +102,6 @@ def main(destination: str, start_timestamp: str, end_timestamp: str) -> None:
         utils.write_to_parquet(df_unique, destination)
         return None
 
-    except InvalidTimestampArgumentError as e:
-        print(f"ERROR: {e}")
-        print(f"ERROR: {sys.argv}")
-        raise
     except FileNotFoundError as e:
         print(f"ERROR: {e}")
         print(f"ERROR: {sys.argv}")
@@ -131,8 +117,10 @@ if __name__ == "__main__":
             "--destination_prefix",
             "Source s3 directory for parquet CQC locations dataset",
         ),
-        ("--start_timestamp", "Start timestamp for location changes"),
-        ("--end_timestamp", "End timestamp for location changes"),
+        (
+            "--end_timestamp",
+            "End timestamp for location changes",
+        ),
     )
     print(f"Running cqc locations delta api download job")
 
@@ -144,4 +132,4 @@ if __name__ == "__main__":
         date=date_today,
         version="3.1.0",
     )
-    main(destination, args.start_timestamp, args.end_timestamp)
+    main(destination, end_timestamp=args.end_timestamp)

--- a/projects/_01_ingest/cqc_api/fargate/cqc_locations_1_delta_api_download.py
+++ b/projects/_01_ingest/cqc_api/fargate/cqc_locations_1_delta_api_download.py
@@ -32,7 +32,7 @@ CQC_ORG_TYPE = "location"
 def main(destination: str, start_timestamp: str, end_timestamp: str) -> None:
     """
     This function performs the following steps:
-    1. Subtracts 15 days from input start_timestamp.
+    1. Subtracts set number of days from input start_timestamp.
     2. Validates the provided start and end timestamps.
     3. Retrieves the CQC API subscription key from AWS Secrets Manager.
     4. Calls the CQC API to fetch updated location objects within the specified
@@ -65,7 +65,7 @@ def main(destination: str, start_timestamp: str, end_timestamp: str) -> None:
         destination = destination if destination[-1] == "/" else f"{destination}/"
 
         start_dt = dt.fromisoformat(start_timestamp.replace("Z", "")) - timedelta(
-            days=15
+            days=cqc.days_to_rollback_start_timestamp
         )
         end_dt = dt.fromisoformat(end_timestamp.replace("Z", ""))
 
@@ -134,9 +134,7 @@ if __name__ == "__main__":
         ("--start_timestamp", "Start timestamp for location changes"),
         ("--end_timestamp", "End timestamp for location changes"),
     )
-    print(
-        f"Running job from 15 days prior to {args.start_timestamp} to {args.end_timestamp}"
-    )
+    print(f"Running cqc locations delta api download job")
 
     date_today = date.today()
     destination = utils.generate_s3_dir(

--- a/projects/_01_ingest/cqc_api/fargate/cqc_locations_1_delta_api_download.py
+++ b/projects/_01_ingest/cqc_api/fargate/cqc_locations_1_delta_api_download.py
@@ -33,13 +33,14 @@ def main(destination: str, start_timestamp: str, end_timestamp: str) -> None:
     """
     This function performs the following steps:
     1. Validates the provided start and end timestamps.
-    2. Retrieves the CQC API subscription key from AWS Secrets Manager.
-    3. Calls the CQC API to fetch updated location objects within the specified
+    2. Subtracts 15 days from input start_timestamp.
+    3. Retrieves the CQC API subscription key from AWS Secrets Manager.
+    4. Calls the CQC API to fetch updated location objects within the specified
        time range.
-    4. Converts the retrieved data into a Polars DataFrame, applying a predefined
+    5. Converts the retrieved data into a Polars DataFrame, applying a predefined
        schema.
-    5. Removes duplicate location entries, keeping only unique locations.
-    6. Writes the unique location data to a Parquet file at the specified
+    6. Removes duplicate location entries, keeping only unique locations.
+    7. Writes the unique location data to a Parquet file at the specified
        destination path, typically an S3 location.
 
     Args:
@@ -63,16 +64,15 @@ def main(destination: str, start_timestamp: str, end_timestamp: str) -> None:
     try:
         destination = destination if destination[-1] == "/" else f"{destination}/"
 
-        start_dt = dt.fromisoformat(start_timestamp.replace("Z", "")) - timedelta(
-            days=15
-        )
-
+        start_dt = dt.fromisoformat(start_timestamp.replace("Z", ""))
         end_dt = dt.fromisoformat(end_timestamp.replace("Z", ""))
 
         if start_dt > end_dt:
             raise InvalidTimestampArgumentError(
                 "start_timestamp is after end_timestamp"
             )
+
+        start_dt = start_dt - timedelta(days=15)
 
         print(f'Getting SecretID "{SECRET_ID}"')
         secret = get_secret(secret_name=SECRET_ID, region_name=AWS_REGION)
@@ -142,5 +142,4 @@ if __name__ == "__main__":
         date=date_today,
         version="3.1.0",
     )
-    main(destination, args.start_timestamp, args.end_timestamp)
     main(destination, args.start_timestamp, args.end_timestamp)

--- a/projects/_01_ingest/cqc_api/fargate/cqc_locations_1_delta_api_download.py
+++ b/projects/_01_ingest/cqc_api/fargate/cqc_locations_1_delta_api_download.py
@@ -31,15 +31,14 @@ def main(
 ) -> None:
     """
     This function performs the following steps:
-    1. Subtracts set number of days from input start_timestamp.
-    2. Validates the provided start and end timestamps.
-    3. Retrieves the CQC API subscription key from AWS Secrets Manager.
-    4. Calls the CQC API to fetch updated location objects within the specified
+    1. Subtracts a number of days from end_timestamp to create a start date.
+    2. Retrieves the CQC API subscription key from AWS Secrets Manager.
+    3. Calls the CQC API to fetch updated location objects within the specified
        time range.
-    5. Converts the retrieved data into a Polars DataFrame, applying a predefined
+    4. Converts the retrieved data into a Polars DataFrame, applying a predefined
        schema.
-    6. Removes duplicate location entries, keeping only unique locations.
-    7. Writes the unique location data to a Parquet file at the specified
+    5. Removes duplicate location entries, keeping only unique locations.
+    6. Writes the unique location data to a Parquet file at the specified
        destination path, typically an S3 location.
 
     Args:

--- a/projects/_01_ingest/cqc_api/fargate/cqc_locations_1_delta_api_download.py
+++ b/projects/_01_ingest/cqc_api/fargate/cqc_locations_1_delta_api_download.py
@@ -5,6 +5,7 @@ import os
 import sys
 from datetime import date
 from datetime import datetime as dt
+from datetime import timedelta
 from typing import Generator
 
 import polars as pl
@@ -62,7 +63,10 @@ def main(destination: str, start_timestamp: str, end_timestamp: str) -> None:
     try:
         destination = destination if destination[-1] == "/" else f"{destination}/"
 
-        start_dt = dt.fromisoformat(start_timestamp.replace("Z", ""))
+        start_dt = dt.fromisoformat(start_timestamp.replace("Z", "")) - timedelta(
+            days=15
+        )
+
         end_dt = dt.fromisoformat(end_timestamp.replace("Z", ""))
 
         if start_dt > end_dt:
@@ -138,4 +142,5 @@ if __name__ == "__main__":
         date=date_today,
         version="3.1.0",
     )
+    main(destination, args.start_timestamp, args.end_timestamp)
     main(destination, args.start_timestamp, args.end_timestamp)

--- a/projects/_01_ingest/cqc_api/fargate/cqc_locations_1_delta_api_download.py
+++ b/projects/_01_ingest/cqc_api/fargate/cqc_locations_1_delta_api_download.py
@@ -27,7 +27,7 @@ CQC_ORG_TYPE = "location"
 def main(
     destination: str,
     end_timestamp: str,
-    previous_days_to_capture: str = cqc.days_to_rollback_start_timestamp,
+    previous_days_to_capture: int = cqc.days_to_rollback_start_timestamp,
 ) -> None:
     """
     This function performs the following steps:
@@ -46,8 +46,7 @@ def main(
             Parquet file will be written.
         end_timestamp (str): The ISO 8601 formatted string representing the
             end of the data retrieval period (e.g., '2023-01-31T23:59:59Z').
-        previous_days_to_capture (str): Number of days before end_timestamp as a
-            string (default "15").
+        previous_days_to_capture (int): Integer of days before end_timestamp.
 
     Return:
         None
@@ -62,7 +61,7 @@ def main(
         destination = destination if destination[-1] == "/" else f"{destination}/"
 
         end_dt = dt.fromisoformat(end_timestamp.replace("Z", ""))
-        start_dt = end_dt - timedelta(days=float(previous_days_to_capture))
+        start_dt = end_dt - timedelta(days=previous_days_to_capture)
 
         print(f'Getting SecretID "{SECRET_ID}"')
         secret = get_secret(secret_name=SECRET_ID, region_name=AWS_REGION)
@@ -136,4 +135,5 @@ if __name__ == "__main__":
         date=date_today,
         version="3.1.0",
     )
-    main(destination, end_timestamp=args.end_timestamp)
+    previous_days_to_capture = int(args.previous_days_to_capture)
+    main(destination, args.end_timestamp, args.previous_days_to_capture)

--- a/projects/_01_ingest/cqc_api/fargate/cqc_locations_1_delta_api_download.py
+++ b/projects/_01_ingest/cqc_api/fargate/cqc_locations_1_delta_api_download.py
@@ -136,4 +136,4 @@ if __name__ == "__main__":
         version="3.1.0",
     )
     previous_days_to_capture = int(args.previous_days_to_capture)
-    main(destination, args.end_timestamp, args.previous_days_to_capture)
+    main(destination, args.end_timestamp, previous_days_to_capture)

--- a/projects/_01_ingest/cqc_api/fargate/cqc_providers_1_delta_api_download.py
+++ b/projects/_01_ingest/cqc_api/fargate/cqc_providers_1_delta_api_download.py
@@ -24,38 +24,35 @@ CQC_OBJECT_TYPE = "providers"
 CQC_ORG_TYPE = "provider"
 
 
-class InvalidTimestampArgumentError(Exception):
-    pass
-
-
-def main(destination: str, start_timestamp: str, end_timestamp: str) -> None:
+def main(
+    destination: str,
+    end_timestamp: str = None,
+    previous_days_to_capture: int = cqc.days_to_rollback_start_timestamp,
+) -> None:
     """Orchestrates the retrieval of updated CQC provider data and writes it to Parquet.
 
     This function performs the following steps:
-    1. Subtracts set number of days from input start_timestamp.
-    2. Validates the provided start and end timestamps
-    3. Retrieves the CQC API subscription key from AWS Secrets Manager.
-    4. Calls the CQC API to fetch updated provider objects within the specified
+    1. Subtracts a number of days from end_timestamp to create a start date.
+    2. Retrieves the CQC API subscription key from AWS Secrets Manager.
+    3. Calls the CQC API to fetch updated provider objects within the specified
        time range.
-    5. Converts the retrieved data into a Polars DataFrame, applying a predefined
+    4. Converts the retrieved data into a Polars DataFrame, applying a predefined
        schema.
-    6. Removes duplicate provider entries, keeping only unique providers.
-    7. Writes the unique provider data to a Parquet file at the specified
+    5. Removes duplicate provider entries, keeping only unique providers.
+    6. Writes the unique provider data to a Parquet file at the specified
        destination path, typically an S3 location.
 
     Args:
         destination (str): The S3 path or local file path where the processed
             Parquet file will be written.
-        start_timestamp (str): The ISO 8601 formatted string representing the
-            start of the data retrieval period (e.g., '2023-01-01T00:00:00Z').
         end_timestamp (str): The ISO 8601 formatted string representing the
             end of the data retrieval period (e.g., '2023-01-31T23:59:59Z').
+        previous_days_to_capture (int): Number of days before end_timestamp (default 15).
 
     Return:
         None.
 
     Raises:
-        InvalidTimestampArgumentError: If `start_timestamp` is after `end_timestamp`.
         FileNotFoundError: If the function is unable to write the Parquet
             file to the specified `destination`.
         Exception: For any other unspecified errors that occur during API
@@ -64,15 +61,8 @@ def main(destination: str, start_timestamp: str, end_timestamp: str) -> None:
     try:
         destination = destination if destination[-1] == "/" else f"{destination}/"
 
-        start_dt = dt.fromisoformat(start_timestamp.replace("Z", "")) - timedelta(
-            days=cqc.days_to_rollback_start_timestamp
-        )
         end_dt = dt.fromisoformat(end_timestamp.replace("Z", ""))
-
-        if start_dt > end_dt:
-            raise InvalidTimestampArgumentError(
-                "Start timestamp is after end timestamp"
-            )
+        start_dt = end_dt - timedelta(days=previous_days_to_capture)
 
         print(f'Getting SecretID "{SECRET_ID}"')
         secret = get_secret(secret_name=SECRET_ID, region_name=AWS_REGION)
@@ -112,9 +102,6 @@ def main(destination: str, start_timestamp: str, end_timestamp: str) -> None:
         utils.write_to_parquet(df_unique, destination)
         return None
 
-    except InvalidTimestampArgumentError:
-        print(f"ERROR: Start timestamp is after end timestamp: Args: {sys.argv}")
-        raise
     except FileNotFoundError:
         print(
             f"ERROR: {sys.argv[0]} was unable to write to destination. Args: {sys.argv}"
@@ -134,8 +121,10 @@ if __name__ == "__main__":
             "--destination_prefix",
             "Source s3 directory for parquet CQC providers dataset",
         ),
-        ("--start_timestamp", "Start timestamp for provider changes"),
-        ("--end_timestamp", "End timestamp for provider changes"),
+        (
+            "--end_timestamp",
+            "End timestamp for provider changes",
+        ),
     )
     print(f"Running cqc providers delta api download job")
 
@@ -147,4 +136,4 @@ if __name__ == "__main__":
         date=todays_date,
         version="3.0.0",
     )
-    main(destination, args.start_timestamp, args.end_timestamp)
+    main(destination, end_timestamp=args.end_timestamp)

--- a/projects/_01_ingest/cqc_api/fargate/cqc_providers_1_delta_api_download.py
+++ b/projects/_01_ingest/cqc_api/fargate/cqc_providers_1_delta_api_download.py
@@ -5,6 +5,7 @@ import os
 import sys
 from datetime import date
 from datetime import datetime as dt
+from datetime import timedelta
 from typing import Generator
 
 import polars as pl
@@ -62,7 +63,9 @@ def main(destination: str, start_timestamp: str, end_timestamp: str) -> None:
     try:
         destination = destination if destination[-1] == "/" else f"{destination}/"
 
-        start_dt = dt.fromisoformat(start_timestamp.replace("Z", ""))
+        start_dt = dt.fromisoformat(start_timestamp.replace("Z", "")) - timedelta(
+            days=15
+        )
         end_dt = dt.fromisoformat(end_timestamp.replace("Z", ""))
 
         if start_dt > end_dt:
@@ -141,4 +144,5 @@ if __name__ == "__main__":
         date=todays_date,
         version="3.0.0",
     )
+    main(destination, args.start_timestamp, args.end_timestamp)
     main(destination, args.start_timestamp, args.end_timestamp)

--- a/projects/_01_ingest/cqc_api/fargate/cqc_providers_1_delta_api_download.py
+++ b/projects/_01_ingest/cqc_api/fargate/cqc_providers_1_delta_api_download.py
@@ -32,8 +32,8 @@ def main(destination: str, start_timestamp: str, end_timestamp: str) -> None:
     """Orchestrates the retrieval of updated CQC provider data and writes it to Parquet.
 
     This function performs the following steps:
-    1. Validates the provided start and end timestamps.
-    2. Subtracts 15 days from input start_timestamp.
+    1. Subtracts 15 days from input start_timestamp.
+    2. Validates the provided start and end timestamps
     3. Retrieves the CQC API subscription key from AWS Secrets Manager.
     4. Calls the CQC API to fetch updated provider objects within the specified
        time range.
@@ -64,7 +64,9 @@ def main(destination: str, start_timestamp: str, end_timestamp: str) -> None:
     try:
         destination = destination if destination[-1] == "/" else f"{destination}/"
 
-        start_dt = dt.fromisoformat(start_timestamp.replace("Z", ""))
+        start_dt = dt.fromisoformat(start_timestamp.replace("Z", "")) - timedelta(
+            days=15
+        )
         end_dt = dt.fromisoformat(end_timestamp.replace("Z", ""))
 
         if start_dt > end_dt:
@@ -72,13 +74,13 @@ def main(destination: str, start_timestamp: str, end_timestamp: str) -> None:
                 "Start timestamp is after end timestamp"
             )
 
-        start_dt = start_dt - timedelta(days=15)
-
         print(f'Getting SecretID "{SECRET_ID}"')
         secret = get_secret(secret_name=SECRET_ID, region_name=AWS_REGION)
         cqc_api_primary_key_value: str = json.loads(secret)["Ocp-Apim-Subscription-Key"]
 
-        print("Collecting providers with changes from API")
+        print(
+            f"Collecting providers with changes from API between {start_dt} and {end_dt}"
+        )
 
         api_generator: Generator[dict, None, None] = cqc.get_updated_objects(
             object_type=CQC_OBJECT_TYPE,
@@ -135,7 +137,9 @@ if __name__ == "__main__":
         ("--start_timestamp", "Start timestamp for provider changes"),
         ("--end_timestamp", "End timestamp for provider changes"),
     )
-    print(f"Running job from {args.start_timestamp} to {args.end_timestamp}")
+    print(
+        f"Running job from 15 days prior to {args.start_timestamp} to {args.end_timestamp}"
+    )
 
     todays_date = date.today()
     destination = utils.generate_s3_dir(

--- a/projects/_01_ingest/cqc_api/fargate/cqc_providers_1_delta_api_download.py
+++ b/projects/_01_ingest/cqc_api/fargate/cqc_providers_1_delta_api_download.py
@@ -26,7 +26,7 @@ CQC_ORG_TYPE = "provider"
 
 def main(
     destination: str,
-    end_timestamp: str = None,
+    end_timestamp: str,
     previous_days_to_capture: int = cqc.days_to_rollback_start_timestamp,
 ) -> None:
     """Orchestrates the retrieval of updated CQC provider data and writes it to Parquet.

--- a/projects/_01_ingest/cqc_api/fargate/cqc_providers_1_delta_api_download.py
+++ b/projects/_01_ingest/cqc_api/fargate/cqc_providers_1_delta_api_download.py
@@ -32,7 +32,7 @@ def main(destination: str, start_timestamp: str, end_timestamp: str) -> None:
     """Orchestrates the retrieval of updated CQC provider data and writes it to Parquet.
 
     This function performs the following steps:
-    1. Subtracts 15 days from input start_timestamp.
+    1. Subtracts set number of days from input start_timestamp.
     2. Validates the provided start and end timestamps
     3. Retrieves the CQC API subscription key from AWS Secrets Manager.
     4. Calls the CQC API to fetch updated provider objects within the specified
@@ -65,7 +65,7 @@ def main(destination: str, start_timestamp: str, end_timestamp: str) -> None:
         destination = destination if destination[-1] == "/" else f"{destination}/"
 
         start_dt = dt.fromisoformat(start_timestamp.replace("Z", "")) - timedelta(
-            days=15
+            days=cqc.days_to_rollback_start_timestamp
         )
         end_dt = dt.fromisoformat(end_timestamp.replace("Z", ""))
 
@@ -137,9 +137,7 @@ if __name__ == "__main__":
         ("--start_timestamp", "Start timestamp for provider changes"),
         ("--end_timestamp", "End timestamp for provider changes"),
     )
-    print(
-        f"Running job from 15 days prior to {args.start_timestamp} to {args.end_timestamp}"
-    )
+    print(f"Running cqc providers delta api download job")
 
     todays_date = date.today()
     destination = utils.generate_s3_dir(

--- a/projects/_01_ingest/cqc_api/fargate/cqc_providers_1_delta_api_download.py
+++ b/projects/_01_ingest/cqc_api/fargate/cqc_providers_1_delta_api_download.py
@@ -33,13 +33,14 @@ def main(destination: str, start_timestamp: str, end_timestamp: str) -> None:
 
     This function performs the following steps:
     1. Validates the provided start and end timestamps.
-    2. Retrieves the CQC API subscription key from AWS Secrets Manager.
-    3. Calls the CQC API to fetch updated provider objects within the specified
+    2. Subtracts 15 days from input start_timestamp.
+    3. Retrieves the CQC API subscription key from AWS Secrets Manager.
+    4. Calls the CQC API to fetch updated provider objects within the specified
        time range.
-    4. Converts the retrieved data into a Polars DataFrame, applying a predefined
+    5. Converts the retrieved data into a Polars DataFrame, applying a predefined
        schema.
-    5. Removes duplicate provider entries, keeping only unique providers.
-    6. Writes the unique provider data to a Parquet file at the specified
+    6. Removes duplicate provider entries, keeping only unique providers.
+    7. Writes the unique provider data to a Parquet file at the specified
        destination path, typically an S3 location.
 
     Args:
@@ -63,15 +64,15 @@ def main(destination: str, start_timestamp: str, end_timestamp: str) -> None:
     try:
         destination = destination if destination[-1] == "/" else f"{destination}/"
 
-        start_dt = dt.fromisoformat(start_timestamp.replace("Z", "")) - timedelta(
-            days=15
-        )
+        start_dt = dt.fromisoformat(start_timestamp.replace("Z", ""))
         end_dt = dt.fromisoformat(end_timestamp.replace("Z", ""))
 
         if start_dt > end_dt:
             raise InvalidTimestampArgumentError(
                 "Start timestamp is after end timestamp"
             )
+
+        start_dt = start_dt - timedelta(days=15)
 
         print(f'Getting SecretID "{SECRET_ID}"')
         secret = get_secret(secret_name=SECRET_ID, region_name=AWS_REGION)
@@ -144,5 +145,4 @@ if __name__ == "__main__":
         date=todays_date,
         version="3.0.0",
     )
-    main(destination, args.start_timestamp, args.end_timestamp)
     main(destination, args.start_timestamp, args.end_timestamp)

--- a/projects/_01_ingest/cqc_api/fargate/cqc_providers_1_delta_api_download.py
+++ b/projects/_01_ingest/cqc_api/fargate/cqc_providers_1_delta_api_download.py
@@ -27,7 +27,7 @@ CQC_ORG_TYPE = "provider"
 def main(
     destination: str,
     end_timestamp: str,
-    previous_days_to_capture: int = cqc.days_to_rollback_start_timestamp,
+    previous_days_to_capture: str = cqc.days_to_rollback_start_timestamp,
 ) -> None:
     """Orchestrates the retrieval of updated CQC provider data and writes it to Parquet.
 
@@ -47,7 +47,8 @@ def main(
             Parquet file will be written.
         end_timestamp (str): The ISO 8601 formatted string representing the
             end of the data retrieval period (e.g., '2023-01-31T23:59:59Z').
-        previous_days_to_capture (int): Number of days before end_timestamp (default 15).
+        previous_days_to_capture (str): Number of days before end_timestamp as a
+            string (default "15").
 
     Return:
         None.
@@ -62,7 +63,7 @@ def main(
         destination = destination if destination[-1] == "/" else f"{destination}/"
 
         end_dt = dt.fromisoformat(end_timestamp.replace("Z", ""))
-        start_dt = end_dt - timedelta(days=previous_days_to_capture)
+        start_dt = end_dt - timedelta(days=float(previous_days_to_capture))
 
         print(f'Getting SecretID "{SECRET_ID}"')
         secret = get_secret(secret_name=SECRET_ID, region_name=AWS_REGION)
@@ -124,6 +125,10 @@ if __name__ == "__main__":
         (
             "--end_timestamp",
             "End timestamp for provider changes",
+        ),
+        (
+            "--previous_days_to_capture",
+            "Number of days prior to end timestamp as a string",
         ),
     )
     print(f"Running cqc providers delta api download job")

--- a/projects/_01_ingest/cqc_api/fargate/cqc_providers_1_delta_api_download.py
+++ b/projects/_01_ingest/cqc_api/fargate/cqc_providers_1_delta_api_download.py
@@ -27,7 +27,7 @@ CQC_ORG_TYPE = "provider"
 def main(
     destination: str,
     end_timestamp: str,
-    previous_days_to_capture: str = cqc.days_to_rollback_start_timestamp,
+    previous_days_to_capture: int = cqc.days_to_rollback_start_timestamp,
 ) -> None:
     """Orchestrates the retrieval of updated CQC provider data and writes it to Parquet.
 
@@ -47,8 +47,7 @@ def main(
             Parquet file will be written.
         end_timestamp (str): The ISO 8601 formatted string representing the
             end of the data retrieval period (e.g., '2023-01-31T23:59:59Z').
-        previous_days_to_capture (str): Number of days before end_timestamp as a
-            string (default "15").
+        previous_days_to_capture (int): Integer of days before end_timestamp.
 
     Return:
         None.
@@ -63,7 +62,7 @@ def main(
         destination = destination if destination[-1] == "/" else f"{destination}/"
 
         end_dt = dt.fromisoformat(end_timestamp.replace("Z", ""))
-        start_dt = end_dt - timedelta(days=float(previous_days_to_capture))
+        start_dt = end_dt - timedelta(days=previous_days_to_capture)
 
         print(f'Getting SecretID "{SECRET_ID}"')
         secret = get_secret(secret_name=SECRET_ID, region_name=AWS_REGION)
@@ -141,4 +140,5 @@ if __name__ == "__main__":
         date=todays_date,
         version="3.0.0",
     )
-    main(destination, end_timestamp=args.end_timestamp)
+    previous_days_to_capture = int(args.previous_days_to_capture)
+    main(destination, args.end_timestamp, args.previous_days_to_capture)

--- a/projects/_01_ingest/cqc_api/fargate/cqc_providers_1_delta_api_download.py
+++ b/projects/_01_ingest/cqc_api/fargate/cqc_providers_1_delta_api_download.py
@@ -141,4 +141,4 @@ if __name__ == "__main__":
         version="3.0.0",
     )
     previous_days_to_capture = int(args.previous_days_to_capture)
-    main(destination, args.end_timestamp, args.previous_days_to_capture)
+    main(destination, args.end_timestamp, previous_days_to_capture)

--- a/projects/_01_ingest/cqc_api/tests/fargate/test_cqc_locations_1_delta_api_download.py
+++ b/projects/_01_ingest/cqc_api/tests/fargate/test_cqc_locations_1_delta_api_download.py
@@ -74,7 +74,8 @@ class TestDeltaDownloadCQCLocations(unittest.TestCase):
         mock_objects.return_value = {}
         dest = os.path.join(self.temp_dir, "test.parquet")
         start = "2025-07-25T15:40:23Z"
-        end = "2025-07-20T14:23:40Z"
+        end = "2025-07-09T14:23:40Z"
+        # start minus 15 days = 2025-07-10, which is after end.
         with self.assertRaises(InvalidTimestampArgumentError):
             main(dest, start, end)
 

--- a/projects/_01_ingest/cqc_api/tests/fargate/test_cqc_locations_1_delta_api_download.py
+++ b/projects/_01_ingest/cqc_api/tests/fargate/test_cqc_locations_1_delta_api_download.py
@@ -7,10 +7,7 @@ from unittest.mock import patch
 
 import polars as pl
 
-from projects._01_ingest.cqc_api.fargate.cqc_locations_1_delta_api_download import (
-    InvalidTimestampArgumentError,
-    main,
-)
+from projects._01_ingest.cqc_api.fargate.cqc_locations_1_delta_api_download import main
 
 PATCH_PATH = "projects._01_ingest.cqc_api.fargate.cqc_locations_1_delta_api_download"
 
@@ -55,29 +52,11 @@ class TestDeltaDownloadCQCLocations(unittest.TestCase):
             {"locationId": 3},
         ]
         mock_build_dataframe_from_api.return_value = self.mock_df
-        start = "2025-07-20T15:40:23Z"
         end = "2025-07-25T14:23:40Z"
-        main(self.temp_dir + "/", start, end)
+        main(self.temp_dir + "/", end_timestamp=end)
         mock_get_secret.assert_called_once_with(
             secret_name="cqc-secret-name", region_name="us-east-1"
         )
-
-    @patch(f"{PATCH_PATH}.get_secret")
-    @patch(f"{PATCH_PATH}.cqc.build_dataframe_from_api")
-    @patch(f"{PATCH_PATH}.cqc.get_updated_objects")
-    @patch(f"{PATCH_PATH}.SECRET_ID", new="cqc-secret-name")
-    @patch(f"{PATCH_PATH}.AWS_REGION", new="us-east-1")
-    def test_main_traps_timestamp_error(
-        self, mock_objects, mockbuild_dataframe_from_api, mock_get_secret
-    ):
-        mock_get_secret.return_value = '{"Ocp-Apim-Subscription-Key": "abc1"}'
-        mock_objects.return_value = {}
-        dest = os.path.join(self.temp_dir, "test.parquet")
-        start = "2025-07-25T15:40:23Z"
-        end = "2025-07-09T14:23:40Z"
-        # start minus 15 days = 2025-07-10, which is after end.
-        with self.assertRaises(InvalidTimestampArgumentError):
-            main(dest, start, end)
 
     @patch(f"{PATCH_PATH}.utils.uuid")
     @patch(f"{PATCH_PATH}.get_secret")
@@ -98,9 +77,8 @@ class TestDeltaDownloadCQCLocations(unittest.TestCase):
         file_name = "abc"
         mock_uuid.uuid4.return_value = file_name
         dest = f"{self.temp_dir}/{file_name}.parquet"
-        start = "2025-07-20T15:40:23Z"
         end = "2025-07-25T14:23:40Z"
-        main(self.temp_dir + "/", start, end)
+        main(self.temp_dir + "/", end_timestamp=end)
         mock_objects.assert_called_once()
         self.assertTrue(pathlib.Path(dest).exists())
         self.assertTrue(pathlib.Path(dest).is_file())
@@ -128,11 +106,10 @@ class TestDeltaDownloadCQCLocations(unittest.TestCase):
         mock_uuid.uuid4.return_value = file_name
 
         dest = f"{self.temp_dir}/new_path/{file_name}.parquet"
-        start = "2025-07-20T15:40:23Z"
         end = "2025-07-25T14:23:40Z"
         new_path = f"{self.temp_dir}/new_path"
         os.mkdir(new_path)
-        main(new_path, start, end)
+        main(new_path, end_timestamp=end)
         self.assertTrue(pathlib.Path(dest).exists())
         self.assertTrue(pathlib.Path(dest).is_file())
         self.assertTrue(pathlib.Path(dest).suffix == ".parquet")
@@ -167,12 +144,11 @@ class TestDeltaDownloadCQCLocations(unittest.TestCase):
 
         # WHEN
         #   we run main twice with timepoints on the same day
-        start = "2025-07-20T09:40:23Z"
-        middle = "2025-07-20T12:23:40Z"
-        end = "2025-07-20T19:40:23Z"
+        end_1 = "2025-07-20T12:23:40Z"
+        end_2 = "2025-07-20T19:40:23Z"
 
-        main(self.temp_dir + "/", start, middle)
-        main(self.temp_dir + "/", middle, end)
+        main(self.temp_dir + "/", end_timestamp=end_1)
+        main(self.temp_dir + "/", end_timestamp=end_2)
 
         # THEN
         expected_paths = [f"{self.temp_dir}/{uuid}.parquet" for uuid in uuids]
@@ -204,9 +180,8 @@ class TestDeltaDownloadCQCLocations(unittest.TestCase):
         file_name = "abc"
         mock_uuid.uuid4.return_value = file_name
         dest = f"{self.temp_dir}/{file_name}.parquet"
-        start = "2025-07-20T15:40:23Z"
         end = "2025-07-25T14:23:40Z"
-        main(self.temp_dir + "/", start, end)
+        main(self.temp_dir + "/", end_timestamp=end)
         returned_result_schema = pl.read_parquet(dest).collect_schema()
 
         self.assertTrue(

--- a/projects/_01_ingest/cqc_api/tests/fargate/test_cqc_providers_1_delta_api_download.py
+++ b/projects/_01_ingest/cqc_api/tests/fargate/test_cqc_providers_1_delta_api_download.py
@@ -76,7 +76,8 @@ class TestDeltaDownloadCQCProviders(unittest.TestCase):
         mock_build_dataframe_from_api.return_value = self.mock_df
         dest = os.path.join(self.temp_dir, "test.parquet")
         start = "2025-07-25T15:40:23Z"
-        end = "2025-07-20T14:23:40Z"
+        end = "2025-07-09T14:23:40Z"
+        # start minus 15 days = 2025-07-10, which is after end.
         with self.assertRaises(InvalidTimestampArgumentError):
             main(dest, start, end)
 

--- a/projects/_01_ingest/cqc_api/tests/fargate/test_cqc_providers_1_delta_api_download.py
+++ b/projects/_01_ingest/cqc_api/tests/fargate/test_cqc_providers_1_delta_api_download.py
@@ -7,10 +7,7 @@ from unittest.mock import patch
 
 import polars as pl
 
-from projects._01_ingest.cqc_api.fargate.cqc_providers_1_delta_api_download import (
-    InvalidTimestampArgumentError,
-    main,
-)
+from projects._01_ingest.cqc_api.fargate.cqc_providers_1_delta_api_download import main
 
 PATCH_PATH = "projects._01_ingest.cqc_api.fargate.cqc_providers_1_delta_api_download"
 
@@ -56,30 +53,11 @@ class TestDeltaDownloadCQCProviders(unittest.TestCase):
         ]
         mock_build_dataframe_from_api.return_value = self.mock_df
 
-        start = "2025-07-20T15:40:23Z"
         end = "2025-07-25T14:23:40Z"
-        main(self.temp_dir + "/", start, end)
+        main(self.temp_dir + "/", end_timestamp=end)
         mock_get_secret.assert_called_once_with(
             secret_name="cqc-secret-name", region_name="us-east-1"
         )
-
-    @patch(f"{PATCH_PATH}.get_secret")
-    @patch(f"{PATCH_PATH}.cqc.build_dataframe_from_api")
-    @patch(f"{PATCH_PATH}.cqc.get_updated_objects")
-    @patch(f"{PATCH_PATH}.SECRET_ID", new="cqc-secret-name")
-    @patch(f"{PATCH_PATH}.AWS_REGION", new="us-east-1")
-    def test_main_traps_timestamp_error(
-        self, mock_objects, mock_build_dataframe_from_api, mock_get_secret
-    ):
-        mock_get_secret.return_value = '{"Ocp-Apim-Subscription-Key": "abc1"}'
-        mock_objects.return_value = {}
-        mock_build_dataframe_from_api.return_value = self.mock_df
-        dest = os.path.join(self.temp_dir, "test.parquet")
-        start = "2025-07-25T15:40:23Z"
-        end = "2025-07-09T14:23:40Z"
-        # start minus 15 days = 2025-07-10, which is after end.
-        with self.assertRaises(InvalidTimestampArgumentError):
-            main(dest, start, end)
 
     @patch(f"{PATCH_PATH}.utils.uuid")
     @patch(f"{PATCH_PATH}.get_secret")
@@ -100,9 +78,8 @@ class TestDeltaDownloadCQCProviders(unittest.TestCase):
         file_name = "abc"
         mock_uuid.uuid4.return_value = file_name
         dest = f"{self.temp_dir}/{file_name}.parquet"
-        start = "2025-07-20T15:40:23Z"
         end = "2025-07-25T14:23:40Z"
-        main(self.temp_dir + "/", start, end)
+        main(self.temp_dir + "/", end_timestamp=end)
         self.assertTrue(pathlib.Path(dest).exists())
         self.assertTrue(pathlib.Path(dest).is_file())
         self.assertTrue(pathlib.Path(dest).suffix == ".parquet")
@@ -129,11 +106,10 @@ class TestDeltaDownloadCQCProviders(unittest.TestCase):
         file_name = "abc"
         mock_uuid.uuid4.return_value = file_name
         dest = f"{self.temp_dir}/new_path/{file_name}.parquet"
-        start = "2025-07-20T15:40:23Z"
         end = "2025-07-25T14:23:40Z"
         new_path = f"{self.temp_dir}/new_path"
         os.mkdir(new_path)
-        main(new_path, start, end)
+        main(new_path, end_timestamp=end)
         self.assertTrue(pathlib.Path(dest).exists())
         self.assertTrue(pathlib.Path(dest).is_file())
         self.assertTrue(pathlib.Path(dest).suffix == ".parquet")
@@ -168,12 +144,11 @@ class TestDeltaDownloadCQCProviders(unittest.TestCase):
 
         # WHEN
         #   we run main twice with timepoints on the same day
-        start = "2025-07-20T09:40:23Z"
-        middle = "2025-07-20T12:23:40Z"
-        end = "2025-07-20T19:40:23Z"
+        end_1 = "2025-07-20T12:23:40Z"
+        end_2 = "2025-07-20T19:40:23Z"
 
-        main(self.temp_dir + "/", start, middle)
-        main(self.temp_dir + "/", middle, end)
+        main(self.temp_dir + "/", end_timestamp=end_1)
+        main(self.temp_dir + "/", end_timestamp=end_2)
 
         # THEN
         expected_paths = [f"{self.temp_dir}/{uuid}.parquet" for uuid in uuids]
@@ -205,9 +180,8 @@ class TestDeltaDownloadCQCProviders(unittest.TestCase):
         file_name = "abc"
         mock_uuid.uuid4.return_value = file_name
         dest = f"{self.temp_dir}/{file_name}.parquet"
-        start = "2025-07-20T15:40:23Z"
         end = "2025-07-25T14:23:40Z"
-        main(self.temp_dir + "/", start, end)
+        main(self.temp_dir + "/", end_timestamp=end)
         returned_result_schema = pl.read_parquet(dest).collect_schema()
 
         self.assertTrue(

--- a/projects/_01_ingest/cqc_api/tests/utils/test_cqc_api.py
+++ b/projects/_01_ingest/cqc_api/tests/utils/test_cqc_api.py
@@ -605,5 +605,10 @@ class BuildDataframeFromApi(CqcApiTests):
         self.assertEqual(output.count("other_new"), 1)
 
 
+class DaysToRollbackStartTimestampTest(unittest.TestCase):
+    def test_expected_value(self):
+        self.assertEqual(cqc.days_to_rollback_start_timestamp, 15)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/projects/_01_ingest/cqc_api/tests/utils/test_cqc_api.py
+++ b/projects/_01_ingest/cqc_api/tests/utils/test_cqc_api.py
@@ -607,7 +607,7 @@ class BuildDataframeFromApi(CqcApiTests):
 
 class DaysToRollbackStartTimestampTest(unittest.TestCase):
     def test_expected_value(self):
-        self.assertEqual(cqc.days_to_rollback_start_timestamp, 15)
+        self.assertEqual(cqc.days_to_rollback_start_timestamp, "15")
 
 
 if __name__ == "__main__":

--- a/projects/_01_ingest/cqc_api/tests/utils/test_cqc_api.py
+++ b/projects/_01_ingest/cqc_api/tests/utils/test_cqc_api.py
@@ -607,7 +607,7 @@ class BuildDataframeFromApi(CqcApiTests):
 
 class DaysToRollbackStartTimestampTest(unittest.TestCase):
     def test_expected_value(self):
-        self.assertEqual(cqc.days_to_rollback_start_timestamp, 15)
+        self.assertEqual(cqc.days_to_rollback_start_timestamp, 30)
 
 
 if __name__ == "__main__":

--- a/projects/_01_ingest/cqc_api/tests/utils/test_cqc_api.py
+++ b/projects/_01_ingest/cqc_api/tests/utils/test_cqc_api.py
@@ -607,7 +607,7 @@ class BuildDataframeFromApi(CqcApiTests):
 
 class DaysToRollbackStartTimestampTest(unittest.TestCase):
     def test_expected_value(self):
-        self.assertEqual(cqc.days_to_rollback_start_timestamp, "15")
+        self.assertEqual(cqc.days_to_rollback_start_timestamp, 15)
 
 
 if __name__ == "__main__":

--- a/projects/_01_ingest/cqc_api/utils/cqc_api.py
+++ b/projects/_01_ingest/cqc_api/utils/cqc_api.py
@@ -14,6 +14,8 @@ DEFAULT_PAGE_SIZE = 500
 CQC_API_BASE_URL = "https://api.service.cqc.org.uk"
 USER_AGENT = "SkillsForCare"
 
+days_to_rollback_start_timestamp = 15
+
 
 class NoProviderOrLocationException(Exception):
     pass

--- a/projects/_01_ingest/cqc_api/utils/cqc_api.py
+++ b/projects/_01_ingest/cqc_api/utils/cqc_api.py
@@ -14,7 +14,7 @@ DEFAULT_PAGE_SIZE = 500
 CQC_API_BASE_URL = "https://api.service.cqc.org.uk"
 USER_AGENT = "SkillsForCare"
 
-days_to_rollback_start_timestamp = 15
+days_to_rollback_start_timestamp = "15"
 
 
 class NoProviderOrLocationException(Exception):

--- a/projects/_01_ingest/cqc_api/utils/cqc_api.py
+++ b/projects/_01_ingest/cqc_api/utils/cqc_api.py
@@ -14,7 +14,7 @@ DEFAULT_PAGE_SIZE = 500
 CQC_API_BASE_URL = "https://api.service.cqc.org.uk"
 USER_AGENT = "SkillsForCare"
 
-days_to_rollback_start_timestamp = "15"
+days_to_rollback_start_timestamp = 15
 
 
 class NoProviderOrLocationException(Exception):

--- a/projects/_01_ingest/cqc_api/utils/cqc_api.py
+++ b/projects/_01_ingest/cqc_api/utils/cqc_api.py
@@ -14,7 +14,7 @@ DEFAULT_PAGE_SIZE = 500
 CQC_API_BASE_URL = "https://api.service.cqc.org.uk"
 USER_AGENT = "SkillsForCare"
 
-days_to_rollback_start_timestamp = 15
+days_to_rollback_start_timestamp = 30
 
 
 class NoProviderOrLocationException(Exception):

--- a/terraform/pipeline/step-functions/dynamic/Ingest-CQC-API-Delta.json
+++ b/terraform/pipeline/step-functions/dynamic/Ingest-CQC-API-Delta.json
@@ -21,8 +21,6 @@
                 "script": "cqc_providers_1_delta_api_download.py",
                 "dest_arg": "--destination_prefix",
                 "dest_value": "${dataset_bucket_uri}",
-                "start_arg": "--start_timestamp",
-                "start_value.$": "$.Parameter.Value",
                 "end_arg": "--end_timestamp",
                 "end_value.$": "$$.State.EnteredTime"
               },
@@ -49,7 +47,7 @@
                   "ContainerOverrides": [
                     {
                       "Name": "cqc-api-container",
-                      "Command.$": "States.Array($.script, $.dest_arg, $.dest_value, $.start_arg, $.start_value, $.end_arg, $.end_value)"
+                      "Command.$": "States.Array($.script, $.dest_arg, $.dest_value, $.end_arg, $.end_value)"
                     }
                   ]
                 }
@@ -118,8 +116,6 @@
                 "script": "cqc_locations_1_delta_api_download.py",
                 "dest_arg": "--destination_prefix",
                 "dest_value": "${dataset_bucket_uri}",
-                "start_arg": "--start_timestamp",
-                "start_value.$": "$.Parameter.Value",
                 "end_arg": "--end_timestamp",
                 "end_value.$": "$$.State.EnteredTime"
               },
@@ -146,7 +142,7 @@
                   "ContainerOverrides": [
                     {
                       "Name": "cqc-api-container",
-                      "Command.$": "States.Array($.script, $.dest_arg, $.dest_value, $.start_arg, $.start_value, $.end_arg, $.end_value)"
+                      "Command.$": "States.Array($.script, $.dest_arg, $.dest_value, $.end_arg, $.end_value)"
                     }
                   ]
                 }

--- a/terraform/pipeline/step-functions/dynamic/Ingest-CQC-API-Delta.json
+++ b/terraform/pipeline/step-functions/dynamic/Ingest-CQC-API-Delta.json
@@ -1,6 +1,6 @@
 {
   "Comment": "State machine for CQC API ingestion data pipeline",
-  "StartAt": "CQC API Ingestion",
+  "StartAt": "Set number of days to capture",
   "States": {
     "Set number of days to capture": {
       "Type": "Pass",

--- a/terraform/pipeline/step-functions/dynamic/Ingest-CQC-API-Delta.json
+++ b/terraform/pipeline/step-functions/dynamic/Ingest-CQC-API-Delta.json
@@ -2,6 +2,13 @@
   "Comment": "State machine for CQC API ingestion data pipeline",
   "StartAt": "CQC API Ingestion",
   "States": {
+    "Set number of days to capture": {
+      "Type": "Pass",
+      "Next": "CQC API Ingestion",
+      "Assign": {
+        "days_value": "15"
+      }
+    },
     "CQC API Ingestion": {
       "Type": "Parallel",
       "Branches": [
@@ -22,7 +29,9 @@
                 "dest_arg": "--destination_prefix",
                 "dest_value": "${dataset_bucket_uri}",
                 "end_arg": "--end_timestamp",
-                "end_value.$": "$$.State.EnteredTime"
+                "end_value.$": "$$.State.EnteredTime",
+                "days_arg": "--previous_days_to_capture",
+                "days_value.$": "$days_value"
               },
               "Next": "Run Delta CQC Providers Download"
             },
@@ -47,7 +56,7 @@
                   "ContainerOverrides": [
                     {
                       "Name": "cqc-api-container",
-                      "Command.$": "States.Array($.script, $.dest_arg, $.dest_value, $.end_arg, $.end_value)"
+                      "Command.$": "States.Array($.script, $.dest_arg, $.dest_value, $.end_arg, $.end_value, $.days_arg, $.days_value)"
                     }
                   ]
                 }
@@ -117,7 +126,9 @@
                 "dest_arg": "--destination_prefix",
                 "dest_value": "${dataset_bucket_uri}",
                 "end_arg": "--end_timestamp",
-                "end_value.$": "$$.State.EnteredTime"
+                "end_value.$": "$$.State.EnteredTime",
+                "days_arg": "--previous_days_to_capture",
+                "days_value.$": "$days_value"
               },
               "Next": "Run Delta CQC Locations Download"
             },
@@ -142,7 +153,7 @@
                   "ContainerOverrides": [
                     {
                       "Name": "cqc-api-container",
-                      "Command.$": "States.Array($.script, $.dest_arg, $.dest_value, $.end_arg, $.end_value)"
+                      "Command.$": "States.Array($.script, $.dest_arg, $.dest_value, $.end_arg, $.end_value, $.days_arg, $.days_value)"
                     }
                   ]
                 }

--- a/terraform/pipeline/step-functions/dynamic/Ingest-CQC-API-Delta.json
+++ b/terraform/pipeline/step-functions/dynamic/Ingest-CQC-API-Delta.json
@@ -29,7 +29,7 @@
                   "ContainerOverrides": [
                     {
                       "Name": "cqc-api-container",
-                      "Command.$": "States.Array('cqc_providers_1_delta_api_download.py', '--destination_prefix', '${dataset_bucket_uri}', '--end_timestamp', $$.State.EnteredTime, '--previous_days_to_capture', '15)"
+                      "Command.$": "States.Array('cqc_providers_1_delta_api_download.py', '--destination_prefix', '${dataset_bucket_uri}', '--end_timestamp', $$.State.EnteredTime, '--previous_days_to_capture', '15')"
                     }
                   ]
                 }

--- a/terraform/pipeline/step-functions/dynamic/Ingest-CQC-API-Delta.json
+++ b/terraform/pipeline/step-functions/dynamic/Ingest-CQC-API-Delta.json
@@ -13,28 +13,8 @@
       "Type": "Parallel",
       "Branches": [
         {
-          "StartAt": "Read Last Providers Run",
+          "StartAt": "Run Delta CQC Providers Download",
           "States": {
-            "Read Last Providers Run": {
-              "Type": "Task",
-              "Resource": "arn:aws:states:::aws-sdk:ssm:getParameter",
-              "Parameters": {
-                "Name": "${last_providers_run_param_name}"
-              },
-              "Assign": {
-                "endDate.$": "$$.State.EnteredTime"
-              },
-              "ResultSelector": {
-                "script": "cqc_providers_1_delta_api_download.py",
-                "dest_arg": "--destination_prefix",
-                "dest_value": "${dataset_bucket_uri}",
-                "end_arg": "--end_timestamp",
-                "end_value.$": "$$.State.EnteredTime",
-                "days_arg": "--previous_days_to_capture",
-                "days_value.$": "$days_value"
-              },
-              "Next": "Run Delta CQC Providers Download"
-            },
             "Run Delta CQC Providers Download": {
               "Type": "Task",
               "Resource": "arn:aws:states:::ecs:runTask.sync",
@@ -56,23 +36,12 @@
                   "ContainerOverrides": [
                     {
                       "Name": "cqc-api-container",
-                      "Command.$": "States.Array($.script, $.dest_arg, $.dest_value, $.end_arg, $.end_value, $.days_arg, $.days_value)"
+                      "Command.$": "States.Array('cqc_providers_1_delta_api_download.py', '--destination_prefix', '${dataset_bucket_uri}', '--end_timestamp', $$.State.EnteredTime, '--previous_days_to_capture', $.days_value)"
                     }
                   ]
                 }
               },
               "ResultPath": "$.providerResult",
-              "Next": "Write Last Providers Run"
-            },
-            "Write Last Providers Run": {
-              "Type": "Task",
-              "Resource": "arn:aws:states:::aws-sdk:ssm:putParameter",
-              "Parameters": {
-                "Name": "${last_providers_run_param_name}",
-                "Value.$": "$endDate",
-                "Overwrite": true,
-                "Type": "String"
-              },
               "Next": "Validate Providers API Raw"
             },
             "Validate Providers API Raw": {
@@ -110,28 +79,8 @@
           }
         },
         {
-          "StartAt": "Read Last Locations Run",
+          "StartAt": "Run Delta CQC Locations Download",
           "States": {
-            "Read Last Locations Run": {
-              "Type": "Task",
-              "Resource": "arn:aws:states:::aws-sdk:ssm:getParameter",
-              "Parameters": {
-                "Name": "${last_locations_run_param_name}"
-              },
-              "Assign": {
-                "endDate.$": "$$.State.EnteredTime"
-              },
-              "ResultSelector": {
-                "script": "cqc_locations_1_delta_api_download.py",
-                "dest_arg": "--destination_prefix",
-                "dest_value": "${dataset_bucket_uri}",
-                "end_arg": "--end_timestamp",
-                "end_value.$": "$$.State.EnteredTime",
-                "days_arg": "--previous_days_to_capture",
-                "days_value.$": "$days_value"
-              },
-              "Next": "Run Delta CQC Locations Download"
-            },
             "Run Delta CQC Locations Download": {
               "Type": "Task",
               "Resource": "arn:aws:states:::ecs:runTask.sync",
@@ -153,32 +102,12 @@
                   "ContainerOverrides": [
                     {
                       "Name": "cqc-api-container",
-                      "Command.$": "States.Array($.script, $.dest_arg, $.dest_value, $.end_arg, $.end_value, $.days_arg, $.days_value)"
+                      "Command.$": "States.Array('cqc_locations_1_delta_api_download.py', '--destination_prefix', '${dataset_bucket_uri}', '--end_timestamp', $$.State.EnteredTime, '--previous_days_to_capture', $days_value)"
                     }
                   ]
                 }
               },
               "ResultPath": "$.locationResult",
-              "Next": "Write Last Locations Run"
-            },
-            "Write Last Locations Run": {
-              "Type": "Task",
-              "Resource": "arn:aws:states:::aws-sdk:ssm:putParameter",
-              "Parameters": {
-                "Name": "${last_locations_run_param_name}",
-                "Value.$": "$endDate",
-                "Overwrite": true,
-                "Type": "String"
-              },
-              "ResultSelector": {
-                "script": "validate_cqc_locations_1_delta_api_download.py",
-                "bucket_name_arg": "--bucket_name",
-                "bucket_name": "${dataset_bucket_name}",
-                "source_path_arg": "--source_path",
-                "source_path": "domain=CQC/dataset=cqc_locations_01_delta_api/version=3.1.0/",
-                "reports_path_arg": "--reports_path",
-                "reports_path": "domain=data_validation_reports/dataset=validation_cqc_locations_01_delta_api/"
-              },
               "Next": "Validate Locations Api Raw"
             },
             "Validate Locations Api Raw": {
@@ -202,7 +131,12 @@
                   "ContainerOverrides": [
                     {
                       "Name": "cqc-api-container",
-                      "Command.$": "States.Array($.script, $.bucket_name_arg, $.bucket_name, $.source_path_arg, $.source_path, $.reports_path_arg, $.reports_path)"
+                      "Command": [
+                        "validate_cqc_locations_1_delta_api_download.py",
+                        "--bucket_name", "${dataset_bucket_name}",
+                        "--source_path", "domain=CQC/dataset=cqc_locations_01_delta_api/version=3.1.0/",
+                        "--reports_path", "domain=data_validation_reports/dataset=validation_cqc_locations_01_delta_api/"
+                      ]
                     }
                   ]
                 }

--- a/terraform/pipeline/step-functions/dynamic/Ingest-CQC-API-Delta.json
+++ b/terraform/pipeline/step-functions/dynamic/Ingest-CQC-API-Delta.json
@@ -29,7 +29,7 @@
                   "ContainerOverrides": [
                     {
                       "Name": "cqc-api-container",
-                      "Command.$": "States.Array('cqc_providers_1_delta_api_download.py', '--destination_prefix', '${dataset_bucket_uri}', '--end_timestamp', $$.State.EnteredTime, '--previous_days_to_capture', '15')"
+                      "Command.$": "States.Array('cqc_providers_1_delta_api_download.py', '--destination_prefix', '${dataset_bucket_uri}', '--end_timestamp', $$.State.EnteredTime, '--previous_days_to_capture', '30')"
                     }
                   ]
                 }
@@ -95,7 +95,7 @@
                   "ContainerOverrides": [
                     {
                       "Name": "cqc-api-container",
-                      "Command.$": "States.Array('cqc_locations_1_delta_api_download.py', '--destination_prefix', '${dataset_bucket_uri}', '--end_timestamp', $$.State.EnteredTime, '--previous_days_to_capture', '15')"
+                      "Command.$": "States.Array('cqc_locations_1_delta_api_download.py', '--destination_prefix', '${dataset_bucket_uri}', '--end_timestamp', $$.State.EnteredTime, '--previous_days_to_capture', '30')"
                     }
                   ]
                 }

--- a/terraform/pipeline/step-functions/dynamic/Ingest-CQC-API-Delta.json
+++ b/terraform/pipeline/step-functions/dynamic/Ingest-CQC-API-Delta.json
@@ -2,13 +2,6 @@
   "Comment": "State machine for CQC API ingestion data pipeline",
   "StartAt": "Set number of days to capture",
   "States": {
-    "Set number of days to capture": {
-      "Type": "Pass",
-      "Next": "CQC API Ingestion",
-      "Assign": {
-        "days_value": "15"
-      }
-    },
     "CQC API Ingestion": {
       "Type": "Parallel",
       "Branches": [
@@ -36,7 +29,7 @@
                   "ContainerOverrides": [
                     {
                       "Name": "cqc-api-container",
-                      "Command.$": "States.Array('cqc_providers_1_delta_api_download.py', '--destination_prefix', '${dataset_bucket_uri}', '--end_timestamp', $$.State.EnteredTime, '--previous_days_to_capture', $.days_value)"
+                      "Command.$": "States.Array('cqc_providers_1_delta_api_download.py', '--destination_prefix', '${dataset_bucket_uri}', '--end_timestamp', $$.State.EnteredTime, '--previous_days_to_capture', '15)"
                     }
                   ]
                 }
@@ -102,7 +95,7 @@
                   "ContainerOverrides": [
                     {
                       "Name": "cqc-api-container",
-                      "Command.$": "States.Array('cqc_locations_1_delta_api_download.py', '--destination_prefix', '${dataset_bucket_uri}', '--end_timestamp', $$.State.EnteredTime, '--previous_days_to_capture', $days_value)"
+                      "Command.$": "States.Array('cqc_locations_1_delta_api_download.py', '--destination_prefix', '${dataset_bucket_uri}', '--end_timestamp', $$.State.EnteredTime, '--previous_days_to_capture', '15')"
                     }
                   ]
                 }

--- a/terraform/pipeline/step-functions/dynamic/Ingest-CQC-API-Delta.json
+++ b/terraform/pipeline/step-functions/dynamic/Ingest-CQC-API-Delta.json
@@ -1,6 +1,6 @@
 {
   "Comment": "State machine for CQC API ingestion data pipeline",
-  "StartAt": "Set number of days to capture",
+  "StartAt": "CQC API Ingestion",
   "States": {
     "CQC API Ingestion": {
       "Type": "Parallel",

--- a/terraform/pipeline/step-functions/dynamic/Ingest-CQC-API-Delta.json
+++ b/terraform/pipeline/step-functions/dynamic/Ingest-CQC-API-Delta.json
@@ -127,7 +127,7 @@
                       "Command": [
                         "validate_cqc_locations_1_delta_api_download.py",
                         "--bucket_name", "${dataset_bucket_name}",
-                        "--source_path", "domain=CQC/dataset=cqc_locations_01_delta_api/version=3.1.0/",
+                        "--source_path", "domain=CQC/dataset=cqc_locations_01_delta_api/version=3.1.1/",
                         "--reports_path", "domain=data_validation_reports/dataset=validation_cqc_locations_01_delta_api/"
                       ]
                     }


### PR DESCRIPTION
## Description
Trello ticket [1560](https://trello.com/c/AfsrnIJN)

Changed the CQC locations and providers delta download jobs like this:
- Replaced main argument start_timestamp with previous_days_to_capture, default to 30 days
- Changed the order of main arguments
- Both functions now get data from cqc changes api over the 30 days prior to end_timestamp
- Even though the functions default to 30 days, the number of days is actually passed in as a magic number in the step function at the container overrides.

Ran the step function passing in the end_timestamp as "2026-04-15T02:00:00.00Z" and number of captures days as 15.

## Testing
- [x] Unit tests passing
- [x] Successful [Step Function run](https://eu-west-2.console.aws.amazon.com/states/home?region=eu-west-2#/statemachines/view/arn:aws:states:eu-west-2:856699698263:stateMachine:1560-api-strt-lag-Ingest-CQC-API-Delta)
- [x] Outputs checked in Athena

I got 1,768 unique locationid's in my branch run and same number in main delta dataset imports 08/04/2026 and 15/04/2026

There's no unit test to check the capture period, since it's not returned or a column in the delta dataframe, but you can see it in the [logs](https://eu-west-2.console.aws.amazon.com/cloudwatch/home?region=eu-west-2#logsV2:log-groups/log-group/%2Fecs%2F1560-api-strt-lag-cqc-api-task-logs/log-events/ecs%2Fcqc-api-container%2F4973b7306361460b96bb99435b7f335a) (4th line down)

## Checklist (delete if not relevant)
- [x] Unit tests added/amended
- [x] Docstrings added/updated
- [x] Updated CHANGELOG
- [x] Moved Trello ticket to PR column
