### PR TITLE
1551 dpr la names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ All notable changes to this project will be documented in this file.
 
 - Converted DPR estimates util function model_using_mean from pyspark to polars.
 
+- Converted DPR local authority name fix util to polars.
+
 ### Changed
 - Removed the PySpark version of IND CQC Clean and Validation jobs.
 

--- a/projects/_04_direct_payment_recipients/Dockerfile_and_requirements/Dockerfile
+++ b/projects/_04_direct_payment_recipients/Dockerfile_and_requirements/Dockerfile
@@ -9,6 +9,7 @@ ENV PYTHONPATH=/app
 # Dependencies
 COPY projects/_04_direct_payment_recipients/fargate/utils /app/projects/_04_direct_payment_recipients/fargate/utils
 COPY projects/_04_direct_payment_recipients/direct_payments_column_names.py /app/projects/_04_direct_payment_recipients/direct_payments_column_names.py
+COPY projects/_04_direct_payment_recipients/direct_payments_configuration.py /app/projects/_04_direct_payment_recipients/direct_payments_configuration.py
 COPY polars_utils /app/polars_utils
 COPY utils/column_names /app/utils/column_names/
 COPY utils/column_values /app/utils/column_values/

--- a/projects/_04_direct_payment_recipients/Dockerfile_and_requirements/Dockerfile
+++ b/projects/_04_direct_payment_recipients/Dockerfile_and_requirements/Dockerfile
@@ -9,7 +9,6 @@ ENV PYTHONPATH=/app
 # Dependencies
 COPY projects/_04_direct_payment_recipients/fargate/utils /app/projects/_04_direct_payment_recipients/fargate/utils
 COPY projects/_04_direct_payment_recipients/direct_payments_column_names.py /app/projects/_04_direct_payment_recipients/direct_payments_column_names.py
-COPY projects/_04_direct_payment_recipients/direct_payments_configuration.py /app/projects/_04_direct_payment_recipients/direct_payments_configuration.py
 COPY polars_utils /app/polars_utils
 COPY utils/column_names /app/utils/column_names/
 COPY utils/column_values /app/utils/column_values/

--- a/projects/_04_direct_payment_recipients/Dockerfile_and_requirements/Dockerfile
+++ b/projects/_04_direct_payment_recipients/Dockerfile_and_requirements/Dockerfile
@@ -16,6 +16,7 @@ COPY utils/value_labels /app/utils/value_labels
 
 # Copy python jobs to WORKDIR
 COPY projects/_04_direct_payment_recipients/fargate/estimate_direct_payments.py /app/estimate_direct_payments.py
+COPY projects/_04_direct_payment_recipients/fargate/validate_estimate_direct_payments.py /app/validate_estimate_direct_payments.py
 
 COPY projects/_04_direct_payment_recipients/Dockerfile_and_requirements/requirements.txt /app/requirements.txt
 RUN pip install --no-cache-dir -r requirements.txt

--- a/projects/_04_direct_payment_recipients/direct_payments_configuration.py
+++ b/projects/_04_direct_payment_recipients/direct_payments_configuration.py
@@ -59,6 +59,7 @@ class EstimatePeriodAsDate:
     DAY: str = "31"
 
 
+# TODO: Remove this dict after signing off DPR estimates in polars.
 @dataclass
 class DirectPaymentsMisspelledLaNames:
     DICT_TO_CORRECT_LA_NAMES = {

--- a/projects/_04_direct_payment_recipients/fargate/estimate_direct_payments.py
+++ b/projects/_04_direct_payment_recipients/fargate/estimate_direct_payments.py
@@ -1,6 +1,11 @@
+import polars as pl
+
 from polars_utils import utils
 from projects._04_direct_payment_recipients.direct_payments_column_names import (
     DirectPaymentColumnNames as DP,
+)
+from projects._04_direct_payment_recipients.direct_payments_configuration import (
+    DirectPaymentsMisspelledLaNames,
 )
 
 direct_payments_columns = [
@@ -24,6 +29,12 @@ def main(
     lf = utils.scan_parquet(
         source=direct_payments_merged_source,
         selected_columns=direct_payments_columns,
+    )
+
+    lf.with_columns(
+        pl.col(DP.LA_AREA).replace(
+            DirectPaymentsMisspelledLaNames.DICT_TO_CORRECT_LA_NAMES
+        )
     )
 
     utils.sink_to_parquet(

--- a/projects/_04_direct_payment_recipients/fargate/estimate_direct_payments.py
+++ b/projects/_04_direct_payment_recipients/fargate/estimate_direct_payments.py
@@ -4,9 +4,7 @@ from polars_utils import utils
 from projects._04_direct_payment_recipients.direct_payments_column_names import (
     DirectPaymentColumnNames as DP,
 )
-from projects._04_direct_payment_recipients.direct_payments_configuration import (
-    DirectPaymentsMisspelledLaNames,
-)
+from utils.column_values.categorical_column_values import ContemporaryCSSR
 
 direct_payments_columns = [
     DP.LA_AREA,
@@ -20,6 +18,17 @@ direct_payments_columns = [
     DP.FILLED_POSTS_PER_EMPLOYER,
 ]
 
+la_name_replacements = {
+    "Bath & N E Somerset": ContemporaryCSSR.bath_and_north_east_somerset,
+    "Blackburn": ContemporaryCSSR.blackburn_with_darwen,
+    "Bournemouth, Christchurch and Poole": ContemporaryCSSR.bournemouth_christchurch_and_poole,
+    "Cornwall": ContemporaryCSSR.cornwall_and_isles_of_scilly,
+    "East Riding": ContemporaryCSSR.east_riding_of_yorkshire,
+    "Isles of Scilly": ContemporaryCSSR.cornwall_and_isles_of_scilly,
+    "Medway Towns": ContemporaryCSSR.medway,
+    "Southend": ContemporaryCSSR.southend_on_sea,
+}
+
 
 def main(
     direct_payments_merged_source: str,
@@ -31,11 +40,7 @@ def main(
         selected_columns=direct_payments_columns,
     )
 
-    lf.with_columns(
-        pl.col(DP.LA_AREA).replace(
-            DirectPaymentsMisspelledLaNames.DICT_TO_CORRECT_LA_NAMES
-        )
-    )
+    lf.with_columns(pl.col(DP.LA_AREA).replace(la_name_replacements))
 
     utils.sink_to_parquet(
         lf,

--- a/projects/_04_direct_payment_recipients/fargate/estimate_direct_payments.py
+++ b/projects/_04_direct_payment_recipients/fargate/estimate_direct_payments.py
@@ -40,7 +40,7 @@ def main(
         selected_columns=direct_payments_columns,
     )
 
-    lf.with_columns(pl.col(DP.LA_AREA).replace(la_name_replacements))
+    lf = lf.with_columns(pl.col(DP.LA_AREA).replace(la_name_replacements))
 
     utils.sink_to_parquet(
         lf,

--- a/projects/_04_direct_payment_recipients/fargate/validate_estimate_direct_payments.py
+++ b/projects/_04_direct_payment_recipients/fargate/validate_estimate_direct_payments.py
@@ -55,19 +55,13 @@ def main(
         # categorical
         .col_vals_in_set(
             DP.LA_AREA,
-            [
-                *CatValues.contemporary_cssr_column_values.categorical_values,
-                *CatValues.current_cssr_column_values.categorical_values,
-            ],
+            [CatValues.contemporary_cssr_column_values.categorical_values],
         )
         # distinct values
         .specially(
             vl.is_unique_count_equal(
                 DP.LA_AREA,
-                (
-                    CatValues.contemporary_cssr_column_values.count_of_categorical_values
-                    + CatValues.current_cssr_column_values.count_of_categorical_values
-                ),
+                CatValues.contemporary_cssr_column_values.count_of_categorical_values,
             ),
             brief=f"{DP.LA_AREA} needs to be one of {CatValues.contemporary_cssr_column_values.categorical_values} or {CatValues.current_cssr_column_values.categorical_values}",
         ).interrogate()

--- a/projects/_04_direct_payment_recipients/fargate/validate_estimate_direct_payments.py
+++ b/projects/_04_direct_payment_recipients/fargate/validate_estimate_direct_payments.py
@@ -57,7 +57,7 @@ def main(
             DP.LA_AREA,
             [
                 *CatValues.contemporary_cssr_column_values.categorical_values,
-                *CatValues.current_cssr_column_values,
+                *CatValues.current_cssr_column_values.categorical_values,
             ],
         )
         # distinct values

--- a/projects/_04_direct_payment_recipients/fargate/validate_estimate_direct_payments.py
+++ b/projects/_04_direct_payment_recipients/fargate/validate_estimate_direct_payments.py
@@ -55,7 +55,7 @@ def main(
         # categorical
         .col_vals_in_set(
             DP.LA_AREA,
-            [CatValues.contemporary_cssr_column_values.categorical_values],
+            CatValues.contemporary_cssr_column_values.categorical_values,
         )
         # distinct values
         .specially(

--- a/projects/_04_direct_payment_recipients/fargate/validate_estimate_direct_payments.py
+++ b/projects/_04_direct_payment_recipients/fargate/validate_estimate_direct_payments.py
@@ -1,0 +1,87 @@
+import sys
+
+import pointblank as pb
+
+from polars_utils import utils
+from polars_utils.validation import actions as vl
+from polars_utils.validation.constants import GLOBAL_ACTIONS, GLOBAL_THRESHOLDS
+from projects._04_direct_payment_recipients.direct_payments_column_names import (
+    DirectPaymentColumnNames as DP,
+)
+from utils.column_values.categorical_columns_by_dataset import (
+    PostcodeDirectoryCleanedCategoricalValues as CatValues,
+)
+
+
+def main(
+    bucket_name: str, source_path: str, reports_path: str, compare_path: str
+) -> None:
+    """Validates a dataset according to a set of provided rules and produces a summary report as well as failure outputs.
+
+    Args:
+        bucket_name (str): the bucket (name only) in which to source the dataset and output the report to
+            - shoud correspond to workspace / feature branch name
+        source_path (str): the source dataset path to be validated
+        reports_path (str): the output path to write reports to
+        compare_path (str): path to a dataset to compare against for expected size
+    """
+
+    source_df = utils.read_parquet(
+        f"s3://{bucket_name}/{source_path}", exclude_complex_types=True
+    )
+    compare_df = utils.read_parquet(f"s3://{bucket_name}/{compare_path}")
+    expected_row_count = compare_df.height
+
+    validation = (
+        pb.Validate(
+            data=source_df,
+            label=f"Validation of {source_path}",
+            thresholds=GLOBAL_THRESHOLDS,
+            brief=True,
+            actions=GLOBAL_ACTIONS,
+        )
+        # dataset size
+        .row_count_match(
+            expected_row_count,
+            brief=f"Merged DPR data file has {source_df.height} rows but expecting {expected_row_count} rows",
+        )
+        # complete columns
+        .col_vals_not_null(
+            [
+                DP.YEAR_AS_INTEGER,
+                DP.LA_AREA,
+            ]
+        )
+        # categorical
+        .col_vals_in_set(
+            DP.LA_AREA,
+            CatValues.contemporary_cssr_column_values.categorical_values,
+        )
+        # distinct values
+        .specially(
+            vl.is_unique_count_equal(
+                DP.LA_AREA,
+                CatValues.contemporary_cssr_column_values.count_of_categorical_values,
+            ),
+            brief=f"{DP.LA_AREA} needs to be one of {CatValues.contemporary_cssr_column_values.categorical_values}",
+        ).interrogate()
+    )
+    vl.write_reports(validation, bucket_name, reports_path)
+
+
+if __name__ == "__main__":
+    print(f"Validation script called with parameters: {sys.argv}")
+
+    args = utils.get_args(
+        ("--bucket_name", "S3 bucket for source dataset and validation report"),
+        ("--source_path", "The filepath of the dataset to validate"),
+        ("--reports_path", "The filepath to output reports"),
+        (
+            "--compare_path",
+            "The filepath to a dataset to compare against for expected size",
+        ),
+    )
+    print(f"Starting validation for {args.source_path}")
+
+    main(args.bucket_name, args.source_path, args.reports_path, args.compare_path)
+    print(f"Validation of {args.source_path} complete")

--- a/projects/_04_direct_payment_recipients/fargate/validate_estimate_direct_payments.py
+++ b/projects/_04_direct_payment_recipients/fargate/validate_estimate_direct_payments.py
@@ -55,15 +55,21 @@ def main(
         # categorical
         .col_vals_in_set(
             DP.LA_AREA,
-            CatValues.contemporary_cssr_column_values.categorical_values,
+            [
+                *CatValues.contemporary_cssr_column_values.categorical_values,
+                *CatValues.current_cssr_column_values,
+            ],
         )
         # distinct values
         .specially(
             vl.is_unique_count_equal(
                 DP.LA_AREA,
-                CatValues.contemporary_cssr_column_values.count_of_categorical_values,
+                (
+                    CatValues.contemporary_cssr_column_values.count_of_categorical_values
+                    + CatValues.current_cssr_column_values.count_of_categorical_values
+                ),
             ),
-            brief=f"{DP.LA_AREA} needs to be one of {CatValues.contemporary_cssr_column_values.categorical_values}",
+            brief=f"{DP.LA_AREA} needs to be one of {CatValues.contemporary_cssr_column_values.categorical_values} or {CatValues.current_cssr_column_values.categorical_values}",
         ).interrogate()
     )
     vl.write_reports(validation, bucket_name, reports_path)

--- a/projects/_04_direct_payment_recipients/tests/fargate/test_estimate_direct_payments.py
+++ b/projects/_04_direct_payment_recipients/tests/fargate/test_estimate_direct_payments.py
@@ -39,6 +39,3 @@ class EstimateDirectPaymentsTests(unittest.TestCase):
             self.SOME_DESTINATION,
             append=False,
         )
-
-    def test_main_returns_expected_values(self):
-        """"""

--- a/projects/_04_direct_payment_recipients/tests/fargate/test_estimate_direct_payments.py
+++ b/projects/_04_direct_payment_recipients/tests/fargate/test_estimate_direct_payments.py
@@ -1,0 +1,44 @@
+import unittest
+from unittest.mock import ANY, Mock, patch
+
+import polars as pl
+import polars.testing as pl_testing
+
+import projects._04_direct_payment_recipients.fargate.estimate_direct_payments as job
+
+PATCH_PATH: str = (
+    "projects._04_direct_payment_recipients.fargate.estimate_direct_payments"
+)
+
+
+class EstimateDirectPaymentsTests(unittest.TestCase):
+    SOME_SOURCE = "some/source"
+    SOME_DESTINATION = "some/destination"
+    SOME_OTHER_DESTINATION = "some/other/destination"
+
+    @patch(f"{PATCH_PATH}.utils.sink_to_parquet")
+    @patch(f"{PATCH_PATH}.utils.scan_parquet")
+    def test_main_succeeds(
+        self,
+        scan_parquet_mock: Mock,
+        sink_to_parquet_mock: Mock,
+    ):
+        job.main(
+            self.SOME_SOURCE,
+            self.SOME_DESTINATION,
+            self.SOME_OTHER_DESTINATION,
+        )
+
+        scan_parquet_mock.assert_called_once_with(
+            source=self.SOME_SOURCE,
+            selected_columns=job.direct_payments_columns,
+        )
+
+        sink_to_parquet_mock.assert_called_once_with(
+            ANY,
+            self.SOME_DESTINATION,
+            append=False,
+        )
+
+    def test_main_returns_expected_values(self):
+        """"""

--- a/projects/_04_direct_payment_recipients/tests/fargate/test_validate_estimate_direct_payments.py
+++ b/projects/_04_direct_payment_recipients/tests/fargate/test_validate_estimate_direct_payments.py
@@ -1,0 +1,102 @@
+import json
+import unittest
+from dataclasses import dataclass
+from unittest.mock import Mock, call, patch
+
+import polars as pl
+
+import projects._04_direct_payment_recipients.fargate.validate_estimate_direct_payments as job
+from projects._04_direct_payment_recipients.direct_payments_column_names import (
+    DirectPaymentColumnNames as DP,
+)
+
+PATCH_PATH = (
+    "projects._04_direct_payment_recipients.fargate.validate_estimate_direct_payments"
+)
+
+
+@dataclass
+class Schemas:
+    merged_schema = pl.Schema(
+        [
+            (DP.LA_AREA, pl.String),
+            (DP.YEAR, pl.String),
+            (DP.YEAR_AS_INTEGER, pl.Int64),
+            (DP.SERVICE_USER_DPRS_DURING_YEAR, pl.Float32),
+            (DP.CARER_DPRS_DURING_YEAR, pl.Float32),
+            (DP.PROPORTION_OF_SERVICE_USERS_EMPLOYING_STAFF, pl.Float32),
+            (DP.HISTORIC_SERVICE_USERS_EMPLOYING_STAFF_ESTIMATE, pl.Float32),
+            (DP.TOTAL_DPRS_DURING_YEAR, pl.Float32),
+            (DP.FILLED_POSTS_PER_EMPLOYER, pl.Float32),
+        ]
+    )
+    estimates_schema = merged_schema
+
+
+@dataclass
+class Data:
+    merged_rows = [("area", "2020", 2020, 10.0, 10.0, 0.5, 0.5, 20.0, 1.9)]
+    estimates_rows = merged_rows
+
+
+class ValidateEstimateDirectPaymentsTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.source_df = pl.DataFrame(
+            data=Data.estimates_rows,
+            schema=Schemas.estimates_schema,
+            orient="row",
+        )
+        self.compare_df = pl.DataFrame(
+            data=Data.merged_rows,
+            schema=Schemas.merged_schema,
+            orient="row",
+        )
+
+    @patch(f"{PATCH_PATH}.vl.write_reports")
+    @patch(f"{PATCH_PATH}.utils.read_parquet")
+    def test_validation_runs(
+        self,
+        mock_read_parquet: Mock,
+        mock_write_reports: Mock,
+    ):
+        mock_read_parquet.side_effect = [self.source_df, self.compare_df]
+        job.main("bucket", "my/dataset/", "my/reports/", "other/dataset/")
+
+        mock_read_parquet.assert_has_calls(
+            [
+                call("s3://bucket/my/dataset/", exclude_complex_types=True),
+                call("s3://bucket/other/dataset/"),
+            ]
+        )
+        mock_write_reports.assert_called_once()
+
+    @patch(f"{PATCH_PATH}.vl.write_reports")
+    @patch(f"{PATCH_PATH}.utils.read_parquet")
+    def test_validation_report_includes_expected_validations(
+        self,
+        mock_read_parquet: Mock,
+        mock_write_reports: Mock,
+    ):
+        mock_read_parquet.side_effect = [self.source_df, self.compare_df]
+        job.main("bucket", "my/dataset/", "my/reports/", "other/dataset/")
+
+        validation_arg = mock_write_reports.call_args[0][0]
+        report_json = json.loads(validation_arg.get_json_report())
+
+        # Extract all assertion types present in the report
+        assertion_types_present = {item["assertion_type"] for item in report_json}
+
+        # Check that key validations were run
+        expected_assertions = {
+            "row_count_match",
+            "col_vals_not_null",
+            "col_vals_in_set",
+            "specially",
+        }
+
+        for assertion in expected_assertions:
+            self.assertIn(
+                assertion,
+                assertion_types_present,
+                f"{assertion} not found in validation report",
+            )

--- a/projects/_04_direct_payment_recipients/utils/_03_estimate_direct_payment_utils/fix_la_names.py
+++ b/projects/_04_direct_payment_recipients/utils/_03_estimate_direct_payment_utils/fix_la_names.py
@@ -8,6 +8,7 @@ from projects._04_direct_payment_recipients.direct_payments_configuration import
 )
 
 
+# converted to polars -> projects\_04_direct_payment_recipients\fargate\estimate_direct_payments.py
 def change_la_names_to_match_ons_cleaned(
     direct_payments_df: DataFrame,
 ) -> DataFrame:

--- a/terraform/pipeline/step-functions/dynamic/Direct-Payment-Recipients.json
+++ b/terraform/pipeline/step-functions/dynamic/Direct-Payment-Recipients.json
@@ -83,19 +83,6 @@
           ]
         }
       },
-      "Next": "Split pa estimates into hybrid areas"
-    },
-    "Split pa estimates into hybrid areas": {
-      "Type": "Task",
-      "Resource": "arn:aws:states:::glue:startJobRun.sync",
-      "Parameters": {
-        "JobName": "${split_pa_filled_posts_into_icb_areas_job_name}",
-        "Arguments":{
-          "--postcode_directory_source": "${dataset_bucket_uri}/domain=ONS/dataset=postcode_directory_cleaned/",
-          "--pa_filled_posts_souce": "${dataset_bucket_uri}/domain=DPR/dataset=direct_payments_estimates/version=2026.01/",
-          "--destination": "${dataset_bucket_uri}/domain=DPR/dataset=direct_payments_estimates_by_icb/version=2026.01/"
-        }
-      },
       "Next": "Validate estimate direct payments polars"
     },
     "Validate estimate direct payments polars": {
@@ -125,6 +112,19 @@
               ]
             }
           ]
+        }
+      },
+      "Next": "Split pa estimates into hybrid areas"
+    },
+    "Split pa estimates into hybrid areas": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::glue:startJobRun.sync",
+      "Parameters": {
+        "JobName": "${split_pa_filled_posts_into_icb_areas_job_name}",
+        "Arguments":{
+          "--postcode_directory_source": "${dataset_bucket_uri}/domain=ONS/dataset=postcode_directory_cleaned/",
+          "--pa_filled_posts_souce": "${dataset_bucket_uri}/domain=DPR/dataset=direct_payments_estimates/version=2026.01/",
+          "--destination": "${dataset_bucket_uri}/domain=DPR/dataset=direct_payments_estimates_by_icb/version=2026.01/"
         }
       },
       "Next": "Run DPR crawler"

--- a/terraform/pipeline/step-functions/dynamic/Direct-Payment-Recipients.json
+++ b/terraform/pipeline/step-functions/dynamic/Direct-Payment-Recipients.json
@@ -96,6 +96,37 @@
           "--destination": "${dataset_bucket_uri}/domain=DPR/dataset=direct_payments_estimates_by_icb/version=2026.01/"
         }
       },
+      "Next": "Validate estimate direct payments polars"
+    },
+    "Validate estimate direct payments polars": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::ecs:runTask.sync",
+      "Parameters": {
+        "Cluster": "${polars_cluster_arn}",
+        "TaskDefinition": "${direct_payments_task_arn}",
+        "LaunchType": "FARGATE",
+        "NetworkConfiguration": {
+          "AwsvpcConfiguration": {
+            "Subnets": ${public_subnet_ids},
+            "SecurityGroups": ["${direct_payments_security_group_id}"],
+            "AssignPublicIp": "ENABLED"
+          }
+        },
+        "Overrides": {
+          "ContainerOverrides": [
+            {
+              "Name": "_04_direct_payments-container",
+              "Command": [
+                "validate_estimate_direct_payments.py",
+                "--bucket_name", "${dataset_bucket_name}",
+                "--source_path", "domain=DPR/dataset=direct_payments_estimates/version=2026.01/",
+                "--reports_path", "domain=data_validation_reports/dataset=direct_payments_estimates/version=2026.01/",
+                "--compare_path", "domain=DPR/dataset=direct_payments_merged/version=2026.01/"
+              ]
+            }
+          ]
+        }
+      },
       "Next": "Run DPR crawler"
     },
     "Run DPR crawler": {


### PR DESCRIPTION
## Description
Trello ticket [1551](https://trello.com/c/xwEgmsCY)

Converted DPR util for correcting LA names from pyspark to polars. Done without wrapping, just called in main, and added a validation script to check LA names are correct in the output.

## Testing
- [x] Unit tests passing
- [x] Successful [Job / Step Function run](https://eu-west-2.console.aws.amazon.com/states/home?region=eu-west-2#/statemachines/view/arn%3Aaws%3Astates%3Aeu-west-2%3A856699698263%3AstateMachine%3A1551-dpr-la-names-Direct-Payment-Recipients?type=standard)

Validation is checking the column only has values from the contemporary cssr class.

## Migration to polars checklist
- [x] Used LazyFrame option for test data
- [x] Unit tests added
- [x] Added comment to pyspark functions which have been migrated with the link to the new location
      `# converted to polars -> filepath.py`
- [x] Use new file structure when saving to S3
      `{dataset}_{sub_dataset_if_relevant}_{order_of_process_if_relevant}_{very_brief_description}`
- [x] Updated CHANGELOG
- [x] Moved Trello ticket to PR column
