### PR TITLE
1557 - Convert DPR calculate_remaining_variables function to Polars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ All notable changes to this project will be documented in this file.
 
 - Converted DPR estimates util function model_using_mean from pyspark to polars.
 
+- Converted DPR utils function calculate_remaining_variables to Polars and added tests for the same.
+
 ### Changed
 - Removed the PySpark version of IND CQC Clean and Validation jobs.
 

--- a/projects/_04_direct_payment_recipients/fargate/utils/estimate_direct_payments_utils/calculate_remaining_variables.py
+++ b/projects/_04_direct_payment_recipients/fargate/utils/estimate_direct_payments_utils/calculate_remaining_variables.py
@@ -1,0 +1,15 @@
+import polars as pl
+
+
+def calculate_remaining_variables(
+    lf: pl.LazyFrame,
+) -> pl.LazyFrame:
+    """
+    """
+    service_users_with_self_employed_staff
+    carers_employing_staff
+    total_dpr_employing_staff
+    total_personal_assistant_filled_posts
+    proportion_of_dpr_employing_staff
+    proportion_of_dpr_who_are_service_users
+    return direct_payments_lf

--- a/projects/_04_direct_payment_recipients/fargate/utils/estimate_direct_payments_utils/calculate_remaining_variables.py
+++ b/projects/_04_direct_payment_recipients/fargate/utils/estimate_direct_payments_utils/calculate_remaining_variables.py
@@ -1,15 +1,77 @@
 import polars as pl
 
+from projects._04_direct_payment_recipients.direct_payments_column_names import (
+    DirectPaymentColumnNames as DP,
+)
+from projects._04_direct_payment_recipients.direct_payments_configuration import (
+    DirectPaymentConfiguration as Config,
+)
+
 
 def calculate_remaining_variables(
     lf: pl.LazyFrame,
 ) -> pl.LazyFrame:
     """
+    Derives additional direct payment columns from an input LazyFrame.
+
+    This function calculates several estimated fields related to service users,
+    carers, and employment of personal assistants. The calculations are based on
+    existing columns in the input LazyFrame and configuration constants.
+
+    The following derived columns are added:
+        - estimated_service_users_with_self_employed_staff
+        - estimated_carers_employing_staff
+        - estimated_total_dpr_employing_staff
+        - estimated_total_personal_assistant_filled_posts
+        - estimated_proportion_of_total_dpr_employing_staff
+        - estimated_proportion_of_dpr_who_are_service_users
+
+    Args:
+        lf (pl.LazyFrame): Input LazyFrame.
+
+    Returns:
+        pl.LazyFrame: A new LazyFrame with additional derived columns appended.
     """
-    service_users_with_self_employed_staff
-    carers_employing_staff
-    total_dpr_employing_staff
-    total_personal_assistant_filled_posts
-    proportion_of_dpr_employing_staff
-    proportion_of_dpr_who_are_service_users
-    return direct_payments_lf
+    service_users_with_self_employed_staff_expr = (
+        pl.col(DP.SERVICE_USER_DPRS_DURING_YEAR)
+        * Config.SELF_EMPLOYED_STAFF_PER_SERVICE_USER
+    )
+
+    carers_employing_staff_expr = (
+        pl.col(DP.CARER_DPRS_DURING_YEAR) * Config.CARERS_EMPLOYING_PERCENTAGE
+    )
+
+    total_dpr_employing_staff_expr = (
+        pl.col(DP.ESTIMATED_SERVICE_USER_DPRS_DURING_YEAR_EMPLOYING_STAFF)
+        + service_users_with_self_employed_staff_expr
+        + carers_employing_staff_expr
+    )
+
+    total_personal_assistant_filled_posts_expr = (
+        total_dpr_employing_staff_expr * pl.col(DP.FILLED_POSTS_PER_EMPLOYER)
+    )
+
+    proportion_of_dpr_employing_staff_expr = total_dpr_employing_staff_expr / pl.col(
+        DP.TOTAL_DPRS_DURING_YEAR
+    )
+
+    proportion_of_dpr_who_are_service_users_expr = pl.col(
+        DP.SERVICE_USER_DPRS_DURING_YEAR
+    ) / pl.col(DP.TOTAL_DPRS_DURING_YEAR)
+
+    return lf.with_columns(
+        service_users_with_self_employed_staff_expr.alias(
+            DP.ESTIMATED_SERVICE_USERS_WITH_SELF_EMPLOYED_STAFF
+        ),
+        carers_employing_staff_expr.alias(DP.ESTIMATED_CARERS_EMPLOYING_STAFF),
+        total_dpr_employing_staff_expr.alias(DP.ESTIMATED_TOTAL_DPR_EMPLOYING_STAFF),
+        total_personal_assistant_filled_posts_expr.alias(
+            DP.ESTIMATED_TOTAL_PERSONAL_ASSISTANT_FILLED_POSTS
+        ),
+        proportion_of_dpr_employing_staff_expr.alias(
+            DP.ESTIMATED_PROPORTION_OF_TOTAL_DPR_EMPLOYING_STAFF
+        ),
+        proportion_of_dpr_who_are_service_users_expr.alias(
+            DP.ESTIMATED_PROPORTION_OF_DPR_WHO_ARE_SERVICE_USERS
+        ),
+    )

--- a/projects/_04_direct_payment_recipients/tests/fargate/utils/test_calculate_remaining_variables.py
+++ b/projects/_04_direct_payment_recipients/tests/fargate/utils/test_calculate_remaining_variables.py
@@ -1,0 +1,45 @@
+import unittest
+import polars as pl
+import polars.testing as pl_testing
+
+import projects._04_direct_payment_recipients.fargate.utils.estimate_direct_payments_utils.calculate_remaining_variables as job
+from projects._04_direct_payment_recipients.direct_payments_column_names import (
+    DirectPaymentColumnNames as DP,
+)
+
+
+class TestCalculateRemainingVariables(unittest.TestCase):
+    def test_function_retuns_expected_values(self):
+        schema = {
+            DP.LA_AREA: pl.String,
+            DP.YEAR_AS_INTEGER: pl.Int32,
+            DP.SERVICE_USER_DPRS_DURING_YEAR: pl.Float32,
+            DP.CARER_DPRS_DURING_YEAR: pl.Float32,
+            DP.TOTAL_DPRS_DURING_YEAR: pl.Float32,
+            DP.ESTIMATED_SERVICE_USER_DPRS_DURING_YEAR_EMPLOYING_STAFF: pl.Float32,
+            DP.FILLED_POSTS_PER_EMPLOYER: pl.Float32,
+            DP.ESTIMATED_SERVICE_USERS_WITH_SELF_EMPLOYED_STAFF: pl.Float32,
+            DP.ESTIMATED_CARERS_EMPLOYING_STAFF: pl.Float32,
+            DP.ESTIMATED_TOTAL_DPR_EMPLOYING_STAFF: pl.Float32,
+            DP.ESTIMATED_TOTAL_PERSONAL_ASSISTANT_FILLED_POSTS: pl.Float32,
+            DP.ESTIMATED_PROPORTION_OF_TOTAL_DPR_EMPLOYING_STAFF: pl.Float32,
+            DP.ESTIMATED_PROPORTION_OF_DPR_WHO_ARE_SERVICE_USERS: pl.Float32,
+        }
+
+        rows = [
+            ("Area A", 2022, 100.0, 40.0, 200.0, 30.0, 2.0, 1.7948, 0.2554, 32.0503, 64.1007, 0.1602, 0.5),
+            ("Area B", 2022, 50.0, 10.0, 100.0, 10.0, 1.5, 0.8974, 0.0638, 10.9613, 16.4419, 0.1096, 0.5),
+        ] # fmt: skip
+
+        expected_lf = pl.LazyFrame(rows, schema, orient="row")
+        test_lf = expected_lf.drop(
+            DP.ESTIMATED_SERVICE_USERS_WITH_SELF_EMPLOYED_STAFF,
+            DP.ESTIMATED_CARERS_EMPLOYING_STAFF,
+            DP.ESTIMATED_TOTAL_DPR_EMPLOYING_STAFF,
+            DP.ESTIMATED_TOTAL_PERSONAL_ASSISTANT_FILLED_POSTS,
+            DP.ESTIMATED_PROPORTION_OF_TOTAL_DPR_EMPLOYING_STAFF,
+            DP.ESTIMATED_PROPORTION_OF_DPR_WHO_ARE_SERVICE_USERS,
+        )
+        returned_lf = job.calculate_remaining_variables(test_lf)
+
+        pl_testing.assert_frame_equal(returned_lf, expected_lf, abs_tol=1e-4)

--- a/projects/_04_direct_payment_recipients/utils/_03_estimate_direct_payment_utils/calculate_remaining_variables.py
+++ b/projects/_04_direct_payment_recipients/utils/_03_estimate_direct_payment_utils/calculate_remaining_variables.py
@@ -9,6 +9,7 @@ from projects._04_direct_payment_recipients.direct_payments_configuration import
 )
 
 
+# converted to polars -> projects\_04_direct_payment_recipients\fargate\utils\estimate_direct_payments_utils\calculate_remaining_variables.py
 def calculate_remaining_variables(
     direct_payments_df: DataFrame,
 ) -> DataFrame:
@@ -27,6 +28,7 @@ def calculate_remaining_variables(
     return direct_payments_df
 
 
+# Not converted this function in Polars. Used Polars Expressions
 def calculate_service_users_with_self_employed_staff(
     direct_payments_df: DataFrame,
 ) -> DataFrame:
@@ -38,6 +40,7 @@ def calculate_service_users_with_self_employed_staff(
     return direct_payments_df
 
 
+# Not converted this function in Polars. Used Polars Expressions
 def calculate_carers_employing_staff(
     direct_payments_df: DataFrame,
 ) -> DataFrame:
@@ -48,6 +51,7 @@ def calculate_carers_employing_staff(
     return direct_payments_df
 
 
+# Not converted this function in Polars. Used Polars Expressions
 def calculate_total_dpr_employing_staff(
     direct_payments_df: DataFrame,
 ) -> DataFrame:
@@ -60,6 +64,7 @@ def calculate_total_dpr_employing_staff(
     return direct_payments_df
 
 
+# Not converted this function in Polars. Used Polars Expressions
 def calculate_total_personal_assistant_filled_posts(
     direct_payments_df: DataFrame,
 ) -> DataFrame:
@@ -71,6 +76,7 @@ def calculate_total_personal_assistant_filled_posts(
     return direct_payments_df
 
 
+# Not converted this function in Polars. Used Polars Expressions
 def calculate_proportion_of_dpr_employing_staff(
     direct_payments_df: DataFrame,
 ) -> DataFrame:
@@ -82,6 +88,7 @@ def calculate_proportion_of_dpr_employing_staff(
     return direct_payments_df
 
 
+# Not converted this function in Polars. Used Polars Expressions
 def calculate_proportion_of_dpr_who_are_service_users(
     direct_payments_df: DataFrame,
 ) -> DataFrame:


### PR DESCRIPTION
## Description
Trello ticket [#1557](https://trello.com/c/ACLTn6JC/1557-dpr-convert-calculateremainingvariables)

Converted DPR calculate_remaining_variables utils function to Polars and added tests for the same.

## Testing
- [x] Unit tests passing

## Migration to polars checklist
- [x] Check that similar utils functions don't already exist, or if one can be created
- [x] Check that utils are being saved in the appropriate place
- [x] Used LazyFrame option for test data
- [x] Unit tests added
- [x] Docstrings added
- [x] Added comment to pyspark functions which have been migrated with the link to the new location
      `# converted to polars -> filepath.py`
- [x] Updated CHANGELOG
- [x] Moved Trello ticket to PR column
