### PR TITLE
1558 - Convert DPR utils function create_summary_table to Polars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ All notable changes to this project will be documented in this file.
 
 - Converted DPR Extrapolation script to Polars and added tests for the same.
 
+- Converted DPR utils function create_summary_table to Polars and added tests for the same.
+
 ### Changed
 - Removed the PySpark version of IND CQC Clean and Validation jobs.
 

--- a/projects/_04_direct_payment_recipients/fargate/utils/estimate_direct_payments_utils/create_summary_table.py
+++ b/projects/_04_direct_payment_recipients/fargate/utils/estimate_direct_payments_utils/create_summary_table.py
@@ -1,0 +1,48 @@
+import polars as pl
+from projects._04_direct_payment_recipients.direct_payments_column_names import (
+    DirectPaymentColumnNames as DP,
+)
+
+
+def create_summary_table(
+    lf: pl.LazyFrame,
+) -> pl.LazyFrame:
+    """
+    Aggregates the data by year, summing all estimated and actual counts
+    across all LA areas to produce a national summary table.
+
+    Args:
+        lf (pl.LazyFrame): Input LazyFrame.
+
+    Returns:
+        pl.LazyFrame: A LazyFrame grouped by year with the following columns:
+            - total_dprs
+            - service_user_dprs
+            - service_users_employing_staff
+            - service_users_with_self_employed_staff
+            - carers_employing_staff
+            - total_dprs_employing_staff
+            - total_personal_assistant_filled_posts
+    """
+    summary_direct_payments_lf = lf.group_by(DP.YEAR).agg(
+        pl.sum(DP.TOTAL_DPRS_DURING_YEAR).cast(pl.Float32).alias(DP.TOTAL_DPRS),
+        pl.sum(DP.SERVICE_USER_DPRS_DURING_YEAR)
+        .cast(pl.Float32)
+        .alias(DP.SERVICE_USER_DPRS),
+        pl.sum(DP.ESTIMATED_SERVICE_USER_DPRS_DURING_YEAR_EMPLOYING_STAFF)
+        .cast(pl.Float32)
+        .alias(DP.SERVICE_USERS_EMPLOYING_STAFF),
+        pl.sum(DP.ESTIMATED_SERVICE_USERS_WITH_SELF_EMPLOYED_STAFF)
+        .cast(pl.Float32)
+        .alias(DP.SERVICE_USERS_WITH_SELF_EMPLOYED_STAFF),
+        pl.sum(DP.ESTIMATED_CARERS_EMPLOYING_STAFF)
+        .cast(pl.Float32)
+        .alias(DP.CARERS_EMPLOYING_STAFF),
+        pl.sum(DP.ESTIMATED_TOTAL_DPR_EMPLOYING_STAFF)
+        .cast(pl.Float32)
+        .alias(DP.TOTAL_DPRS_EMPLOYING_STAFF),
+        pl.sum(DP.ESTIMATED_TOTAL_PERSONAL_ASSISTANT_FILLED_POSTS)
+        .cast(pl.Float32)
+        .alias(DP.TOTAL_PERSONAL_ASSISTANT_FILLED_POSTS),
+    )
+    return summary_direct_payments_lf

--- a/projects/_04_direct_payment_recipients/tests/fargate/utils/test_create_summary_table.py
+++ b/projects/_04_direct_payment_recipients/tests/fargate/utils/test_create_summary_table.py
@@ -1,0 +1,51 @@
+import unittest
+import polars as pl
+import polars.testing as pl_testing
+
+import projects._04_direct_payment_recipients.fargate.utils.estimate_direct_payments_utils.create_summary_table as job
+from projects._04_direct_payment_recipients.direct_payments_column_names import (
+    DirectPaymentColumnNames as DP,
+)
+
+
+class TestCreateSummaryTable(unittest.TestCase):
+    def test_function_returns_expected_values(self):
+        input_schema = {
+            DP.YEAR: pl.String,
+            DP.LA_AREA: pl.String,
+            DP.TOTAL_DPRS_DURING_YEAR: pl.Float64,
+            DP.SERVICE_USER_DPRS_DURING_YEAR: pl.Float64,
+            DP.ESTIMATED_SERVICE_USER_DPRS_DURING_YEAR_EMPLOYING_STAFF: pl.Float64,
+            DP.ESTIMATED_SERVICE_USERS_WITH_SELF_EMPLOYED_STAFF: pl.Float64,
+            DP.ESTIMATED_CARERS_EMPLOYING_STAFF: pl.Float64,
+            DP.ESTIMATED_TOTAL_DPR_EMPLOYING_STAFF: pl.Float64,
+            DP.ESTIMATED_TOTAL_PERSONAL_ASSISTANT_FILLED_POSTS: pl.Float64,
+        }
+        input_rows = [
+            ("2020", "area_1", 100.0, 80.0, 40.0, 10.0, 5.0, 45.0, 50.0),
+            ("2020", "area_2", 200.0, 160.0, 80.0, 20.0, 10.0, 90.0, 100.0),
+            ("2021", "area_1", 110.0, 90.0, 45.0, 11.0, 6.0, 51.0, 55.0),
+            ("2021", "area_2", 210.0, 170.0, 85.0, 21.0, 11.0, 96.0, 105.0),
+        ]
+
+        expected_schema = {
+            DP.YEAR: pl.String,
+            DP.TOTAL_DPRS: pl.Float32,
+            DP.SERVICE_USER_DPRS: pl.Float32,
+            DP.SERVICE_USERS_EMPLOYING_STAFF: pl.Float32,
+            DP.SERVICE_USERS_WITH_SELF_EMPLOYED_STAFF: pl.Float32,
+            DP.CARERS_EMPLOYING_STAFF: pl.Float32,
+            DP.TOTAL_DPRS_EMPLOYING_STAFF: pl.Float32,
+            DP.TOTAL_PERSONAL_ASSISTANT_FILLED_POSTS: pl.Float32,
+        }
+        expected_rows = [
+            ("2020", 300.0, 240.0, 120.0, 30.0, 15.0, 135.0, 150.0),
+            ("2021", 320.0, 260.0, 130.0, 32.0, 17.0, 147.0, 160.0),
+        ]
+
+        test_lf = pl.LazyFrame(input_rows, schema=input_schema, orient="row")
+        expected_lf = pl.LazyFrame(expected_rows, schema=expected_schema, orient="row")
+
+        returned_lf = job.create_summary_table(test_lf)
+
+        pl_testing.assert_frame_equal(returned_lf, expected_lf, check_row_order=False)

--- a/projects/_04_direct_payment_recipients/utils/_03_estimate_direct_payment_utils/create_summary_table.py
+++ b/projects/_04_direct_payment_recipients/utils/_03_estimate_direct_payment_utils/create_summary_table.py
@@ -6,6 +6,7 @@ from projects._04_direct_payment_recipients.direct_payments_column_names import 
 )
 
 
+# converted to polars -> projects\_04_direct_payment_recipients\fargate\utils\estimate_direct_payments_utils\create_summary_table.py
 def create_summary_table(
     direct_payments_df: DataFrame,
 ) -> DataFrame:


### PR DESCRIPTION
## Description
Trello ticket [#1558](https://trello.com/c/hijqTA7G/1558-dpr-convert-createsummarytable)

Converted DPR utils function create_summary_table to Polars and added tests for the same.

## Testing
- [x] Unit tests passing

## Migration to polars checklist
- [x] Check that similar utils functions don't already exist, or if one can be created
- [x] Check that utils are being saved in the appropriate place
- [x] Used LazyFrame option for test data
- [x] Unit tests added
- [x] Docstrings added
- [x] Added comment to pyspark functions which have been migrated with the link to the new location
      `# converted to polars -> filepath.py`
- [x] Updated CHANGELOG
- [x] Moved Trello ticket to PR column
