### PR TITLE
1561 - Update terraform to use new version of CQC deltas which includes missing data

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -251,6 +251,7 @@ jobs:
             aws s3 sync "s3://sfc-main-datasets/domain=CQC/dataset=cqc_locations_04_full_cleaned_registered/" "s3://$BRANCH_DATASET_BUCKET/domain=CQC/dataset=cqc_locations_04_full_cleaned_registered/"
             aws s3 sync "s3://sfc-main-datasets/domain=CQC/dataset=postcode_corrections/" "s3://$BRANCH_DATASET_BUCKET/domain=CQC/dataset=postcode_corrections/"
             aws s3 sync "s3://sfc-main-datasets/domain=CQC/dataset=cqc_locations_01_delta_api/" "s3://$BRANCH_DATASET_BUCKET/domain=CQC/dataset=cqc_locations_01_delta_api/"
+            aws s3 sync "s3://sfc-main-datasets/domain=CQC/dataset=cqc_providers_01_delta_api/" "s3://$BRANCH_DATASET_BUCKET/domain=CQC/dataset=cqc_providers_01_delta_api/"
             aws s3 sync "s3://sfc-main-datasets/domain=ONS/dataset=postcode_directory_cleaned/" "s3://$BRANCH_DATASET_BUCKET/domain=ONS/dataset=postcode_directory_cleaned/"
             aws s3 sync "s3://sfc-main-datasets/domain=ASCWDS/dataset=workplace_cleaned/" "s3://$BRANCH_DATASET_BUCKET/domain=ASCWDS/dataset=workplace_cleaned/"
             aws s3 sync "s3://sfc-main-datasets/domain=ASCWDS/dataset=worker_cleaned/" "s3://$BRANCH_DATASET_BUCKET/domain=ASCWDS/dataset=worker_cleaned/"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -250,8 +250,6 @@ jobs:
           command: |
             aws s3 sync "s3://sfc-main-datasets/domain=CQC/dataset=cqc_locations_04_full_cleaned_registered/" "s3://$BRANCH_DATASET_BUCKET/domain=CQC/dataset=cqc_locations_04_full_cleaned_registered/"
             aws s3 sync "s3://sfc-main-datasets/domain=CQC/dataset=postcode_corrections/" "s3://$BRANCH_DATASET_BUCKET/domain=CQC/dataset=postcode_corrections/"
-            aws s3 sync "s3://sfc-main-datasets/domain=CQC/dataset=cqc_locations_01_delta_api/" "s3://$BRANCH_DATASET_BUCKET/domain=CQC/dataset=cqc_locations_01_delta_api/"
-            aws s3 sync "s3://sfc-main-datasets/domain=CQC/dataset=cqc_providers_01_delta_api/" "s3://$BRANCH_DATASET_BUCKET/domain=CQC/dataset=cqc_providers_01_delta_api/"
             aws s3 sync "s3://sfc-main-datasets/domain=ONS/dataset=postcode_directory_cleaned/" "s3://$BRANCH_DATASET_BUCKET/domain=ONS/dataset=postcode_directory_cleaned/"
             aws s3 sync "s3://sfc-main-datasets/domain=ASCWDS/dataset=workplace_cleaned/" "s3://$BRANCH_DATASET_BUCKET/domain=ASCWDS/dataset=workplace_cleaned/"
             aws s3 sync "s3://sfc-main-datasets/domain=ASCWDS/dataset=worker_cleaned/" "s3://$BRANCH_DATASET_BUCKET/domain=ASCWDS/dataset=worker_cleaned/"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -250,6 +250,7 @@ jobs:
           command: |
             aws s3 sync "s3://sfc-main-datasets/domain=CQC/dataset=cqc_locations_04_full_cleaned_registered/" "s3://$BRANCH_DATASET_BUCKET/domain=CQC/dataset=cqc_locations_04_full_cleaned_registered/"
             aws s3 sync "s3://sfc-main-datasets/domain=CQC/dataset=postcode_corrections/" "s3://$BRANCH_DATASET_BUCKET/domain=CQC/dataset=postcode_corrections/"
+            aws s3 sync "s3://sfc-main-datasets/domain=CQC/dataset=cqc_locations_01_delta_api/" "s3://$BRANCH_DATASET_BUCKET/domain=CQC/dataset=cqc_locations_01_delta_api/"
             aws s3 sync "s3://sfc-main-datasets/domain=ONS/dataset=postcode_directory_cleaned/" "s3://$BRANCH_DATASET_BUCKET/domain=ONS/dataset=postcode_directory_cleaned/"
             aws s3 sync "s3://sfc-main-datasets/domain=ASCWDS/dataset=workplace_cleaned/" "s3://$BRANCH_DATASET_BUCKET/domain=ASCWDS/dataset=workplace_cleaned/"
             aws s3 sync "s3://sfc-main-datasets/domain=ASCWDS/dataset=worker_cleaned/" "s3://$BRANCH_DATASET_BUCKET/domain=ASCWDS/dataset=worker_cleaned/"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 - Update setup instructions with pre-commit hooks setup
 
+- Added missing CQC locations delta data in s3 and updated pipeline to version 3.1.1 of locations delta data.
+
 
 ## [v2026.03.1] - 21/04/2026
 

--- a/projects/_01_ingest/cqc_api/fargate/cqc_locations_1_delta_api_download.py
+++ b/projects/_01_ingest/cqc_api/fargate/cqc_locations_1_delta_api_download.py
@@ -136,6 +136,6 @@ if __name__ == "__main__":
         domain="CQC",
         dataset="cqc_locations_01_delta_api",
         date=date_today,
-        version="3.1.0",
+        version="3.1.1",
     )
     main(destination, args.start_timestamp, args.end_timestamp)

--- a/terraform/pipeline/glue.tf
+++ b/terraform/pipeline/glue.tf
@@ -306,7 +306,7 @@ module "flatten_cqc_ratings_job" {
 
   job_parameters = {
     "--cqc_full_snapshot_source"       = "${module.datasets_bucket.bucket_uri}/domain=CQC/dataset=cqc_locations_04_latest_snapshot/"
-    "--cqc_locations_api_delta_source" = "${module.datasets_bucket.bucket_uri}/domain=CQC/dataset=cqc_locations_01_delta_api/version=3.1.0/"
+    "--cqc_locations_api_delta_source" = "${module.datasets_bucket.bucket_uri}/domain=CQC/dataset=cqc_locations_01_delta_api/version=3.1.1/"
     "--ascwds_workplace_source"        = "${module.datasets_bucket.bucket_uri}/domain=ASCWDS/dataset=workplace/"
     "--cqc_ratings_destination"        = "${module.datasets_bucket.bucket_uri}/domain=SfC/dataset=sfc_cqc_ratings_for_data_requests/"
     "--benchmark_ratings_destination"  = "${module.datasets_bucket.bucket_uri}/domain=SfC/dataset=sfc_cqc_ratings_for_benchmarks/version=2.0.0/"

--- a/terraform/pipeline/step-functions/dynamic/Ingest-CQC-API-Delta.json
+++ b/terraform/pipeline/step-functions/dynamic/Ingest-CQC-API-Delta.json
@@ -168,7 +168,7 @@
                 "bucket_name_arg": "--bucket_name",
                 "bucket_name": "${dataset_bucket_name}",
                 "source_path_arg": "--source_path",
-                "source_path": "domain=CQC/dataset=cqc_locations_01_delta_api/version=3.1.0/",
+                "source_path": "domain=CQC/dataset=cqc_locations_01_delta_api/version=3.1.1/",
                 "reports_path_arg": "--reports_path",
                 "reports_path": "domain=data_validation_reports/dataset=validation_cqc_locations_01_delta_api/"
               },

--- a/terraform/pipeline/step-functions/dynamic/SfC-Internal.json
+++ b/terraform/pipeline/step-functions/dynamic/SfC-Internal.json
@@ -15,7 +15,7 @@
                 "JobName": "${flatten_cqc_ratings_job_name}",
                 "Arguments": {
                   "--cqc_full_snapshot_source": "${dataset_bucket_uri}/domain=CQC/dataset=cqc_locations_04_latest_snapshot/",
-                  "--cqc_locations_api_delta_source": "${dataset_bucket_uri}/domain=CQC/dataset=cqc_locations_01_delta_api/version=3.1.0/",
+                  "--cqc_locations_api_delta_source": "${dataset_bucket_uri}/domain=CQC/dataset=cqc_locations_01_delta_api/version=3.1.1/",
                   "--ascwds_workplace_source": "${dataset_bucket_uri}/domain=ASCWDS/dataset=workplace/",
                   "--cqc_ratings_destination": "${dataset_bucket_uri}/domain=SfC/dataset=sfc_cqc_ratings_for_data_requests/",
                   "--benchmark_ratings_destination": "${dataset_bucket_uri}/domain=SfC/dataset=sfc_cqc_ratings_for_benchmarks/version=2.0.0/"

--- a/terraform/pipeline/step-functions/dynamic/Transform-CQC-Data.json
+++ b/terraform/pipeline/step-functions/dynamic/Transform-CQC-Data.json
@@ -251,7 +251,7 @@
                       "Name": "cqc-api-container",
                       "Command": [
                         "cqc_locations_2_delta_flatten.py",
-                        "--cqc_locations_api_delta_source", "${dataset_bucket_uri}/domain=CQC/dataset=cqc_locations_01_delta_api/version=3.1.0/",
+                        "--cqc_locations_api_delta_source", "${dataset_bucket_uri}/domain=CQC/dataset=cqc_locations_01_delta_api/version=3.1.1/",
                         "--cqc_locations_flattened_destination", "${dataset_bucket_uri}/domain=CQC/dataset=cqc_locations_02_delta_flattened/"
                       ]
                     }

--- a/terraform/pipeline/step-functions/dynamic/Transform-CQC-Data.json
+++ b/terraform/pipeline/step-functions/dynamic/Transform-CQC-Data.json
@@ -325,7 +325,7 @@
                                 "--bucket_name", "${dataset_bucket_name}",
                                 "--source_path", "domain=CQC/dataset=cqc_locations_02_delta_flattened/",
                                 "--reports_path", "domain=data_validation_reports/dataset=validation_cqc_locations_02_delta_flattened/",
-                                "--compare_path", "domain=CQC/dataset=cqc_locations_01_delta_api/version=3.1.0/"
+                                "--compare_path", "domain=CQC/dataset=cqc_locations_01_delta_api/version=3.1.1/"
                               ]
                             }
                           ]


### PR DESCRIPTION
## Description
Trello ticket [#1561](https://trello.com/c/g5IjRB9w/1561-cqc-amend-missed-historical-data-using-data-on-23rd-april)

Update terraform to use new version of CQC deltas which includes missing data

## Testing
- [x] Unit tests passing
- [x] Successful [Step Function run](https://eu-west-2.console.aws.amazon.com/states/home?region=eu-west-2#/statemachines/view/arn%3Aaws%3Astates%3Aeu-west-2%3A856699698263%3AstateMachine%3A1561-fix-deltas-Transform-CQC-Data?type=standard) [IndCQC run](https://eu-west-2.console.aws.amazon.com/states/home?region=eu-west-2#/v2/executions/details/arn:aws:states:eu-west-2:856699698263:execution:1561-fix-deltas-Ind-CQC-Filled-Post-Estimates:499ae7d3-2bde-497a-bfe1-a41a95a21025)
- [x] Outputs checked in Excel (see trello)

## Checklist (delete if not relevant)
- [x] Updated CHANGELOG
- [x] Moved Trello ticket to PR column
