### PR TITLE
1552 DPR - calculate estimated proportion employing staff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ All notable changes to this project will be documented in this file.
 
 - Converted DPR estimates util for calculating rolling mean of proportion DPR employing staff.
 
+- Converted DPR estimates util estimate_service_users_employing_staff to polars.
+
 ### Changed
 - Removed the PySpark version of IND CQC Clean and Validation jobs.
 

--- a/projects/_04_direct_payment_recipients/Dockerfile_and_requirements/Dockerfile
+++ b/projects/_04_direct_payment_recipients/Dockerfile_and_requirements/Dockerfile
@@ -9,6 +9,7 @@ ENV PYTHONPATH=/app
 # Dependencies
 COPY projects/_04_direct_payment_recipients/fargate/utils /app/projects/_04_direct_payment_recipients/fargate/utils
 COPY projects/_04_direct_payment_recipients/direct_payments_column_names.py /app/projects/_04_direct_payment_recipients/direct_payments_column_names.py
+COPY projects/_04_direct_payment_recipients/direct_payments_config_polars.py /app/projects/_04_direct_payment_recipients/direct_payments_config_polars.py
 COPY polars_utils /app/polars_utils
 COPY utils/column_names /app/utils/column_names/
 COPY utils/column_values /app/utils/column_values/

--- a/projects/_04_direct_payment_recipients/direct_payments_column_names.py
+++ b/projects/_04_direct_payment_recipients/direct_payments_column_names.py
@@ -62,6 +62,9 @@ class DirectPaymentColumnNames:
     ESTIMATED_PROPORTION_OF_SERVICE_USERS_EMPLOYING_STAFF: str = (
         "estimated_proportion_of_service_users_employing_staff"
     )
+    ESTIMATED_PROPORTION_OF_SERVICE_USERS_EMPLOYING_STAFF_SOURCE: str = (
+        "estimated_proportion_of_service_users_employing_staff_source"
+    )
 
     # Model extrapolation
     EXTRAPOLATION_RATIO: str = "extrapolation_ratio"

--- a/projects/_04_direct_payment_recipients/direct_payments_config_polars.py
+++ b/projects/_04_direct_payment_recipients/direct_payments_config_polars.py
@@ -1,0 +1,28 @@
+from dataclasses import dataclass
+
+from utils.column_values.categorical_column_values import ContemporaryCSSR
+
+
+@dataclass
+class DirectPaymentConfiguration:
+    # The carer's employing percentage was calculated from a question in older surveys. As this is so close to zero it was removed as a question from more recent surveys and we use the most recent value.
+    CARERS_EMPLOYING_PERCENTAGE: float = 0.0063872289536592
+    PROPORTION_OF_SERVICE_USERS_EMPLOYING_STAFF_THRESHOLD: float = 1.0
+    ADASS_PROPORTION_OUTLIER_THRESHOLD: float = 0.3
+    SELF_EMPLOYED_STAFF_PER_SERVICE_USER: float = 0.0179487641096729
+    NUMBER_OF_YEARS_ROLLING_AVERAGE: int = 3
+    FIRST_YEAR: int = 2011
+
+
+@dataclass
+class DirectPaymentsMisspelledLaNames:
+    DICT_TO_CORRECT_LA_NAMES = {
+        "Bath & N E Somerset": ContemporaryCSSR.bath_and_north_east_somerset,
+        "Blackburn": ContemporaryCSSR.blackburn_with_darwen,
+        "Bournemouth, Christchurch and Poole": ContemporaryCSSR.bournemouth_christchurch_and_poole,
+        "Cornwall": ContemporaryCSSR.cornwall_and_isles_of_scilly,
+        "East Riding": ContemporaryCSSR.east_riding_of_yorkshire,
+        "Isles of Scilly": ContemporaryCSSR.cornwall_and_isles_of_scilly,
+        "Medway Towns": ContemporaryCSSR.medway,
+        "Southend": ContemporaryCSSR.southend_on_sea,
+    }

--- a/projects/_04_direct_payment_recipients/direct_payments_configuration.py
+++ b/projects/_04_direct_payment_recipients/direct_payments_configuration.py
@@ -11,6 +11,7 @@ from projects._04_direct_payment_recipients.direct_payments_column_names import 
 from utils.column_values.categorical_column_values import ContemporaryCSSR
 
 
+# converted to polars -> projects\_04_direct_payment_recipients\direct_payments_config_polars.py
 @dataclass
 class DirectPaymentConfiguration:
     # The carer's employing percentage was calculated from a question in older surveys. As this is so close to zero it was removed as a question from more recent surveys and we use the most recent value.
@@ -59,7 +60,7 @@ class EstimatePeriodAsDate:
     DAY: str = "31"
 
 
-# TODO: Remove this dict after signing off DPR estimates in polars.
+# converted to polars -> projects\_04_direct_payment_recipients\direct_payments_config_polars.py
 @dataclass
 class DirectPaymentsMisspelledLaNames:
     DICT_TO_CORRECT_LA_NAMES = {

--- a/projects/_04_direct_payment_recipients/fargate/estimate_direct_payments.py
+++ b/projects/_04_direct_payment_recipients/fargate/estimate_direct_payments.py
@@ -10,6 +10,9 @@ from projects._04_direct_payment_recipients.direct_payments_config_polars import
 from projects._04_direct_payment_recipients.fargate.utils.estimate_direct_payments_utils.calculate_remaining_variables import (
     calculate_remaining_variables,
 )
+from projects._04_direct_payment_recipients.fargate.utils.estimate_direct_payments_utils.create_summary_table import (
+    create_summary_table,
+)
 from projects._04_direct_payment_recipients.fargate.utils.estimate_direct_payments_utils.estimate_service_users_employing_staff import (
     calculate_estimated_service_users_employing_staff,
 )
@@ -45,9 +48,17 @@ def main(
 
     lf = calculate_remaining_variables(lf)
 
+    summary_lf = create_summary_table(lf)
+
     utils.sink_to_parquet(
         lf,
         destination,
+        append=False,
+    )
+
+    utils.sink_to_parquet(
+        summary_lf,
+        summary_destination,
         append=False,
     )
 

--- a/projects/_04_direct_payment_recipients/fargate/estimate_direct_payments.py
+++ b/projects/_04_direct_payment_recipients/fargate/estimate_direct_payments.py
@@ -4,6 +4,9 @@ from polars_utils import utils
 from projects._04_direct_payment_recipients.direct_payments_column_names import (
     DirectPaymentColumnNames as DP,
 )
+from projects._04_direct_payment_recipients.fargate.utils.estimate_direct_payments_utils.estimate_service_users_employing_staff import (
+    calculate_estimated_service_users_employing_staff,
+)
 from utils.column_values.categorical_column_values import ContemporaryCSSR
 
 direct_payments_columns = [
@@ -42,6 +45,8 @@ def main(
 
     lf = lf.with_columns(pl.col(DP.LA_AREA).replace(la_name_replacements))
 
+    lf = calculate_estimated_service_users_employing_staff(lf)
+
     utils.sink_to_parquet(
         lf,
         destination,
@@ -73,4 +78,5 @@ if __name__ == "__main__":
         summary_destination=args.summary_destination,
     )
 
+    print("Finished estimate direct payments job")
     print("Finished estimate direct payments job")

--- a/projects/_04_direct_payment_recipients/fargate/estimate_direct_payments.py
+++ b/projects/_04_direct_payment_recipients/fargate/estimate_direct_payments.py
@@ -4,13 +4,15 @@ from polars_utils import utils
 from projects._04_direct_payment_recipients.direct_payments_column_names import (
     DirectPaymentColumnNames as DP,
 )
+from projects._04_direct_payment_recipients.direct_payments_config_polars import (
+    DirectPaymentsMisspelledLaNames as LANameCorrections,
+)
 from projects._04_direct_payment_recipients.fargate.utils.estimate_direct_payments_utils.calculate_remaining_variables import (
     calculate_remaining_variables,
 )
 from projects._04_direct_payment_recipients.fargate.utils.estimate_direct_payments_utils.estimate_service_users_employing_staff import (
     calculate_estimated_service_users_employing_staff,
 )
-from utils.column_values.categorical_column_values import ContemporaryCSSR
 
 direct_payments_columns = [
     DP.LA_AREA,
@@ -24,17 +26,6 @@ direct_payments_columns = [
     DP.FILLED_POSTS_PER_EMPLOYER,
 ]
 
-la_name_replacements = {
-    "Bath & N E Somerset": ContemporaryCSSR.bath_and_north_east_somerset,
-    "Blackburn": ContemporaryCSSR.blackburn_with_darwen,
-    "Bournemouth, Christchurch and Poole": ContemporaryCSSR.bournemouth_christchurch_and_poole,
-    "Cornwall": ContemporaryCSSR.cornwall_and_isles_of_scilly,
-    "East Riding": ContemporaryCSSR.east_riding_of_yorkshire,
-    "Isles of Scilly": ContemporaryCSSR.cornwall_and_isles_of_scilly,
-    "Medway Towns": ContemporaryCSSR.medway,
-    "Southend": ContemporaryCSSR.southend_on_sea,
-}
-
 
 def main(
     direct_payments_merged_source: str,
@@ -46,7 +37,9 @@ def main(
         selected_columns=direct_payments_columns,
     )
 
-    lf = lf.with_columns(pl.col(DP.LA_AREA).replace(la_name_replacements))
+    lf = lf.with_columns(
+        pl.col(DP.LA_AREA).replace(LANameCorrections.DICT_TO_CORRECT_LA_NAMES)
+    )
 
     lf = calculate_estimated_service_users_employing_staff(lf)
 
@@ -83,6 +76,8 @@ if __name__ == "__main__":
         summary_destination=args.summary_destination,
     )
 
+    print("Finished estimate direct payments job")
+    print("Finished estimate direct payments job")
     print("Finished estimate direct payments job")
     print("Finished estimate direct payments job")
     print("Finished estimate direct payments job")

--- a/projects/_04_direct_payment_recipients/fargate/estimate_direct_payments.py
+++ b/projects/_04_direct_payment_recipients/fargate/estimate_direct_payments.py
@@ -4,6 +4,9 @@ from polars_utils import utils
 from projects._04_direct_payment_recipients.direct_payments_column_names import (
     DirectPaymentColumnNames as DP,
 )
+from projects._04_direct_payment_recipients.fargate.utils.estimate_direct_payments_utils.calculate_remaining_variables import (
+    calculate_remaining_variables,
+)
 from projects._04_direct_payment_recipients.fargate.utils.estimate_direct_payments_utils.estimate_service_users_employing_staff import (
     calculate_estimated_service_users_employing_staff,
 )
@@ -47,6 +50,8 @@ def main(
 
     lf = calculate_estimated_service_users_employing_staff(lf)
 
+    lf = calculate_remaining_variables(lf)
+
     utils.sink_to_parquet(
         lf,
         destination,
@@ -78,5 +83,7 @@ if __name__ == "__main__":
         summary_destination=args.summary_destination,
     )
 
+    print("Finished estimate direct payments job")
+    print("Finished estimate direct payments job")
     print("Finished estimate direct payments job")
     print("Finished estimate direct payments job")

--- a/projects/_04_direct_payment_recipients/fargate/estimate_direct_payments.py
+++ b/projects/_04_direct_payment_recipients/fargate/estimate_direct_payments.py
@@ -77,8 +77,3 @@ if __name__ == "__main__":
     )
 
     print("Finished estimate direct payments job")
-    print("Finished estimate direct payments job")
-    print("Finished estimate direct payments job")
-    print("Finished estimate direct payments job")
-    print("Finished estimate direct payments job")
-    print("Finished estimate direct payments job")

--- a/projects/_04_direct_payment_recipients/fargate/utils/estimate_direct_payments_utils/calculate_remaining_variables.py
+++ b/projects/_04_direct_payment_recipients/fargate/utils/estimate_direct_payments_utils/calculate_remaining_variables.py
@@ -3,7 +3,7 @@ import polars as pl
 from projects._04_direct_payment_recipients.direct_payments_column_names import (
     DirectPaymentColumnNames as DP,
 )
-from projects._04_direct_payment_recipients.direct_payments_configuration import (
+from projects._04_direct_payment_recipients.direct_payments_config_polars import (
     DirectPaymentConfiguration as Config,
 )
 

--- a/projects/_04_direct_payment_recipients/fargate/utils/estimate_direct_payments_utils/estimate_service_users_employing_staff.py
+++ b/projects/_04_direct_payment_recipients/fargate/utils/estimate_direct_payments_utils/estimate_service_users_employing_staff.py
@@ -23,20 +23,19 @@ def calculate_estimated_service_users_employing_staff(lf: pl.LazyFrame) -> pl.La
     Calculate estimated service users employing staff using a hierarchy of
     methods:
         1. Use known proportions where available.
-        2. Use extrapolation ratio to estimate missing proportions in earliest
-           year with data.
-        3. Use interpolation to estimate missing proportions between known data
-           points.
-        4. Use mean imputation to estimate any remaining missing proportions
+        2. Use extrapolated and interpolated proportions from known proportions.
+        4. Use mean imputation to estimate any remaining missing proportions.
         5. Use interpolation to estimate any remaining missing proportions after
-           mean imputation, as mean imputation may create new known data points
+           mean imputation, as mean imputation creates new known data points
            which can be used for interpolation.
         6. Calculate rolling average to smooth final estimates.
-        7. Calculate estimated service users employing staff by applying the
-           estimated proportion to the count of service user DPRS during the year.
+        7. Calculate estimated service users employing staff by applying the rolling
+           average proportions to the count of service user DPRS during the year.
 
     Args:
         lf (pl.LazyFrame): LazyFrame containing direct payments data with columns:
+            - LA_AREA
+            - YEAR_AS_INTEGER
             - SERVICE_USER_DPRS_DURING_YEAR
             - PROPORTION_OF_SERVICE_USERS_EMPLOYING_STAFF
 

--- a/projects/_04_direct_payment_recipients/fargate/utils/estimate_direct_payments_utils/estimate_service_users_employing_staff.py
+++ b/projects/_04_direct_payment_recipients/fargate/utils/estimate_direct_payments_utils/estimate_service_users_employing_staff.py
@@ -1,0 +1,59 @@
+import polars as pl
+
+from projects._04_direct_payment_recipients.direct_payments_column_names import (
+    DirectPaymentColumnNames as DP,
+)
+from projects._04_direct_payment_recipients.fargate.utils.models.interpolation import (
+    model_interpolation,
+)
+from projects._04_direct_payment_recipients.fargate.utils.models.mean_imputation import (
+    model_using_mean,
+)
+
+
+def calculate_estimated_service_users_employing_staff(lf: pl.LazyFrame) -> pl.LazyFrame:
+    """
+    Doc string here
+    """
+
+    lf = lf.with_columns(
+        pl.col(DP.PROPORTION_OF_SERVICE_USERS_EMPLOYING_STAFF).alias(
+            DP.ESTIMATED_PROPORTION_OF_SERVICE_USERS_EMPLOYING_STAFF
+        )
+    )
+
+    # lf = expolation_function(lf)
+
+    lf = model_interpolation(lf)
+
+    lf = lf.with_columns(
+        pl.coalesce(
+            [
+                DP.ESTIMATED_PROPORTION_OF_SERVICE_USERS_EMPLOYING_STAFF,
+                DP.ESTIMATE_USING_EXTRAPOLATION_RATIO,
+                DP.ESTIMATED_PROPORTION_OF_SERVICE_USERS_EMPLOYING_STAFF,
+            ]
+        ).alias(DP.ESTIMATED_PROPORTION_OF_SERVICE_USERS_EMPLOYING_STAFF)
+    )
+
+    lf = model_using_mean(lf)
+
+    lf = lf.with_columns(
+        pl.coalesce(
+            [DP.ESTIMATE_USING_MEAN, DP.HISTORIC_SERVICE_USERS_EMPLOYING_STAFF_ESTIMATE]
+        ).alias(DP.ESTIMATE_USING_MEAN)
+    )
+
+    lf = lf.with_columns(
+        pl.coalesce(
+            [
+                DP.ESTIMATED_PROPORTION_OF_SERVICE_USERS_EMPLOYING_STAFF,
+                DP.ESTIMATE_USING_MEAN,
+            ]
+        ).alias(DP.ESTIMATED_PROPORTION_OF_SERVICE_USERS_EMPLOYING_STAFF)
+    )
+
+    # Why does the interpolation happen again after the mean is applied?
+    # Area with 1 known value gets extrpolated, area with more than 1 gets interpolated, then no known values gets the mean.
+
+    return lf

--- a/projects/_04_direct_payment_recipients/fargate/utils/estimate_direct_payments_utils/estimate_service_users_employing_staff.py
+++ b/projects/_04_direct_payment_recipients/fargate/utils/estimate_direct_payments_utils/estimate_service_users_employing_staff.py
@@ -20,7 +20,35 @@ from projects._04_direct_payment_recipients.fargate.utils.models.mean_imputation
 
 def calculate_estimated_service_users_employing_staff(lf: pl.LazyFrame) -> pl.LazyFrame:
     """
-    Doc string here
+    Calculate estimated service users employing staff using a hierarchy of
+    methods:
+        1. Use known proportions where available.
+        2. Use extrapolation ratio to estimate missing proportions in earliest
+           year with data.
+        3. Use interpolation to estimate missing proportions between known data
+           points.
+        4. Use mean imputation to estimate any remaining missing proportions
+        5. Use interpolation to estimate any remaining missing proportions after
+           mean imputation, as mean imputation may create new known data points
+           which can be used for interpolation.
+        6. Calculate rolling average to smooth final estimates.
+        7. Calculate estimated service users employing staff by applying the
+           estimated proportion to the count of service user DPRS during the year.
+
+    Args:
+        lf (pl.LazyFrame): LazyFrame containing direct payments data with columns:
+            - SERVICE_USER_DPRS_DURING_YEAR
+            - PROPORTION_OF_SERVICE_USERS_EMPLOYING_STAFF
+
+    Returns:
+        pl.LazyFrame: LazyFrame with additional columns:
+            - ESTIMATE_USING_MEAN
+            - ESTIMATE_USING_EXTRAPOLATION_RATIO
+            - ESTIMATE_USING_INTERPOLATION
+            - ESTIMATED_PROPORTION_OF_SERVICE_USERS_EMPLOYING_STAFF
+            - ESTIMATED_PROPORTION_OF_SERVICE_USERS_EMPLOYING_STAFF_SOURCE
+            - ROLLING_AVERAGE_ESTIMATED_PROPORTION_OF_SERVICE_USERS_EMPLOYING_STAFF
+            - ESTIMATED_SERVICE_USER_DPRS_DURING_YEAR_EMPLOYING_STAFF
     """
 
     lf = model_using_mean(lf)
@@ -64,9 +92,9 @@ def calculate_estimated_service_users_employing_staff(lf: pl.LazyFrame) -> pl.La
         )
         .then(pl.lit(DP.ESTIMATE_USING_INTERPOLATION))
         .otherwise(
-            pl.col("estimated_proportion_of_service_users_employing_staff_source")
+            pl.col(DP.ESTIMATED_PROPORTION_OF_SERVICE_USERS_EMPLOYING_STAFF_SOURCE)
         )
-        .alias("estimated_proportion_of_service_users_employing_staff_source")
+        .alias(DP.ESTIMATED_PROPORTION_OF_SERVICE_USERS_EMPLOYING_STAFF_SOURCE)
     )
 
     lf = calculate_rolling_mean(lf)

--- a/projects/_04_direct_payment_recipients/fargate/utils/estimate_direct_payments_utils/estimate_service_users_employing_staff.py
+++ b/projects/_04_direct_payment_recipients/fargate/utils/estimate_direct_payments_utils/estimate_service_users_employing_staff.py
@@ -75,13 +75,13 @@ def calculate_estimated_service_users_employing_staff(lf: pl.LazyFrame) -> pl.La
 
     # Drop the interpolation column and re-run interpolation to fill any remaining nulls.
     # This is to populate year = 2014 where there are no values for proportion of service users employing staff.
-    # Mean imputaiton populates 2013, proportions are known in 2015 and later, so interpolation is being used to estimate 2014.
+    # Mean imputation populates 2013, proportions are known in 2015 and later, so interpolation is being used to estimate 2014.
     lf = lf.drop(DP.ESTIMATE_USING_INTERPOLATION)
     lf = model_interpolation(
         lf, DP.ESTIMATED_PROPORTION_OF_SERVICE_USERS_EMPLOYING_STAFF
     )
 
-    lf = lf.with_columns(
+    source_update_exprs = (
         pl.when(
             (
                 pl.col(
@@ -95,14 +95,14 @@ def calculate_estimated_service_users_employing_staff(lf: pl.LazyFrame) -> pl.La
             pl.col(DP.ESTIMATED_PROPORTION_OF_SERVICE_USERS_EMPLOYING_STAFF_SOURCE)
         )
         .alias(DP.ESTIMATED_PROPORTION_OF_SERVICE_USERS_EMPLOYING_STAFF_SOURCE)
-    ).with_columns(
-        pl.coalesce(
-            [
-                DP.ESTIMATED_PROPORTION_OF_SERVICE_USERS_EMPLOYING_STAFF,
-                DP.ESTIMATE_USING_INTERPOLATION,
-            ]
-        ).alias(DP.ESTIMATED_PROPORTION_OF_SERVICE_USERS_EMPLOYING_STAFF)
     )
+    estimate_update_expr = pl.coalesce(
+        [
+            DP.ESTIMATED_PROPORTION_OF_SERVICE_USERS_EMPLOYING_STAFF,
+            DP.ESTIMATE_USING_INTERPOLATION,
+        ]
+    ).alias(DP.ESTIMATED_PROPORTION_OF_SERVICE_USERS_EMPLOYING_STAFF)
+    lf = lf.with_columns(estimate_update_expr, source_update_exprs)
 
     lf = calculate_rolling_mean(lf)
 

--- a/projects/_04_direct_payment_recipients/fargate/utils/estimate_direct_payments_utils/estimate_service_users_employing_staff.py
+++ b/projects/_04_direct_payment_recipients/fargate/utils/estimate_direct_payments_utils/estimate_service_users_employing_staff.py
@@ -74,27 +74,35 @@ def calculate_estimated_service_users_employing_staff(lf: pl.LazyFrame) -> pl.La
         )
     )
 
+    # Drop the interpolation column and re-run interpolation to fill any remaining nulls.
+    # This is to populate year = 2014 where there are no values for proportion of service users employing staff.
+    # Mean imputaiton populates 2013, proportions are known in 2015 and later, so interpolation is being used to estimate 2014.
     lf = lf.drop(DP.ESTIMATE_USING_INTERPOLATION)
     lf = model_interpolation(
         lf, DP.ESTIMATED_PROPORTION_OF_SERVICE_USERS_EMPLOYING_STAFF
     )
 
     lf = lf.with_columns(
-        pl.coalesce(
-            [
-                DP.ESTIMATED_PROPORTION_OF_SERVICE_USERS_EMPLOYING_STAFF,
-                DP.ESTIMATE_USING_INTERPOLATION,
-            ]
-        ).alias(DP.ESTIMATED_PROPORTION_OF_SERVICE_USERS_EMPLOYING_STAFF)
-    ).with_columns(
         pl.when(
-            pl.col(DP.ESTIMATED_PROPORTION_OF_SERVICE_USERS_EMPLOYING_STAFF).is_null()
+            (
+                pl.col(
+                    DP.ESTIMATED_PROPORTION_OF_SERVICE_USERS_EMPLOYING_STAFF
+                ).is_null()
+                & pl.col(DP.ESTIMATE_USING_INTERPOLATION).is_not_null()
+            )
         )
         .then(pl.lit(DP.ESTIMATE_USING_INTERPOLATION))
         .otherwise(
             pl.col(DP.ESTIMATED_PROPORTION_OF_SERVICE_USERS_EMPLOYING_STAFF_SOURCE)
         )
         .alias(DP.ESTIMATED_PROPORTION_OF_SERVICE_USERS_EMPLOYING_STAFF_SOURCE)
+    ).with_columns(
+        pl.coalesce(
+            [
+                DP.ESTIMATED_PROPORTION_OF_SERVICE_USERS_EMPLOYING_STAFF,
+                DP.ESTIMATE_USING_INTERPOLATION,
+            ]
+        ).alias(DP.ESTIMATED_PROPORTION_OF_SERVICE_USERS_EMPLOYING_STAFF)
     )
 
     lf = calculate_rolling_mean(lf)

--- a/projects/_04_direct_payment_recipients/fargate/utils/estimate_direct_payments_utils/estimate_service_users_employing_staff.py
+++ b/projects/_04_direct_payment_recipients/fargate/utils/estimate_direct_payments_utils/estimate_service_users_employing_staff.py
@@ -1,7 +1,11 @@
 import polars as pl
 
+from polars_utils.utils import coalesce_with_source_labels
 from projects._04_direct_payment_recipients.direct_payments_column_names import (
     DirectPaymentColumnNames as DP,
+)
+from projects._04_direct_payment_recipients.fargate.utils.models.extrapolation_ratio import (
+    model_extrapolation,
 )
 from projects._04_direct_payment_recipients.fargate.utils.models.interpolation import (
     model_interpolation,
@@ -16,44 +20,47 @@ def calculate_estimated_service_users_employing_staff(lf: pl.LazyFrame) -> pl.La
     Doc string here
     """
 
-    lf = lf.with_columns(
-        pl.col(DP.PROPORTION_OF_SERVICE_USERS_EMPLOYING_STAFF).alias(
-            DP.ESTIMATED_PROPORTION_OF_SERVICE_USERS_EMPLOYING_STAFF
-        )
-    )
-
-    # lf = expolation_function(lf)
-
-    lf = model_interpolation(lf)
-
-    lf = lf.with_columns(
-        pl.coalesce(
-            [
-                DP.ESTIMATED_PROPORTION_OF_SERVICE_USERS_EMPLOYING_STAFF,
-                DP.ESTIMATE_USING_EXTRAPOLATION_RATIO,
-                DP.ESTIMATED_PROPORTION_OF_SERVICE_USERS_EMPLOYING_STAFF,
-            ]
-        ).alias(DP.ESTIMATED_PROPORTION_OF_SERVICE_USERS_EMPLOYING_STAFF)
-    )
-
     lf = model_using_mean(lf)
-
     lf = lf.with_columns(
         pl.coalesce(
             [DP.ESTIMATE_USING_MEAN, DP.HISTORIC_SERVICE_USERS_EMPLOYING_STAFF_ESTIMATE]
         ).alias(DP.ESTIMATE_USING_MEAN)
     )
 
+    lf = model_extrapolation(lf)
+
+    lf = model_interpolation(lf)
+
+    lf = lf.with_columns(
+        coalesce_with_source_labels(
+            cols=[
+                DP.PROPORTION_OF_SERVICE_USERS_EMPLOYING_STAFF,
+                DP.ESTIMATE_USING_EXTRAPOLATION_RATIO,
+                DP.ESTIMATE_USING_INTERPOLATION,
+                DP.ESTIMATE_USING_MEAN,
+            ],
+            name=DP.ESTIMATED_PROPORTION_OF_SERVICE_USERS_EMPLOYING_STAFF,
+        )
+    )
+
+    lf = lf.drop(DP.ESTIMATE_USING_INTERPOLATION)
+    lf = model_interpolation(lf)
+
     lf = lf.with_columns(
         pl.coalesce(
             [
                 DP.ESTIMATED_PROPORTION_OF_SERVICE_USERS_EMPLOYING_STAFF,
-                DP.ESTIMATE_USING_MEAN,
+                DP.ESTIMATE_USING_INTERPOLATION,
             ]
         ).alias(DP.ESTIMATED_PROPORTION_OF_SERVICE_USERS_EMPLOYING_STAFF)
+    ).with_columns(
+        pl.when(
+            pl.col(DP.ESTIMATED_PROPORTION_OF_SERVICE_USERS_EMPLOYING_STAFF).is_null()
+        )
+        .then(pl.lit(DP.ESTIMATE_USING_INTERPOLATION))
+        .alias("estimated_proportion_of_service_users_employing_staff_source")
     )
 
-    # Why does the interpolation happen again after the mean is applied?
-    # Area with 1 known value gets extrpolated, area with more than 1 gets interpolated, then no known values gets the mean.
+    # lf = calculate_rolling_mean(lf)
 
     return lf

--- a/projects/_04_direct_payment_recipients/fargate/utils/estimate_direct_payments_utils/estimate_service_users_employing_staff.py
+++ b/projects/_04_direct_payment_recipients/fargate/utils/estimate_direct_payments_utils/estimate_service_users_employing_staff.py
@@ -4,6 +4,9 @@ from polars_utils.utils import coalesce_with_source_labels
 from projects._04_direct_payment_recipients.direct_payments_column_names import (
     DirectPaymentColumnNames as DP,
 )
+from projects._04_direct_payment_recipients.fargate.utils.estimate_direct_payments_utils.calculate_rolling_mean import (
+    calculate_rolling_mean,
+)
 from projects._04_direct_payment_recipients.fargate.utils.models.extrapolation_ratio import (
     model_extrapolation,
 )
@@ -43,24 +46,33 @@ def calculate_estimated_service_users_employing_staff(lf: pl.LazyFrame) -> pl.La
         )
     )
 
-    lf = lf.drop(DP.ESTIMATE_USING_INTERPOLATION)
-    lf = model_interpolation(lf)
+    # lf = lf.drop(DP.ESTIMATE_USING_INTERPOLATION)
+    # lf = model_interpolation(lf)
+
+    # lf = lf.with_columns(
+    #     pl.coalesce(
+    #         [
+    #             DP.ESTIMATED_PROPORTION_OF_SERVICE_USERS_EMPLOYING_STAFF,
+    #             DP.ESTIMATE_USING_INTERPOLATION,
+    #         ]
+    #     ).alias(DP.ESTIMATED_PROPORTION_OF_SERVICE_USERS_EMPLOYING_STAFF)
+    # ).with_columns(
+    #     pl.when(
+    #         pl.col(DP.ESTIMATED_PROPORTION_OF_SERVICE_USERS_EMPLOYING_STAFF).is_null()
+    #     )
+    #     .then(pl.lit(DP.ESTIMATE_USING_INTERPOLATION))
+    #     .alias("estimated_proportion_of_service_users_employing_staff_source")
+    # )
+
+    lf = calculate_rolling_mean(lf)
 
     lf = lf.with_columns(
-        pl.coalesce(
-            [
-                DP.ESTIMATED_PROPORTION_OF_SERVICE_USERS_EMPLOYING_STAFF,
-                DP.ESTIMATE_USING_INTERPOLATION,
-            ]
-        ).alias(DP.ESTIMATED_PROPORTION_OF_SERVICE_USERS_EMPLOYING_STAFF)
-    ).with_columns(
-        pl.when(
-            pl.col(DP.ESTIMATED_PROPORTION_OF_SERVICE_USERS_EMPLOYING_STAFF).is_null()
-        )
-        .then(pl.lit(DP.ESTIMATE_USING_INTERPOLATION))
-        .alias("estimated_proportion_of_service_users_employing_staff_source")
+        (
+            pl.col(DP.SERVICE_USER_DPRS_DURING_YEAR)
+            * pl.col(
+                DP.ROLLING_AVERAGE_ESTIMATED_PROPORTION_OF_SERVICE_USERS_EMPLOYING_STAFF
+            )
+        ).alias(DP.ESTIMATED_SERVICE_USER_DPRS_DURING_YEAR_EMPLOYING_STAFF)
     )
-
-    # lf = calculate_rolling_mean(lf)
 
     return lf

--- a/projects/_04_direct_payment_recipients/fargate/utils/estimate_direct_payments_utils/estimate_service_users_employing_staff.py
+++ b/projects/_04_direct_payment_recipients/fargate/utils/estimate_direct_payments_utils/estimate_service_users_employing_staff.py
@@ -63,6 +63,9 @@ def calculate_estimated_service_users_employing_staff(lf: pl.LazyFrame) -> pl.La
             pl.col(DP.ESTIMATED_PROPORTION_OF_SERVICE_USERS_EMPLOYING_STAFF).is_null()
         )
         .then(pl.lit(DP.ESTIMATE_USING_INTERPOLATION))
+        .otherwise(
+            pl.col("estimated_proportion_of_service_users_employing_staff_source")
+        )
         .alias("estimated_proportion_of_service_users_employing_staff_source")
     )
 

--- a/projects/_04_direct_payment_recipients/fargate/utils/estimate_direct_payments_utils/estimate_service_users_employing_staff.py
+++ b/projects/_04_direct_payment_recipients/fargate/utils/estimate_direct_payments_utils/estimate_service_users_employing_staff.py
@@ -32,7 +32,7 @@ def calculate_estimated_service_users_employing_staff(lf: pl.LazyFrame) -> pl.La
 
     lf = model_extrapolation(lf)
 
-    lf = model_interpolation(lf)
+    lf = model_interpolation(lf, DP.PROPORTION_OF_SERVICE_USERS_EMPLOYING_STAFF)
 
     lf = lf.with_columns(
         coalesce_with_source_labels(
@@ -46,23 +46,25 @@ def calculate_estimated_service_users_employing_staff(lf: pl.LazyFrame) -> pl.La
         )
     )
 
-    # lf = lf.drop(DP.ESTIMATE_USING_INTERPOLATION)
-    # lf = model_interpolation(lf)
+    lf = lf.drop(DP.ESTIMATE_USING_INTERPOLATION)
+    lf = model_interpolation(
+        lf, DP.ESTIMATED_PROPORTION_OF_SERVICE_USERS_EMPLOYING_STAFF
+    )
 
-    # lf = lf.with_columns(
-    #     pl.coalesce(
-    #         [
-    #             DP.ESTIMATED_PROPORTION_OF_SERVICE_USERS_EMPLOYING_STAFF,
-    #             DP.ESTIMATE_USING_INTERPOLATION,
-    #         ]
-    #     ).alias(DP.ESTIMATED_PROPORTION_OF_SERVICE_USERS_EMPLOYING_STAFF)
-    # ).with_columns(
-    #     pl.when(
-    #         pl.col(DP.ESTIMATED_PROPORTION_OF_SERVICE_USERS_EMPLOYING_STAFF).is_null()
-    #     )
-    #     .then(pl.lit(DP.ESTIMATE_USING_INTERPOLATION))
-    #     .alias("estimated_proportion_of_service_users_employing_staff_source")
-    # )
+    lf = lf.with_columns(
+        pl.coalesce(
+            [
+                DP.ESTIMATED_PROPORTION_OF_SERVICE_USERS_EMPLOYING_STAFF,
+                DP.ESTIMATE_USING_INTERPOLATION,
+            ]
+        ).alias(DP.ESTIMATED_PROPORTION_OF_SERVICE_USERS_EMPLOYING_STAFF)
+    ).with_columns(
+        pl.when(
+            pl.col(DP.ESTIMATED_PROPORTION_OF_SERVICE_USERS_EMPLOYING_STAFF).is_null()
+        )
+        .then(pl.lit(DP.ESTIMATE_USING_INTERPOLATION))
+        .alias("estimated_proportion_of_service_users_employing_staff_source")
+    )
 
     lf = calculate_rolling_mean(lf)
 

--- a/projects/_04_direct_payment_recipients/fargate/utils/models/interpolation.py
+++ b/projects/_04_direct_payment_recipients/fargate/utils/models/interpolation.py
@@ -14,14 +14,14 @@ def model_interpolation(
 
     Args:
         direct_payments_lf (pl.LazyFrame): Input LazyFrame with columns LA_AREA,
-            YEAR_AS_INTEGER and ESTIMATED_PROPORTION_OF_SERVICE_USERS_EMPLOYING_STAFF
+            YEAR_AS_INTEGER and PROPORTION_OF_SERVICE_USERS_EMPLOYING_STAFF
 
     Returns:
         pl.LazyFrame: Original LazyFrame with an additional column
             ESTIMATE_USING_INTERPOLATION
     """
     return direct_payments_lf.with_columns(
-        pl.col(DP.ESTIMATED_PROPORTION_OF_SERVICE_USERS_EMPLOYING_STAFF)
+        pl.col(DP.PROPORTION_OF_SERVICE_USERS_EMPLOYING_STAFF)
         .interpolate_by(DP.YEAR_AS_INTEGER)
         .over(DP.LA_AREA)
         .alias(DP.ESTIMATE_USING_INTERPOLATION)

--- a/projects/_04_direct_payment_recipients/fargate/utils/models/interpolation.py
+++ b/projects/_04_direct_payment_recipients/fargate/utils/models/interpolation.py
@@ -7,6 +7,7 @@ from projects._04_direct_payment_recipients.direct_payments_column_names import 
 
 def model_interpolation(
     direct_payments_lf: pl.LazyFrame,
+    col_with_nulls: str,
 ) -> pl.LazyFrame:
     """
     Performs straight line interpolation of missing values for the
@@ -15,13 +16,14 @@ def model_interpolation(
     Args:
         direct_payments_lf (pl.LazyFrame): Input LazyFrame with columns LA_AREA,
             YEAR_AS_INTEGER and PROPORTION_OF_SERVICE_USERS_EMPLOYING_STAFF
+        col_with_nulls (str): A column with null values to interpolate between.
 
     Returns:
         pl.LazyFrame: Original LazyFrame with an additional column
             ESTIMATE_USING_INTERPOLATION
     """
     return direct_payments_lf.with_columns(
-        pl.col(DP.PROPORTION_OF_SERVICE_USERS_EMPLOYING_STAFF)
+        pl.col(col_with_nulls)
         .interpolate_by(DP.YEAR_AS_INTEGER)
         .over(DP.LA_AREA)
         .alias(DP.ESTIMATE_USING_INTERPOLATION)

--- a/projects/_04_direct_payment_recipients/tests/fargate/test_estimate_direct_payments.py
+++ b/projects/_04_direct_payment_recipients/tests/fargate/test_estimate_direct_payments.py
@@ -1,9 +1,6 @@
 import unittest
 from unittest.mock import ANY, Mock, patch
 
-import polars as pl
-import polars.testing as pl_testing
-
 import projects._04_direct_payment_recipients.fargate.estimate_direct_payments as job
 
 PATCH_PATH: str = (

--- a/projects/_04_direct_payment_recipients/tests/fargate/test_estimate_direct_payments.py
+++ b/projects/_04_direct_payment_recipients/tests/fargate/test_estimate_direct_payments.py
@@ -1,5 +1,5 @@
 import unittest
-from unittest.mock import ANY, Mock, patch
+from unittest.mock import ANY, Mock, call, patch
 
 import projects._04_direct_payment_recipients.fargate.estimate_direct_payments as job
 
@@ -14,10 +14,16 @@ class EstimateDirectPaymentsTests(unittest.TestCase):
     SOME_OTHER_DESTINATION = "some/other/destination"
 
     @patch(f"{PATCH_PATH}.utils.sink_to_parquet")
+    @patch(f"{PATCH_PATH}.create_summary_table")
+    @patch(f"{PATCH_PATH}.calculate_remaining_variables")
+    @patch(f"{PATCH_PATH}.calculate_estimated_service_users_employing_staff")
     @patch(f"{PATCH_PATH}.utils.scan_parquet")
     def test_main_succeeds(
         self,
         scan_parquet_mock: Mock,
+        calculate_estimated_service_users_employing_staff_mock: Mock,
+        calculate_remaining_variables_mock: Mock,
+        create_summary_table_mock: Mock,
         sink_to_parquet_mock: Mock,
     ):
         job.main(
@@ -31,8 +37,22 @@ class EstimateDirectPaymentsTests(unittest.TestCase):
             selected_columns=job.direct_payments_columns,
         )
 
-        sink_to_parquet_mock.assert_called_once_with(
-            ANY,
-            self.SOME_DESTINATION,
-            append=False,
+        calculate_estimated_service_users_employing_staff_mock.assert_called_once()
+        calculate_remaining_variables_mock.assert_called_once()
+        create_summary_table_mock.assert_called_once()
+
+        self.assertEqual(sink_to_parquet_mock.call_count, 2)
+        sink_to_parquet_mock.assert_has_calls(
+            [
+                call(
+                    ANY,
+                    self.SOME_DESTINATION,
+                    append=False,
+                ),
+                call(
+                    ANY,
+                    self.SOME_OTHER_DESTINATION,
+                    append=False,
+                ),
+            ]
         )

--- a/projects/_04_direct_payment_recipients/tests/fargate/utils/models/test_interpolation.py
+++ b/projects/_04_direct_payment_recipients/tests/fargate/utils/models/test_interpolation.py
@@ -32,6 +32,8 @@ class TestDPRModelInterpolation(unittest.TestCase):
         }
         expected_lf = pl.LazyFrame(rows, schema=test_schema, orient="row")
         test_lf = expected_lf.drop(DP.ESTIMATE_USING_INTERPOLATION)
-        returned_lf = job.model_interpolation(test_lf)
+        returned_lf = job.model_interpolation(
+            test_lf, DP.PROPORTION_OF_SERVICE_USERS_EMPLOYING_STAFF
+        )
         pl_testing.assert_frame_equal(returned_lf, expected_lf, check_row_order=False)
         pl_testing.assert_frame_equal(returned_lf, expected_lf, check_row_order=False)

--- a/projects/_04_direct_payment_recipients/tests/fargate/utils/models/test_interpolation.py
+++ b/projects/_04_direct_payment_recipients/tests/fargate/utils/models/test_interpolation.py
@@ -36,4 +36,3 @@ class TestDPRModelInterpolation(unittest.TestCase):
             test_lf, DP.PROPORTION_OF_SERVICE_USERS_EMPLOYING_STAFF
         )
         pl_testing.assert_frame_equal(returned_lf, expected_lf, check_row_order=False)
-        pl_testing.assert_frame_equal(returned_lf, expected_lf, check_row_order=False)

--- a/projects/_04_direct_payment_recipients/tests/fargate/utils/models/test_interpolation.py
+++ b/projects/_04_direct_payment_recipients/tests/fargate/utils/models/test_interpolation.py
@@ -1,4 +1,5 @@
 import unittest
+
 import polars as pl
 import polars.testing as pl_testing
 
@@ -26,10 +27,11 @@ class TestDPRModelInterpolation(unittest.TestCase):
         test_schema = {
             DP.LA_AREA: pl.String,
             DP.YEAR_AS_INTEGER: pl.Int64,
-            DP.ESTIMATED_PROPORTION_OF_SERVICE_USERS_EMPLOYING_STAFF: pl.Float64,
+            DP.PROPORTION_OF_SERVICE_USERS_EMPLOYING_STAFF: pl.Float64,
             DP.ESTIMATE_USING_INTERPOLATION: pl.Float64,
         }
         expected_lf = pl.LazyFrame(rows, schema=test_schema, orient="row")
         test_lf = expected_lf.drop(DP.ESTIMATE_USING_INTERPOLATION)
         returned_lf = job.model_interpolation(test_lf)
+        pl_testing.assert_frame_equal(returned_lf, expected_lf, check_row_order=False)
         pl_testing.assert_frame_equal(returned_lf, expected_lf, check_row_order=False)

--- a/projects/_04_direct_payment_recipients/tests/fargate/utils/test_estimate_service_users_employing_staff.py
+++ b/projects/_04_direct_payment_recipients/tests/fargate/utils/test_estimate_service_users_employing_staff.py
@@ -43,7 +43,7 @@ estimated_service_users_employing_staff_test_cases = [
             ("area_2", 2021, 10.0, 0.5, None),
         ], # fmt: skip
         expected_data=[
-            ("area_1", 2020, 10.0, None, None, 0.3, 2021, 2021, 0.3, None, 0.3, "estimate_using_extrapolation_ratio", 0.3, 3.0),
+            ("area_1", 2020, 10.0, None, None, 0.3, 2021, 2021, 0.3, 0.3, 0.3, "estimate_using_extrapolation_ratio", 0.3, 3.0),
             ("area_1", 2021, 10.0, 0.5, None, 0.5, 2021, 2021, None, 0.5, 0.5, "proportion_su_only_employing_staff", 0.4, 4.0),
             ("area_2", 2020, 10.0, 0.3, None, 0.3, 2020, 2021, None, 0.3, 0.3, "proportion_su_only_employing_staff", 0.3, 3.0),
             ("area_2", 2021, 10.0, 0.5, None, 0.5, 2020, 2021, None, 0.5, 0.5, "proportion_su_only_employing_staff", 0.4, 4.0),
@@ -69,8 +69,8 @@ estimated_service_users_employing_staff_test_cases = [
             ("area_1", 2021, 10.0, None, 0.4),
         ], # fmt: skip
         expected_data=[
-            ("area_1", 2020, 10.0, None, 0.5, 0.5, None, None, None, None, 0.5, "estimate_using_mean", 0.5, 5.0),
-            ("area_1", 2021, 10.0, None, 0.4, 0.4, None, None, None, None, 0.4, "estimate_using_mean", 0.45, 4.5),
+            ("area_1", 2020, 10.0, None, 0.5, 0.5, None, None, None, 0.5, 0.5, "estimate_using_mean", 0.5, 5.0),
+            ("area_1", 2021, 10.0, None, 0.4, 0.4, None, None, None, 0.4, 0.4, "estimate_using_mean", 0.45, 4.5),
         ] # fmt: skip
     ),
 ]

--- a/projects/_04_direct_payment_recipients/tests/fargate/utils/test_estimate_service_users_employing_staff.py
+++ b/projects/_04_direct_payment_recipients/tests/fargate/utils/test_estimate_service_users_employing_staff.py
@@ -110,7 +110,7 @@ class TestEstimateServiceUsersEmployingStaff:
                 DP.ESTIMATE_USING_EXTRAPOLATION_RATIO: pl.Float32,
                 DP.ESTIMATE_USING_INTERPOLATION: pl.Float32,
                 DP.ESTIMATED_PROPORTION_OF_SERVICE_USERS_EMPLOYING_STAFF: pl.Float32,
-                "estimated_proportion_of_service_users_employing_staff_source": pl.String,
+                DP.ESTIMATED_PROPORTION_OF_SERVICE_USERS_EMPLOYING_STAFF_SOURCE: pl.String,
                 DP.ROLLING_AVERAGE_ESTIMATED_PROPORTION_OF_SERVICE_USERS_EMPLOYING_STAFF: pl.Float32,
                 DP.ESTIMATED_SERVICE_USER_DPRS_DURING_YEAR_EMPLOYING_STAFF: pl.Float32,
             },

--- a/projects/_04_direct_payment_recipients/tests/fargate/utils/test_estimate_service_users_employing_staff.py
+++ b/projects/_04_direct_payment_recipients/tests/fargate/utils/test_estimate_service_users_employing_staff.py
@@ -23,7 +23,7 @@ class EstimateServiceUsersEmployingStaffTestCase:
 
 estimated_service_users_employing_staff_test_cases = [
     EstimateServiceUsersEmployingStaffTestCase(
-        id="known_proportions_in_all_years_gives_known_proportions",
+        id="known_proportions_used_when_known",
         expected_data=
             {
                 DP.LA_AREA: ["area_1", "area_1"],
@@ -43,7 +43,7 @@ estimated_service_users_employing_staff_test_cases = [
             }, # fmt: skip
     ),
     EstimateServiceUsersEmployingStaffTestCase(
-        id="null_proportion_in_earliest_year_gives_extrapolated_proportion_from_mean_of_known_proportions",
+        id="extrapolation_used_when_first_year_missing",
         expected_data={
                 DP.LA_AREA: ["area_1", "area_1", "area_2", "area_2"],
                 DP.YEAR_AS_INTEGER: [2020, 2021, 2020, 2021],
@@ -62,7 +62,7 @@ estimated_service_users_employing_staff_test_cases = [
             }, # fmt: skip
     ),
     EstimateServiceUsersEmployingStaffTestCase(
-        id="null_proportion_between_known_years_gives_interpolated_proportion",
+        id="interpolation_used_to_populate_missing_value_between_known",
         expected_data={
             DP.LA_AREA: ["area_1", "area_1", "area_1"],
             DP.YEAR_AS_INTEGER: [2020, 2021, 2022],
@@ -81,7 +81,7 @@ estimated_service_users_employing_staff_test_cases = [
         } # fmt: skip
     ),
     EstimateServiceUsersEmployingStaffTestCase(
-        id="only_historic_data_is_known_gives_mean_proportion",
+        id="mean_used_only_historic_estimate_available",
         expected_data={
             DP.LA_AREA: ["area_1", "area_1"],
             DP.YEAR_AS_INTEGER: [2020, 2021],
@@ -97,6 +97,25 @@ estimated_service_users_employing_staff_test_cases = [
             DP.ESTIMATED_PROPORTION_OF_SERVICE_USERS_EMPLOYING_STAFF_SOURCE: [DP.ESTIMATE_USING_MEAN, DP.ESTIMATE_USING_MEAN],
             DP.ROLLING_AVERAGE_ESTIMATED_PROPORTION_OF_SERVICE_USERS_EMPLOYING_STAFF: [0.5, 0.45],
             DP.ESTIMATED_SERVICE_USER_DPRS_DURING_YEAR_EMPLOYING_STAFF: [5.0, 4.5],
+        } # fmt: skip
+    ),
+    EstimateServiceUsersEmployingStaffTestCase(
+        id="no_known_proportions_or_historic_proportions",
+        expected_data={
+            DP.LA_AREA: ["area_1", "area_1"],
+            DP.YEAR_AS_INTEGER: [2020, 2021],
+            DP.SERVICE_USER_DPRS_DURING_YEAR: [10.0, 10.0],
+            DP.PROPORTION_OF_SERVICE_USERS_EMPLOYING_STAFF: [None, None],
+            DP.HISTORIC_SERVICE_USERS_EMPLOYING_STAFF_ESTIMATE: [None, None],
+            DP.ESTIMATE_USING_MEAN: [None, None],
+            DP.FIRST_YEAR_WITH_DATA: [None, None],
+            DP.LAST_YEAR_WITH_DATA: [None, None],
+            DP.ESTIMATE_USING_EXTRAPOLATION_RATIO: [None, None],
+            DP.ESTIMATE_USING_INTERPOLATION: [None, None],
+            DP.ESTIMATED_PROPORTION_OF_SERVICE_USERS_EMPLOYING_STAFF: [None, None],
+            DP.ESTIMATED_PROPORTION_OF_SERVICE_USERS_EMPLOYING_STAFF_SOURCE: [None, None],
+            DP.ROLLING_AVERAGE_ESTIMATED_PROPORTION_OF_SERVICE_USERS_EMPLOYING_STAFF: [None, None],
+            DP.ESTIMATED_SERVICE_USER_DPRS_DURING_YEAR_EMPLOYING_STAFF: [None, None],
         } # fmt: skip
     ),
 ]

--- a/projects/_04_direct_payment_recipients/tests/fargate/utils/test_estimate_service_users_employing_staff.py
+++ b/projects/_04_direct_payment_recipients/tests/fargate/utils/test_estimate_service_users_employing_staff.py
@@ -14,46 +14,110 @@ from projects._04_direct_payment_recipients.direct_payments_column_names import 
 @dataclass
 class EstimateServiceUsersEmployingStaffTestCase:
     id: str
-    data: list[Any]
+    input_data: list[Any]
+    expected_data: list[Any]
 
     def as_pytest_param(self):
         """Return test case as pytest ParameterSet."""
-        return pytest.param(self.data, id=self.id)
+        return pytest.param(self.input_data, self.expected_data, id=self.id)
 
 
 estimated_service_users_employing_staff_test_cases = [
     EstimateServiceUsersEmployingStaffTestCase(
-        id="Test_1",
-        data=[
-            ("area_1", 2021, 0.6, 0.5),
-            ("area_1", 2020, 0.5, 0.4),
-            ("area_1", 2019, 0.4, 0.3),
-            ("area_1", 2018, 0.3, 0.2),
-            ("area_1", 2017, 0.2, 0.15),
-            ("area_1", 2016, 0.1, 0.1),
-        ],
+        id="known_proportions_in_all_years",
+        input_data=[
+            ("area_1", 2020, 10.0, 0.5, None),
+            ("area_1", 2021, 10.0, 0.5, None),
+        ], # fmt: skip
+        expected_data=[
+            ("area_1", 2020, 10.0, 0.5, None, 0.5, 2020, 2021, None, 0.5, 0.5, "proportion_su_only_employing_staff", 0.5, 5.0),
+            ("area_1", 2021, 10.0, 0.5, None, 0.5, 2020, 2021, None, 0.5, 0.5, "proportion_su_only_employing_staff", 0.5, 5.0),
+        ] # fmt: skip
+    ),
+    EstimateServiceUsersEmployingStaffTestCase(
+        id="an_area_is_missing_single_year",
+        input_data=[
+            ("area_1", 2020, 10.0, None, None),
+            ("area_1", 2021, 10.0, 0.5, None),
+            ("area_2", 2020, 10.0, 0.3, None),
+            ("area_2", 2021, 10.0, 0.5, None),
+        ], # fmt: skip
+        expected_data=[
+            ("area_1", 2020, 10.0, None, None, 0.3, 2021, 2021, 0.3, None, 0.3, "estimate_using_extrapolation_ratio", 0.3, 3.0),
+            ("area_1", 2021, 10.0, 0.5, None, 0.5, 2021, 2021, None, 0.5, 0.5, "proportion_su_only_employing_staff", 0.4, 4.0),
+            ("area_2", 2020, 10.0, 0.3, None, 0.3, 2020, 2021, None, 0.3, 0.3, "proportion_su_only_employing_staff", 0.3, 3.0),
+            ("area_2", 2021, 10.0, 0.5, None, 0.5, 2020, 2021, None, 0.5, 0.5, "proportion_su_only_employing_staff", 0.4, 4.0),
+        ] # fmt: skip
+    ),
+    EstimateServiceUsersEmployingStaffTestCase(
+        id="an_area_is_missing_middle_year",
+        input_data=[
+            ("area_1", 2020, 10.0, 0.5, None),
+            ("area_1", 2021, 10.0, None, None),
+            ("area_1", 2022, 10.0, 0.3, None),
+        ], # fmt: skip
+        expected_data=[
+            ("area_1", 2020, 10.0, 0.5, None, 0.5, 2020, 2022, None, 0.5, 0.5, "proportion_su_only_employing_staff", 0.5, 5.0),
+            ("area_1", 2021, 10.0, None, None, None, 2020, 2022, None, 0.4, 0.4, "estimate_using_interpolation", 0.45, 4.5),
+            ("area_1", 2022, 10.0, 0.3, None, 0.3, 2020, 2022, None, 0.3, 0.3, "proportion_su_only_employing_staff", 0.4, 4.0),
+        ] # fmt: skip
+    ),
+    EstimateServiceUsersEmployingStaffTestCase(
+        id="only_historic_data",
+        input_data=[
+            ("area_1", 2020, 10.0, None, 0.5),
+            ("area_1", 2021, 10.0, None, 0.4),
+        ], # fmt: skip
+        expected_data=[
+            ("area_1", 2020, 10.0, None, 0.5, 0.5, None, None, None, None, 0.5, "estimate_using_mean", 0.5, 5.0),
+            ("area_1", 2021, 10.0, None, 0.4, 0.4, None, None, None, None, 0.4, "estimate_using_mean", 0.45, 4.5),
+        ] # fmt: skip
     ),
 ]
 
 
 class TestEstimateServiceUsersEmployingStaff:
     @pytest.mark.parametrize(
-        "test_data",
+        ("input_data", "expected_data"),
         [
             case.as_pytest_param()
             for case in estimated_service_users_employing_staff_test_cases
         ],
     )
-    def test_function_returns_expected_values(self, test_data):
-        expected_lf = pl.LazyFrame(
-            test_data,
+    def test_function_returns_expected_values(self, input_data, expected_data):
+        input_lf = pl.LazyFrame(
+            input_data,
             schema={
                 DP.LA_AREA: pl.String,
                 DP.YEAR_AS_INTEGER: pl.Int64,
-                DP.PROPORTION_OF_SERVICE_USERS_EMPLOYING_STAFF: pl.Float64,
+                DP.SERVICE_USER_DPRS_DURING_YEAR: pl.Float32,
+                DP.PROPORTION_OF_SERVICE_USERS_EMPLOYING_STAFF: pl.Float32,
+                DP.HISTORIC_SERVICE_USERS_EMPLOYING_STAFF_ESTIMATE: pl.Float32,
             },
             orient="row",
         )
-        test_lf = expected_lf.drop(DP.ESTIMATE_USING_MEAN)
-        returned_lf = job.calculate_estimated_service_users_employing_staff(test_lf)
-        pl_testing.assert_frame_equal(returned_lf, expected_lf)
+        expected_lf = pl.LazyFrame(
+            expected_data,
+            schema={
+                DP.LA_AREA: pl.String,
+                DP.YEAR_AS_INTEGER: pl.Int64,
+                DP.SERVICE_USER_DPRS_DURING_YEAR: pl.Float32,
+                DP.PROPORTION_OF_SERVICE_USERS_EMPLOYING_STAFF: pl.Float32,
+                DP.HISTORIC_SERVICE_USERS_EMPLOYING_STAFF_ESTIMATE: pl.Float32,
+                DP.ESTIMATE_USING_MEAN: pl.Float32,
+                DP.FIRST_YEAR_WITH_DATA: pl.Int32,
+                DP.LAST_YEAR_WITH_DATA: pl.Int32,
+                DP.ESTIMATE_USING_EXTRAPOLATION_RATIO: pl.Float32,
+                DP.ESTIMATE_USING_INTERPOLATION: pl.Float32,
+                DP.ESTIMATED_PROPORTION_OF_SERVICE_USERS_EMPLOYING_STAFF: pl.Float32,
+                "estimated_proportion_of_service_users_employing_staff_source": pl.String,
+                DP.ROLLING_AVERAGE_ESTIMATED_PROPORTION_OF_SERVICE_USERS_EMPLOYING_STAFF: pl.Float32,
+                DP.ESTIMATED_SERVICE_USER_DPRS_DURING_YEAR_EMPLOYING_STAFF: pl.Float32,
+            },
+            orient="row",
+        )
+        returned_lf = job.calculate_estimated_service_users_employing_staff(input_lf)
+
+        pl_testing.assert_frame_equal(
+            returned_lf, expected_lf, check_column_order=False
+        )

--- a/projects/_04_direct_payment_recipients/tests/fargate/utils/test_estimate_service_users_employing_staff.py
+++ b/projects/_04_direct_payment_recipients/tests/fargate/utils/test_estimate_service_users_employing_staff.py
@@ -1,0 +1,59 @@
+from dataclasses import dataclass
+from typing import Any
+
+import polars as pl
+import polars.testing as pl_testing
+import pytest
+
+import projects._04_direct_payment_recipients.fargate.utils.estimate_direct_payments_utils.estimate_service_users_employing_staff as job
+from projects._04_direct_payment_recipients.direct_payments_column_names import (
+    DirectPaymentColumnNames as DP,
+)
+
+
+@dataclass
+class EstimateServiceUsersEmployingStaffTestCase:
+    id: str
+    data: list[Any]
+
+    def as_pytest_param(self):
+        """Return test case as pytest ParameterSet."""
+        return pytest.param(self.data, id=self.id)
+
+
+estimated_service_users_employing_staff_test_cases = [
+    EstimateServiceUsersEmployingStaffTestCase(
+        id="Test_1",
+        data=[
+            ("area_1", 2021, 0.6, 0.5),
+            ("area_1", 2020, 0.5, 0.4),
+            ("area_1", 2019, 0.4, 0.3),
+            ("area_1", 2018, 0.3, 0.2),
+            ("area_1", 2017, 0.2, 0.15),
+            ("area_1", 2016, 0.1, 0.1),
+        ],
+    ),
+]
+
+
+class TestEstimateServiceUsersEmployingStaff:
+    @pytest.mark.parametrize(
+        "test_data",
+        [
+            case.as_pytest_param()
+            for case in estimated_service_users_employing_staff_test_cases
+        ],
+    )
+    def test_function_returns_expected_values(self, test_data):
+        expected_lf = pl.LazyFrame(
+            test_data,
+            schema={
+                DP.LA_AREA: pl.String,
+                DP.YEAR_AS_INTEGER: pl.Int64,
+                DP.PROPORTION_OF_SERVICE_USERS_EMPLOYING_STAFF: pl.Float64,
+            },
+            orient="row",
+        )
+        test_lf = expected_lf.drop(DP.ESTIMATE_USING_MEAN)
+        returned_lf = job.calculate_estimated_service_users_employing_staff(test_lf)
+        pl_testing.assert_frame_equal(returned_lf, expected_lf)

--- a/projects/_04_direct_payment_recipients/tests/fargate/utils/test_estimate_service_users_employing_staff.py
+++ b/projects/_04_direct_payment_recipients/tests/fargate/utils/test_estimate_service_users_employing_staff.py
@@ -35,7 +35,7 @@ estimated_service_users_employing_staff_test_cases = [
         ] # fmt: skip
     ),
     EstimateServiceUsersEmployingStaffTestCase(
-        id="an_area_is_missing_single_year",
+        id="null_proportion_in_earliest_year",
         input_data=[
             ("area_1", 2020, 10.0, None, None),
             ("area_1", 2021, 10.0, 0.5, None),
@@ -50,7 +50,7 @@ estimated_service_users_employing_staff_test_cases = [
         ] # fmt: skip
     ),
     EstimateServiceUsersEmployingStaffTestCase(
-        id="an_area_is_missing_middle_year",
+        id="null_proportion_between_known_years",
         input_data=[
             ("area_1", 2020, 10.0, 0.5, None),
             ("area_1", 2021, 10.0, None, None),
@@ -63,7 +63,7 @@ estimated_service_users_employing_staff_test_cases = [
         ] # fmt: skip
     ),
     EstimateServiceUsersEmployingStaffTestCase(
-        id="only_historic_data",
+        id="only_historic_data_is_known",
         input_data=[
             ("area_1", 2020, 10.0, None, 0.5),
             ("area_1", 2021, 10.0, None, 0.4),

--- a/projects/_04_direct_payment_recipients/tests/fargate/utils/test_estimate_service_users_employing_staff.py
+++ b/projects/_04_direct_payment_recipients/tests/fargate/utils/test_estimate_service_users_employing_staff.py
@@ -14,88 +14,103 @@ from projects._04_direct_payment_recipients.direct_payments_column_names import 
 @dataclass
 class EstimateServiceUsersEmployingStaffTestCase:
     id: str
-    input_data: list[Any]
     expected_data: list[Any]
 
     def as_pytest_param(self):
         """Return test case as pytest ParameterSet."""
-        return pytest.param(self.input_data, self.expected_data, id=self.id)
+        return pytest.param(self.expected_data, id=self.id)
 
 
 estimated_service_users_employing_staff_test_cases = [
     EstimateServiceUsersEmployingStaffTestCase(
-        id="known_proportions_in_all_years",
-        input_data=[
-            ("area_1", 2020, 10.0, 0.5, None),
-            ("area_1", 2021, 10.0, 0.5, None),
-        ], # fmt: skip
-        expected_data=[
-            ("area_1", 2020, 10.0, 0.5, None, 0.5, 2020, 2021, None, 0.5, 0.5, "proportion_su_only_employing_staff", 0.5, 5.0),
-            ("area_1", 2021, 10.0, 0.5, None, 0.5, 2020, 2021, None, 0.5, 0.5, "proportion_su_only_employing_staff", 0.5, 5.0),
-        ] # fmt: skip
+        id="known_proportions_in_all_years_gives_known_proportions",
+        expected_data=
+            {
+                DP.LA_AREA: ["area_1", "area_1"],
+                DP.YEAR_AS_INTEGER: [2020, 2021],
+                DP.SERVICE_USER_DPRS_DURING_YEAR: [10.0, 10.0],
+                DP.PROPORTION_OF_SERVICE_USERS_EMPLOYING_STAFF: [0.5, 0.5],
+                DP.HISTORIC_SERVICE_USERS_EMPLOYING_STAFF_ESTIMATE: [None, None],
+                DP.ESTIMATE_USING_MEAN: [0.5, 0.5],
+                DP.FIRST_YEAR_WITH_DATA: [2020, 2020],
+                DP.LAST_YEAR_WITH_DATA: [2021, 2021],
+                DP.ESTIMATE_USING_EXTRAPOLATION_RATIO: [None, None],
+                DP.ESTIMATE_USING_INTERPOLATION: [0.5, 0.5],
+                DP.ESTIMATED_PROPORTION_OF_SERVICE_USERS_EMPLOYING_STAFF: [0.5, 0.5],
+                DP.ESTIMATED_PROPORTION_OF_SERVICE_USERS_EMPLOYING_STAFF_SOURCE: ["proportion_su_only_employing_staff", "proportion_su_only_employing_staff"],
+                DP.ROLLING_AVERAGE_ESTIMATED_PROPORTION_OF_SERVICE_USERS_EMPLOYING_STAFF: [0.5, 0.5],
+                DP.ESTIMATED_SERVICE_USER_DPRS_DURING_YEAR_EMPLOYING_STAFF: [5.0, 5.0],
+            }, # fmt: skip
     ),
     EstimateServiceUsersEmployingStaffTestCase(
-        id="null_proportion_in_earliest_year",
-        input_data=[
-            ("area_1", 2020, 10.0, None, None),
-            ("area_1", 2021, 10.0, 0.5, None),
-            ("area_2", 2020, 10.0, 0.3, None),
-            ("area_2", 2021, 10.0, 0.5, None),
-        ], # fmt: skip
-        expected_data=[
-            ("area_1", 2020, 10.0, None, None, 0.3, 2021, 2021, 0.3, 0.3, 0.3, "estimate_using_extrapolation_ratio", 0.3, 3.0),
-            ("area_1", 2021, 10.0, 0.5, None, 0.5, 2021, 2021, None, 0.5, 0.5, "proportion_su_only_employing_staff", 0.4, 4.0),
-            ("area_2", 2020, 10.0, 0.3, None, 0.3, 2020, 2021, None, 0.3, 0.3, "proportion_su_only_employing_staff", 0.3, 3.0),
-            ("area_2", 2021, 10.0, 0.5, None, 0.5, 2020, 2021, None, 0.5, 0.5, "proportion_su_only_employing_staff", 0.4, 4.0),
-        ] # fmt: skip
+        id="null_proportion_in_earliest_year_gives_extrapolated_proportion_from_mean_of_known_proportions",
+        expected_data={
+                DP.LA_AREA: ["area_1", "area_1", "area_2", "area_2"],
+                DP.YEAR_AS_INTEGER: [2020, 2021, 2020, 2021],
+                DP.SERVICE_USER_DPRS_DURING_YEAR: [10.0, 10.0, 10.0, 10.0],
+                DP.PROPORTION_OF_SERVICE_USERS_EMPLOYING_STAFF: [None, 0.5, 0.3, 0.5],
+                DP.HISTORIC_SERVICE_USERS_EMPLOYING_STAFF_ESTIMATE: [None, None, None, None],
+                DP.ESTIMATE_USING_MEAN: [0.3, 0.5, 0.3, 0.5],
+                DP.FIRST_YEAR_WITH_DATA: [2021, 2021, 2020, 2020],
+                DP.LAST_YEAR_WITH_DATA: [2021, 2021, 2021, 2021],
+                DP.ESTIMATE_USING_EXTRAPOLATION_RATIO: [0.3, None, None, None],
+                DP.ESTIMATE_USING_INTERPOLATION: [0.3, 0.5, 0.3, 0.5],
+                DP.ESTIMATED_PROPORTION_OF_SERVICE_USERS_EMPLOYING_STAFF: [0.3, 0.5, 0.3, 0.5],
+                DP.ESTIMATED_PROPORTION_OF_SERVICE_USERS_EMPLOYING_STAFF_SOURCE: [DP.ESTIMATE_USING_EXTRAPOLATION_RATIO, DP.PROPORTION_OF_SERVICE_USERS_EMPLOYING_STAFF, DP.PROPORTION_OF_SERVICE_USERS_EMPLOYING_STAFF, DP.PROPORTION_OF_SERVICE_USERS_EMPLOYING_STAFF],
+                DP.ROLLING_AVERAGE_ESTIMATED_PROPORTION_OF_SERVICE_USERS_EMPLOYING_STAFF: [0.3, 0.4, 0.3, 0.4],
+                DP.ESTIMATED_SERVICE_USER_DPRS_DURING_YEAR_EMPLOYING_STAFF: [3.0, 4.0, 3.0, 4.0],
+            }, # fmt: skip
     ),
     EstimateServiceUsersEmployingStaffTestCase(
-        id="null_proportion_between_known_years",
-        input_data=[
-            ("area_1", 2020, 10.0, 0.5, None),
-            ("area_1", 2021, 10.0, None, None),
-            ("area_1", 2022, 10.0, 0.3, None),
-        ], # fmt: skip
-        expected_data=[
-            ("area_1", 2020, 10.0, 0.5, None, 0.5, 2020, 2022, None, 0.5, 0.5, "proportion_su_only_employing_staff", 0.5, 5.0),
-            ("area_1", 2021, 10.0, None, None, None, 2020, 2022, None, 0.4, 0.4, "estimate_using_interpolation", 0.45, 4.5),
-            ("area_1", 2022, 10.0, 0.3, None, 0.3, 2020, 2022, None, 0.3, 0.3, "proportion_su_only_employing_staff", 0.4, 4.0),
-        ] # fmt: skip
+        id="null_proportion_between_known_years_gives_interpolated_proportion",
+        expected_data={
+            DP.LA_AREA: ["area_1", "area_1", "area_1"],
+            DP.YEAR_AS_INTEGER: [2020, 2021, 2022],
+            DP.SERVICE_USER_DPRS_DURING_YEAR: [10.0, 10.0, 10.0],
+            DP.PROPORTION_OF_SERVICE_USERS_EMPLOYING_STAFF: [0.5, None, 0.3],
+            DP.HISTORIC_SERVICE_USERS_EMPLOYING_STAFF_ESTIMATE: [None, None, None],
+            DP.ESTIMATE_USING_MEAN: [0.5, None, 0.3],
+            DP.FIRST_YEAR_WITH_DATA: [2020, 2020, 2020],
+            DP.LAST_YEAR_WITH_DATA: [2022, 2022, 2022],
+            DP.ESTIMATE_USING_EXTRAPOLATION_RATIO: [None, None, None],
+            DP.ESTIMATE_USING_INTERPOLATION: [0.5, 0.4, 0.3],
+            DP.ESTIMATED_PROPORTION_OF_SERVICE_USERS_EMPLOYING_STAFF: [0.5, 0.4, 0.3],
+            DP.ESTIMATED_PROPORTION_OF_SERVICE_USERS_EMPLOYING_STAFF_SOURCE: [DP.PROPORTION_OF_SERVICE_USERS_EMPLOYING_STAFF, DP.ESTIMATE_USING_INTERPOLATION, DP.PROPORTION_OF_SERVICE_USERS_EMPLOYING_STAFF],
+            DP.ROLLING_AVERAGE_ESTIMATED_PROPORTION_OF_SERVICE_USERS_EMPLOYING_STAFF: [0.5, 0.45, 0.4],
+            DP.ESTIMATED_SERVICE_USER_DPRS_DURING_YEAR_EMPLOYING_STAFF: [5.0, 4.5, 4.0],
+        } # fmt: skip
     ),
     EstimateServiceUsersEmployingStaffTestCase(
-        id="only_historic_data_is_known",
-        input_data=[
-            ("area_1", 2020, 10.0, None, 0.5),
-            ("area_1", 2021, 10.0, None, 0.4),
-        ], # fmt: skip
-        expected_data=[
-            ("area_1", 2020, 10.0, None, 0.5, 0.5, None, None, None, 0.5, 0.5, "estimate_using_mean", 0.5, 5.0),
-            ("area_1", 2021, 10.0, None, 0.4, 0.4, None, None, None, 0.4, 0.4, "estimate_using_mean", 0.45, 4.5),
-        ] # fmt: skip
+        id="only_historic_data_is_known_gives_mean_proportion",
+        expected_data={
+            DP.LA_AREA: ["area_1", "area_1"],
+            DP.YEAR_AS_INTEGER: [2020, 2021],
+            DP.SERVICE_USER_DPRS_DURING_YEAR: [10.0, 10.0],
+            DP.PROPORTION_OF_SERVICE_USERS_EMPLOYING_STAFF: [None, None],
+            DP.HISTORIC_SERVICE_USERS_EMPLOYING_STAFF_ESTIMATE: [0.5, 0.4],
+            DP.ESTIMATE_USING_MEAN: [0.5, 0.4],
+            DP.FIRST_YEAR_WITH_DATA: [None, None],
+            DP.LAST_YEAR_WITH_DATA: [None, None],
+            DP.ESTIMATE_USING_EXTRAPOLATION_RATIO: [None, None],
+            DP.ESTIMATE_USING_INTERPOLATION: [0.5, 0.4],
+            DP.ESTIMATED_PROPORTION_OF_SERVICE_USERS_EMPLOYING_STAFF: [0.5, 0.4],
+            DP.ESTIMATED_PROPORTION_OF_SERVICE_USERS_EMPLOYING_STAFF_SOURCE: [DP.ESTIMATE_USING_MEAN, DP.ESTIMATE_USING_MEAN],
+            DP.ROLLING_AVERAGE_ESTIMATED_PROPORTION_OF_SERVICE_USERS_EMPLOYING_STAFF: [0.5, 0.45],
+            DP.ESTIMATED_SERVICE_USER_DPRS_DURING_YEAR_EMPLOYING_STAFF: [5.0, 4.5],
+        } # fmt: skip
     ),
 ]
 
 
 class TestEstimateServiceUsersEmployingStaff:
     @pytest.mark.parametrize(
-        ("input_data", "expected_data"),
+        "expected_data",
         [
             case.as_pytest_param()
             for case in estimated_service_users_employing_staff_test_cases
         ],
     )
-    def test_function_returns_expected_values(self, input_data, expected_data):
-        input_lf = pl.LazyFrame(
-            input_data,
-            schema={
-                DP.LA_AREA: pl.String,
-                DP.YEAR_AS_INTEGER: pl.Int64,
-                DP.SERVICE_USER_DPRS_DURING_YEAR: pl.Float32,
-                DP.PROPORTION_OF_SERVICE_USERS_EMPLOYING_STAFF: pl.Float32,
-                DP.HISTORIC_SERVICE_USERS_EMPLOYING_STAFF_ESTIMATE: pl.Float32,
-            },
-            orient="row",
-        )
+    def test_function_returns_expected_values(self, expected_data):
         expected_lf = pl.LazyFrame(
             expected_data,
             schema={
@@ -115,6 +130,19 @@ class TestEstimateServiceUsersEmployingStaff:
                 DP.ESTIMATED_SERVICE_USER_DPRS_DURING_YEAR_EMPLOYING_STAFF: pl.Float32,
             },
             orient="row",
+        )
+        input_lf = expected_lf.drop(
+            [
+                DP.ESTIMATE_USING_MEAN,
+                DP.FIRST_YEAR_WITH_DATA,
+                DP.LAST_YEAR_WITH_DATA,
+                DP.ESTIMATE_USING_EXTRAPOLATION_RATIO,
+                DP.ESTIMATE_USING_INTERPOLATION,
+                DP.ESTIMATED_PROPORTION_OF_SERVICE_USERS_EMPLOYING_STAFF,
+                DP.ESTIMATED_PROPORTION_OF_SERVICE_USERS_EMPLOYING_STAFF_SOURCE,
+                DP.ROLLING_AVERAGE_ESTIMATED_PROPORTION_OF_SERVICE_USERS_EMPLOYING_STAFF,
+                DP.ESTIMATED_SERVICE_USER_DPRS_DURING_YEAR_EMPLOYING_STAFF,
+            ]
         )
         returned_lf = job.calculate_estimated_service_users_employing_staff(input_lf)
 

--- a/projects/_04_direct_payment_recipients/utils/_03_estimate_direct_payment_utils/estimate_service_users_employing_staff.py
+++ b/projects/_04_direct_payment_recipients/utils/_03_estimate_direct_payment_utils/estimate_service_users_employing_staff.py
@@ -18,6 +18,7 @@ from projects._04_direct_payment_recipients.utils._03_estimate_direct_payment_ut
 )
 
 
+# converted to polars -> projects\_04_direct_payment_recipients\fargate\utils\estimate_direct_payments_utils\estimate_service_users_employing_staff.py
 def estimate_service_users_employing_staff(
     direct_payments_df: DataFrame,
 ) -> DataFrame:


### PR DESCRIPTION
## Description
Trello ticket [1552](https://trello.com/c/g23NgY69)

The bulk of this PR is calling the utils for estimating proportion of DPR employing staff and merging their estimates in the correct sequence.

Bits I had to change to get this working are:
- Interpolation util function - Added an argument so I could pass in raw proportion data first, then estimated proportion later on.
- Moved the config data into a separate script and added it to the dockerfile, imported it into jobs.

The AI review gave the idea for formatting the test data.

## Testing
- [x] Unit tests passing
- [x] Successful [Job / Step Function run](https://eu-west-2.console.aws.amazon.com/states/home?region=eu-west-2#/statemachines/view/arn:aws:states:eu-west-2:856699698263:stateMachine:1552-dpr-mrg-estms-Direct-Payment-Recipients)
- [x] Outputs checked in Athena
- [x] Output Screenshots added to Trello ticket

Checked the outputs by running the job as if it was last year. The whole dataset is tiny, so downloaded all in Athena and compared branch to main. See trello ticket attachment.

Got 0 differences, except for Cornwall and Isles and Scilly. Going to solve that issue in a separate ticket.

## Migration to polars checklist
- [x] Check that similar utils functions don't already exist, or if one can be created
- [x] Check that utils are being saved in the appropriate place
- [x] Used LazyFrame option for test data
- [x] Unit tests added
- [x] Docstrings added
- [x] Added comment to pyspark functions which have been migrated with the link to the new location
      `# converted to polars -> filepath.py`
- [x] Updated CHANGELOG
- [x] Code reviewed by AI
- [x] Moved Trello ticket to PR column
