### PR TITLE
1567 Capacity tracker care home cleaning

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -257,6 +257,7 @@ jobs:
             aws s3 sync "s3://sfc-main-datasets/domain=capacity_tracker/dataset=capacity_tracker_non_residential_cleaned/" "s3://$BRANCH_DATASET_BUCKET/domain=capacity_tracker/dataset=capacity_tracker_non_residential_cleaned/"
             aws s3 sync "s3://sfc-main-datasets/domain=CQC/dataset=pir_cleaned/" "s3://$BRANCH_DATASET_BUCKET/domain=CQC/dataset=pir_cleaned/"
             aws s3 sync "s3://sfc-main-datasets/domain=ind_cqc_filled_posts/dataset=ind_cqc_06_estimated_filled_posts/" "s3://$BRANCH_DATASET_BUCKET/domain=ind_cqc_filled_posts/dataset=main_ind_cqc_06_estimated_filled_posts/"
+            aws s3 sync "s3://sfc-main-datasets/domain=capacity_tracker/dataset=capacity_tracker_care_home/" "s3://$BRANCH_DATASET_BUCKET/domain=capacity_tracker/dataset=capacity_tracker_care_home/"
       - run:
           name: Copy models to non-prod dataset
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -257,7 +257,6 @@ jobs:
             aws s3 sync "s3://sfc-main-datasets/domain=capacity_tracker/dataset=capacity_tracker_non_residential_cleaned/" "s3://$BRANCH_DATASET_BUCKET/domain=capacity_tracker/dataset=capacity_tracker_non_residential_cleaned/"
             aws s3 sync "s3://sfc-main-datasets/domain=CQC/dataset=pir_cleaned/" "s3://$BRANCH_DATASET_BUCKET/domain=CQC/dataset=pir_cleaned/"
             aws s3 sync "s3://sfc-main-datasets/domain=ind_cqc_filled_posts/dataset=ind_cqc_06_estimated_filled_posts/" "s3://$BRANCH_DATASET_BUCKET/domain=ind_cqc_filled_posts/dataset=main_ind_cqc_06_estimated_filled_posts/"
-            aws s3 sync "s3://sfc-main-datasets/domain=capacity_tracker/dataset=capacity_tracker_care_home/" "s3://$BRANCH_DATASET_BUCKET/domain=capacity_tracker/dataset=capacity_tracker_care_home/"
       - run:
           name: Copy models to non-prod dataset
           command: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,8 @@ All notable changes to this project will be documented in this file.
 
 - Changed cqc api delta download to get changes from 30 days prior to start time up to end time.
 
+- Updated clean_capacity_tracker_care_home_data job so that agencynoncareworkersemployed is nulled when above 1,000.
+
 ### Fixed
 - Update setup instructions with pre-commit hooks setup
 

--- a/projects/_01_ingest/capacity_tracker/jobs/clean_capacity_tracker_care_home_data.py
+++ b/projects/_01_ingest/capacity_tracker/jobs/clean_capacity_tracker_care_home_data.py
@@ -66,6 +66,7 @@ def main(
         CTCH.nurses_employed,
         CTCH.care_workers_employed,
         CTCH.non_care_workers_employed,
+        CTCH.agency_non_care_workers_employed,
     ]
     capacity_tracker_care_home_df = cUtils.set_bounds_for_columns(
         capacity_tracker_care_home_df,


### PR DESCRIPTION
## Description
Trello ticket [1567](https://trello.com/c/rhM8LonR)

Capacity tracker care home ingestion failed on validation because agencynoncareworkersemployed has extreme value.

The cleaning job nulls other columns when > 1,000. This PR adds the failing column to list of cols to null.

## Testing
- [x] Successful [Step Function run](https://eu-west-2.console.aws.amazon.com/states/home?region=eu-west-2#/v2/executions/details/arn:aws:states:eu-west-2:856699698263:execution:1567-ct-ch-cln-Ingest-Capacity-Tracker-Care-Home:fb6d6211-24aa-468e-9a74-ce3a650f6343)
- [x] Outputs checked in Athena

See Trello ticket comments.

## Checklist (delete if not relevant)
- [x] Updated CHANGELOG
- [x] Moved Trello ticket to PR column
