### PR TITLE
1565 dpr cornwall

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ All notable changes to this project will be documented in this file.
 
 - Converted DPR estimates util estimate_service_users_employing_staff to polars.
 
+- Added a function to DPR estimates to group Cornwall and Isles of Scilly.
+
 ### Changed
 - Removed the PySpark version of IND CQC Clean and Validation jobs.
 

--- a/projects/_04_direct_payment_recipients/direct_payments_config_polars.py
+++ b/projects/_04_direct_payment_recipients/direct_payments_config_polars.py
@@ -21,7 +21,6 @@ class DirectPaymentsMisspelledLaNames:
         "Blackburn": ContemporaryCSSR.blackburn_with_darwen,
         "Bournemouth, Christchurch and Poole": ContemporaryCSSR.bournemouth_christchurch_and_poole,
         "East Riding": ContemporaryCSSR.east_riding_of_yorkshire,
-        "Isles of Scilly": ContemporaryCSSR.cornwall_and_isles_of_scilly,
         "Medway Towns": ContemporaryCSSR.medway,
         "Southend": ContemporaryCSSR.southend_on_sea,
     }

--- a/projects/_04_direct_payment_recipients/direct_payments_config_polars.py
+++ b/projects/_04_direct_payment_recipients/direct_payments_config_polars.py
@@ -20,7 +20,6 @@ class DirectPaymentsMisspelledLaNames:
         "Bath & N E Somerset": ContemporaryCSSR.bath_and_north_east_somerset,
         "Blackburn": ContemporaryCSSR.blackburn_with_darwen,
         "Bournemouth, Christchurch and Poole": ContemporaryCSSR.bournemouth_christchurch_and_poole,
-        "Cornwall": ContemporaryCSSR.cornwall_and_isles_of_scilly,
         "East Riding": ContemporaryCSSR.east_riding_of_yorkshire,
         "Isles of Scilly": ContemporaryCSSR.cornwall_and_isles_of_scilly,
         "Medway Towns": ContemporaryCSSR.medway,

--- a/projects/_04_direct_payment_recipients/fargate/estimate_direct_payments.py
+++ b/projects/_04_direct_payment_recipients/fargate/estimate_direct_payments.py
@@ -13,6 +13,9 @@ from projects._04_direct_payment_recipients.fargate.utils.estimate_direct_paymen
 from projects._04_direct_payment_recipients.fargate.utils.estimate_direct_payments_utils.estimate_service_users_employing_staff import (
     calculate_estimated_service_users_employing_staff,
 )
+from projects._04_direct_payment_recipients.fargate.utils.estimate_direct_payments_utils.merge_cornwall_and_isles_of_scilly import (
+    merge_cornwall_and_isles_of_scilly,
+)
 
 direct_payments_columns = [
     DP.LA_AREA,
@@ -36,6 +39,8 @@ def main(
         source=direct_payments_merged_source,
         selected_columns=direct_payments_columns,
     )
+
+    lf = merge_cornwall_and_isles_of_scilly(lf)
 
     lf = lf.with_columns(
         pl.col(DP.LA_AREA).replace(LANameCorrections.DICT_TO_CORRECT_LA_NAMES)

--- a/projects/_04_direct_payment_recipients/fargate/estimate_direct_payments.py
+++ b/projects/_04_direct_payment_recipients/fargate/estimate_direct_payments.py
@@ -19,7 +19,6 @@ from projects._04_direct_payment_recipients.fargate.utils.estimate_direct_paymen
 
 direct_payments_columns = [
     DP.LA_AREA,
-    DP.YEAR,
     DP.YEAR_AS_INTEGER,
     DP.SERVICE_USER_DPRS_DURING_YEAR,
     DP.CARER_DPRS_DURING_YEAR,

--- a/projects/_04_direct_payment_recipients/fargate/utils/estimate_direct_payments_utils/create_summary_table.py
+++ b/projects/_04_direct_payment_recipients/fargate/utils/estimate_direct_payments_utils/create_summary_table.py
@@ -1,4 +1,5 @@
 import polars as pl
+
 from projects._04_direct_payment_recipients.direct_payments_column_names import (
     DirectPaymentColumnNames as DP,
 )
@@ -24,7 +25,7 @@ def create_summary_table(
             - total_dprs_employing_staff
             - total_personal_assistant_filled_posts
     """
-    summary_direct_payments_lf = lf.group_by(DP.YEAR).agg(
+    summary_direct_payments_lf = lf.group_by(DP.YEAR_AS_INTEGER).agg(
         pl.sum(DP.TOTAL_DPRS_DURING_YEAR).cast(pl.Float32).alias(DP.TOTAL_DPRS),
         pl.sum(DP.SERVICE_USER_DPRS_DURING_YEAR)
         .cast(pl.Float32)

--- a/projects/_04_direct_payment_recipients/fargate/utils/estimate_direct_payments_utils/merge_cornwall_and_isles_of_scilly.py
+++ b/projects/_04_direct_payment_recipients/fargate/utils/estimate_direct_payments_utils/merge_cornwall_and_isles_of_scilly.py
@@ -30,7 +30,6 @@ def merge_cornwall_and_isles_of_scilly(lf: pl.LazyFrame) -> pl.LazyFrame:
         lf.filter(
             (pl.col(DP.LA_AREA) == cornwall) | (pl.col(DP.LA_AREA) == isles_of_scilly)
         )
-        .sort(DP.LA_AREA)
         .group_by([DP.YEAR_AS_INTEGER])
         .agg(
             pl.when(pl.col(DP.SERVICE_USER_DPRS_DURING_YEAR).count() > 0).then(
@@ -39,12 +38,21 @@ def merge_cornwall_and_isles_of_scilly(lf: pl.LazyFrame) -> pl.LazyFrame:
             pl.when(pl.col(DP.CARER_DPRS_DURING_YEAR).count() > 0).then(
                 pl.sum(DP.CARER_DPRS_DURING_YEAR)
             ),
-            pl.first(DP.PROPORTION_OF_SERVICE_USERS_EMPLOYING_STAFF),
-            pl.first(DP.HISTORIC_SERVICE_USERS_EMPLOYING_STAFF_ESTIMATE),
+            pl.col(DP.PROPORTION_OF_SERVICE_USERS_EMPLOYING_STAFF)
+            .filter(pl.col(DP.LA_AREA) == cornwall)
+            .first()
+            .alias(DP.PROPORTION_OF_SERVICE_USERS_EMPLOYING_STAFF),
+            pl.col(DP.HISTORIC_SERVICE_USERS_EMPLOYING_STAFF_ESTIMATE)
+            .filter(pl.col(DP.LA_AREA) == cornwall)
+            .first()
+            .alias(DP.HISTORIC_SERVICE_USERS_EMPLOYING_STAFF_ESTIMATE),
             pl.when(pl.col(DP.TOTAL_DPRS_DURING_YEAR).count() > 0).then(
                 pl.sum(DP.TOTAL_DPRS_DURING_YEAR)
             ),
-            pl.first(DP.FILLED_POSTS_PER_EMPLOYER),
+            pl.col(DP.FILLED_POSTS_PER_EMPLOYER)
+            .filter(pl.col(DP.LA_AREA) == cornwall)
+            .first()
+            .alias(DP.FILLED_POSTS_PER_EMPLOYER),
         )
         .with_columns(
             pl.lit(ContemporaryCSSR.cornwall_and_isles_of_scilly).alias(DP.LA_AREA)

--- a/projects/_04_direct_payment_recipients/fargate/utils/estimate_direct_payments_utils/merge_cornwall_and_isles_of_scilly.py
+++ b/projects/_04_direct_payment_recipients/fargate/utils/estimate_direct_payments_utils/merge_cornwall_and_isles_of_scilly.py
@@ -1,0 +1,62 @@
+import polars as pl
+
+from projects._04_direct_payment_recipients.direct_payments_column_names import (
+    DirectPaymentColumnNames as DP,
+)
+from utils.column_values.categorical_column_values import ContemporaryCSSR
+
+
+def merge_cornwall_and_isles_of_scilly(lf: pl.LazyFrame) -> pl.LazyFrame:
+    """
+    Merge Cornwall and Isles of Scilly into one area.
+
+    Both areas are merged into cornwall_and_isles_of_scilly whereby:
+        - service user and carer DPR values are summed.
+        - proportion of DPR employing staff, historic proportion and filled
+          posts per employer are taken from Cornwall only.
+
+    Args:
+        lf (pl.LazyFrame): LazyFrame containing direct payments data with
+            separate rows for Cornwall and Isles of Scilly.
+
+    Returns:
+        pl.LazyFrame: LazyFrame with Cornwall and Isles of Scilly merged into
+            one area.
+    """
+    cornwall = "Cornwall"
+    isles_of_scilly = "Isles of Scilly"
+
+    merged_lf = (
+        lf.filter(
+            (pl.col(DP.LA_AREA) == cornwall) | (pl.col(DP.LA_AREA) == isles_of_scilly)
+        )
+        .sort(DP.LA_AREA)
+        .group_by([DP.YEAR_AS_INTEGER])
+        .agg(
+            pl.when(pl.col(DP.SERVICE_USER_DPRS_DURING_YEAR).count() > 0).then(
+                pl.sum(DP.SERVICE_USER_DPRS_DURING_YEAR)
+            ),
+            pl.when(pl.col(DP.CARER_DPRS_DURING_YEAR).count() > 0).then(
+                pl.sum(DP.CARER_DPRS_DURING_YEAR)
+            ),
+            pl.first(DP.PROPORTION_OF_SERVICE_USERS_EMPLOYING_STAFF),
+            pl.first(DP.HISTORIC_SERVICE_USERS_EMPLOYING_STAFF_ESTIMATE),
+            pl.when(pl.col(DP.TOTAL_DPRS_DURING_YEAR).count() > 0).then(
+                pl.sum(DP.TOTAL_DPRS_DURING_YEAR)
+            ),
+            pl.first(DP.FILLED_POSTS_PER_EMPLOYER),
+        )
+        .with_columns(
+            pl.lit(ContemporaryCSSR.cornwall_and_isles_of_scilly).alias(DP.LA_AREA)
+        )
+        .select(DP.LA_AREA, pl.all().exclude(DP.LA_AREA))
+    )
+
+    lf = lf.filter(
+        (pl.col(DP.LA_AREA) != cornwall) & (pl.col(DP.LA_AREA) != isles_of_scilly)
+    )
+
+    return pl.concat(
+        [lf, merged_lf],
+        how="vertical",
+    )

--- a/projects/_04_direct_payment_recipients/tests/fargate/test_estimate_direct_payments.py
+++ b/projects/_04_direct_payment_recipients/tests/fargate/test_estimate_direct_payments.py
@@ -14,10 +14,12 @@ class EstimateDirectPaymentsTests(unittest.TestCase):
     SOME_OTHER_DESTINATION = "some/other/destination"
 
     @patch(f"{PATCH_PATH}.utils.sink_to_parquet")
+    @patch(f"{PATCH_PATH}.merge_cornwall_and_isles_of_scilly")
     @patch(f"{PATCH_PATH}.utils.scan_parquet")
     def test_main_succeeds(
         self,
         scan_parquet_mock: Mock,
+        merge_cornwall_and_isles_of_scilly_mock: Mock,
         sink_to_parquet_mock: Mock,
     ):
         job.main(
@@ -30,6 +32,8 @@ class EstimateDirectPaymentsTests(unittest.TestCase):
             source=self.SOME_SOURCE,
             selected_columns=job.direct_payments_columns,
         )
+
+        merge_cornwall_and_isles_of_scilly_mock.assert_called_once()
 
         sink_to_parquet_mock.assert_called_once_with(
             ANY,

--- a/projects/_04_direct_payment_recipients/tests/fargate/utils/test_create_summary_table.py
+++ b/projects/_04_direct_payment_recipients/tests/fargate/utils/test_create_summary_table.py
@@ -1,4 +1,5 @@
 import unittest
+
 import polars as pl
 import polars.testing as pl_testing
 
@@ -11,7 +12,7 @@ from projects._04_direct_payment_recipients.direct_payments_column_names import 
 class TestCreateSummaryTable(unittest.TestCase):
     def test_function_returns_expected_values(self):
         input_schema = {
-            DP.YEAR: pl.String,
+            DP.YEAR_AS_INTEGER: pl.Int32,
             DP.LA_AREA: pl.String,
             DP.TOTAL_DPRS_DURING_YEAR: pl.Float64,
             DP.SERVICE_USER_DPRS_DURING_YEAR: pl.Float64,
@@ -22,14 +23,14 @@ class TestCreateSummaryTable(unittest.TestCase):
             DP.ESTIMATED_TOTAL_PERSONAL_ASSISTANT_FILLED_POSTS: pl.Float64,
         }
         input_rows = [
-            ("2020", "area_1", 100.0, 80.0, 40.0, 10.0, 5.0, 45.0, 50.0),
-            ("2020", "area_2", 200.0, 160.0, 80.0, 20.0, 10.0, 90.0, 100.0),
-            ("2021", "area_1", 110.0, 90.0, 45.0, 11.0, 6.0, 51.0, 55.0),
-            ("2021", "area_2", 210.0, 170.0, 85.0, 21.0, 11.0, 96.0, 105.0),
+            (2020, "area_1", 100.0, 80.0, 40.0, 10.0, 5.0, 45.0, 50.0),
+            (2020, "area_2", 200.0, 160.0, 80.0, 20.0, 10.0, 90.0, 100.0),
+            (2021, "area_1", 110.0, 90.0, 45.0, 11.0, 6.0, 51.0, 55.0),
+            (2021, "area_2", 210.0, 170.0, 85.0, 21.0, 11.0, 96.0, 105.0),
         ]
 
         expected_schema = {
-            DP.YEAR: pl.String,
+            DP.YEAR_AS_INTEGER: pl.Int32,
             DP.TOTAL_DPRS: pl.Float32,
             DP.SERVICE_USER_DPRS: pl.Float32,
             DP.SERVICE_USERS_EMPLOYING_STAFF: pl.Float32,
@@ -39,8 +40,8 @@ class TestCreateSummaryTable(unittest.TestCase):
             DP.TOTAL_PERSONAL_ASSISTANT_FILLED_POSTS: pl.Float32,
         }
         expected_rows = [
-            ("2020", 300.0, 240.0, 120.0, 30.0, 15.0, 135.0, 150.0),
-            ("2021", 320.0, 260.0, 130.0, 32.0, 17.0, 147.0, 160.0),
+            (2020, 300.0, 240.0, 120.0, 30.0, 15.0, 135.0, 150.0),
+            (2021, 320.0, 260.0, 130.0, 32.0, 17.0, 147.0, 160.0),
         ]
 
         test_lf = pl.LazyFrame(input_rows, schema=input_schema, orient="row")

--- a/projects/_04_direct_payment_recipients/tests/fargate/utils/test_merge_cornwall_and_isles_of_scilly.py
+++ b/projects/_04_direct_payment_recipients/tests/fargate/utils/test_merge_cornwall_and_isles_of_scilly.py
@@ -1,0 +1,115 @@
+from dataclasses import dataclass
+from typing import Any
+
+import polars as pl
+import polars.testing as pl_testing
+import pytest
+
+import projects._04_direct_payment_recipients.fargate.utils.estimate_direct_payments_utils.merge_cornwall_and_isles_of_scilly as job
+from projects._04_direct_payment_recipients.direct_payments_column_names import (
+    DirectPaymentColumnNames as DP,
+)
+
+
+@dataclass
+class MergeCornwallAndIslesOfScillyTestCase:
+    id: str
+    input_data: list[Any]
+    expected_data: list[Any]
+
+    def as_pytest_param(self):
+        """Return test case as pytest ParameterSet."""
+        return pytest.param(self.input_data, self.expected_data, id=self.id)
+
+
+merge_cornwall_and_isles_of_scilly_test_cases = [
+    MergeCornwallAndIslesOfScillyTestCase(
+        id="aggregates_single_year",
+        input_data=[
+            ("any_other_area",  2020, 1.0, 4.0, 0.1, 0.4, 6.0, 1.9),
+            ("Cornwall",        2020, 2.0, 5.0, 0.2, 0.5, 7.0, 1.9),
+            ("Isles of Scilly", 2020, 3.0, 6.0, 0.3, 0.6, 8.0, 1.9),
+        ],  # fmt: skip
+        expected_data=[
+            ("any_other_area",               2020, 1.0, 4.0, 0.1, 0.4, 6.0, 1.9),
+            ("Cornwall and Isles of Scilly", 2020, 5.0, 11.0, 0.2, 0.5, 15.0, 1.9),
+        ],  # fmt: skip
+    ),
+    MergeCornwallAndIslesOfScillyTestCase(
+        id="aggregates_multiple_years",
+        input_data=[
+            ("any_other_area",  2020, 1.0, 4.0, 0.1, 0.4, 6.0, 1.9),
+            ("any_other_area",  2021, 1.0, 4.0, 0.1, 0.4, 6.0, 1.9),
+            ("Cornwall",        2020, 2.0, 5.0, 0.2, 0.5, 7.0, 1.9),
+            ("Isles of Scilly", 2020, 3.0, 6.0, 0.3, 0.6, 8.0, 1.9),
+            ("Cornwall",        2021, 2.5, 5.5, 0.25, 0.55, 7.5, 1.9),
+            ("Isles of Scilly", 2021, 3.5, 6.5, 0.35, 0.65, 8.5, 1.9),
+        ],  # fmt: skip
+        expected_data=[
+            ("any_other_area",               2020, 1.0, 4.0, 0.1, 0.4, 6.0, 1.9),
+            ("any_other_area",               2021, 1.0, 4.0, 0.1, 0.4, 6.0, 1.9),
+            ("Cornwall and Isles of Scilly", 2020, 5.0, 11.0, 0.2, 0.5, 15.0, 1.9),
+            ("Cornwall and Isles of Scilly", 2021, 6.0, 12.0, 0.25, 0.55, 16.0, 1.9),
+        ],  # fmt: skip
+    ),
+    MergeCornwallAndIslesOfScillyTestCase(
+        id="handles_areas_when_not_in_alphabetical_order",
+        input_data=[
+            ("Isles of Scilly", 2020, 3.0, 6.0, 0.3, 0.6, 8.0, 1.9),
+            ("Isles of Scilly", 2021, 3.5, 6.5, 0.35, 0.65, 8.5, 1.9),
+            ("Cornwall",        2020, 2.0, 5.0, 0.2, 0.5, 7.0, 1.9),
+            ("Cornwall",        2021, 2.5, 5.5, 0.25, 0.55, 7.5, 1.9),
+        ],  # fmt: skip
+        expected_data=[
+            ("Cornwall and Isles of Scilly", 2020, 5.0, 11.0, 0.2, 0.5, 15.0, 1.9),
+            ("Cornwall and Isles of Scilly", 2021, 6.0, 12.0, 0.25, 0.55, 16.0, 1.9),
+        ],  # fmt: skip
+    ),
+    MergeCornwallAndIslesOfScillyTestCase(
+        id="handles_null_values",
+        input_data=[
+            ("Cornwall",        2020, None, None, None, None, None, None),
+            ("Isles of Scilly", 2020, 3.0, 6.0, 0.3, 0.6, 8.0, 1.9),
+            ("Cornwall",        2021, None, None, None, None, None, None),
+            ("Isles of Scilly", 2021, None, None, None, None, None, None),
+        ],  # fmt: skip
+        expected_data=[
+            ("Cornwall and Isles of Scilly", 2020, 3.0, 6.0, None, None, 8.0, None),
+            ("Cornwall and Isles of Scilly", 2021, None, None, None, None, None, None),
+        ],  # fmt: skip
+    ),
+]
+
+
+class TestMergeCornwallAndIslesOfScilly:
+    @pytest.mark.parametrize(
+        ("input_data", "expected_data"),
+        [
+            case.as_pytest_param()
+            for case in merge_cornwall_and_isles_of_scilly_test_cases
+        ],
+    )
+    def test_function_returns_expected_values(self, input_data, expected_data):
+        test_schema = {
+            DP.LA_AREA: pl.String,
+            DP.YEAR_AS_INTEGER: pl.Int32,
+            DP.SERVICE_USER_DPRS_DURING_YEAR: pl.Float32,
+            DP.CARER_DPRS_DURING_YEAR: pl.Float32,
+            DP.PROPORTION_OF_SERVICE_USERS_EMPLOYING_STAFF: pl.Float32,
+            DP.HISTORIC_SERVICE_USERS_EMPLOYING_STAFF_ESTIMATE: pl.Float32,
+            DP.TOTAL_DPRS_DURING_YEAR: pl.Float32,
+            DP.FILLED_POSTS_PER_EMPLOYER: pl.Float32,
+        }
+        input_lf = pl.LazyFrame(
+            input_data,
+            schema=test_schema,
+            orient="row",
+        )
+        expected_lf = pl.LazyFrame(
+            expected_data,
+            schema=test_schema,
+            orient="row",
+        )
+        returned_lf = job.merge_cornwall_and_isles_of_scilly(input_lf)
+
+        pl_testing.assert_frame_equal(returned_lf, expected_lf, check_row_order=False)


### PR DESCRIPTION
## Description
Trello ticket [1565](https://trello.com/c/9jjiVZ1u)

Cornwall and Isles of Scilly are separate areas in the raw DPR data, but a combined geography in our publications.

The bulk of this PR is a function to merge these areas. Counts of DPR's are summed across areas but proportions of DPR employing staff are taken from Cornwall only (Isles of Scilly has never given a proportion in over 10 years).

Some other bits i've changed are:
- Removing both areas from the dict to correct LA names.
- Remove "year" column from estimates data. We have "year_as_interger". Updated the function that was using this column.

## Testing
- [x] Unit tests passing
- [x] Successful [Job / Step Function run](https://eu-west-2.console.aws.amazon.com/states/home?region=eu-west-2#/statemachines/view/arn:aws:states:eu-west-2:856699698263:stateMachine:1565-dpr-cornwall-Direct-Payment-Recipients)
- [x] Outputs checked in Athena

See Trello ticket for output comparison. 
I prepared the data as if it was last year, then took the whole summary dataset and compared it to main. No differences.
I took the estimates datasets as well. The sum of estimated_total_dpr_employing_staff last years C + IoS in main = Cornwall IoS in branch.

## Migration to polars checklist
- [x] Check that similar utils functions don't already exist, or if one can be created
- [x] Check that utils are being saved in the appropriate place
- [x] Used LazyFrame option for test data
- [x] Unit tests added
- [x] Docstrings added
- [x] Added comment to pyspark functions which have been migrated with the link to the new location
      `# converted to polars -> filepath.py`
- [x] Updated CHANGELOG
- [x] Code reviewed by AI
- [x] Moved Trello ticket to PR column
