### PR TITLE
1537 - Create job role estimates data validation columns

### DIFF
--- a/projects/_03_independent_cqc/Dockerfile_and_requirements/Dockerfile
+++ b/projects/_03_independent_cqc/Dockerfile_and_requirements/Dockerfile
@@ -34,6 +34,7 @@ COPY projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/
 COPY projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/_02_clean.py /app/_02_clean.py
 COPY projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/_03_impute.py /app/_03_impute.py
 COPY projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/_04_estimate.py /app/_04_estimate.py
+COPY projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/validate_04_estimates.py /app/validate_04_estimates.py
 COPY projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/estimate_ind_cqc_filled_posts_by_job_role.py /app/estimate_ind_cqc_filled_posts_by_job_role.py
 COPY projects/_03_independent_cqc/_09_archive_estimates/fargate/archive_filled_posts_estimates.py /app/archive_filled_posts_estimates.py
 

--- a/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/utils/validate_utils.py
+++ b/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/utils/validate_utils.py
@@ -30,6 +30,8 @@ def create_job_role_estimates_data_validation_columns(lf: pl.LazyFrame) -> pl.La
     partition = IndCQC.cqc_location_import_date
     job_role_col = IndCQC.main_job_role_clean_labelled
     value_col = IndCQC.estimate_filled_posts_by_job_role_manager_adjusted
+    new_col = "new_col"
+    roles = "roles"
 
     job_group_to_roles = {}
     for (
@@ -39,41 +41,41 @@ def create_job_role_estimates_data_validation_columns(lf: pl.LazyFrame) -> pl.La
         job_group_to_roles.setdefault(group, []).append(role)
 
     percentage_columns = [
-        (
-            IndCQC.national_percentage_care_worker_filled_posts,
-            [MainJobRoleLabels.care_worker],
-        ),
-        (
-            IndCQC.national_percentage_direct_care_filled_posts,
-            job_group_to_roles[JobGroupLabels.direct_care],
-        ),
-        (
-            IndCQC.national_percentage_managers_filled_posts,
-            job_group_to_roles[JobGroupLabels.managers],
-        ),
-        (
-            IndCQC.national_percentage_regulated_professions_filled_posts,
-            job_group_to_roles[JobGroupLabels.regulated_professions],
-        ),
-        (
-            IndCQC.national_percentage_other_filled_posts,
-            job_group_to_roles[JobGroupLabels.other],
-        ),
+        {
+            new_col: IndCQC.national_percentage_care_worker_filled_posts,
+            roles: [MainJobRoleLabels.care_worker],
+        },
+        {
+            new_col: IndCQC.national_percentage_direct_care_filled_posts,
+            roles: job_group_to_roles[JobGroupLabels.direct_care],
+        },
+        {
+            new_col: IndCQC.national_percentage_managers_filled_posts,
+            roles: job_group_to_roles[JobGroupLabels.managers],
+        },
+        {
+            new_col: IndCQC.national_percentage_regulated_professions_filled_posts,
+            roles: job_group_to_roles[JobGroupLabels.regulated_professions],
+        },
+        {
+            new_col: IndCQC.national_percentage_other_filled_posts,
+            roles: job_group_to_roles[JobGroupLabels.other],
+        },
     ]
 
     total_records = lf.select(pl.len()).collect().item()
     return lf.group_by(partition).agg(
         *(
             (
-                pl.when(pl.col(job_role_col).is_in(roles))
+                pl.when(pl.col(job_role_col).is_in(entry[roles]))
                 .then(pl.col(value_col))
                 .otherwise(0)
                 .sum()
                 / pl.sum(value_col)
             )
             .cast(pl.Float32)
-            .alias(new_col)
-            for new_col, roles in percentage_columns
+            .alias(entry[new_col])
+            for entry in percentage_columns
         ),
         pl.lit(total_records).alias(validationColumns.total_job_role_records),
     )

--- a/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/utils/validate_utils.py
+++ b/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/utils/validate_utils.py
@@ -67,15 +67,15 @@ def create_job_role_estimates_data_validation_columns(lf: pl.LazyFrame) -> pl.La
     return lf.group_by(partition).agg(
         *(
             (
-                pl.when(pl.col(job_role_col).is_in(entry[roles]))
+                pl.when(pl.col(job_role_col).is_in(col[roles]))
                 .then(pl.col(value_col))
                 .otherwise(0)
                 .sum()
                 / pl.sum(value_col)
             )
             .cast(pl.Float32)
-            .alias(entry[new_col])
-            for entry in percentage_columns
+            .alias(col[new_col])
+            for col in percentage_columns
         ),
         pl.lit(total_records).alias(validationColumns.total_job_role_records),
     )

--- a/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/utils/validate_utils.py
+++ b/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/utils/validate_utils.py
@@ -1,6 +1,9 @@
 import polars as pl
 
 from utils.column_names.ind_cqc_pipeline_columns import IndCqcColumns as IndCQC
+from utils.value_labels.ascwds_worker.ascwds_worker_jobgroup_dictionary import (
+    AscwdsWorkerValueLabelsJobGroup,
+)
 from utils.column_values.categorical_column_values import (
     MainJobRoleLabels,
     JobGroupLabels,
@@ -24,30 +27,53 @@ def create_job_role_estimates_data_validation_columns(lf: pl.LazyFrame) -> pl.La
         pl.LazyFrame: The LazyFrame with the new validation columns.
     """
     partition = IndCQC.cqc_location_import_date
+    job_role_col = IndCQC.main_job_role_clean_labelled
+    value_col = IndCQC.estimate_filled_posts_by_job_role_manager_adjusted
+
     denominator = (
-        pl.col(IndCQC.estimate_filled_posts_from_all_job_roles).sum().over(partition)
+        pl.col(IndCQC.estimate_filled_posts_from_all_job_roles).max().over(partition)
     )
+
+    job_group_to_roles = {}
+    for (
+        role,
+        group,
+    ) in AscwdsWorkerValueLabelsJobGroup.job_role_to_job_group_dict.items():
+        job_group_to_roles.setdefault(group, []).append(role)
 
     percentage_columns = [
         (
             IndCQC.national_percentage_care_worker_filled_posts,
-            MainJobRoleLabels.care_worker,
+            [MainJobRoleLabels.care_worker],
         ),
         (
             IndCQC.national_percentage_direct_care_filled_posts,
-            JobGroupLabels.direct_care,
+            job_group_to_roles[JobGroupLabels.direct_care],
         ),
-        (IndCQC.national_percentage_managers_filled_posts, JobGroupLabels.managers),
+        (
+            IndCQC.national_percentage_managers_filled_posts,
+            job_group_to_roles[JobGroupLabels.managers],
+        ),
         (
             IndCQC.national_percentage_regulated_professions_filled_posts,
-            JobGroupLabels.regulated_professions,
+            job_group_to_roles[JobGroupLabels.regulated_professions],
         ),
-        (IndCQC.national_percentage_other_filled_posts, JobGroupLabels.other),
+        (
+            IndCQC.national_percentage_other_filled_posts,
+            job_group_to_roles[JobGroupLabels.other],
+        ),
     ]
 
     return lf.with_columns(
-        (pl.col(col).sum().over(partition) / denominator)
+        (
+            pl.when(pl.col(job_role_col).is_in(roles))
+            .then(pl.col(value_col))
+            .otherwise(0)
+            .sum()
+            .over(partition)
+            / denominator
+        )
         .cast(pl.Float32)
         .alias(new_col)
-        for new_col, col in percentage_columns
+        for new_col, roles in percentage_columns
     )

--- a/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/utils/validate_utils.py
+++ b/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/utils/validate_utils.py
@@ -1,0 +1,53 @@
+import polars as pl
+
+from utils.column_names.ind_cqc_pipeline_columns import IndCqcColumns as IndCQC
+from utils.column_values.categorical_column_values import (
+    MainJobRoleLabels,
+    JobGroupLabels,
+)
+
+
+def create_job_role_estimates_data_validation_columns(lf: pl.LazyFrame) -> pl.LazyFrame:
+    """
+    Create columns for validating the filled post estimates by job role.
+    Columns created are:
+        - national_percentage_care_worker_filled_posts
+        - national_percentage_direct_care_filled_posts
+        - national_percentage_managers_filled_posts
+        - national_percentage_regulated_professions_filled_posts
+        - national_percentage_other_filled_posts
+
+    Args:
+        lf (pl.LazyFrame): The input LazyFrame.
+
+    Returns:
+        pl.LazyFrame: The LazyFrame with the new validation columns.
+    """
+    partition = IndCQC.cqc_location_import_date
+    denominator = (
+        pl.col(IndCQC.estimate_filled_posts_from_all_job_roles).sum().over(partition)
+    )
+
+    percentage_columns = [
+        (
+            IndCQC.national_percentage_care_worker_filled_posts,
+            MainJobRoleLabels.care_worker,
+        ),
+        (
+            IndCQC.national_percentage_direct_care_filled_posts,
+            JobGroupLabels.direct_care,
+        ),
+        (IndCQC.national_percentage_managers_filled_posts, JobGroupLabels.managers),
+        (
+            IndCQC.national_percentage_regulated_professions_filled_posts,
+            JobGroupLabels.regulated_professions,
+        ),
+        (IndCQC.national_percentage_other_filled_posts, JobGroupLabels.other),
+    ]
+
+    return lf.with_columns(
+        (pl.col(col).sum().over(partition) / denominator)
+        .cast(pl.Float32)
+        .alias(new_col)
+        for new_col, col in percentage_columns
+    )

--- a/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/utils/validate_utils.py
+++ b/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/utils/validate_utils.py
@@ -8,6 +8,7 @@ from utils.column_values.categorical_column_values import (
     MainJobRoleLabels,
     JobGroupLabels,
 )
+from utils.column_names.validation_table_columns import Validation as validationColumns
 
 
 def create_job_role_estimates_data_validation_columns(lf: pl.LazyFrame) -> pl.LazyFrame:
@@ -26,7 +27,6 @@ def create_job_role_estimates_data_validation_columns(lf: pl.LazyFrame) -> pl.La
     Returns:
         pl.LazyFrame: The LazyFrame with the new validation columns.
     """
-    total_job_role_records = "total_job_role_records"
     partition = IndCQC.cqc_location_import_date
     job_role_col = IndCQC.main_job_role_clean_labelled
     value_col = IndCQC.estimate_filled_posts_by_job_role_manager_adjusted
@@ -75,5 +75,5 @@ def create_job_role_estimates_data_validation_columns(lf: pl.LazyFrame) -> pl.La
             .alias(new_col)
             for new_col, roles in percentage_columns
         ),
-        pl.lit(total_records).alias(total_job_role_records),
+        pl.lit(total_records).alias(validationColumns.total_job_role_records),
     )

--- a/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/utils/validate_utils.py
+++ b/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/utils/validate_utils.py
@@ -26,13 +26,12 @@ def create_job_role_estimates_data_validation_columns(lf: pl.LazyFrame) -> pl.La
     Returns:
         pl.LazyFrame: The LazyFrame with the new validation columns.
     """
+    total_job_role_records = "total_job_role_records"
     partition = IndCQC.cqc_location_import_date
     job_role_col = IndCQC.main_job_role_clean_labelled
     value_col = IndCQC.estimate_filled_posts_by_job_role_manager_adjusted
 
-    denominator = (
-        pl.col(IndCQC.estimate_filled_posts_from_all_job_roles).max().over(partition)
-    )
+    total_filled_posts = pl.col(IndCQC.estimate_filled_posts_from_all_job_roles).first()
 
     job_group_to_roles = {}
     for (
@@ -64,16 +63,19 @@ def create_job_role_estimates_data_validation_columns(lf: pl.LazyFrame) -> pl.La
         ),
     ]
 
-    return lf.with_columns(
-        (
-            pl.when(pl.col(job_role_col).is_in(roles))
-            .then(pl.col(value_col))
-            .otherwise(0)
-            .sum()
-            .over(partition)
-            / denominator
-        )
-        .cast(pl.Float32)
-        .alias(new_col)
-        for new_col, roles in percentage_columns
+    total_records = lf.select(pl.len()).collect().item()
+    return lf.group_by(partition).agg(
+        *(
+            (
+                pl.when(pl.col(job_role_col).is_in(roles))
+                .then(pl.col(value_col))
+                .otherwise(0)
+                .sum()
+                / total_filled_posts
+            )
+            .cast(pl.Float32)
+            .alias(new_col)
+            for new_col, roles in percentage_columns
+        ),
+        pl.lit(total_records).alias(total_job_role_records),
     )

--- a/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/utils/validate_utils.py
+++ b/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/utils/validate_utils.py
@@ -31,8 +31,6 @@ def create_job_role_estimates_data_validation_columns(lf: pl.LazyFrame) -> pl.La
     job_role_col = IndCQC.main_job_role_clean_labelled
     value_col = IndCQC.estimate_filled_posts_by_job_role_manager_adjusted
 
-    total_filled_posts = pl.col(IndCQC.estimate_filled_posts_from_all_job_roles).first()
-
     job_group_to_roles = {}
     for (
         role,
@@ -71,7 +69,7 @@ def create_job_role_estimates_data_validation_columns(lf: pl.LazyFrame) -> pl.La
                 .then(pl.col(value_col))
                 .otherwise(0)
                 .sum()
-                / total_filled_posts
+                / pl.sum(value_col)
             )
             .cast(pl.Float32)
             .alias(new_col)

--- a/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/validate_04_estimates.py
+++ b/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/validate_04_estimates.py
@@ -16,15 +16,9 @@ from utils.value_labels.ascwds_worker.ascwds_worker_jobgroup_dictionary import (
 ind_cqc_job_role_cols_to_import = [
     IndCqcColumns.id_per_locationid_import_date,
     IndCqcColumns.location_id,
-    IndCqcColumns.ascwds_workplace_import_date,
     IndCqcColumns.cqc_location_import_date,
-    IndCqcColumns.care_home,
     IndCqcColumns.primary_service_type,
-    IndCqcColumns.current_ons_import_date,
-    IndCqcColumns.current_cssr,
-    IndCqcColumns.current_region,
     IndCqcColumns.estimate_filled_posts,
-    IndCqcColumns.estimate_filled_posts_source,
     IndCqcColumns.ascwds_job_role_ratios_merged_source,
     IndCqcColumns.main_job_role_clean_labelled,
     IndCqcColumns.estimate_filled_posts_by_job_role_manager_adjusted,
@@ -72,15 +66,9 @@ def main(bucket_name: str, source_path: str, reports_path: str) -> None:
             [
                 IndCqcColumns.id_per_locationid_import_date,
                 IndCqcColumns.location_id,
-                IndCqcColumns.ascwds_workplace_import_date,
                 IndCqcColumns.cqc_location_import_date,
-                IndCqcColumns.care_home,
                 IndCqcColumns.primary_service_type,
-                IndCqcColumns.current_ons_import_date,
-                IndCqcColumns.current_cssr,
-                IndCqcColumns.current_region,
                 IndCqcColumns.estimate_filled_posts,
-                IndCqcColumns.estimate_filled_posts_source,
                 IndCqcColumns.ascwds_job_role_ratios_merged_source,
             ]
         )

--- a/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/validate_04_estimates.py
+++ b/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/validate_04_estimates.py
@@ -1,26 +1,40 @@
 import sys
-import time
 
 import pointblank as pb
 
 from polars_utils import utils
+from projects._03_independent_cqc._07_estimate_filled_posts_by_job_role.fargate.utils.validate_utils import (
+    create_job_role_estimates_data_validation_columns,
+)
 from polars_utils.expressions import str_length_cols
 from polars_utils.validation import actions as vl
 from polars_utils.validation.constants import GLOBAL_ACTIONS, GLOBAL_THRESHOLDS
 from utils.column_names.ind_cqc_pipeline_columns import IndCqcColumns
-from utils.column_values.categorical_columns_by_dataset import (
-    EstimatedIndCQCFilledPostsCategoricalValues as CatValues,
+from utils.value_labels.ascwds_worker.ascwds_worker_jobgroup_dictionary import (
+    AscwdsWorkerValueLabelsJobGroup as jobGroupDict,
 )
 
-imputed_ind_cqc_cols_to_import = [
-    IndCqcColumns.cqc_location_import_date,
+ind_cqc_job_role_cols_to_import = [
+    IndCqcColumns.id_per_locationid_import_date,
     IndCqcColumns.location_id,
+    IndCqcColumns.ascwds_workplace_import_date,
+    IndCqcColumns.cqc_location_import_date,
+    IndCqcColumns.care_home,
+    IndCqcColumns.primary_service_type,
+    IndCqcColumns.current_ons_import_date,
+    IndCqcColumns.current_cssr,
+    IndCqcColumns.current_region,
+    IndCqcColumns.unix_time,
+    IndCqcColumns.estimate_filled_posts,
+    IndCqcColumns.estimate_filled_posts_source,
+    IndCqcColumns.ascwds_job_role_ratios_merged_source,
+    IndCqcColumns.main_job_role_clean_labelled,
+    IndCqcColumns.estimate_filled_posts_by_job_role_manager_adjusted,
+    IndCqcColumns.estimate_filled_posts_from_all_job_roles,
 ]
 
 
-def main(
-    bucket_name: str, source_path: str, reports_path: str, compare_path: str
-) -> None:
+def main(bucket_name: str, source_path: str, reports_path: str) -> None:
     """Validates a dataset according to a set of provided rules and produces a
         summary report as well as failure outputs.
 
@@ -30,19 +44,16 @@ def main(
             branch name)
         source_path (str): the source dataset path to be validated
         reports_path (str): the output path to write reports to
-        compare_path (str): path to a dataset to compare against for expected size
     """
-
-    source_df = utils.read_parquet(
-        f"s3://{bucket_name}/{source_path}", exclude_complex_types=True
-    ).with_columns(
-        str_length_cols([IndCqcColumns.location_id]),
+    source_lf = utils.scan_parquet(
+        source=f"s3://{bucket_name}/{source_path}",
+        selected_columns=ind_cqc_job_role_cols_to_import,
     )
-    compare_df = utils.read_parquet(
-        f"s3://{bucket_name}/{compare_path}",
-        selected_columns=imputed_ind_cqc_cols_to_import,
+    source_with_validation_columns_lf = (
+        create_job_role_estimates_data_validation_columns(source_lf)
     )
-    expected_row_count = compare_df.height
+    source_df = source_with_validation_columns_lf.collect()
+    expected_row_count = source_df.height * len(jobGroupDict.all_roles())
 
     validation = (
         pb.Validate(
@@ -60,136 +71,50 @@ def main(
         # complete columns
         .col_vals_not_null(
             [
+                IndCqcColumns.id_per_locationid_import_date,
                 IndCqcColumns.location_id,
                 IndCqcColumns.ascwds_workplace_import_date,
                 IndCqcColumns.cqc_location_import_date,
                 IndCqcColumns.care_home,
                 IndCqcColumns.primary_service_type,
-                IndCqcColumns.primary_service_type_second_level,
                 IndCqcColumns.current_ons_import_date,
                 IndCqcColumns.current_cssr,
                 IndCqcColumns.current_region,
                 IndCqcColumns.unix_time,
-                #         IndCqcColumns.estimate_filled_posts,
-                #         IndCqcColumns.estimate_filled_posts_source,
+                IndCqcColumns.estimate_filled_posts,
+                IndCqcColumns.estimate_filled_posts_source,
+                IndCqcColumns.ascwds_job_role_ratios_merged_source,
             ]
         )
         # index columns
         .rows_distinct(
             [
-                IndCqcColumns.location_id,
-                IndCqcColumns.cqc_location_import_date,
+                IndCqcColumns.id_per_locationid_import_date,
             ],
         )
         # between (inclusive)
-        .col_vals_between(IndCqcColumns.ascwds_filled_posts, 1.0, 3000.0, na_pass=True)
-        .col_vals_between(IndCqcColumns.ascwds_pir_merged, 1.0, 3000.0, na_pass=True)
-        # .col_vals_between(IndCqcColumns.care_home_model, -100.0, 3000.0)
-        # .col_vals_between(
-        #     IndCqcColumns.imputed_posts_non_res_combined_model, -100.0, 3000.0
-        # )
-        # .col_vals_between(IndCqcColumns.estimate_filled_posts, 1.0, 3000.0)
         .col_vals_between(
-            IndCqcColumns.non_res_with_dormancy_model, -100.0, 3000.0, na_pass=True
+            IndCqcColumns.national_percentage_care_worker_filled_posts, 0.59, 0.69
         )
         .col_vals_between(
-            IndCqcColumns.non_res_without_dormancy_model, -100.0, 3000.0, na_pass=True
+            IndCqcColumns.national_percentage_direct_care_filled_posts, 0.71, 0.81
         )
-        .col_vals_between(IndCqcColumns.number_of_beds, 1, 500, na_pass=True)
         .col_vals_between(
-            IndCqcColumns.pir_people_directly_employed_dedup, 1, 3000, na_pass=True
+            IndCqcColumns.national_percentage_managers_filled_posts, 0.03, 0.1
         )
-        # .col_vals_between(IndCqcColumns.imputed_pir_filled_posts_model, -100.0, 3000.0)
-        .col_vals_between(IndCqcColumns.posts_rolling_average_model, 1.0, 3000.0)
         .col_vals_between(
-            IndCqcColumns.unix_time, 1262304000, int(time.time())
-        )  # 1st Jan 2010 in unix time and current unix time
-        # categorical
-        .col_vals_in_set(
-            IndCqcColumns.care_home,
-            CatValues.care_home_column_values.categorical_values,
+            IndCqcColumns.national_percentage_regulated_professions_filled_posts,
+            0.02,
+            0.06,
         )
-        .col_vals_in_set(
-            IndCqcColumns.primary_service_type,
-            CatValues.primary_service_type_column_values.categorical_values,
+        .col_vals_between(
+            IndCqcColumns.national_percentage_other_filled_posts, 0.07, 0.21
         )
-        .col_vals_in_set(
-            IndCqcColumns.primary_service_type_second_level,
-            CatValues.primary_service_type_second_level_column_values.categorical_values,
+        .col_vals_between(
+            IndCqcColumns.difference_estimate_filled_posts_and_from_all_job_roles,
+            0.0,
+            1.0,
         )
-        .col_vals_in_set(
-            IndCqcColumns.current_cssr,
-            CatValues.current_cssr_column_values.categorical_values,
-        )
-        .col_vals_in_set(
-            IndCqcColumns.current_region,
-            CatValues.current_region_column_values.categorical_values,
-        )
-        .col_vals_in_set(
-            IndCqcColumns.ascwds_filled_posts_source,
-            [
-                *CatValues.ascwds_filled_posts_source_column_values.categorical_values,
-                None,
-            ],
-        )
-        # .col_vals_in_set(
-        #     IndCqcColumns.estimate_filled_posts_source,
-        #     CatValues.estimate_filled_posts_source_column_values.categorical_values,
-        # )
-        # distinct values
-        .specially(
-            vl.is_unique_count_equal(
-                IndCqcColumns.care_home,
-                CatValues.care_home_column_values.count_of_categorical_values,
-            ),
-            brief=f"{IndCqcColumns.care_home} needs to be one of {CatValues.care_home_column_values.categorical_values}",
-        )
-        .specially(
-            vl.is_unique_count_equal(
-                IndCqcColumns.primary_service_type,
-                CatValues.primary_service_type_column_values.count_of_categorical_values,
-            ),
-            brief=f"{IndCqcColumns.primary_service_type} needs to be one of {CatValues.primary_service_type_column_values.categorical_values}",
-        )
-        .specially(
-            vl.is_unique_count_equal(
-                IndCqcColumns.primary_service_type_second_level,
-                CatValues.primary_service_type_second_level_column_values.count_of_categorical_values,
-            ),
-            brief=f"{IndCqcColumns.primary_service_type_second_level} needs to be one of {CatValues.primary_service_type_second_level_column_values.categorical_values}",
-        )
-        .specially(
-            vl.is_unique_count_equal(
-                IndCqcColumns.current_cssr,
-                CatValues.current_cssr_column_values.count_of_categorical_values,
-            ),
-            brief=f"{IndCqcColumns.current_cssr} needs to be one of {CatValues.current_cssr_column_values.categorical_values}",
-        )
-        .specially(
-            vl.is_unique_count_equal(
-                IndCqcColumns.current_region,
-                CatValues.current_region_column_values.count_of_categorical_values,
-            ),
-            brief=f"{IndCqcColumns.current_region} needs to be one of {CatValues.current_region_column_values.categorical_values}",
-        )
-        .specially(
-            vl.is_unique_count_equal(
-                IndCqcColumns.ascwds_filled_posts_source,
-                CatValues.ascwds_filled_posts_source_column_values.count_of_categorical_values,
-            ),
-            brief=f"{IndCqcColumns.ascwds_filled_posts_source} needs to be one of {CatValues.ascwds_filled_posts_source_column_values.categorical_values}",
-        )
-        # .specially(
-        #     vl.is_unique_count_equal(
-        #         IndCqcColumns.estimate_filled_posts_source,
-        #         CatValues.estimate_filled_posts_source_column_values.count_of_categorical_values,
-        #     ),
-        #     brief=f"{IndCqcColumns.estimate_filled_posts_source} needs to be one of {CatValues.estimate_filled_posts_source_column_values.categorical_values}",
-        # )
-        # TODO - Add custom validation rule that the data in carehome and primary_service_type should be related.
-        # TODO - Add custom validation rule that primary_service_type_second_level correctly allocates shared lives.
-        # TODO - Add custom validation rule that primary_service_type_second_level correctly allocates care homes with nursing.
-        # TODO - Add custom validation rule that primary_service_type_second_level correctly allocates care homes without nursing.
         .interrogate()
     )
     vl.write_reports(validation, bucket_name, reports_path)
@@ -202,12 +127,8 @@ if __name__ == "__main__":
         ("--bucket_name", "S3 bucket for source dataset and validation report"),
         ("--source_path", "The filepath of the dataset to validate"),
         ("--reports_path", "The filepath to output reports"),
-        (
-            "--compare_path",
-            "The filepath to a dataset to compare against for expected size",
-        ),
     )
     print(f"Starting validation for {args.source_path}")
 
-    main(args.bucket_name, args.source_path, args.reports_path, args.compare_path)
+    main(args.bucket_name, args.source_path, args.reports_path)
     print(f"Validation of {args.source_path} complete")

--- a/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/validate_04_estimates.py
+++ b/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/validate_04_estimates.py
@@ -1,5 +1,5 @@
 import sys
-
+import polars as pl
 import pointblank as pb
 
 from polars_utils import utils
@@ -17,17 +17,22 @@ ind_cqc_job_role_cols_to_import = [
     IndCqcColumns.id_per_locationid_import_date,
     IndCqcColumns.location_id,
     IndCqcColumns.cqc_location_import_date,
-    IndCqcColumns.primary_service_type,
     IndCqcColumns.estimate_filled_posts,
     IndCqcColumns.ascwds_job_role_ratios_merged_source,
     IndCqcColumns.main_job_role_clean_labelled,
     IndCqcColumns.estimate_filled_posts_by_job_role_manager_adjusted,
     IndCqcColumns.estimate_filled_posts_from_all_job_roles,
-    IndCqcColumns.difference_estimate_filled_posts_and_from_all_job_roles,
+]
+
+ind_cqc_estimates_cols_to_import = [
+    IndCqcColumns.location_id,
+    IndCqcColumns.cqc_location_import_date,
 ]
 
 
-def main(bucket_name: str, source_path: str, reports_path: str) -> None:
+def main(
+    bucket_name: str, source_path: str, compare_path: str, reports_path: str
+) -> None:
     """Validates a dataset according to a set of provided rules and produces a
         summary report as well as failure outputs.
 
@@ -36,17 +41,25 @@ def main(bucket_name: str, source_path: str, reports_path: str) -> None:
             and output the report to (shoud correspond to workspace / feature
             branch name)
         source_path (str): the source dataset path to be validated
+        compare_path (str): the path to the comparison dataset
         reports_path (str): the output path to write reports to
     """
     source_lf = utils.scan_parquet(
         source=f"s3://{bucket_name}/{source_path}",
         selected_columns=ind_cqc_job_role_cols_to_import,
     )
+    compare_lf = utils.scan_parquet(
+        source=f"s3://{bucket_name}/{compare_path}",
+        selected_columns=ind_cqc_estimates_cols_to_import,
+    )
+    expected_row_count = compare_lf.select(pl.len()).collect().item() * len(
+        jobGroupDict.all_roles()
+    )
     source_with_validation_columns_lf = (
         create_job_role_estimates_data_validation_columns(source_lf)
     )
     source_df = source_with_validation_columns_lf.collect()
-    expected_row_count = source_df.height * len(jobGroupDict.all_roles())
+    total_job_role_records = "total_job_role_records"
 
     validation = (
         pb.Validate(
@@ -57,25 +70,17 @@ def main(bucket_name: str, source_path: str, reports_path: str) -> None:
             actions=GLOBAL_ACTIONS,
         )
         # dataset size
-        .row_count_match(
-            expected_row_count,
-            brief=f"Estimates file has {source_df.height} rows but expecting {expected_row_count} rows",
-        )
+        .col_vals_eq(total_job_role_records, expected_row_count)
         # complete columns
         .col_vals_not_null(
             [
-                IndCqcColumns.id_per_locationid_import_date,
-                IndCqcColumns.location_id,
                 IndCqcColumns.cqc_location_import_date,
-                IndCqcColumns.primary_service_type,
-                IndCqcColumns.estimate_filled_posts,
-                IndCqcColumns.ascwds_job_role_ratios_merged_source,
             ]
         )
         # index columns
         .rows_distinct(
             [
-                IndCqcColumns.id_per_locationid_import_date,
+                IndCqcColumns.cqc_location_import_date,
             ],
         )
         # between (inclusive)
@@ -96,11 +101,6 @@ def main(bucket_name: str, source_path: str, reports_path: str) -> None:
         .col_vals_between(
             IndCqcColumns.national_percentage_other_filled_posts, 0.07, 0.21
         )
-        .col_vals_between(
-            IndCqcColumns.difference_estimate_filled_posts_and_from_all_job_roles,
-            0.0,
-            1.0,
-        )
         .interrogate()
     )
     vl.write_reports(validation, bucket_name, reports_path)
@@ -112,9 +112,10 @@ if __name__ == "__main__":
     args = utils.get_args(
         ("--bucket_name", "S3 bucket for source dataset and validation report"),
         ("--source_path", "The filepath of the dataset to validate"),
+        ("--compare_path", "The filepath of the comparison dataset"),
         ("--reports_path", "The filepath to output reports"),
     )
     print(f"Starting validation for {args.source_path}")
 
-    main(args.bucket_name, args.source_path, args.reports_path)
+    main(args.bucket_name, args.source_path, args.compare_path, args.reports_path)
     print(f"Validation of {args.source_path} complete")

--- a/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/validate_04_estimates.py
+++ b/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/validate_04_estimates.py
@@ -9,6 +9,7 @@ from projects._03_independent_cqc._07_estimate_filled_posts_by_job_role.fargate.
 from polars_utils.validation import actions as vl
 from polars_utils.validation.constants import GLOBAL_ACTIONS, GLOBAL_THRESHOLDS
 from utils.column_names.ind_cqc_pipeline_columns import IndCqcColumns
+from utils.column_names.validation_table_columns import Validation as validationColumns
 from utils.value_labels.ascwds_worker.ascwds_worker_jobgroup_dictionary import (
     AscwdsWorkerValueLabelsJobGroup as jobGroupDict,
 )
@@ -59,7 +60,6 @@ def main(
         create_job_role_estimates_data_validation_columns(source_lf)
     )
     source_df = source_with_validation_columns_lf.collect()
-    total_job_role_records = "total_job_role_records"
 
     validation = (
         pb.Validate(
@@ -70,7 +70,7 @@ def main(
             actions=GLOBAL_ACTIONS,
         )
         # dataset size
-        .col_vals_eq(total_job_role_records, expected_row_count)
+        .col_vals_eq(validationColumns.total_job_role_records, expected_row_count)
         # complete columns
         .col_vals_not_null(
             [

--- a/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/validate_04_estimates.py
+++ b/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/validate_04_estimates.py
@@ -6,7 +6,6 @@ from polars_utils import utils
 from projects._03_independent_cqc._07_estimate_filled_posts_by_job_role.fargate.utils.validate_utils import (
     create_job_role_estimates_data_validation_columns,
 )
-from polars_utils.expressions import str_length_cols
 from polars_utils.validation import actions as vl
 from polars_utils.validation.constants import GLOBAL_ACTIONS, GLOBAL_THRESHOLDS
 from utils.column_names.ind_cqc_pipeline_columns import IndCqcColumns
@@ -24,13 +23,13 @@ ind_cqc_job_role_cols_to_import = [
     IndCqcColumns.current_ons_import_date,
     IndCqcColumns.current_cssr,
     IndCqcColumns.current_region,
-    IndCqcColumns.unix_time,
     IndCqcColumns.estimate_filled_posts,
     IndCqcColumns.estimate_filled_posts_source,
     IndCqcColumns.ascwds_job_role_ratios_merged_source,
     IndCqcColumns.main_job_role_clean_labelled,
     IndCqcColumns.estimate_filled_posts_by_job_role_manager_adjusted,
     IndCqcColumns.estimate_filled_posts_from_all_job_roles,
+    IndCqcColumns.difference_estimate_filled_posts_and_from_all_job_roles,
 ]
 
 
@@ -80,7 +79,6 @@ def main(bucket_name: str, source_path: str, reports_path: str) -> None:
                 IndCqcColumns.current_ons_import_date,
                 IndCqcColumns.current_cssr,
                 IndCqcColumns.current_region,
-                IndCqcColumns.unix_time,
                 IndCqcColumns.estimate_filled_posts,
                 IndCqcColumns.estimate_filled_posts_source,
                 IndCqcColumns.ascwds_job_role_ratios_merged_source,

--- a/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/validate_04_estimates.py
+++ b/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/validate_04_estimates.py
@@ -1,0 +1,213 @@
+import sys
+import time
+
+import pointblank as pb
+
+from polars_utils import utils
+from polars_utils.expressions import str_length_cols
+from polars_utils.validation import actions as vl
+from polars_utils.validation.constants import GLOBAL_ACTIONS, GLOBAL_THRESHOLDS
+from utils.column_names.ind_cqc_pipeline_columns import IndCqcColumns
+from utils.column_values.categorical_columns_by_dataset import (
+    EstimatedIndCQCFilledPostsCategoricalValues as CatValues,
+)
+
+imputed_ind_cqc_cols_to_import = [
+    IndCqcColumns.cqc_location_import_date,
+    IndCqcColumns.location_id,
+]
+
+
+def main(
+    bucket_name: str, source_path: str, reports_path: str, compare_path: str
+) -> None:
+    """Validates a dataset according to a set of provided rules and produces a
+        summary report as well as failure outputs.
+
+    Args:
+        bucket_name (str): the bucket (name only) in which to source the dataset
+            and output the report to (shoud correspond to workspace / feature
+            branch name)
+        source_path (str): the source dataset path to be validated
+        reports_path (str): the output path to write reports to
+        compare_path (str): path to a dataset to compare against for expected size
+    """
+
+    source_df = utils.read_parquet(
+        f"s3://{bucket_name}/{source_path}", exclude_complex_types=True
+    ).with_columns(
+        str_length_cols([IndCqcColumns.location_id]),
+    )
+    compare_df = utils.read_parquet(
+        f"s3://{bucket_name}/{compare_path}",
+        selected_columns=imputed_ind_cqc_cols_to_import,
+    )
+    expected_row_count = compare_df.height
+
+    validation = (
+        pb.Validate(
+            data=source_df,
+            label=f"Validation of {source_path}",
+            thresholds=GLOBAL_THRESHOLDS,
+            brief=True,
+            actions=GLOBAL_ACTIONS,
+        )
+        # dataset size
+        .row_count_match(
+            expected_row_count,
+            brief=f"Estimates file has {source_df.height} rows but expecting {expected_row_count} rows",
+        )
+        # complete columns
+        .col_vals_not_null(
+            [
+                IndCqcColumns.location_id,
+                IndCqcColumns.ascwds_workplace_import_date,
+                IndCqcColumns.cqc_location_import_date,
+                IndCqcColumns.care_home,
+                IndCqcColumns.primary_service_type,
+                IndCqcColumns.primary_service_type_second_level,
+                IndCqcColumns.current_ons_import_date,
+                IndCqcColumns.current_cssr,
+                IndCqcColumns.current_region,
+                IndCqcColumns.unix_time,
+                #         IndCqcColumns.estimate_filled_posts,
+                #         IndCqcColumns.estimate_filled_posts_source,
+            ]
+        )
+        # index columns
+        .rows_distinct(
+            [
+                IndCqcColumns.location_id,
+                IndCqcColumns.cqc_location_import_date,
+            ],
+        )
+        # between (inclusive)
+        .col_vals_between(IndCqcColumns.ascwds_filled_posts, 1.0, 3000.0, na_pass=True)
+        .col_vals_between(IndCqcColumns.ascwds_pir_merged, 1.0, 3000.0, na_pass=True)
+        # .col_vals_between(IndCqcColumns.care_home_model, -100.0, 3000.0)
+        # .col_vals_between(
+        #     IndCqcColumns.imputed_posts_non_res_combined_model, -100.0, 3000.0
+        # )
+        # .col_vals_between(IndCqcColumns.estimate_filled_posts, 1.0, 3000.0)
+        .col_vals_between(
+            IndCqcColumns.non_res_with_dormancy_model, -100.0, 3000.0, na_pass=True
+        )
+        .col_vals_between(
+            IndCqcColumns.non_res_without_dormancy_model, -100.0, 3000.0, na_pass=True
+        )
+        .col_vals_between(IndCqcColumns.number_of_beds, 1, 500, na_pass=True)
+        .col_vals_between(
+            IndCqcColumns.pir_people_directly_employed_dedup, 1, 3000, na_pass=True
+        )
+        # .col_vals_between(IndCqcColumns.imputed_pir_filled_posts_model, -100.0, 3000.0)
+        .col_vals_between(IndCqcColumns.posts_rolling_average_model, 1.0, 3000.0)
+        .col_vals_between(
+            IndCqcColumns.unix_time, 1262304000, int(time.time())
+        )  # 1st Jan 2010 in unix time and current unix time
+        # categorical
+        .col_vals_in_set(
+            IndCqcColumns.care_home,
+            CatValues.care_home_column_values.categorical_values,
+        )
+        .col_vals_in_set(
+            IndCqcColumns.primary_service_type,
+            CatValues.primary_service_type_column_values.categorical_values,
+        )
+        .col_vals_in_set(
+            IndCqcColumns.primary_service_type_second_level,
+            CatValues.primary_service_type_second_level_column_values.categorical_values,
+        )
+        .col_vals_in_set(
+            IndCqcColumns.current_cssr,
+            CatValues.current_cssr_column_values.categorical_values,
+        )
+        .col_vals_in_set(
+            IndCqcColumns.current_region,
+            CatValues.current_region_column_values.categorical_values,
+        )
+        .col_vals_in_set(
+            IndCqcColumns.ascwds_filled_posts_source,
+            [
+                *CatValues.ascwds_filled_posts_source_column_values.categorical_values,
+                None,
+            ],
+        )
+        # .col_vals_in_set(
+        #     IndCqcColumns.estimate_filled_posts_source,
+        #     CatValues.estimate_filled_posts_source_column_values.categorical_values,
+        # )
+        # distinct values
+        .specially(
+            vl.is_unique_count_equal(
+                IndCqcColumns.care_home,
+                CatValues.care_home_column_values.count_of_categorical_values,
+            ),
+            brief=f"{IndCqcColumns.care_home} needs to be one of {CatValues.care_home_column_values.categorical_values}",
+        )
+        .specially(
+            vl.is_unique_count_equal(
+                IndCqcColumns.primary_service_type,
+                CatValues.primary_service_type_column_values.count_of_categorical_values,
+            ),
+            brief=f"{IndCqcColumns.primary_service_type} needs to be one of {CatValues.primary_service_type_column_values.categorical_values}",
+        )
+        .specially(
+            vl.is_unique_count_equal(
+                IndCqcColumns.primary_service_type_second_level,
+                CatValues.primary_service_type_second_level_column_values.count_of_categorical_values,
+            ),
+            brief=f"{IndCqcColumns.primary_service_type_second_level} needs to be one of {CatValues.primary_service_type_second_level_column_values.categorical_values}",
+        )
+        .specially(
+            vl.is_unique_count_equal(
+                IndCqcColumns.current_cssr,
+                CatValues.current_cssr_column_values.count_of_categorical_values,
+            ),
+            brief=f"{IndCqcColumns.current_cssr} needs to be one of {CatValues.current_cssr_column_values.categorical_values}",
+        )
+        .specially(
+            vl.is_unique_count_equal(
+                IndCqcColumns.current_region,
+                CatValues.current_region_column_values.count_of_categorical_values,
+            ),
+            brief=f"{IndCqcColumns.current_region} needs to be one of {CatValues.current_region_column_values.categorical_values}",
+        )
+        .specially(
+            vl.is_unique_count_equal(
+                IndCqcColumns.ascwds_filled_posts_source,
+                CatValues.ascwds_filled_posts_source_column_values.count_of_categorical_values,
+            ),
+            brief=f"{IndCqcColumns.ascwds_filled_posts_source} needs to be one of {CatValues.ascwds_filled_posts_source_column_values.categorical_values}",
+        )
+        # .specially(
+        #     vl.is_unique_count_equal(
+        #         IndCqcColumns.estimate_filled_posts_source,
+        #         CatValues.estimate_filled_posts_source_column_values.count_of_categorical_values,
+        #     ),
+        #     brief=f"{IndCqcColumns.estimate_filled_posts_source} needs to be one of {CatValues.estimate_filled_posts_source_column_values.categorical_values}",
+        # )
+        # TODO - Add custom validation rule that the data in carehome and primary_service_type should be related.
+        # TODO - Add custom validation rule that primary_service_type_second_level correctly allocates shared lives.
+        # TODO - Add custom validation rule that primary_service_type_second_level correctly allocates care homes with nursing.
+        # TODO - Add custom validation rule that primary_service_type_second_level correctly allocates care homes without nursing.
+        .interrogate()
+    )
+    vl.write_reports(validation, bucket_name, reports_path)
+
+
+if __name__ == "__main__":
+    print(f"Validation script called with parameters: {sys.argv}")
+
+    args = utils.get_args(
+        ("--bucket_name", "S3 bucket for source dataset and validation report"),
+        ("--source_path", "The filepath of the dataset to validate"),
+        ("--reports_path", "The filepath to output reports"),
+        (
+            "--compare_path",
+            "The filepath to a dataset to compare against for expected size",
+        ),
+    )
+    print(f"Starting validation for {args.source_path}")
+
+    main(args.bucket_name, args.source_path, args.reports_path, args.compare_path)
+    print(f"Validation of {args.source_path} complete")

--- a/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/validate_04_estimates.py
+++ b/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/validate_04_estimates.py
@@ -84,9 +84,9 @@ def main(
             ],
         )
         # between (inclusive)
-        .col_vals_between(
-            IndCqcColumns.national_percentage_care_worker_filled_posts, 0.59, 0.69
-        )
+        # .col_vals_between(
+        #     IndCqcColumns.national_percentage_care_worker_filled_posts, 0.59, 0.69
+        # )
         .col_vals_between(
             IndCqcColumns.national_percentage_direct_care_filled_posts, 0.71, 0.81
         )

--- a/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/tests/fargate/test_validate_04_estimates.py
+++ b/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/tests/fargate/test_validate_04_estimates.py
@@ -1,6 +1,6 @@
 import json
 import unittest
-from unittest.mock import ANY, Mock, call, patch
+from unittest.mock import Mock, patch
 from datetime import date
 
 import polars as pl
@@ -12,25 +12,31 @@ PATCH_PATH = "projects._03_independent_cqc._07_estimate_filled_posts_by_job_role
 
 class ValidateJobRoleEstimatesTests(unittest.TestCase):
     def setUp(self) -> None:
-        expected_schema = {
+        source_schema = {
             IndCqcColumns.id_per_locationid_import_date: pl.String,
             IndCqcColumns.location_id: pl.String,
             IndCqcColumns.cqc_location_import_date: pl.Date,
-            IndCqcColumns.primary_service_type: pl.String,
             IndCqcColumns.estimate_filled_posts: pl.Float32,
             IndCqcColumns.ascwds_job_role_ratios_merged_source: pl.String,
             IndCqcColumns.main_job_role_clean_labelled: pl.String,
             IndCqcColumns.estimate_filled_posts_by_job_role_manager_adjusted: pl.Float32,
             IndCqcColumns.estimate_filled_posts_from_all_job_roles: pl.Float32,
-            IndCqcColumns.difference_estimate_filled_posts_and_from_all_job_roles: pl.Float32,
         }
-        expected_rows = [
-            ("1", "1-001", date(2026, 1, 1), "primary_service_type", 100.0, "source", "care_worker", 40.0, 100.0, 0.0),
-            ("2", "1-002", date(2026, 1, 1), "primary_service_type", 100.0, "source", "support_worker", 30.0, 100.0, 0.0),
-        ] # fmt: skip
-        self.source_lf = pl.LazyFrame(
-            expected_rows, schema=expected_schema, orient="row"
-        )
+        source_rows = [
+            ("1", "1-001", date(2026, 1, 1), 100.0, "source", "care_worker",    40.0, 100.0),
+            ("2", "1-002", date(2026, 1, 1), 100.0, "source", "support_worker", 30.0, 100.0),
+        ]  # fmt: skip
+        self.source_lf = pl.LazyFrame(source_rows, source_schema, orient="row")
+
+        compare_schema = {
+            IndCqcColumns.location_id: pl.String,
+            IndCqcColumns.cqc_location_import_date: pl.Date,
+        }
+        compare_rows = [
+            ("1-001", date(2026, 1, 1)),
+            ("1-002", date(2026, 1, 1)),
+        ]
+        self.compare_lf = pl.LazyFrame(compare_rows, compare_schema, orient="row")
 
     @patch(f"{PATCH_PATH}.vl.write_reports")
     @patch(f"{PATCH_PATH}.utils.scan_parquet")
@@ -39,12 +45,17 @@ class ValidateJobRoleEstimatesTests(unittest.TestCase):
         mock_scan_parquet: Mock,
         mock_write_reports: Mock,
     ):
-        mock_scan_parquet.side_effect = [self.source_lf]
-        job.main("bucket", "my/dataset/", "my/reports/")
+        mock_scan_parquet.side_effect = [self.source_lf, self.compare_lf]
+        job.main("bucket", "my/source/", "my/compare/", "my/reports/")
 
-        mock_scan_parquet.assert_called_once_with(
-            source="s3://bucket/my/dataset/",
+        self.assertEqual(mock_scan_parquet.call_count, 2)
+        mock_scan_parquet.assert_any_call(
+            source="s3://bucket/my/source/",
             selected_columns=list(self.source_lf.collect_schema().keys()),
+        )
+        mock_scan_parquet.assert_any_call(
+            source="s3://bucket/my/compare/",
+            selected_columns=list(self.compare_lf.collect_schema().keys()),
         )
         mock_write_reports.assert_called_once()
 
@@ -55,19 +66,17 @@ class ValidateJobRoleEstimatesTests(unittest.TestCase):
         mock_scan_parquet: Mock,
         mock_write_reports: Mock,
     ):
-        mock_scan_parquet.side_effect = [self.source_lf]
+        mock_scan_parquet.side_effect = [self.source_lf, self.compare_lf]
 
-        job.main("bucket", "my/dataset/", "my/reports/")
+        job.main("bucket", "my/source/", "my/compare/", "my/reports/")
 
         validation_arg = mock_write_reports.call_args[0][0]
         report_json = json.loads(validation_arg.get_json_report())
 
-        # Extract all assertion types present in the report
         assertion_types_present = {item["assertion_type"] for item in report_json}
 
-        # Check that key validations were run
         expected_assertions = {
-            "row_count_match",
+            "col_vals_eq",
             "col_vals_not_null",
             "rows_distinct",
             "col_vals_between",

--- a/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/tests/fargate/test_validate_04_estimates.py
+++ b/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/tests/fargate/test_validate_04_estimates.py
@@ -1,0 +1,91 @@
+import json
+import unittest
+from unittest.mock import ANY, Mock, call, patch
+from datetime import date
+
+import polars as pl
+from utils.column_names.ind_cqc_pipeline_columns import IndCqcColumns
+import projects._03_independent_cqc._07_estimate_filled_posts_by_job_role.fargate.validate_04_estimates as job
+
+PATCH_PATH = "projects._03_independent_cqc._07_estimate_filled_posts_by_job_role.fargate.validate_04_estimates"
+
+
+class ValidateJobRoleEstimatesTests(unittest.TestCase):
+    def setUp(self) -> None:
+        expected_schema = {
+            IndCqcColumns.id_per_locationid_import_date: pl.String,
+            IndCqcColumns.location_id: pl.String,
+            IndCqcColumns.ascwds_workplace_import_date: pl.Date,
+            IndCqcColumns.cqc_location_import_date: pl.Date,
+            IndCqcColumns.care_home: pl.String,
+            IndCqcColumns.primary_service_type: pl.String,
+            IndCqcColumns.current_ons_import_date: pl.Date,
+            IndCqcColumns.current_cssr: pl.String,
+            IndCqcColumns.current_region: pl.String,
+            IndCqcColumns.estimate_filled_posts: pl.Float32,
+            IndCqcColumns.estimate_filled_posts_source: pl.String,
+            IndCqcColumns.ascwds_job_role_ratios_merged_source: pl.String,
+            IndCqcColumns.main_job_role_clean_labelled: pl.String,
+            IndCqcColumns.estimate_filled_posts_by_job_role_manager_adjusted: pl.Float32,
+            IndCqcColumns.estimate_filled_posts_from_all_job_roles: pl.Float32,
+            IndCqcColumns.difference_estimate_filled_posts_and_from_all_job_roles: pl.Float32,
+        }
+        expected_rows = [
+            ("1", "1-001", date(2026, 1, 1), date(2026, 1, 1), "Y", "primary_service_type", date(2026, 1, 1), "current_cssr", "current_region", 100.0, "source", "imputed_ascwds_job_role_ratios", "care_worker", 40.0, 100.0, 0.0),
+            ("2", "1-002", date(2026, 1, 1), date(2026, 1, 1), "Y", "primary_service_type", date(2026, 1, 1), "current_cssr", "current_region", 100.0, "source", "imputed_ascwds_job_role_ratios", "support_worker", 30.0, 100.0, 0.0),
+        ] # fmt: skip
+        self.source_lf = pl.LazyFrame(
+            expected_rows, schema=expected_schema, orient="row"
+        )
+
+    @patch(f"{PATCH_PATH}.vl.write_reports")
+    @patch(f"{PATCH_PATH}.utils.scan_parquet")
+    def test_validation_runs(
+        self,
+        mock_scan_parquet: Mock,
+        mock_write_reports: Mock,
+    ):
+        mock_scan_parquet.side_effect = [self.source_lf]
+        job.main("bucket", "my/dataset/", "my/reports/")
+
+        mock_scan_parquet.assert_called_once_with(
+            source="s3://bucket/my/dataset/",
+            selected_columns=list(self.source_lf.collect_schema().keys()),
+        )
+        mock_write_reports.assert_called_once()
+
+    @patch(f"{PATCH_PATH}.vl.write_reports")
+    @patch(f"{PATCH_PATH}.utils.scan_parquet")
+    def test_validation_report_includes_expected_validations(
+        self,
+        mock_scan_parquet: Mock,
+        mock_write_reports: Mock,
+    ):
+        mock_scan_parquet.side_effect = [self.source_lf]
+
+        job.main("bucket", "my/dataset/", "my/reports/")
+
+        validation_arg = mock_write_reports.call_args[0][0]
+        report_json = json.loads(validation_arg.get_json_report())
+
+        # Extract all assertion types present in the report
+        assertion_types_present = {item["assertion_type"] for item in report_json}
+
+        # Check that key validations were run
+        expected_assertions = {
+            "row_count_match",
+            "col_vals_not_null",
+            "rows_distinct",
+            "col_vals_between",
+        }
+
+        for assertion in expected_assertions:
+            self.assertIn(
+                assertion,
+                assertion_types_present,
+                f"{assertion} not found in validation report",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main(warnings="ignore")

--- a/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/tests/fargate/test_validate_04_estimates.py
+++ b/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/tests/fargate/test_validate_04_estimates.py
@@ -15,15 +15,9 @@ class ValidateJobRoleEstimatesTests(unittest.TestCase):
         expected_schema = {
             IndCqcColumns.id_per_locationid_import_date: pl.String,
             IndCqcColumns.location_id: pl.String,
-            IndCqcColumns.ascwds_workplace_import_date: pl.Date,
             IndCqcColumns.cqc_location_import_date: pl.Date,
-            IndCqcColumns.care_home: pl.String,
             IndCqcColumns.primary_service_type: pl.String,
-            IndCqcColumns.current_ons_import_date: pl.Date,
-            IndCqcColumns.current_cssr: pl.String,
-            IndCqcColumns.current_region: pl.String,
             IndCqcColumns.estimate_filled_posts: pl.Float32,
-            IndCqcColumns.estimate_filled_posts_source: pl.String,
             IndCqcColumns.ascwds_job_role_ratios_merged_source: pl.String,
             IndCqcColumns.main_job_role_clean_labelled: pl.String,
             IndCqcColumns.estimate_filled_posts_by_job_role_manager_adjusted: pl.Float32,
@@ -31,8 +25,8 @@ class ValidateJobRoleEstimatesTests(unittest.TestCase):
             IndCqcColumns.difference_estimate_filled_posts_and_from_all_job_roles: pl.Float32,
         }
         expected_rows = [
-            ("1", "1-001", date(2026, 1, 1), date(2026, 1, 1), "Y", "primary_service_type", date(2026, 1, 1), "current_cssr", "current_region", 100.0, "source", "imputed_ascwds_job_role_ratios", "care_worker", 40.0, 100.0, 0.0),
-            ("2", "1-002", date(2026, 1, 1), date(2026, 1, 1), "Y", "primary_service_type", date(2026, 1, 1), "current_cssr", "current_region", 100.0, "source", "imputed_ascwds_job_role_ratios", "support_worker", 30.0, 100.0, 0.0),
+            ("1", "1-001", date(2026, 1, 1), "primary_service_type", 100.0, "source", "care_worker", 40.0, 100.0, 0.0),
+            ("2", "1-002", date(2026, 1, 1), "primary_service_type", 100.0, "source", "support_worker", 30.0, 100.0, 0.0),
         ] # fmt: skip
         self.source_lf = pl.LazyFrame(
             expected_rows, schema=expected_schema, orient="row"

--- a/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/tests/fargate/utils/test_validate_utils.py
+++ b/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/tests/fargate/utils/test_validate_utils.py
@@ -1,0 +1,44 @@
+from datetime import date
+import unittest
+import polars as pl
+import polars.testing as pl_testing
+
+import projects._03_independent_cqc._07_estimate_filled_posts_by_job_role.fargate.utils.validate_utils as job
+from utils.column_names.ind_cqc_pipeline_columns import IndCqcColumns as IndCQC
+from utils.column_values.categorical_column_values import (
+    MainJobRoleLabels,
+    JobGroupLabels,
+)
+
+
+class TestCreateJobRoleEstimatesDataValidationColumns(unittest.TestCase):
+    def test_function_returns_expected_values(self):
+        expected_schema = {
+            IndCQC.cqc_location_import_date: pl.Date,
+            IndCQC.estimate_filled_posts_from_all_job_roles: pl.Float32,
+            MainJobRoleLabels.care_worker: pl.Float32,
+            JobGroupLabels.direct_care: pl.Float32,
+            JobGroupLabels.managers: pl.Float32,
+            JobGroupLabels.regulated_professions: pl.Float32,
+            JobGroupLabels.other: pl.Float32,
+            IndCQC.national_percentage_care_worker_filled_posts: pl.Float32,
+            IndCQC.national_percentage_direct_care_filled_posts: pl.Float32,
+            IndCQC.national_percentage_managers_filled_posts: pl.Float32,
+            IndCQC.national_percentage_regulated_professions_filled_posts: pl.Float32,
+            IndCQC.national_percentage_other_filled_posts: pl.Float32,
+        }
+        expected_rows = [
+            (date(2020, 1, 1), 100.0, 50.0, 30.0, 10.0, 5.0, 5.0, 0.5, 0.3, 0.1, 0.05, 0.05),
+            (date(2020, 1, 1), 200.0, 100.0, 60.0, 20.0, 10.0, 10.0, 0.5, 0.3, 0.1, 0.05, 0.05),
+            (date(2021, 1, 1), 150.0, 75.0, 45.0, 15.0, 7.5, 7.5, 0.5, 0.3, 0.1, 0.05, 0.05),
+        ] # fmt: skip
+        expected_lf = pl.LazyFrame(expected_rows, schema=expected_schema, orient="row")
+        test_lf = expected_lf.drop(
+            IndCQC.national_percentage_care_worker_filled_posts,
+            IndCQC.national_percentage_direct_care_filled_posts,
+            IndCQC.national_percentage_managers_filled_posts,
+            IndCQC.national_percentage_regulated_professions_filled_posts,
+            IndCQC.national_percentage_other_filled_posts,
+        )
+        returned_lf = job.create_job_role_estimates_data_validation_columns(test_lf)
+        pl_testing.assert_frame_equal(returned_lf, expected_lf, check_row_order=False)

--- a/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/tests/fargate/utils/test_validate_utils.py
+++ b/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/tests/fargate/utils/test_validate_utils.py
@@ -6,6 +6,7 @@ import polars.testing as pl_testing
 import projects._03_independent_cqc._07_estimate_filled_posts_by_job_role.fargate.utils.validate_utils as job
 from utils.column_names.ind_cqc_pipeline_columns import IndCqcColumns as IndCQC
 from utils.column_values.categorical_column_values import MainJobRoleLabels
+from utils.column_names.validation_table_columns import Validation as validationColumns
 
 
 class TestCreateJobRoleEstimatesDataValidationColumns(unittest.TestCase):
@@ -34,7 +35,7 @@ class TestCreateJobRoleEstimatesDataValidationColumns(unittest.TestCase):
             IndCQC.national_percentage_managers_filled_posts: pl.Float32,
             IndCQC.national_percentage_regulated_professions_filled_posts: pl.Float32,
             IndCQC.national_percentage_other_filled_posts: pl.Float32,
-            "total_job_role_records": pl.Int32,
+            validationColumns.total_job_role_records: pl.Int32,
         }
         expected_rows = [
             (date(2026, 1, 1), 0.4, 0.7, 0.2, 0.1, 0.0, 8),

--- a/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/tests/fargate/utils/test_validate_utils.py
+++ b/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/tests/fargate/utils/test_validate_utils.py
@@ -5,43 +5,44 @@ import polars.testing as pl_testing
 
 import projects._03_independent_cqc._07_estimate_filled_posts_by_job_role.fargate.utils.validate_utils as job
 from utils.column_names.ind_cqc_pipeline_columns import IndCqcColumns as IndCQC
-from utils.column_values.categorical_column_values import (
-    MainJobRoleLabels,
-    JobGroupLabels,
-)
+from utils.column_values.categorical_column_values import MainJobRoleLabels
 
 
 class TestCreateJobRoleEstimatesDataValidationColumns(unittest.TestCase):
     def test_function_returns_expected_values(self):
-        expected_schema = {
+        input_schema = {
             IndCQC.cqc_location_import_date: pl.Date,
             IndCQC.main_job_role_clean_labelled: pl.String,
             IndCQC.estimate_filled_posts_by_job_role_manager_adjusted: pl.Float32,
             IndCQC.estimate_filled_posts_from_all_job_roles: pl.Float32,
+        }
+        input_rows = [
+            (date(2026, 1, 1), MainJobRoleLabels.care_worker, 40.0, 100.0),
+            (date(2026, 1, 1), MainJobRoleLabels.support_worker, 30.0, 100.0),
+            (date(2026, 1, 1), MainJobRoleLabels.registered_manager, 20.0, 100.0),
+            (date(2026, 1, 1), MainJobRoleLabels.registered_nurse, 10.0, 100.0),
+            (date(2026, 2, 1), MainJobRoleLabels.care_worker, 60.0, 200.0),
+            (date(2026, 2, 1), MainJobRoleLabels.support_worker, 40.0, 200.0),
+            (date(2026, 2, 1), MainJobRoleLabels.registered_manager, 60.0, 200.0),
+            (date(2026, 2, 1), MainJobRoleLabels.software_developer, 40.0, 200.0),
+        ]
+
+        expected_schema = {
+            IndCQC.cqc_location_import_date: pl.Date,
             IndCQC.national_percentage_care_worker_filled_posts: pl.Float32,
             IndCQC.national_percentage_direct_care_filled_posts: pl.Float32,
             IndCQC.national_percentage_managers_filled_posts: pl.Float32,
             IndCQC.national_percentage_regulated_professions_filled_posts: pl.Float32,
             IndCQC.national_percentage_other_filled_posts: pl.Float32,
+            "total_job_role_records": pl.Int32,
         }
         expected_rows = [
-            # date,         job_role,               filled_posts, est_all,  %cw, %dc, %mgr, %reg, %other
-            (date(2026, 1, 1), "care_worker",        40.0, 100.0, 0.4, 0.7, 0.2, 0.1, 0.0),
-            (date(2026, 1, 1), "support_worker",     30.0, 100.0, 0.4, 0.7, 0.2, 0.1, 0.0),
-            (date(2026, 1, 1), "registered_manager", 20.0, 100.0, 0.4, 0.7, 0.2, 0.1, 0.0),
-            (date(2026, 1, 1), "registered_nurse",   10.0, 100.0, 0.4, 0.7, 0.2, 0.1, 0.0),
-            (date(2026, 2, 1), "care_worker",        60.0, 200.0, 0.3, 0.5, 0.3, 0.2, 0.0),
-            (date(2026, 2, 1), "support_worker",     40.0, 200.0, 0.3, 0.5, 0.3, 0.2, 0.0),
-            (date(2026, 2, 1), "registered_manager", 60.0, 200.0, 0.3, 0.5, 0.3, 0.2, 0.0),
-            (date(2026, 2, 1), "registered_nurse",   40.0, 200.0, 0.3, 0.5, 0.3, 0.2, 0.0),
-        ] # fmt: skip
-        expected_lf = pl.LazyFrame(expected_rows, schema=expected_schema, orient="row")
-        test_lf = expected_lf.drop(
-            IndCQC.national_percentage_care_worker_filled_posts,
-            IndCQC.national_percentage_direct_care_filled_posts,
-            IndCQC.national_percentage_managers_filled_posts,
-            IndCQC.national_percentage_regulated_professions_filled_posts,
-            IndCQC.national_percentage_other_filled_posts,
-        )
+            (date(2026, 1, 1), 0.4, 0.7, 0.2, 0.1, 0.0, 8),
+            (date(2026, 2, 1), 0.3, 0.5, 0.3, 0.0, 0.2, 8),
+        ]
+
+        test_lf = pl.LazyFrame(input_rows, input_schema, orient="row")
+        expected_lf = pl.LazyFrame(expected_rows, expected_schema, orient="row")
+
         returned_lf = job.create_job_role_estimates_data_validation_columns(test_lf)
         pl_testing.assert_frame_equal(returned_lf, expected_lf, check_row_order=False)

--- a/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/tests/fargate/utils/test_validate_utils.py
+++ b/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/tests/fargate/utils/test_validate_utils.py
@@ -15,12 +15,9 @@ class TestCreateJobRoleEstimatesDataValidationColumns(unittest.TestCase):
     def test_function_returns_expected_values(self):
         expected_schema = {
             IndCQC.cqc_location_import_date: pl.Date,
+            IndCQC.main_job_role_clean_labelled: pl.String,
+            IndCQC.estimate_filled_posts_by_job_role_manager_adjusted: pl.Float32,
             IndCQC.estimate_filled_posts_from_all_job_roles: pl.Float32,
-            MainJobRoleLabels.care_worker: pl.Float32,
-            JobGroupLabels.direct_care: pl.Float32,
-            JobGroupLabels.managers: pl.Float32,
-            JobGroupLabels.regulated_professions: pl.Float32,
-            JobGroupLabels.other: pl.Float32,
             IndCQC.national_percentage_care_worker_filled_posts: pl.Float32,
             IndCQC.national_percentage_direct_care_filled_posts: pl.Float32,
             IndCQC.national_percentage_managers_filled_posts: pl.Float32,
@@ -28,9 +25,15 @@ class TestCreateJobRoleEstimatesDataValidationColumns(unittest.TestCase):
             IndCQC.national_percentage_other_filled_posts: pl.Float32,
         }
         expected_rows = [
-            (date(2020, 1, 1), 100.0, 50.0, 30.0, 10.0, 5.0, 5.0, 0.5, 0.3, 0.1, 0.05, 0.05),
-            (date(2020, 1, 1), 200.0, 100.0, 60.0, 20.0, 10.0, 10.0, 0.5, 0.3, 0.1, 0.05, 0.05),
-            (date(2021, 1, 1), 150.0, 75.0, 45.0, 15.0, 7.5, 7.5, 0.5, 0.3, 0.1, 0.05, 0.05),
+            # date,         job_role,               filled_posts, est_all,  %cw, %dc, %mgr, %reg, %other
+            (date(2026, 1, 1), "care_worker",        40.0, 100.0, 0.4, 0.7, 0.2, 0.1, 0.0),
+            (date(2026, 1, 1), "support_worker",     30.0, 100.0, 0.4, 0.7, 0.2, 0.1, 0.0),
+            (date(2026, 1, 1), "registered_manager", 20.0, 100.0, 0.4, 0.7, 0.2, 0.1, 0.0),
+            (date(2026, 1, 1), "registered_nurse",   10.0, 100.0, 0.4, 0.7, 0.2, 0.1, 0.0),
+            (date(2026, 2, 1), "care_worker",        60.0, 200.0, 0.3, 0.5, 0.3, 0.2, 0.0),
+            (date(2026, 2, 1), "support_worker",     40.0, 200.0, 0.3, 0.5, 0.3, 0.2, 0.0),
+            (date(2026, 2, 1), "registered_manager", 60.0, 200.0, 0.3, 0.5, 0.3, 0.2, 0.0),
+            (date(2026, 2, 1), "registered_nurse",   40.0, 200.0, 0.3, 0.5, 0.3, 0.2, 0.0),
         ] # fmt: skip
         expected_lf = pl.LazyFrame(expected_rows, schema=expected_schema, orient="row")
         test_lf = expected_lf.drop(

--- a/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/utils/utils.py
+++ b/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/utils/utils.py
@@ -933,6 +933,7 @@ def create_estimate_filled_posts_job_group_columns(
     return df
 
 
+# converted to polars -> projects\_03_independent_cqc\_07_estimate_filled_posts_by_job_role\fargate\utils\validate_utils.py
 def create_job_role_estimates_data_validation_columns(df: DataFrame) -> DataFrame:
     """
     Creates new columns for checking the job role estimates data. These are:

--- a/terraform/pipeline/step-functions/dynamic/Ind-CQC-Filled-Post-Estimates-By-Role.json
+++ b/terraform/pipeline/step-functions/dynamic/Ind-CQC-Filled-Post-Estimates-By-Role.json
@@ -195,6 +195,7 @@
                         "validate_04_estimates.py",
                         "--bucket_name", "${dataset_bucket_name}",
                         "--source_path", "domain=ind_cqc_filled_posts/dataset=ind_cqc_07_04_estimate_job_roles/",
+                        "--compare_path", "domain=ind_cqc_filled_posts/dataset=main_ind_cqc_06_estimated_filled_posts/",
                         "--reports_path", "domain=data_validation_reports/dataset=validation_ind_cqc_07_04_estimate_job_roles/"
                       ]
                     }

--- a/terraform/pipeline/step-functions/dynamic/Ind-CQC-Filled-Post-Estimates-By-Role.json
+++ b/terraform/pipeline/step-functions/dynamic/Ind-CQC-Filled-Post-Estimates-By-Role.json
@@ -171,6 +171,36 @@
                   ]
                 }
               },
+              "Next": "Validate Job Role Estimates"
+            },
+            "Validate Job Role Estimates": {
+              "Type": "Task",
+              "Resource": "arn:aws:states:::ecs:runTask.sync",
+              "Parameters": {
+                "Cluster": "${polars_cluster_arn}",
+                "TaskDefinition": "${independent_cqc_task_arn}",
+                "LaunchType": "FARGATE",
+                "NetworkConfiguration": {
+                  "AwsvpcConfiguration": {
+                    "Subnets": ${public_subnet_ids},
+                    "SecurityGroups": ["${independent_cqc_security_group_id}"],
+                    "AssignPublicIp": "ENABLED"
+                  }
+                },
+                "Overrides": {
+                  "ContainerOverrides": [
+                    {
+                      "Name": "_03_independent_cqc-container",
+                      "Command": [
+                        "validate_04_estimates.py",
+                        "--bucket_name", "${dataset_bucket_name}",
+                        "--source_path", "domain=ind_cqc_filled_posts/dataset=ind_cqc_07_04_estimate_job_roles/",
+                        "--reports_path", "domain=data_validation_reports/dataset=validation_ind_cqc_07_04_estimate_job_roles/"
+                      ]
+                    }
+                  ]
+                }
+              },
               "End": true
             }
           }

--- a/terraform/pipeline/step-functions/dynamic/Ind-CQC-Filled-Post-Estimates-By-Role.json
+++ b/terraform/pipeline/step-functions/dynamic/Ind-CQC-Filled-Post-Estimates-By-Role.json
@@ -195,7 +195,7 @@
                         "validate_04_estimates.py",
                         "--bucket_name", "${dataset_bucket_name}",
                         "--source_path", "domain=ind_cqc_filled_posts/dataset=ind_cqc_07_04_estimate_job_roles/",
-                        "--compare_path", "domain=ind_cqc_filled_posts/dataset=main_ind_cqc_06_estimated_filled_posts/",
+                        "--compare_path", "domain=ind_cqc_filled_posts/dataset=ind_cqc_06_estimated_filled_posts/",
                         "--reports_path", "domain=data_validation_reports/dataset=validation_ind_cqc_07_04_estimate_job_roles/"
                       ]
                     }

--- a/terraform/pipeline/step-functions/dynamic/Ind-CQC-Filled-Post-Estimates.json
+++ b/terraform/pipeline/step-functions/dynamic/Ind-CQC-Filled-Post-Estimates.json
@@ -925,7 +925,7 @@
                               "Name": "_03_independent_cqc-container",
                               "Command": [
                                 "_01_merge.py",
-                                "--estimates_source", "${dataset_bucket_uri}/domain=ind_cqc_filled_posts/dataset=ind_cqc_06_estimated_filled_posts/",
+                                "--estimates_source", "${dataset_bucket_uri}/domain=ind_cqc_filled_posts/dataset=main_ind_cqc_06_estimated_filled_posts/",
                                 "--ascwds_job_role_counts_source", "${dataset_bucket_uri}/domain=ind_cqc_filled_posts/dataset=ind_cqc_01_ascwds_prepared_job_role_counts/",
                                 "--merged_data_destination","${dataset_bucket_uri}/domain=ind_cqc_filled_posts/dataset=ind_cqc_07_01_merge_job_roles/",
                                 "--metadata_destination","${dataset_bucket_uri}/domain=ind_cqc_filled_posts/dataset=ind_cqc_07_01_merge_metadata_job_roles/"

--- a/terraform/pipeline/step-functions/dynamic/Ind-CQC-Filled-Post-Estimates.json
+++ b/terraform/pipeline/step-functions/dynamic/Ind-CQC-Filled-Post-Estimates.json
@@ -925,7 +925,7 @@
                               "Name": "_03_independent_cqc-container",
                               "Command": [
                                 "_01_merge.py",
-                                "--estimates_source", "${dataset_bucket_uri}/domain=ind_cqc_filled_posts/dataset=main_ind_cqc_06_estimated_filled_posts/",
+                                "--estimates_source", "${dataset_bucket_uri}/domain=ind_cqc_filled_posts/dataset=ind_cqc_06_estimated_filled_posts/",
                                 "--ascwds_job_role_counts_source", "${dataset_bucket_uri}/domain=ind_cqc_filled_posts/dataset=ind_cqc_01_ascwds_prepared_job_role_counts/",
                                 "--merged_data_destination","${dataset_bucket_uri}/domain=ind_cqc_filled_posts/dataset=ind_cqc_07_01_merge_job_roles/",
                                 "--metadata_destination","${dataset_bucket_uri}/domain=ind_cqc_filled_posts/dataset=ind_cqc_07_01_merge_metadata_job_roles/"
@@ -1016,6 +1016,37 @@
                                 "_04_estimate.py",
                                 "--imputed_data_source", "${dataset_bucket_uri}/domain=ind_cqc_filled_posts/dataset=ind_cqc_07_03_impute_job_roles/",
                                 "--estimated_data_destination","${dataset_bucket_uri}/domain=ind_cqc_filled_posts/dataset=ind_cqc_07_04_estimate_job_roles/"
+                              ]
+                            }
+                          ]
+                        }
+                      },
+                      "Next": "Validate Job Role Estimates"
+                    },
+                    "Validate Job Role Estimates": {
+                      "Type": "Task",
+                      "Resource": "arn:aws:states:::ecs:runTask.sync",
+                      "Parameters": {
+                        "Cluster": "${polars_cluster_arn}",
+                        "TaskDefinition": "${independent_cqc_task_arn}",
+                        "LaunchType": "FARGATE",
+                        "NetworkConfiguration": {
+                          "AwsvpcConfiguration": {
+                            "Subnets": ${public_subnet_ids},
+                            "SecurityGroups": ["${independent_cqc_security_group_id}"],
+                            "AssignPublicIp": "ENABLED"
+                          }
+                        },
+                        "Overrides": {
+                          "ContainerOverrides": [
+                            {
+                              "Name": "_03_independent_cqc-container",
+                              "Command": [
+                                "validate_04_estimates.py",
+                                "--bucket_name", "${dataset_bucket_name}",
+                                "--source_path", "domain=ind_cqc_filled_posts/dataset=ind_cqc_07_04_estimate_job_roles/",
+                                "--compare_path", "domain=ind_cqc_filled_posts/dataset=main_ind_cqc_06_estimated_filled_posts/",
+                                "--reports_path", "domain=data_validation_reports/dataset=validation_ind_cqc_07_04_estimate_job_roles/"
                               ]
                             }
                           ]

--- a/terraform/pipeline/step-functions/dynamic/Ind-CQC-Filled-Post-Estimates.json
+++ b/terraform/pipeline/step-functions/dynamic/Ind-CQC-Filled-Post-Estimates.json
@@ -1045,7 +1045,7 @@
                                 "validate_04_estimates.py",
                                 "--bucket_name", "${dataset_bucket_name}",
                                 "--source_path", "domain=ind_cqc_filled_posts/dataset=ind_cqc_07_04_estimate_job_roles/",
-                                "--compare_path", "domain=ind_cqc_filled_posts/dataset=main_ind_cqc_06_estimated_filled_posts/",
+                                "--compare_path", "domain=ind_cqc_filled_posts/dataset=ind_cqc_06_estimated_filled_posts/",
                                 "--reports_path", "domain=data_validation_reports/dataset=validation_ind_cqc_07_04_estimate_job_roles/"
                               ]
                             }

--- a/utils/column_names/validation_table_columns.py
+++ b/utils/column_names/validation_table_columns.py
@@ -15,3 +15,4 @@ class Validation:
     constraint_message: str = "constraint_message"
     location_id_length: str = CQCLCLean.location_id + "_length"
     provider_id_length: str = CQCLCLean.provider_id + "_length"
+    total_job_role_records: str = "total_job_role_records"


### PR DESCRIPTION
## Description
Trello ticket [#1537](https://trello.com/c/LCRYW4tP/1537-create-job-role-estimates-data-validation-columns)

Created job role estimates data validation columns in Polars and added validation and test validation scripts for the Estimates job. 

## Testing
- [x] Unit tests passing
- [x] Successful [Job / Step Function run](https://eu-west-2.console.aws.amazon.com/states/home?region=eu-west-2#/v2/executions/details/arn:aws:states:eu-west-2:856699698263:execution:1537-job-role-val-Ind-CQC-Filled-Post-Estimates-By-Role:8edfb997-5b88-42ce-b194-8fc970dcab33)

## Migration to polars checklist
- [x] Check that similar utils functions don't already exist, or if one can be created
- [x] Check that utils are being saved in the appropriate place
- [x] Used LazyFrame option for test data
- [x] Unit tests added
- [x] Docstrings added
- [x] Added comment to pyspark functions which have been migrated with the link to the new location
      `# converted to polars -> filepath.py`
- [x] Use new file structure when saving to S3
      `{dataset}_{sub_dataset_if_relevant}_{order_of_process_if_relevant}_{very_brief_description}`
- [x] Updated CHANGELOG
- [x] Code reviewed by AI
- [x] Moved Trello ticket to PR column
