### PR TITLE
1585 - Update dataset name in IND CQC step function for Job Role job

### DIFF
--- a/terraform/pipeline/step-functions/dynamic/Ind-CQC-Filled-Post-Estimates-By-Role.json
+++ b/terraform/pipeline/step-functions/dynamic/Ind-CQC-Filled-Post-Estimates-By-Role.json
@@ -75,7 +75,7 @@
                       "Name": "_03_independent_cqc-container",
                       "Command": [
                         "_01_merge.py",
-                        "--estimates_source", "${dataset_bucket_uri}/domain=ind_cqc_filled_posts/dataset=ind_cqc_06_estimated_filled_posts/",
+                        "--estimates_source", "${dataset_bucket_uri}/domain=ind_cqc_filled_posts/dataset=main_ind_cqc_06_estimated_filled_posts/",
                         "--ascwds_job_role_counts_source", "${dataset_bucket_uri}/domain=ind_cqc_filled_posts/dataset=ind_cqc_01_ascwds_prepared_job_role_counts/",
                         "--merged_data_destination","${dataset_bucket_uri}/domain=ind_cqc_filled_posts/dataset=ind_cqc_07_01_merge_job_roles/",
                         "--metadata_destination","${dataset_bucket_uri}/domain=ind_cqc_filled_posts/dataset=ind_cqc_07_01_merge_metadata_job_roles/"

--- a/terraform/pipeline/step-functions/dynamic/Ind-CQC-Filled-Post-Estimates-By-Role.json
+++ b/terraform/pipeline/step-functions/dynamic/Ind-CQC-Filled-Post-Estimates-By-Role.json
@@ -75,7 +75,7 @@
                       "Name": "_03_independent_cqc-container",
                       "Command": [
                         "_01_merge.py",
-                        "--estimates_source", "${dataset_bucket_uri}/domain=ind_cqc_filled_posts/dataset=main_ind_cqc_06_estimated_filled_posts/",
+                        "--estimates_source", "${dataset_bucket_uri}/domain=ind_cqc_filled_posts/dataset=ind_cqc_06_estimated_filled_posts/",
                         "--ascwds_job_role_counts_source", "${dataset_bucket_uri}/domain=ind_cqc_filled_posts/dataset=ind_cqc_01_ascwds_prepared_job_role_counts/",
                         "--merged_data_destination","${dataset_bucket_uri}/domain=ind_cqc_filled_posts/dataset=ind_cqc_07_01_merge_job_roles/",
                         "--metadata_destination","${dataset_bucket_uri}/domain=ind_cqc_filled_posts/dataset=ind_cqc_07_01_merge_metadata_job_roles/"

--- a/terraform/pipeline/step-functions/dynamic/Ind-CQC-Filled-Post-Estimates.json
+++ b/terraform/pipeline/step-functions/dynamic/Ind-CQC-Filled-Post-Estimates.json
@@ -925,7 +925,7 @@
                               "Name": "_03_independent_cqc-container",
                               "Command": [
                                 "_01_merge.py",
-                                "--estimates_source", "${dataset_bucket_uri}/domain=ind_cqc_filled_posts/dataset=main_ind_cqc_06_estimated_filled_posts/",
+                                "--estimates_source", "${dataset_bucket_uri}/domain=ind_cqc_filled_posts/dataset=ind_cqc_06_estimated_filled_posts/",
                                 "--ascwds_job_role_counts_source", "${dataset_bucket_uri}/domain=ind_cqc_filled_posts/dataset=ind_cqc_01_ascwds_prepared_job_role_counts/",
                                 "--merged_data_destination","${dataset_bucket_uri}/domain=ind_cqc_filled_posts/dataset=ind_cqc_07_01_merge_job_roles/",
                                 "--metadata_destination","${dataset_bucket_uri}/domain=ind_cqc_filled_posts/dataset=ind_cqc_07_01_merge_metadata_job_roles/"


### PR DESCRIPTION
## Description
Trello ticket [#1585 ](https://trello.com/c/0jIwSmcQ/1585-ind-cqc-pipeline-fails-at-job-role-job-due-to-wrong-dataset-name)

Ind CQC pipeline failed in main at the start of Job Role job. This was due to wrong dataset name and this PR is to update it to the correct one.

## Testing
- [x] Unit tests passing
- [x] Successful [Step Function run](https://eu-west-2.console.aws.amazon.com/states/home?region=eu-west-2#/v2/executions/details/arn:aws:states:eu-west-2:856699698263:execution:1585-fix-job-role-Ind-CQC-Filled-Post-Estimates:b1323adc-7661-420b-b552-af8a2b7e3ab2)

## Checklist (delete if not relevant)
- [x] Moved Trello ticket to PR column
