### PR TITLE
1575 - Add expressions functions for commonly used expressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Added
-
+- Added reusable Polars expression helper functions in `polars_utils/expressions.py` for `is_care_home()`, `is_not_care_home()`, and `is_dormant()`.
 
 ### Changed
 

--- a/polars_utils/cleaning_utils.py
+++ b/polars_utils/cleaning_utils.py
@@ -1,9 +1,7 @@
 import polars as pl
 from typing import List
-
+from polars_utils.expressions import is_care_home, is_not_care_home
 from utils.column_names.ind_cqc_pipeline_columns import IndCqcColumns as IndCQC
-from utils.column_names.ind_cqc_pipeline_columns import PartitionKeys as Keys
-from utils.column_values.categorical_column_values import CareHome
 
 
 def add_aligned_date_column(
@@ -97,7 +95,7 @@ def calculate_filled_posts_per_bed_ratio(
     """
     lf = input_lf.with_columns(
         pl.when(
-            (pl.col(IndCQC.care_home) == CareHome.care_home)
+            is_care_home()
             & pl.col(IndCQC.number_of_beds).is_not_null()
             & (pl.col(IndCQC.number_of_beds) != 0)
         )
@@ -158,8 +156,5 @@ def create_banded_bed_count_column(
     )
 
     return input_lf.with_columns(
-        pl.when(pl.col(IndCQC.care_home) == CareHome.not_care_home)
-        .then(zero)
-        .otherwise(expr)
-        .alias(new_col)
+        pl.when(is_not_care_home()).then(zero).otherwise(expr).alias(new_col)
     )

--- a/polars_utils/expressions.py
+++ b/polars_utils/expressions.py
@@ -1,4 +1,6 @@
 import polars as pl
+from utils.column_names.ind_cqc_pipeline_columns import IndCqcColumns as IndCQC
+from utils.column_values.categorical_column_values import CareHome
 
 
 def has_value(df: pl.DataFrame, column: str, partition_by: str) -> pl.Expr:
@@ -56,3 +58,13 @@ def str_length_cols(columns: list[str]) -> list[pl.Expr]:
     return [
         pl.col(column).str.len_chars().alias(f"{column}_length") for column in columns
     ]
+
+
+def is_care_home() -> pl.Expr:
+    """Expression to identify care home records."""
+    return pl.col(IndCQC.care_home) == CareHome.care_home
+
+
+def is_not_care_home() -> pl.Expr:
+    """Expression to identify non-care home records."""
+    return pl.col(IndCQC.care_home) == CareHome.not_care_home

--- a/polars_utils/expressions.py
+++ b/polars_utils/expressions.py
@@ -1,6 +1,6 @@
 import polars as pl
 from utils.column_names.ind_cqc_pipeline_columns import IndCqcColumns as IndCQC
-from utils.column_values.categorical_column_values import CareHome
+from utils.column_values.categorical_column_values import CareHome, Dormancy
 
 
 def has_value(df: pl.DataFrame, column: str, partition_by: str) -> pl.Expr:
@@ -68,3 +68,8 @@ def is_care_home() -> pl.Expr:
 def is_not_care_home() -> pl.Expr:
     """Expression to identify non-care home records."""
     return pl.col(IndCQC.care_home) == CareHome.not_care_home
+
+
+def is_dormant() -> pl.Expr:
+    """Expression to identify dormant records."""
+    return pl.col(IndCQC.dormancy) == Dormancy.dormant

--- a/projects/_03_independent_cqc/_02_clean/fargate/utils/clean_ascwds_filled_post_outliers/non_res_brand_id_filter.py
+++ b/projects/_03_independent_cqc/_02_clean/fargate/utils/clean_ascwds_filled_post_outliers/non_res_brand_id_filter.py
@@ -3,8 +3,9 @@ from datetime import date
 from projects._03_independent_cqc._02_clean.fargate.utils.filtering_utils import (
     update_filtering_rule,
 )
+from polars_utils.expressions import is_not_care_home
 from utils.column_names.ind_cqc_pipeline_columns import IndCqcColumns as IndCQC
-from utils.column_values.categorical_column_values import AscwdsFilteringRule, CareHome
+from utils.column_values.categorical_column_values import AscwdsFilteringRule
 
 
 def non_res_brand_id_filter(lf: pl.LazyFrame) -> pl.LazyFrame:
@@ -38,7 +39,7 @@ def non_res_brand_id_filter(lf: pl.LazyFrame) -> pl.LazyFrame:
 
     lf = lf.with_columns(
         pl.when(
-            (pl.col(IndCQC.care_home) == CareHome.not_care_home)
+            is_not_care_home()
             & (pl.col(IndCQC.brand_id) == target_brand_id)
             & (pl.col(IndCQC.cqc_location_import_date) > start_date)
             & (pl.col(IndCQC.cqc_location_import_date) < end_date)

--- a/projects/_03_independent_cqc/_02_clean/fargate/utils/clean_ascwds_filled_post_outliers/null_grouped_providers.py
+++ b/projects/_03_independent_cqc/_02_clean/fargate/utils/clean_ascwds_filled_post_outliers/null_grouped_providers.py
@@ -6,12 +6,12 @@ import polars_utils.cleaning_utils as pUtils
 from projects._03_independent_cqc._02_clean.fargate.utils.filtering_utils import (
     update_filtering_rule,
 )
-
+from polars_utils.expressions import is_not_care_home, is_care_home
 from utils.column_names.ind_cqc_pipeline_columns import IndCqcColumns as IndCQC
 from utils.column_names.ind_cqc_pipeline_columns import (
     NullGroupedProviderColumns as NGPcol,
 )
-from utils.column_values.categorical_column_values import AscwdsFilteringRule, CareHome
+from utils.column_values.categorical_column_values import AscwdsFilteringRule
 
 
 @dataclass
@@ -170,7 +170,7 @@ def null_care_home_grouped_providers(lf: pl.LazyFrame) -> pl.LazyFrame:
     Returns:
         pl.LazyFrame: A polars LazyFrame with grouped providers' care home data nulled.
     """
-    location_is_a_care_home = pl.col(IndCQC.care_home) == CareHome.care_home
+    location_is_a_care_home = is_care_home()
     location_identified_as_a_potential_grouped_provider = (
         pl.col(NGPcol.potential_grouped_provider) == True
     )
@@ -243,7 +243,7 @@ def null_non_residential_grouped_providers(lf: pl.LazyFrame) -> pl.LazyFrame:
         pl.LazyFrame: A polars LazyFrame with grouped providers' non-residential
             data nulled.
     """
-    location_is_not_a_care_home = pl.col(IndCQC.care_home) == CareHome.not_care_home
+    location_is_not_a_care_home = is_not_care_home()
     location_identified_as_a_potential_grouped_provider = (
         pl.col(NGPcol.potential_grouped_provider) == True
     )

--- a/projects/_03_independent_cqc/_02_clean/fargate/utils/clean_ascwds_filled_post_outliers/winsorize_care_home_filled_posts_per_bed_ratio_outliers.py
+++ b/projects/_03_independent_cqc/_02_clean/fargate/utils/clean_ascwds_filled_post_outliers/winsorize_care_home_filled_posts_per_bed_ratio_outliers.py
@@ -6,8 +6,9 @@ import polars_utils.cleaning_utils as pUtils
 from projects._03_independent_cqc._02_clean.fargate.utils.filtering_utils import (
     update_filtering_rule,
 )
+from polars_utils.expressions import is_care_home
 from utils.column_names.ind_cqc_pipeline_columns import IndCqcColumns as IndCQC
-from utils.column_values.categorical_column_values import AscwdsFilteringRule, CareHome
+from utils.column_values.categorical_column_values import AscwdsFilteringRule
 
 
 @dataclass
@@ -131,7 +132,7 @@ def filter_lf_to_care_homes_with_known_beds_and_filled_posts(
             filled posts.
     """
     lf = lf.filter(
-        (pl.col(IndCQC.care_home) == CareHome.care_home)
+        is_care_home()
         & pl.col(IndCQC.number_of_beds).is_not_null()
         & (pl.col(IndCQC.number_of_beds) > 0)
         & pl.col(IndCQC.ascwds_filled_posts_dedup_clean).is_not_null()

--- a/projects/_03_independent_cqc/_02_clean/fargate/utils/clean_ind_cqc_filled_posts_utils.py
+++ b/projects/_03_independent_cqc/_02_clean/fargate/utils/clean_ind_cqc_filled_posts_utils.py
@@ -1,7 +1,6 @@
 import polars as pl
-from polars_utils.expressions import is_care_home, is_not_care_home
+from polars_utils.expressions import is_care_home, is_not_care_home, is_dormant
 from utils.column_names.ind_cqc_pipeline_columns import IndCqcColumns as IndCQC
-from utils.column_values.categorical_column_values import Dormancy
 
 average_number_of_beds: str = "avg_beds"
 
@@ -60,7 +59,7 @@ def calculate_time_since_dormant(lf: pl.LazyFrame) -> pl.LazyFrame:
     """
     lf = lf.sort([IndCQC.location_id, IndCQC.cqc_location_import_date])
     lf = lf.with_columns(
-        pl.when(pl.col(IndCQC.dormancy) == Dormancy.dormant)
+        pl.when(is_dormant())
         .then(pl.col(IndCQC.cqc_location_import_date))
         .otherwise(None)
         .alias(IndCQC.dormant_date)
@@ -76,7 +75,7 @@ def calculate_time_since_dormant(lf: pl.LazyFrame) -> pl.LazyFrame:
     lf = lf.with_columns(
         pl.when(pl.col(IndCQC.last_dormant_date).is_not_null())
         .then(
-            pl.when(pl.col(IndCQC.dormancy) == Dormancy.dormant)
+            pl.when(is_dormant())
             .then(1)
             .otherwise(
                 (

--- a/projects/_03_independent_cqc/_02_clean/fargate/utils/clean_ind_cqc_filled_posts_utils.py
+++ b/projects/_03_independent_cqc/_02_clean/fargate/utils/clean_ind_cqc_filled_posts_utils.py
@@ -1,7 +1,7 @@
 import polars as pl
-
+from polars_utils.expressions import is_care_home, is_not_care_home
 from utils.column_names.ind_cqc_pipeline_columns import IndCqcColumns as IndCQC
-from utils.column_values.categorical_column_values import CareHome, Dormancy
+from utils.column_values.categorical_column_values import Dormancy
 
 average_number_of_beds: str = "avg_beds"
 
@@ -163,11 +163,11 @@ def deduplicate_care_homes(
     """
     lf = lf.sort(duplicate_columns + distinguishing_columns)
 
-    care_home_deduped = lf.filter(
-        pl.col(IndCQC.care_home) == CareHome.care_home
-    ).unique(subset=duplicate_columns, keep="first")
+    care_home_deduped = lf.filter(is_care_home()).unique(
+        subset=duplicate_columns, keep="first"
+    )
 
-    not_care_home = lf.filter(pl.col(IndCQC.care_home) == CareHome.not_care_home)
+    not_care_home = lf.filter(is_not_care_home())
 
     return pl.concat([care_home_deduped, not_care_home])
 
@@ -189,7 +189,7 @@ def copy_ascwds_data_across_duplicate_rows(
     """
     lf = lf.with_columns(
         [
-            pl.when(pl.col(IndCQC.care_home) == CareHome.care_home)
+            pl.when(is_care_home())
             .then(
                 pl.coalesce(
                     [
@@ -202,7 +202,7 @@ def copy_ascwds_data_across_duplicate_rows(
             )
             .otherwise(pl.col(IndCQC.total_staff_bounded))
             .alias(IndCQC.total_staff_bounded),
-            pl.when(pl.col(IndCQC.care_home) == CareHome.care_home)
+            pl.when(is_care_home())
             .then(
                 pl.coalesce(
                     [
@@ -270,9 +270,7 @@ def filter_to_care_homes_with_known_beds(lf: pl.LazyFrame) -> pl.LazyFrame:
         pl.LazyFrame: A polars LazyFrame containing only care homes with
         non-null number_of_beds values.
     """
-    return lf.filter(pl.col(IndCQC.care_home) == CareHome.care_home).filter(
-        pl.col(IndCQC.number_of_beds).is_not_null()
-    )
+    return lf.filter(is_care_home()).filter(pl.col(IndCQC.number_of_beds).is_not_null())
 
 
 def average_beds_per_location(lf: pl.LazyFrame) -> pl.LazyFrame:

--- a/projects/_03_independent_cqc/_03_impute/fargate/utils/convert_pir_people_to_filled_posts.py
+++ b/projects/_03_independent_cqc/_03_impute/fargate/utils/convert_pir_people_to_filled_posts.py
@@ -1,7 +1,6 @@
 import polars as pl
-
+from polars_utils.expressions import is_not_care_home
 from utils.column_names.ind_cqc_pipeline_columns import IndCqcColumns as IndCQC
-from utils.column_values.categorical_column_values import CareHome
 
 posts_col = pl.col(IndCQC.ascwds_filled_posts_dedup_clean)
 people_col = pl.col(IndCQC.pir_people_directly_employed_dedup)
@@ -25,11 +24,7 @@ def convert_pir_to_filled_posts(lf: pl.LazyFrame) -> pl.LazyFrame:
     print(f"PIR people to filled posts ratio: {ratio:.4f}")
 
     return lf.with_columns(
-        pl.when(
-            (pl.col(IndCQC.care_home) == CareHome.not_care_home)
-            & people_col.is_not_null()
-            & (people_col > 0)
-        )
+        pl.when(is_not_care_home() & people_col.is_not_null() & (people_col > 0))
         .then(people_col * ratio)
         .alias(IndCQC.pir_filled_posts_model)
     )
@@ -54,7 +49,7 @@ def compute_global_ratio(lf: pl.LazyFrame) -> float:
 
     return (
         lf.filter(
-            (pl.col(IndCQC.care_home) == CareHome.not_care_home)
+            is_not_care_home()
             & people_col.is_not_null()
             & (people_col > 0)
             & posts_col.is_not_null()

--- a/projects/_03_independent_cqc/_04_model/fargate/model_01_features_care_home.py
+++ b/projects/_03_independent_cqc/_04_model/fargate/model_01_features_care_home.py
@@ -13,9 +13,9 @@ from projects._03_independent_cqc._04_model.utils.value_labels import (
     ServicesLabels,
     SpecialismsLabels,
 )
+from polars_utils.expressions import is_care_home
 from utils.column_names.ind_cqc_pipeline_columns import IndCqcColumns as IndCQC
 from utils.column_names.ind_cqc_pipeline_columns import ModelRegistryKeys as MRKeys
-from utils.column_values.categorical_column_values import CareHome
 
 
 def main(bucket_name: str, model_name: str) -> None:
@@ -47,9 +47,7 @@ def main(bucket_name: str, model_name: str) -> None:
     dependent_col = model_registry[model_name][MRKeys.dependent]
     feature_cols = model_registry[model_name][MRKeys.features]
 
-    lf = utils.scan_parquet(source).filter(
-        pl.col(IndCQC.care_home) == CareHome.care_home
-    )
+    lf = utils.scan_parquet(source).filter(is_care_home())
     lf = fUtils.add_date_index_column(lf)
 
     lf = fUtils.add_array_column_count(

--- a/projects/_03_independent_cqc/_04_model/fargate/model_01_features_non_res_with_dormancy.py
+++ b/projects/_03_independent_cqc/_04_model/fargate/model_01_features_non_res_with_dormancy.py
@@ -14,9 +14,9 @@ from projects._03_independent_cqc._04_model.utils.value_labels import (
     ServicesLabels,
     SpecialismsLabels,
 )
+from polars_utils.expressions import is_not_care_home
 from utils.column_names.ind_cqc_pipeline_columns import IndCqcColumns as IndCQC
 from utils.column_names.ind_cqc_pipeline_columns import ModelRegistryKeys as MRKeys
-from utils.column_values.categorical_column_values import CareHome
 
 
 def main(bucket_name: str, model_name: str) -> None:
@@ -51,8 +51,7 @@ def main(bucket_name: str, model_name: str) -> None:
     feature_cols = model_registry[model_name][MRKeys.features]
 
     lf = utils.scan_parquet(source).filter(
-        (pl.col(IndCQC.care_home) == CareHome.not_care_home)
-        & pl.col(IndCQC.dormancy).is_not_null()
+        is_not_care_home() & pl.col(IndCQC.dormancy).is_not_null()
     )
     lf = fUtils.add_date_index_column(lf)
     lf = fUtils.add_power_column(

--- a/projects/_03_independent_cqc/_04_model/fargate/model_01_features_non_res_without_dormancy.py
+++ b/projects/_03_independent_cqc/_04_model/fargate/model_01_features_non_res_without_dormancy.py
@@ -16,9 +16,9 @@ from projects._03_independent_cqc._04_model.utils.value_labels import (
     ServicesLabels,
     SpecialismsLabels,
 )
+from polars_utils.expressions import is_not_care_home
 from utils.column_names.ind_cqc_pipeline_columns import IndCqcColumns as IndCQC
 from utils.column_names.ind_cqc_pipeline_columns import ModelRegistryKeys as MRKeys
-from utils.column_values.categorical_column_values import CareHome
 
 
 def main(bucket_name: str, model_name: str) -> None:
@@ -54,7 +54,7 @@ def main(bucket_name: str, model_name: str) -> None:
     feature_cols = model_registry[model_name][MRKeys.features]
 
     lf = utils.scan_parquet(source).filter(
-        (pl.col(IndCQC.care_home) == CareHome.not_care_home)
+        is_not_care_home()
         & (pl.col(IndCQC.cqc_location_import_date) < date(2025, 1, 1))
     )
     lf = fUtils.add_date_index_column(lf)

--- a/projects/_03_independent_cqc/_04_model/utils/validate_models.py
+++ b/projects/_03_independent_cqc/_04_model/utils/validate_models.py
@@ -1,9 +1,8 @@
 from datetime import date
 
 import polars as pl
-
+from polars_utils.expressions import is_care_home, is_not_care_home
 from utils.column_names.ind_cqc_pipeline_columns import IndCqcColumns as IndCQC
-from utils.column_values.categorical_column_values import CareHome
 
 non_res_with_dormancy_cols_for_features = [
     IndCQC.dormancy,
@@ -61,7 +60,7 @@ def get_expected_row_count_for_model_features(df: pl.DataFrame, model: str) -> i
     if model == "non_res_with_dormancy_model":
         df = df.with_columns(pl.col(IndCQC.time_since_dormant).fill_null(999))
         df = df.filter(
-            pl.col(IndCQC.care_home) == CareHome.not_care_home,
+            is_not_care_home(),
             pl.all_horizontal(
                 [
                     pl.col(col_for_features).is_not_null()
@@ -71,7 +70,7 @@ def get_expected_row_count_for_model_features(df: pl.DataFrame, model: str) -> i
         )
     elif model == "non_res_without_dormancy_model":
         df = df.filter(
-            pl.col(IndCQC.care_home) == CareHome.not_care_home,
+            is_not_care_home(),
             pl.col(IndCQC.cqc_location_import_date) < date(2025, 1, 1),
             pl.all_horizontal(
                 [
@@ -82,7 +81,7 @@ def get_expected_row_count_for_model_features(df: pl.DataFrame, model: str) -> i
         )
     elif model == "care_home_model":
         df = df.filter(
-            pl.col(IndCQC.care_home) == CareHome.care_home,
+            is_care_home(),
             pl.all_horizontal(
                 [
                     pl.col(col_for_features).is_not_null()

--- a/projects/_03_independent_cqc/_06_estimate_filled_posts/fargate/utils/models/estimate_non_res_ct_filled_posts.py
+++ b/projects/_03_independent_cqc/_06_estimate_filled_posts/fargate/utils/models/estimate_non_res_ct_filled_posts.py
@@ -1,10 +1,8 @@
-from datetime import date
-
 import polars as pl
 
 from polars_utils import utils
+from polars_utils.expressions import is_not_care_home
 from utils.column_names.ind_cqc_pipeline_columns import IndCqcColumns as IndCQC
-from utils.column_values.categorical_column_values import CareHome
 
 
 def estimate_non_res_capacity_tracker_filled_posts(lf: pl.LazyFrame) -> pl.LazyFrame:
@@ -37,7 +35,7 @@ def estimate_non_res_capacity_tracker_filled_posts(lf: pl.LazyFrame) -> pl.LazyF
     care_worker_ratio = calculate_care_worker_ratio()
 
     lf = lf.with_columns(
-        pl.when(pl.col(IndCQC.care_home) == CareHome.not_care_home)
+        pl.when(is_not_care_home())
         .then(
             pl.col(IndCQC.ct_non_res_care_workers_employed_imputed).truediv(
                 care_worker_ratio
@@ -54,10 +52,7 @@ def estimate_non_res_capacity_tracker_filled_posts(lf: pl.LazyFrame) -> pl.LazyF
         name=IndCQC.ct_non_res_filled_post_estimate,
     )
     lf = lf.with_columns(
-        [
-            pl.when(pl.col(IndCQC.care_home) == CareHome.not_care_home).then(expression)
-            for expression in coalesce_expr
-        ]
+        [pl.when(is_not_care_home()).then(expression) for expression in coalesce_expr]
     )
 
     lf = lf.with_columns(
@@ -90,7 +85,7 @@ def calculate_care_worker_ratio() -> pl.Expr:
         and all filled posts at non-residential services.
     """
     ratio_filter = (
-        (pl.col(IndCQC.care_home) == CareHome.not_care_home)
+        is_not_care_home()
         & (pl.col(IndCQC.ct_non_res_care_workers_employed_imputed).is_not_null())
         & (pl.col(IndCQC.estimate_filled_posts).is_not_null())
     )

--- a/projects/_03_independent_cqc/_06_estimate_filled_posts/fargate/utils/models/non_res_with_and_without_dormancy_combined.py
+++ b/projects/_03_independent_cqc/_06_estimate_filled_posts/fargate/utils/models/non_res_with_and_without_dormancy_combined.py
@@ -3,11 +3,11 @@ import polars as pl
 from projects._03_independent_cqc._06_estimate_filled_posts.fargate.utils.models.utils import (
     join_model_predictions,
 )
+from polars_utils.expressions import is_not_care_home
 from utils.column_names.ind_cqc_pipeline_columns import IndCqcColumns as IndCqc
 from utils.column_names.ind_cqc_pipeline_columns import (
     NonResWithAndWithoutDormancyCombinedColumns as TempColumns,
 )
-from utils.column_values.categorical_column_values import CareHome
 
 non_res_columns_to_select = [
     IndCqc.location_id,
@@ -37,7 +37,7 @@ def combine_non_res_with_and_without_dormancy_models(
             joined in.
     """
     non_res_locations_lf = lf.select(non_res_columns_to_select).filter(
-        pl.col(IndCqc.care_home) == CareHome.not_care_home
+        is_not_care_home()
     )
 
     combined_models_lf = group_time_registered_to_six_month_bands(non_res_locations_lf)

--- a/tests/test_polars_utils/test_expressions.py
+++ b/tests/test_polars_utils/test_expressions.py
@@ -4,7 +4,14 @@ import polars as pl
 import polars.testing as pl_testing
 import pytest
 
-from polars_utils.expressions import has_value, percentage_share, str_length_cols
+from polars_utils.expressions import (
+    has_value,
+    percentage_share,
+    str_length_cols,
+    is_care_home,
+    is_not_care_home,
+    is_dormant,
+)
 
 
 class TestExpressions(unittest.TestCase):
@@ -149,6 +156,30 @@ class TestStrLengthCols(TestExpressions):
         df = pl.DataFrame({"num_col": [1, 2, 3]})
         with self.assertRaises(pl.exceptions.SchemaError):
             df.with_columns(str_length_cols(["num_col"]))
+
+
+class TestIsCareHome(TestExpressions):
+    def test_is_care_home(self):
+        df = pl.DataFrame({"careHome": ["Y", "N", "Y"]}).with_columns(
+            is_care_home().alias("is_care_home")
+        )
+        self.assertEqual(df["is_care_home"].to_list(), [True, False, True])
+
+
+class TestIsNotCareHome(TestExpressions):
+    def test_is_not_care_home(self):
+        df = pl.DataFrame({"careHome": ["Y", "N", "Y"]}).with_columns(
+            is_not_care_home().alias("is_not_care_home")
+        )
+        self.assertEqual(df["is_not_care_home"].to_list(), [False, True, False])
+
+
+class TestIsDormant(TestExpressions):
+    def test_is_dormant(self):
+        df = pl.DataFrame({"dormancy": ["Y", "N", "Y"]}).with_columns(
+            is_dormant().alias("is_dormant")
+        )
+        self.assertEqual(df["is_dormant"].to_list(), [True, False, True])
 
 
 if __name__ == "__main__":

--- a/tests/test_polars_utils/test_expressions.py
+++ b/tests/test_polars_utils/test_expressions.py
@@ -160,26 +160,26 @@ class TestStrLengthCols(TestExpressions):
 
 class TestIsCareHome(TestExpressions):
     def test_is_care_home(self):
-        df = pl.DataFrame({"careHome": ["Y", "N", "Y"]}).with_columns(
+        df = pl.DataFrame({"careHome": ["Y", "N", "Y", None]}).with_columns(
             is_care_home().alias("is_care_home")
         )
-        self.assertEqual(df["is_care_home"].to_list(), [True, False, True])
+        self.assertEqual(df["is_care_home"].to_list(), [True, False, True, None])
 
 
 class TestIsNotCareHome(TestExpressions):
     def test_is_not_care_home(self):
-        df = pl.DataFrame({"careHome": ["Y", "N", "Y"]}).with_columns(
+        df = pl.DataFrame({"careHome": ["Y", "N", "Y", None]}).with_columns(
             is_not_care_home().alias("is_not_care_home")
         )
-        self.assertEqual(df["is_not_care_home"].to_list(), [False, True, False])
+        self.assertEqual(df["is_not_care_home"].to_list(), [False, True, False, None])
 
 
 class TestIsDormant(TestExpressions):
     def test_is_dormant(self):
-        df = pl.DataFrame({"dormancy": ["Y", "N", "Y"]}).with_columns(
+        df = pl.DataFrame({"dormancy": ["Y", "N", "Y", None]}).with_columns(
             is_dormant().alias("is_dormant")
         )
-        self.assertEqual(df["is_dormant"].to_list(), [True, False, True])
+        self.assertEqual(df["is_dormant"].to_list(), [True, False, True, None])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description
Trello ticket [#1575](https://trello.com/c/Minz9MHf/1575-s-create-standard-expressions-file)

The polars_utils already contains an expressions.py script for commonly reused Polars expressions. This PR adds three new expression helpers: is_care_home(), is_not_care_home(), and is_dormant(). I have also added tests for the same. 
All existing instances of these conditions/checks across the repository have been updated to use the shared expressions for consistency and reuse.

The same expressions.py script can continue to be extended with additional commonly used expressions as needed.

## Testing
- [x] Unit tests passing
- [x] Successful [Step Function run](https://eu-west-2.console.aws.amazon.com/states/home?region=eu-west-2#/v2/executions/details/arn:aws:states:eu-west-2:856699698263:execution:1575-add-expr-file-Ind-CQC-Filled-Post-Estimates:ce5ef953-d12c-4b8f-8ecb-58c4017299b7)
- [x] Outputs checked in Athena

## Checklist
- [x] Unit tests added/amended
- [x] Docstrings added/updated
- [x] Updated CHANGELOG
- [x] Code reviewed by AI
- [x] Moved Trello ticket to PR column

## Reviewer checklist
- [x] PR solves the Trello ticket requirements
- [ ] Outputs appear reasonable and understandable
- [x] The overall approach is appropriate and not over-engineered
- [x] No obvious scalability, performance or interdependency concerns
- [ ] Tests appropriately cover the main behaviour/edge cases
- [x] Naming and structure are broadly understandable and consistent
- [x] Docstrings are sufficient for future maintenance
- [x] Docstrings cover non-obvious behaviour
