### PR TITLE
1577 geog codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ All notable changes to this project will be documented in this file.
 ### Changed
 - Renamed replace_care_navigator_with_care_coordinator to remap_mainjrid_codes for clarity and optimised implementation to use dictionary-based replacements targeting the main_job_role_clean column and updated corresponding test data names. Added Technician Job Role('22') in the dictionary to replace it with Other non-care-providing job roles ('27').
 
+- Changed apply_categorical_labels so it can reverse labels by swapping the k:v in the label dict.
+
 ### Fixed
 
 

--- a/projects/_03_independent_cqc/_06_estimate_filled_posts/jobs/estimate_ind_cqc_filled_posts.py
+++ b/projects/_03_independent_cqc/_06_estimate_filled_posts/jobs/estimate_ind_cqc_filled_posts.py
@@ -21,7 +21,7 @@ from utils import utils
 from utils.cleaning_utils import apply_categorical_labels
 from utils.column_names.ind_cqc_pipeline_columns import IndCqcColumns as IndCQC
 from utils.value_labels.ons_pd.label_dictionaries import (
-    estimate_filled_posts_labels_dict,
+    estimate_filled_posts_geography_labels_dict as geog_dict,
 )
 
 ind_cqc_columns = [
@@ -177,10 +177,10 @@ def main(
 
     estimate_filled_posts_df = apply_categorical_labels(
         df=estimate_filled_posts_df,
-        labels=estimate_filled_posts_labels_dict,
-        column_names=estimate_filled_posts_labels_dict.keys(),
+        labels=geog_dict,
+        column_names=geog_dict.keys(),
         add_as_new_column=True,
-        reversed=True,
+        reverse_mapping=True,
     )
 
     print(f"Exporting as parquet to {estimated_ind_cqc_destination}")

--- a/projects/_03_independent_cqc/_06_estimate_filled_posts/jobs/estimate_ind_cqc_filled_posts.py
+++ b/projects/_03_independent_cqc/_06_estimate_filled_posts/jobs/estimate_ind_cqc_filled_posts.py
@@ -18,7 +18,11 @@ from projects._03_independent_cqc._06_estimate_filled_posts.utils.models.utils i
 )
 from projects._03_independent_cqc.utils.utils.utils import merge_columns_in_order
 from utils import utils
+from utils.cleaning_utils import apply_categorical_labels
 from utils.column_names.ind_cqc_pipeline_columns import IndCqcColumns as IndCQC
+from utils.value_labels.ons_pd.label_dictionaries import (
+    estimate_filled_posts_labels_dict,
+)
 
 ind_cqc_columns = [
     IndCQC.cqc_location_import_date,
@@ -169,6 +173,14 @@ def main(
 
     estimate_filled_posts_df = estimate_non_res_capacity_tracker_filled_posts(
         estimate_filled_posts_df
+    )
+
+    estimate_filled_posts_df = apply_categorical_labels(
+        df=estimate_filled_posts_df,
+        labels=estimate_filled_posts_labels_dict,
+        column_names=estimate_filled_posts_labels_dict.keys(),
+        add_as_new_column=True,
+        reversed=True,
     )
 
     print(f"Exporting as parquet to {estimated_ind_cqc_destination}")

--- a/projects/_03_independent_cqc/_06_estimate_filled_posts/tests/jobs/test_estimate_ind_cqc_filled_posts.py
+++ b/projects/_03_independent_cqc/_06_estimate_filled_posts/tests/jobs/test_estimate_ind_cqc_filled_posts.py
@@ -17,6 +17,7 @@ class EstimateIndCQCFilledPostsTests(SparkBaseTest):
         self.mock_ind_cqc_df = Mock(name="ind_cqc_df")
 
     @patch(f"{PATCH_PATH}.utils.write_to_parquet")
+    @patch(f"{PATCH_PATH}.apply_categorical_labels")
     @patch(f"{PATCH_PATH}.estimate_non_res_capacity_tracker_filled_posts")
     @patch(f"{PATCH_PATH}.set_min_value")
     @patch(f"{PATCH_PATH}.merge_columns_in_order")
@@ -33,6 +34,7 @@ class EstimateIndCQCFilledPostsTests(SparkBaseTest):
         merge_columns_in_order_mock: Mock,
         set_min_value_mock: Mock,
         estimate_non_res_capacity_tracker_filled_posts_mock: Mock,
+        apply_categorical_labels_mock: Mock,
         write_to_parquet_patch: Mock,
     ):
         read_from_parquet_patch.return_value = self.mock_ind_cqc_df
@@ -56,6 +58,7 @@ class EstimateIndCQCFilledPostsTests(SparkBaseTest):
             ANY, IndCQC.estimate_filled_posts, 1.0
         )
         estimate_non_res_capacity_tracker_filled_posts_mock.assert_called_once()
+        apply_categorical_labels_mock.assert_called_once()
         write_to_parquet_patch.assert_called_once_with(
             ANY,
             self.ESTIMATES_DESTINATION,

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -115,8 +115,8 @@ class CleaningUtilsData:
         ("3", CurrentCSSR.coventry),
     ]
     expected_worker_rows_for_testing_label_dict_with_duplicate_values = [
-        ("1", CurrentCSSR.cornwall_and_isles_of_scilly, "906"),
-        ("2", CurrentCSSR.cornwall_and_isles_of_scilly, "906"),
+        ("1", CurrentCSSR.cornwall_and_isles_of_scilly, "902"),
+        ("2", CurrentCSSR.cornwall_and_isles_of_scilly, "902"),
         ("3", CurrentCSSR.coventry, "407"),
     ]
 

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -4,7 +4,7 @@ from datetime import date
 from utils.column_names.ind_cqc_pipeline_columns import IndCqcColumns as IndCQC
 from utils.column_values.categorical_column_values import (
     CareHome,
-    CurrentCSSR,
+    ContemporaryCSSR,
     PrimaryServiceType,
     Sector,
 )
@@ -60,10 +60,10 @@ class CleaningUtilsData:
         "103": "Portuguese",
     }
 
-    current_cssr = {
-        "902": CurrentCSSR.cornwall_and_isles_of_scilly,
-        "906": CurrentCSSR.cornwall_and_isles_of_scilly,
-        "407": CurrentCSSR.coventry,
+    contemporary_cssr = {
+        "902": ContemporaryCSSR.cornwall_and_isles_of_scilly,
+        "906": ContemporaryCSSR.cornwall_and_isles_of_scilly,
+        "407": ContemporaryCSSR.coventry,
     }
 
     expected_rows_with_new_columns = [
@@ -110,14 +110,14 @@ class CleaningUtilsData:
     ]
 
     worker_rows_for_testing_label_dict_with_duplicate_values = [
-        ("1", CurrentCSSR.cornwall_and_isles_of_scilly),
-        ("2", CurrentCSSR.cornwall_and_isles_of_scilly),
-        ("3", CurrentCSSR.coventry),
+        ("1", ContemporaryCSSR.cornwall_and_isles_of_scilly),
+        ("2", ContemporaryCSSR.cornwall_and_isles_of_scilly),
+        ("3", ContemporaryCSSR.coventry),
     ]
     expected_worker_rows_for_testing_label_dict_with_duplicate_values = [
-        ("1", CurrentCSSR.cornwall_and_isles_of_scilly, "902"),
-        ("2", CurrentCSSR.cornwall_and_isles_of_scilly, "902"),
-        ("3", CurrentCSSR.coventry, "407"),
+        ("1", ContemporaryCSSR.cornwall_and_isles_of_scilly, "902"),
+        ("2", ContemporaryCSSR.cornwall_and_isles_of_scilly, "902"),
+        ("3", ContemporaryCSSR.coventry, "407"),
     ]
 
     scale_data = [

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -77,6 +77,15 @@ class CleaningUtilsData:
         ("6", "female", None),
     ]
 
+    expected_rows_with_new_code_columns = [
+        ("1", "male", "British", "1", "100"),
+        ("2", "male", "French", "1", "101"),
+        ("3", "female", "Spanish", "2", "102"),
+        ("4", "female", "Portuguese", "2", "103"),
+        ("5", None, "Portuguese", None, "103"),
+        ("6", "female", None, "2", None),
+    ]
+
     worker_rows_with_unmatched_labels = [
         ("1", "0", "100"),
         ("2", "1", "104"),

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -4,6 +4,7 @@ from datetime import date
 from utils.column_names.ind_cqc_pipeline_columns import IndCqcColumns as IndCQC
 from utils.column_values.categorical_column_values import (
     CareHome,
+    CurrentCSSR,
     PrimaryServiceType,
     Sector,
 )
@@ -59,6 +60,12 @@ class CleaningUtilsData:
         "103": "Portuguese",
     }
 
+    current_cssr = {
+        "902": CurrentCSSR.cornwall_and_isles_of_scilly,
+        "906": CurrentCSSR.cornwall_and_isles_of_scilly,
+        "407": CurrentCSSR.coventry,
+    }
+
     expected_rows_with_new_columns = [
         ("1", "1", "100", "male", "British"),
         ("2", "1", "101", "male", "French"),
@@ -100,6 +107,17 @@ class CleaningUtilsData:
         ("1", "0", "British"),
         ("2", "male", "104"),
         ("3", None, None),
+    ]
+
+    worker_rows_for_testing_label_dict_with_duplicate_values = [
+        ("1", CurrentCSSR.cornwall_and_isles_of_scilly),
+        ("2", CurrentCSSR.cornwall_and_isles_of_scilly),
+        ("3", CurrentCSSR.coventry),
+    ]
+    expected_worker_rows_for_testing_label_dict_with_duplicate_values = [
+        ("1", CurrentCSSR.cornwall_and_isles_of_scilly, "906"),
+        ("2", CurrentCSSR.cornwall_and_isles_of_scilly, "906"),
+        ("3", CurrentCSSR.coventry, "407"),
     ]
 
     scale_data = [

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -74,6 +74,16 @@ class CleaningUtilsSchemas:
         ]
     )
 
+    expected_schema_with_new_code_columns = StructType(
+        [
+            StructField(AWK.worker_id, StringType(), True),
+            StructField(AWK.gender, StringType(), True),
+            StructField(AWK.nationality, StringType(), True),
+            StructField("gender_codes", StringType(), True),
+            StructField("nationality_codes", StringType(), True),
+        ]
+    )
+
     scale_schema = StructType(
         [
             StructField("int", IntegerType(), True),

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -87,14 +87,14 @@ class CleaningUtilsSchemas:
     worker_schema_for_testing_label_dict_with_duplicate_values = StructType(
         [
             StructField(AWK.worker_id, StringType(), True),
-            StructField(IndCQC.current_cssr, StringType(), True),
+            StructField(IndCQC.contemporary_cssr, StringType(), True),
         ]
     )
     expected_worker_schema_for_testing_label_dict_with_duplicate_values = StructType(
         [
             StructField(AWK.worker_id, StringType(), True),
-            StructField(IndCQC.current_cssr, StringType(), True),
-            StructField(IndCQC.current_cssr + "_codes", StringType(), True),
+            StructField(IndCQC.contemporary_cssr, StringType(), True),
+            StructField(IndCQC.contemporary_cssr + "_codes", StringType(), True),
         ]
     )
 

--- a/tests/test_file_schemas.py
+++ b/tests/test_file_schemas.py
@@ -84,6 +84,20 @@ class CleaningUtilsSchemas:
         ]
     )
 
+    worker_schema_for_testing_label_dict_with_duplicate_values = StructType(
+        [
+            StructField(AWK.worker_id, StringType(), True),
+            StructField(IndCQC.current_cssr, StringType(), True),
+        ]
+    )
+    expected_worker_schema_for_testing_label_dict_with_duplicate_values = StructType(
+        [
+            StructField(AWK.worker_id, StringType(), True),
+            StructField(IndCQC.current_cssr, StringType(), True),
+            StructField(IndCQC.current_cssr + "_codes", StringType(), True),
+        ]
+    )
+
     scale_schema = StructType(
         [
             StructField("int", IntegerType(), True),

--- a/tests/unit/test_cleaning_utils.py
+++ b/tests/unit/test_cleaning_utils.py
@@ -33,6 +33,10 @@ class ApplyCategoricalLabelsTests(SparkBaseTest):
             AWK.nationality: Data.nationality,
             IndCQC.contemporary_cssr: Data.contemporary_cssr,
         }
+        self.label_dict_missing_gender = {
+            AWK.nationality: Data.nationality,
+            IndCQC.contemporary_cssr: Data.contemporary_cssr,
+        }
         self.expected_df_with_new_columns = self.spark.createDataFrame(
             Data.expected_rows_with_new_columns,
             Schemas.expected_schema_with_new_columns,
@@ -254,6 +258,38 @@ class ApplyCategoricalLabelsTests(SparkBaseTest):
         expected_data = expected_df.sort(AWK.worker_id).collect()
 
         self.assertEqual(returned_data, expected_data)
+
+    def test_raises_value_error_when_column_not_in_dataframe(
+        self,
+    ):
+        with self.assertRaises(ValueError) as context:
+            job.apply_categorical_labels(
+                self.test_worker_df,
+                self.label_dict,
+                [AWK.age],
+                add_as_new_column=True,
+            )
+
+        self.assertEqual(
+            str(context.exception),
+            "Column age not found in DataFrame.",
+        )
+
+    def test_raises_key_error_when_column_not_in_labels_dict(
+        self,
+    ):
+        with self.assertRaises(ValueError) as context:
+            job.apply_categorical_labels(
+                self.test_worker_df,
+                self.label_dict_missing_gender,
+                [AWK.gender],
+                add_as_new_column=True,
+            )
+
+        self.assertEqual(
+            str(context.exception),
+            "No label mapping found for gender.",
+        )
 
 
 class TestCleaningUtilsScale(SparkBaseTest):

--- a/tests/unit/test_cleaning_utils.py
+++ b/tests/unit/test_cleaning_utils.py
@@ -31,7 +31,7 @@ class ApplyCategoricalLabelsTests(SparkBaseTest):
         self.label_dict = {
             AWK.gender: Data.gender,
             AWK.nationality: Data.nationality,
-            IndCQC.current_cssr: Data.current_cssr,
+            IndCQC.contemporary_cssr: Data.contemporary_cssr,
         }
         self.expected_df_with_new_columns = self.spark.createDataFrame(
             Data.expected_rows_with_new_columns,
@@ -44,11 +44,11 @@ class ApplyCategoricalLabelsTests(SparkBaseTest):
         self.expected_df_without_new_columns = self.spark.createDataFrame(
             Data.expected_rows_without_new_columns, Schemas.worker_schema
         )
-        self.test_worker_df_for_testing_label_dict_with_duplicate_values = self.spark.createDataFrame(
+        self.test_df_when_duplicate_values_in_label_dict = self.spark.createDataFrame(
             Data.worker_rows_for_testing_label_dict_with_duplicate_values,
             schema=Schemas.worker_schema_for_testing_label_dict_with_duplicate_values,
         )
-        self.expected_df_for_testing_label_dict_with_duplicate_values = self.spark.createDataFrame(
+        self.expected_df_when_duplicate_values_in_label_dict = self.spark.createDataFrame(
             Data.expected_worker_rows_for_testing_label_dict_with_duplicate_values,
             schema=Schemas.expected_worker_schema_for_testing_label_dict_with_duplicate_values,
         )
@@ -129,7 +129,7 @@ class ApplyCategoricalLabelsTests(SparkBaseTest):
             self.label_dict,
             [AWK.gender, AWK.nationality],
             add_as_new_column=False,
-            reversed=True,
+            reverse_mapping=True,
         )
         returned_data = (
             returned_df.select(self.test_worker_df.columns)
@@ -151,7 +151,7 @@ class ApplyCategoricalLabelsTests(SparkBaseTest):
             self.label_dict,
             [AWK.gender, AWK.nationality],
             add_as_new_column=True,
-            reversed=True,
+            reverse_mapping=True,
         )
         returned_data = (
             returned_df.select(self.expected_df_with_new_code_columns.columns)
@@ -171,30 +171,25 @@ class ApplyCategoricalLabelsTests(SparkBaseTest):
         self,
     ):
         returned_df = job.apply_categorical_labels(
-            self.test_worker_df_for_testing_label_dict_with_duplicate_values,
+            self.test_df_when_duplicate_values_in_label_dict,
             self.label_dict,
-            [IndCQC.current_cssr],
+            [IndCQC.contemporary_cssr],
             add_as_new_column=True,
-            reversed=True,
+            reverse_mapping=True,
         )
         returned_data = (
             returned_df.select(
-                self.expected_df_for_testing_label_dict_with_duplicate_values.columns
+                self.expected_df_when_duplicate_values_in_label_dict.columns
             )
             .sort(AWK.worker_id)
             .collect()
         )
-        expected_data = (
-            self.expected_df_for_testing_label_dict_with_duplicate_values.sort(
-                AWK.worker_id
-            ).collect()
-        )
+        expected_data = self.expected_df_when_duplicate_values_in_label_dict.sort(
+            AWK.worker_id
+        ).collect()
 
         expected_columns = (
-            len(
-                self.test_worker_df_for_testing_label_dict_with_duplicate_values.columns
-            )
-            + 1
+            len(self.test_df_when_duplicate_values_in_label_dict.columns) + 1
         )
 
         self.assertEqual(len(returned_df.columns), expected_columns)

--- a/tests/unit/test_cleaning_utils.py
+++ b/tests/unit/test_cleaning_utils.py
@@ -33,6 +33,10 @@ class ApplyCategoricalLabelsTests(SparkBaseTest):
             Data.expected_rows_with_new_columns,
             Schemas.expected_schema_with_new_columns,
         )
+        self.expected_df_with_new_code_columns = self.spark.createDataFrame(
+            Data.expected_rows_with_new_code_columns,
+            Schemas.expected_schema_with_new_code_columns,
+        )
         self.expected_df_without_new_columns = self.spark.createDataFrame(
             Data.expected_rows_without_new_columns, Schemas.worker_schema
         )
@@ -101,6 +105,52 @@ class ApplyCategoricalLabelsTests(SparkBaseTest):
         ).collect()
 
         expected_columns = len(self.test_worker_df.columns)
+
+        self.assertEqual(len(returned_df.columns), expected_columns)
+        self.assertEqual(returned_data, expected_data)
+
+    def test_reverse_label_strings_into_code_strings_when_new_column_is_set_to_false(
+        self,
+    ):
+        returned_df = job.apply_categorical_labels(
+            self.expected_df_without_new_columns,
+            self.label_dict,
+            [AWK.gender, AWK.nationality],
+            add_as_new_column=False,
+            reversed=True,
+        )
+        returned_data = (
+            returned_df.select(self.test_worker_df.columns)
+            .sort(AWK.worker_id)
+            .collect()
+        )
+        expected_data = self.test_worker_df.sort(AWK.worker_id).collect()
+
+        expected_columns = len(self.test_worker_df.columns)
+
+        self.assertEqual(len(returned_df.columns), expected_columns)
+        self.assertEqual(returned_data, expected_data)
+
+    def test_reverse_label_strings_into_code_strings_when_new_column_is_set_to_true(
+        self,
+    ):
+        returned_df = job.apply_categorical_labels(
+            self.expected_df_without_new_columns,
+            self.label_dict,
+            [AWK.gender, AWK.nationality],
+            add_as_new_column=True,
+            reversed=True,
+        )
+        returned_data = (
+            returned_df.select(self.expected_df_with_new_code_columns.columns)
+            .sort(AWK.worker_id)
+            .collect()
+        )
+        expected_data = self.expected_df_with_new_code_columns.sort(
+            AWK.worker_id
+        ).collect()
+
+        expected_columns = len(self.test_worker_df.columns) + 2
 
         self.assertEqual(len(returned_df.columns), expected_columns)
         self.assertEqual(returned_data, expected_data)

--- a/tests/unit/test_cleaning_utils.py
+++ b/tests/unit/test_cleaning_utils.py
@@ -28,7 +28,11 @@ class ApplyCategoricalLabelsTests(SparkBaseTest):
         self.test_worker_df = self.spark.createDataFrame(
             Data.worker_rows, schema=Schemas.worker_schema
         )
-        self.label_dict = {AWK.gender: Data.gender, AWK.nationality: Data.nationality}
+        self.label_dict = {
+            AWK.gender: Data.gender,
+            AWK.nationality: Data.nationality,
+            IndCQC.current_cssr: Data.current_cssr,
+        }
         self.expected_df_with_new_columns = self.spark.createDataFrame(
             Data.expected_rows_with_new_columns,
             Schemas.expected_schema_with_new_columns,
@@ -39,6 +43,14 @@ class ApplyCategoricalLabelsTests(SparkBaseTest):
         )
         self.expected_df_without_new_columns = self.spark.createDataFrame(
             Data.expected_rows_without_new_columns, Schemas.worker_schema
+        )
+        self.test_worker_df_for_testing_label_dict_with_duplicate_values = self.spark.createDataFrame(
+            Data.worker_rows_for_testing_label_dict_with_duplicate_values,
+            schema=Schemas.worker_schema_for_testing_label_dict_with_duplicate_values,
+        )
+        self.expected_df_for_testing_label_dict_with_duplicate_values = self.spark.createDataFrame(
+            Data.expected_worker_rows_for_testing_label_dict_with_duplicate_values,
+            schema=Schemas.expected_worker_schema_for_testing_label_dict_with_duplicate_values,
         )
 
     def test_apply_categorical_labels_completes(self):
@@ -151,6 +163,39 @@ class ApplyCategoricalLabelsTests(SparkBaseTest):
         ).collect()
 
         expected_columns = len(self.test_worker_df.columns) + 2
+
+        self.assertEqual(len(returned_df.columns), expected_columns)
+        self.assertEqual(returned_data, expected_data)
+
+    def test_reverse_label_strings_into_code_strings_when_label_dict_has_duplicate_values(
+        self,
+    ):
+        returned_df = job.apply_categorical_labels(
+            self.test_worker_df_for_testing_label_dict_with_duplicate_values,
+            self.label_dict,
+            [IndCQC.current_cssr],
+            add_as_new_column=True,
+            reversed=True,
+        )
+        returned_data = (
+            returned_df.select(
+                self.expected_df_for_testing_label_dict_with_duplicate_values.columns
+            )
+            .sort(AWK.worker_id)
+            .collect()
+        )
+        expected_data = (
+            self.expected_df_for_testing_label_dict_with_duplicate_values.sort(
+                AWK.worker_id
+            ).collect()
+        )
+
+        expected_columns = (
+            len(
+                self.test_worker_df_for_testing_label_dict_with_duplicate_values.columns
+            )
+            + 1
+        )
 
         self.assertEqual(len(returned_df.columns), expected_columns)
         self.assertEqual(returned_data, expected_data)

--- a/utils/cleaning_utils.py
+++ b/utils/cleaning_utils.py
@@ -32,8 +32,8 @@ def apply_categorical_labels(
     Labels can either be added as new columns or replace the original columns.
 
     An optional argument is to reverse the mapping from a label string to a code string.
-    Warning: the values in 'labels' passed in must be unique, otherwise only last of
-    duplicates will be used in the mapping.
+    Warning: the values in 'labels' dict should be unique, otherwise only first key of
+    duplicate values will be used in the mapping.
 
     Args:
         df (DataFrame): Input Spark DataFrame.
@@ -59,7 +59,10 @@ def apply_categorical_labels(
         )
 
         if reversed == True:
-            mapping_dict = {v: k for k, v in labels[column_name].items()}
+            mapping_dict = {}
+            for k, v in labels[column_name].items():
+                if v not in mapping_dict:
+                    mapping_dict[v] = k
             mapping_dict = mapping_dict.items()
         else:
             mapping_dict = labels[column_name].items()

--- a/utils/cleaning_utils.py
+++ b/utils/cleaning_utils.py
@@ -16,7 +16,11 @@ pir_submission_date_uri_format = "dd-MMM-yy"
 
 
 def apply_categorical_labels(
-    df: DataFrame, labels: dict, column_names: list, add_as_new_column: bool = True
+    df: DataFrame,
+    labels: dict,
+    column_names: list,
+    add_as_new_column: bool = True,
+    reversed: bool = False,
 ) -> DataFrame:
     """
     Apply categorical label mappings to one or more columns using a join-based lookup.
@@ -27,6 +31,10 @@ def apply_categorical_labels(
 
     Labels can either be added as new columns or replace the original columns.
 
+    An optional argument is to reverse the mapping from a label string to a code string.
+    Warning: the values in 'labels' passed in must be unique, otherwise only last of
+    duplicates will be used in the mapping.
+
     Args:
         df (DataFrame): Input Spark DataFrame.
         labels (dict): Dictionary of column-to-mapping dictionaries.
@@ -34,6 +42,7 @@ def apply_categorical_labels(
         add_as_new_column (bool, optional): If True, adds a new column with
             "_labels" suffix. If False, replaces the original column.
             Defaults to True.
+        reversed (bool, optional): If True, reverts labels to codes.
 
     Returns:
         DataFrame: DataFrame with categorical labels applied. Unmapped values
@@ -48,16 +57,26 @@ def apply_categorical_labels(
                 StructField(f"{column_name}_labels", StringType(), True),
             ]
         )
-        mapping_df = spark.createDataFrame(
-            labels[column_name].items(), schema=mapping_schema
-        )
+
+        if reversed == True:
+            mapping_dict = {v: k for k, v in labels[column_name].items()}
+            mapping_dict = mapping_dict.items()
+        else:
+            mapping_dict = labels[column_name].items()
+
+        mapping_df = spark.createDataFrame(mapping_dict, schema=mapping_schema)
 
         df = df.join(mapping_df, on=column_name, how="left")
 
         merged_col = F.coalesce(F.col(f"{column_name}_labels"), F.col(column_name))
 
         if add_as_new_column:
-            df = df.withColumn(f"{column_name}_labels", merged_col)
+            if reversed == True:
+                df = df.withColumn(f"{column_name}_codes", merged_col).drop(
+                    f"{column_name}_labels"
+                )
+            else:
+                df = df.withColumn(f"{column_name}_labels", merged_col)
         else:
             df = df.withColumn(column_name, merged_col).drop(f"{column_name}_labels")
 

--- a/utils/cleaning_utils.py
+++ b/utils/cleaning_utils.py
@@ -47,8 +47,19 @@ def apply_categorical_labels(
     Returns:
         DataFrame: DataFrame with categorical labels applied. Unmapped values
         are preserved.
+
+    Raises:
+        ValueError: If column to apply labels is not in DataFrame or has no
+            mapping in labels dict.
+
     """
     spark = utils.get_spark()
+
+    for column_name in column_names:
+        if column_name not in df.columns:
+            raise ValueError(f"Column {column_name} not found in DataFrame.")
+        if column_name not in labels:
+            raise ValueError(f"No label mapping found for {column_name}.")
 
     for column_name in column_names:
         mapping_schema = StructType(

--- a/utils/cleaning_utils.py
+++ b/utils/cleaning_utils.py
@@ -20,7 +20,7 @@ def apply_categorical_labels(
     labels: dict,
     column_names: list,
     add_as_new_column: bool = True,
-    reversed: bool = False,
+    reverse_mapping: bool = False,
 ) -> DataFrame:
     """
     Apply categorical label mappings to one or more columns using a join-based lookup.
@@ -31,7 +31,7 @@ def apply_categorical_labels(
 
     Labels can either be added as new columns or replace the original columns.
 
-    An optional argument is to reverse the mapping from a label string to a code string.
+    reverse_mapping is an optional argument to revert columns from a label string to a code string.
     Warning: the values in 'labels' dict should be unique, otherwise only first key of
     duplicate values will be used in the mapping.
 
@@ -42,7 +42,7 @@ def apply_categorical_labels(
         add_as_new_column (bool, optional): If True, adds a new column with
             "_labels" suffix. If False, replaces the original column.
             Defaults to True.
-        reversed (bool, optional): If True, reverts labels to codes.
+        reverse_mapping (bool, optional): If True, reverts labels to codes.
 
     Returns:
         DataFrame: DataFrame with categorical labels applied. Unmapped values
@@ -58,7 +58,7 @@ def apply_categorical_labels(
             ]
         )
 
-        if reversed == True:
+        if reverse_mapping:
             mapping_dict = {}
             for k, v in labels[column_name].items():
                 if v not in mapping_dict:
@@ -74,7 +74,7 @@ def apply_categorical_labels(
         merged_col = F.coalesce(F.col(f"{column_name}_labels"), F.col(column_name))
 
         if add_as_new_column:
-            if reversed == True:
+            if reverse_mapping:
                 df = df.withColumn(f"{column_name}_codes", merged_col).drop(
                     f"{column_name}_labels"
                 )

--- a/utils/value_labels/ons_pd/label_dictionaries.py
+++ b/utils/value_labels/ons_pd/label_dictionaries.py
@@ -1,3 +1,4 @@
+from utils.column_names.ind_cqc_pipeline_columns import IndCqcColumns as IndCQC
 from utils.value_labels.ons_pd.onspd_cssr import OnspdCssr
 from utils.value_labels.ons_pd.onspd_icb import OnspdIcb
 from utils.value_labels.ons_pd.onspd_icb_region import OnspdIcbRegion
@@ -18,4 +19,16 @@ onspd_labels_dict = {
     OnspdRegion.column_name: OnspdRegion.labels_dict,
     OnspdRuralUrbanIndicator2011.column_name: OnspdRuralUrbanIndicator2011.labels_dict,
     OnspdSubIcb.column_name: OnspdSubIcb.labels_dict,
+}
+
+estimate_filled_posts_labels_dict = {
+    IndCQC.current_cssr: OnspdCssr.labels_dict,
+    IndCQC.current_icb: OnspdIcb.labels_dict,
+    IndCQC.current_icb_region: OnspdIcbRegion.labels_dict,
+    IndCQC.current_lsoa21: OnspdLsoa21.labels_dict,
+    IndCQC.current_msoa21: OnspdMsoa21.labels_dict,
+    IndCQC.current_constituency: OnspdPcon.labels_dict,
+    IndCQC.current_region: OnspdRegion.labels_dict,
+    IndCQC.current_rural_urban_indicator_2011: OnspdRuralUrbanIndicator2011.labels_dict,
+    IndCQC.current_sub_icb: OnspdSubIcb.labels_dict,
 }

--- a/utils/value_labels/ons_pd/label_dictionaries.py
+++ b/utils/value_labels/ons_pd/label_dictionaries.py
@@ -21,10 +21,9 @@ onspd_labels_dict = {
     OnspdSubIcb.column_name: OnspdSubIcb.labels_dict,
 }
 
-estimate_filled_posts_labels_dict = {
-    IndCQC.current_cssr: OnspdCssr.labels_dict,
-    IndCQC.current_lsoa21: OnspdLsoa21.labels_dict,
-    IndCQC.current_msoa21: OnspdMsoa21.labels_dict,
-    IndCQC.current_region: OnspdRegion.labels_dict,
-    IndCQC.current_rural_urban_indicator_2011: OnspdRuralUrbanIndicator2011.labels_dict,
+estimate_filled_posts_geography_labels_dict = {
+    IndCQC.contemporary_cssr: OnspdCssr.labels_dict,
+    IndCQC.contemporary_lsoa21: OnspdLsoa21.labels_dict,
+    IndCQC.contemporary_msoa21: OnspdMsoa21.labels_dict,
+    IndCQC.contemporary_region: OnspdRegion.labels_dict,
 }

--- a/utils/value_labels/ons_pd/label_dictionaries.py
+++ b/utils/value_labels/ons_pd/label_dictionaries.py
@@ -24,11 +24,8 @@ onspd_labels_dict = {
 estimate_filled_posts_labels_dict = {
     IndCQC.current_cssr: OnspdCssr.labels_dict,
     IndCQC.current_icb: OnspdIcb.labels_dict,
-    IndCQC.current_icb_region: OnspdIcbRegion.labels_dict,
     IndCQC.current_lsoa21: OnspdLsoa21.labels_dict,
     IndCQC.current_msoa21: OnspdMsoa21.labels_dict,
-    IndCQC.current_constituency: OnspdPcon.labels_dict,
     IndCQC.current_region: OnspdRegion.labels_dict,
     IndCQC.current_rural_urban_indicator_2011: OnspdRuralUrbanIndicator2011.labels_dict,
-    IndCQC.current_sub_icb: OnspdSubIcb.labels_dict,
 }

--- a/utils/value_labels/ons_pd/label_dictionaries.py
+++ b/utils/value_labels/ons_pd/label_dictionaries.py
@@ -22,8 +22,10 @@ onspd_labels_dict = {
 }
 
 estimate_filled_posts_geography_labels_dict = {
+    IndCQC.current_cssr: OnspdCssr.labels_dict,
+    IndCQC.current_region: OnspdRegion.labels_dict,
     IndCQC.contemporary_cssr: OnspdCssr.labels_dict,
-    IndCQC.contemporary_lsoa21: OnspdLsoa21.labels_dict,
-    IndCQC.contemporary_msoa21: OnspdMsoa21.labels_dict,
     IndCQC.contemporary_region: OnspdRegion.labels_dict,
+    IndCQC.current_lsoa21: OnspdLsoa21.labels_dict,
+    IndCQC.current_msoa21: OnspdMsoa21.labels_dict,
 }

--- a/utils/value_labels/ons_pd/label_dictionaries.py
+++ b/utils/value_labels/ons_pd/label_dictionaries.py
@@ -23,7 +23,6 @@ onspd_labels_dict = {
 
 estimate_filled_posts_labels_dict = {
     IndCQC.current_cssr: OnspdCssr.labels_dict,
-    IndCQC.current_icb: OnspdIcb.labels_dict,
     IndCQC.current_lsoa21: OnspdLsoa21.labels_dict,
     IndCQC.current_msoa21: OnspdMsoa21.labels_dict,
     IndCQC.current_region: OnspdRegion.labels_dict,


### PR DESCRIPTION
## Description
Trello ticket [1577](https://trello.com/c/4koVTRyx)

Analyst requested the codes for CSSR, region, MSOA and LSOA be added to estimates dataset.

I added an argument to apply_categorical_labels so it can reverse the labels dictionary, then apply the labels, so it reverts word labels to code labels.

When a labels dict has duplicate values at different keys (e.g. Cornwall and Isles of Scilly CSSR, West Yorkshire ICB), then only the first key is applied. E.g. Cornwall and Isles of Scilly always becomes 902, not 906.

I've not applied codes for ICB areas (not part of this ticket) but if we do need them later on, then we need to update its labels dict so West_Yorkshire becomes West_Yorkshire_FromYear_ToYear or something unique per key.

## Testing
- [x] Unit tests passing
- [x] Successful [Glue job](https://eu-west-2.console.aws.amazon.com/gluestudio/home?region=eu-west-2#/editor/job/1577-geog-codes-estimate_ind_cqc_filled_posts_job/runs)
- [x] Outputs checked in Athena

I got the distinct words/codes values for each geography and put them in Excel attached to Trello ticket.

## Checklist (delete if not relevant)
- [x] Unit tests added/amended
- [x] Docstrings added/updated
- [x] Updated CHANGELOG
- [ ] Code reviewed by AI
- [x] Moved Trello ticket to PR column

## Reviewer checklist
- [ ] PR solves the Trello ticket requirements
- [ ] Outputs appear reasonable and understandable
- [ ] The overall approach is appropriate and not over-engineered
- [ ] No obvious scalability, performance or interdependency concerns
- [ ] Tests appropriately cover the main behaviour/edge cases
- [ ] Naming and structure are broadly understandable and consistent
- [ ] Docstrings are sufficient for future maintenance
- [ ] Docstrings cover non-obvious behaviour
