### PR TITLE
1643 - Ran isort profile black against whole repository

### DIFF
--- a/polars_utils/cleaning_utils.py
+++ b/polars_utils/cleaning_utils.py
@@ -1,5 +1,7 @@
-import polars as pl
 from typing import List
+
+import polars as pl
+
 from polars_utils.expressions import is_care_home, is_not_care_home
 from utils.column_names.ind_cqc_pipeline_columns import IndCqcColumns as IndCQC
 

--- a/polars_utils/expressions.py
+++ b/polars_utils/expressions.py
@@ -1,4 +1,5 @@
 import polars as pl
+
 from utils.column_names.ind_cqc_pipeline_columns import IndCqcColumns as IndCQC
 from utils.column_values.categorical_column_values import CareHome, Dormancy
 

--- a/projects/_01_ingest/cqc_api/fargate/utils/cleaning_utils.py
+++ b/projects/_01_ingest/cqc_api/fargate/utils/cleaning_utils.py
@@ -4,7 +4,10 @@ from polars_utils import utils
 from utils.column_names.cleaned_data_files.cqc_location_cleaned import (
     CqcLocationCleanedColumns as CQCLClean,
 )
-from utils.column_values.categorical_column_values import CareHome, PrimaryServiceType
+from utils.column_values.categorical_column_values import (
+    CareHome,
+    PrimaryServiceType,
+)
 from utils.column_values.categorical_column_values import (
     PrimaryServiceTypeSecondLevel as PSSL_values,
 )

--- a/projects/_01_ingest/cqc_api/fargate/validate_cqc_providers_3_full_flattened.py
+++ b/projects/_01_ingest/cqc_api/fargate/validate_cqc_providers_3_full_flattened.py
@@ -5,10 +5,10 @@ import pointblank as pb
 from polars_utils import utils
 from polars_utils.validation import actions as vl
 from polars_utils.validation.constants import GLOBAL_ACTIONS, GLOBAL_THRESHOLDS
+from utils.column_names.ind_cqc_pipeline_columns import PartitionKeys as Keys
 from utils.column_names.raw_data_files.cqc_provider_api_columns import (
     CqcProviderApiColumns as CQCP,
 )
-from utils.column_names.ind_cqc_pipeline_columns import PartitionKeys as Keys
 
 
 def main(bucket_name: str, source_path: str, reports_path: str) -> None:

--- a/projects/_02_sfc_internal/cqc_coverage/fargate/validate_merge_coverage_data.py
+++ b/projects/_02_sfc_internal/cqc_coverage/fargate/validate_merge_coverage_data.py
@@ -10,15 +10,15 @@ from polars_utils.validation.constants import GLOBAL_ACTIONS, GLOBAL_THRESHOLDS
 from utils.column_names.cleaned_data_files.ascwds_workplace_cleaned import (
     AscwdsWorkplaceCleanedColumns as AscWdsColumns,
 )
-from utils.column_values.categorical_columns_by_dataset import (
-    LocationsApiCleanedCategoricalValues as CatValues,
-)
 from utils.column_names.coverage_columns import CoverageColumns
 from utils.column_names.cqc_ratings_columns import CQCRatingsColumns
 from utils.column_names.ind_cqc_pipeline_columns import IndCqcColumns
 from utils.column_names.ind_cqc_pipeline_columns import PartitionKeys as Keys
 from utils.column_names.reconciliation_columns import ReconciliationColumns
 from utils.column_names.validation_table_columns import Validation
+from utils.column_values.categorical_columns_by_dataset import (
+    LocationsApiCleanedCategoricalValues as CatValues,
+)
 
 
 def main(

--- a/projects/_03_independent_cqc/_01_merge/fargate/validate_merged_ind_cqc_data.py
+++ b/projects/_03_independent_cqc/_01_merge/fargate/validate_merged_ind_cqc_data.py
@@ -12,10 +12,10 @@ from utils.column_names.cleaned_data_files.cqc_location_cleaned import (
 )
 from utils.column_names.ind_cqc_pipeline_columns import IndCqcColumns
 from utils.column_names.validation_table_columns import Validation
+from utils.column_values.categorical_column_values import Sector
 from utils.column_values.categorical_columns_by_dataset import (
     MergedIndCQCCategoricalValues as CatValues,
 )
-from utils.column_values.categorical_column_values import Sector
 
 cleaned_cqc_locations_columns_to_import = [
     CQCLClean.cqc_location_import_date,

--- a/projects/_03_independent_cqc/_01_merge/tests/fargate/test_validate_merged_ind_cqc_data.py
+++ b/projects/_03_independent_cqc/_01_merge/tests/fargate/test_validate_merged_ind_cqc_data.py
@@ -3,15 +3,16 @@ import unittest
 from unittest.mock import Mock, call, patch
 
 import polars as pl
-from utils.column_names.cleaned_data_files.cqc_location_cleaned import (
-    CqcLocationCleanedColumns as CQCLClean,
-)
+
 import projects._03_independent_cqc._01_merge.fargate.validate_merged_ind_cqc_data as job
 from projects._03_independent_cqc.unittest_data.polars_ind_cqc_test_file_data import (
     ValidateMergeIndCQCData as Data,
 )
 from projects._03_independent_cqc.unittest_data.polars_ind_cqc_test_file_schemas import (
     ValidateMergeIndCQCSchemas as Schemas,
+)
+from utils.column_names.cleaned_data_files.cqc_location_cleaned import (
+    CqcLocationCleanedColumns as CQCLClean,
 )
 
 PATCH_PATH = (

--- a/projects/_03_independent_cqc/_02_clean/fargate/utils/clean_ascwds_filled_post_outliers/clean_ascwds_filled_post_outliers.py
+++ b/projects/_03_independent_cqc/_02_clean/fargate/utils/clean_ascwds_filled_post_outliers/clean_ascwds_filled_post_outliers.py
@@ -1,5 +1,8 @@
 import polars as pl
 
+from polars_utils.filtering_utils import (
+    add_filtering_rule_column,
+)
 from projects._03_independent_cqc._02_clean.fargate.utils.clean_ascwds_filled_post_outliers.non_res_brand_id_filter import (
     non_res_brand_id_filter,
 )
@@ -11,9 +14,6 @@ from projects._03_independent_cqc._02_clean.fargate.utils.clean_ascwds_filled_po
 )
 from projects._03_independent_cqc._02_clean.fargate.utils.clean_ascwds_filled_post_outliers.winsorize_care_home_filled_posts_per_bed_ratio_outliers import (
     winsorize_care_home_filled_posts_per_bed_ratio_outliers,
-)
-from polars_utils.filtering_utils import (
-    add_filtering_rule_column,
 )
 from utils.column_names.ind_cqc_pipeline_columns import IndCqcColumns as IndCQC
 from utils.column_values.categorical_column_values import AscwdsFilteringRule

--- a/projects/_03_independent_cqc/_02_clean/fargate/utils/clean_ascwds_filled_post_outliers/non_res_brand_id_filter.py
+++ b/projects/_03_independent_cqc/_02_clean/fargate/utils/clean_ascwds_filled_post_outliers/non_res_brand_id_filter.py
@@ -2,10 +2,10 @@ from datetime import date
 
 import polars as pl
 
+from polars_utils.expressions import is_not_care_home
 from polars_utils.filtering_utils import (
     update_filtering_rule,
 )
-from polars_utils.expressions import is_not_care_home
 from utils.column_names.ind_cqc_pipeline_columns import IndCqcColumns as IndCQC
 from utils.column_values.categorical_column_values import AscwdsFilteringRule
 

--- a/projects/_03_independent_cqc/_02_clean/fargate/utils/clean_ascwds_filled_post_outliers/null_grouped_providers.py
+++ b/projects/_03_independent_cqc/_02_clean/fargate/utils/clean_ascwds_filled_post_outliers/null_grouped_providers.py
@@ -3,10 +3,10 @@ from dataclasses import dataclass, fields
 import polars as pl
 
 import polars_utils.cleaning_utils as pUtils
+from polars_utils.expressions import is_care_home, is_not_care_home
 from polars_utils.filtering_utils import (
     update_filtering_rule,
 )
-from polars_utils.expressions import is_not_care_home, is_care_home
 from utils.column_names.ind_cqc_pipeline_columns import IndCqcColumns as IndCQC
 from utils.column_names.ind_cqc_pipeline_columns import (
     NullGroupedProviderColumns as NGPcol,

--- a/projects/_03_independent_cqc/_02_clean/fargate/utils/clean_ascwds_filled_post_outliers/winsorize_care_home_filled_posts_per_bed_ratio_outliers.py
+++ b/projects/_03_independent_cqc/_02_clean/fargate/utils/clean_ascwds_filled_post_outliers/winsorize_care_home_filled_posts_per_bed_ratio_outliers.py
@@ -3,10 +3,10 @@ from dataclasses import dataclass
 import polars as pl
 
 import polars_utils.cleaning_utils as pUtils
+from polars_utils.expressions import is_care_home
 from polars_utils.filtering_utils import (
     update_filtering_rule,
 )
-from polars_utils.expressions import is_care_home
 from utils.column_names.ind_cqc_pipeline_columns import IndCqcColumns as IndCQC
 from utils.column_values.categorical_column_values import AscwdsFilteringRule
 

--- a/projects/_03_independent_cqc/_02_clean/fargate/utils/clean_ind_cqc_filled_posts_utils.py
+++ b/projects/_03_independent_cqc/_02_clean/fargate/utils/clean_ind_cqc_filled_posts_utils.py
@@ -1,5 +1,6 @@
 import polars as pl
-from polars_utils.expressions import is_care_home, is_not_care_home, is_dormant
+
+from polars_utils.expressions import is_care_home, is_dormant, is_not_care_home
 from utils.column_names.ind_cqc_pipeline_columns import IndCqcColumns as IndCQC
 
 average_number_of_beds: str = "avg_beds"

--- a/projects/_03_independent_cqc/_02_clean/fargate/utils/utils.py
+++ b/projects/_03_independent_cqc/_02_clean/fargate/utils/utils.py
@@ -1,5 +1,7 @@
 from typing import Optional
+
 import polars as pl
+
 from utils.column_names.ind_cqc_pipeline_columns import IndCqcColumns as IndCQC
 
 

--- a/projects/_03_independent_cqc/_02_clean/tests/fargate/utils/clean_ascwds_filled_post_outliers/test_non_res_brand_id_filter.py
+++ b/projects/_03_independent_cqc/_02_clean/tests/fargate/utils/clean_ascwds_filled_post_outliers/test_non_res_brand_id_filter.py
@@ -1,6 +1,7 @@
 import unittest
-from unittest.mock import Mock, patch
 from datetime import date
+from unittest.mock import Mock, patch
+
 import polars as pl
 import polars.testing as pl_testing
 

--- a/projects/_03_independent_cqc/_02_clean/tests/fargate/utils/clean_ascwds_filled_post_outliers/test_null_grouped_providers.py
+++ b/projects/_03_independent_cqc/_02_clean/tests/fargate/utils/clean_ascwds_filled_post_outliers/test_null_grouped_providers.py
@@ -5,14 +5,12 @@ import polars as pl
 import polars.testing as pl_testing
 
 import projects._03_independent_cqc._02_clean.fargate.utils.clean_ascwds_filled_post_outliers.null_grouped_providers as job
-
 from projects._03_independent_cqc.unittest_data.polars_ind_cqc_test_file_data import (
     NullGroupedProvidersData as Data,
 )
 from projects._03_independent_cqc.unittest_data.polars_ind_cqc_test_file_schemas import (
     NullGroupedProvidersSchema as Schemas,
 )
-
 from utils.column_names.ind_cqc_pipeline_columns import IndCqcColumns as IndCQC
 
 PATCH_PATH: str = (

--- a/projects/_03_independent_cqc/_02_clean/tests/fargate/utils/clean_ascwds_filled_post_outliers/test_winsorize_care_home_filled_posts_per_bed_ratio_outliers.py
+++ b/projects/_03_independent_cqc/_02_clean/tests/fargate/utils/clean_ascwds_filled_post_outliers/test_winsorize_care_home_filled_posts_per_bed_ratio_outliers.py
@@ -13,7 +13,6 @@ from projects._03_independent_cqc.unittest_data.polars_ind_cqc_test_file_data im
 from projects._03_independent_cqc.unittest_data.polars_ind_cqc_test_file_schemas import (
     WinsorizeCareHomeFilledPostsPerBedRatioOutliersSchema as Schemas,
 )
-
 from utils.column_names.ind_cqc_pipeline_columns import IndCqcColumns as IndCQC
 
 

--- a/projects/_03_independent_cqc/_02_clean/tests/fargate/utils/test_utils.py
+++ b/projects/_03_independent_cqc/_02_clean/tests/fargate/utils/test_utils.py
@@ -1,6 +1,8 @@
 import unittest
+
 import polars as pl
 import polars.testing as pl_testing
+
 import projects._03_independent_cqc._02_clean.fargate.utils.utils as job
 from projects._03_independent_cqc.unittest_data.polars_ind_cqc_test_file_data import (
     CleanUtilsData as Data,
@@ -8,7 +10,6 @@ from projects._03_independent_cqc.unittest_data.polars_ind_cqc_test_file_data im
 from projects._03_independent_cqc.unittest_data.polars_ind_cqc_test_file_schemas import (
     CleanUtilsSchemas as Schemas,
 )
-
 from utils.column_names.ind_cqc_pipeline_columns import IndCqcColumns as IndCQC
 
 

--- a/projects/_03_independent_cqc/_03_impute/fargate/impute_ind_cqc_ascwds_and_pir.py
+++ b/projects/_03_independent_cqc/_03_impute/fargate/impute_ind_cqc_ascwds_and_pir.py
@@ -2,16 +2,17 @@ from dataclasses import dataclass
 
 import polars as pl
 
-from polars_utils import utils, cleaning_utils as cUtils
+from polars_utils import cleaning_utils as cUtils
+from polars_utils import utils
 from polars_utils.expressions import is_care_home
-from projects._03_independent_cqc._03_impute.fargate.utils.primary_service_rate_of_change import (
-    model_primary_service_rate_of_change_trendline,
-)
 from projects._03_independent_cqc._03_impute.fargate.utils.convert_pir_people_to_filled_posts import (
     convert_pir_to_filled_posts,
 )
 from projects._03_independent_cqc._03_impute.fargate.utils.forward_fill_latest_known_value import (
     forward_fill_latest_known_value,
+)
+from projects._03_independent_cqc._03_impute.fargate.utils.primary_service_rate_of_change import (
+    model_primary_service_rate_of_change_trendline,
 )
 from utils.column_names.ind_cqc_pipeline_columns import IndCqcColumns as IndCQC
 

--- a/projects/_03_independent_cqc/_03_impute/jobs/impute_ind_cqc_ascwds_and_pir.py
+++ b/projects/_03_independent_cqc/_03_impute/jobs/impute_ind_cqc_ascwds_and_pir.py
@@ -7,7 +7,6 @@ os.environ["SPARK_VERSION"] = "3.5"
 from pyspark.sql import DataFrame
 
 import utils.cleaning_utils as cUtils
-
 from projects._03_independent_cqc._03_impute.utils.forward_fill_latest_known_value import (
     forward_fill_latest_known_value,
 )

--- a/projects/_03_independent_cqc/_03_impute/tests/fargate/utils/test_forward_fill_latest_known_value.py
+++ b/projects/_03_independent_cqc/_03_impute/tests/fargate/utils/test_forward_fill_latest_known_value.py
@@ -1,7 +1,8 @@
 import unittest
+from unittest.mock import ANY, Mock, patch
+
 import polars as pl
 import polars.testing as pl_testing
-from unittest.mock import ANY, Mock, patch
 
 import projects._03_independent_cqc._03_impute.fargate.utils.forward_fill_latest_known_value as job
 from projects._03_independent_cqc.unittest_data.polars_ind_cqc_test_file_data import (
@@ -10,7 +11,6 @@ from projects._03_independent_cqc.unittest_data.polars_ind_cqc_test_file_data im
 from projects._03_independent_cqc.unittest_data.polars_ind_cqc_test_file_schemas import (
     ForwardFillLatestKnownValue as Schemas,
 )
-
 from utils.column_names.ind_cqc_pipeline_columns import IndCqcColumns as IndCQC
 
 PATCH_PATH = "projects._03_independent_cqc._03_impute.fargate.utils.forward_fill_latest_known_value"

--- a/projects/_03_independent_cqc/_04_model/fargate/model_01_features_non_res_with_dormancy.py
+++ b/projects/_03_independent_cqc/_04_model/fargate/model_01_features_non_res_with_dormancy.py
@@ -4,6 +4,7 @@ import projects._03_independent_cqc._04_model.utils.feature_utils as fUtils
 import projects._03_independent_cqc._04_model.utils.paths as pUtils
 import projects._03_independent_cqc._04_model.utils.validate_model_definitions as vUtils
 from polars_utils import utils
+from polars_utils.expressions import is_not_care_home
 from projects._03_independent_cqc._04_model.registry.model_registry import (
     model_registry,
 )
@@ -14,7 +15,6 @@ from projects._03_independent_cqc._04_model.utils.value_labels import (
     ServicesLabels,
     SpecialismsLabels,
 )
-from polars_utils.expressions import is_not_care_home
 from utils.column_names.ind_cqc_pipeline_columns import IndCqcColumns as IndCQC
 from utils.column_names.ind_cqc_pipeline_columns import ModelRegistryKeys as MRKeys
 

--- a/projects/_03_independent_cqc/_04_model/fargate/model_01_features_non_res_without_dormancy.py
+++ b/projects/_03_independent_cqc/_04_model/fargate/model_01_features_non_res_without_dormancy.py
@@ -6,6 +6,7 @@ import projects._03_independent_cqc._04_model.utils.feature_utils as fUtils
 import projects._03_independent_cqc._04_model.utils.paths as pUtils
 import projects._03_independent_cqc._04_model.utils.validate_model_definitions as vUtils
 from polars_utils import utils
+from polars_utils.expressions import is_not_care_home
 from projects._03_independent_cqc._04_model.registry.model_registry import (
     model_registry,
 )
@@ -16,7 +17,6 @@ from projects._03_independent_cqc._04_model.utils.value_labels import (
     ServicesLabels,
     SpecialismsLabels,
 )
-from polars_utils.expressions import is_not_care_home
 from utils.column_names.ind_cqc_pipeline_columns import IndCqcColumns as IndCQC
 from utils.column_names.ind_cqc_pipeline_columns import ModelRegistryKeys as MRKeys
 

--- a/projects/_03_independent_cqc/_04_model/utils/validate_models.py
+++ b/projects/_03_independent_cqc/_04_model/utils/validate_models.py
@@ -1,6 +1,7 @@
 from datetime import date
 
 import polars as pl
+
 from polars_utils.expressions import is_care_home, is_not_care_home
 from utils.column_names.ind_cqc_pipeline_columns import IndCqcColumns as IndCQC
 

--- a/projects/_03_independent_cqc/_06_estimate_filled_posts/fargate/utils/models/non_res_with_and_without_dormancy_combined.py
+++ b/projects/_03_independent_cqc/_06_estimate_filled_posts/fargate/utils/models/non_res_with_and_without_dormancy_combined.py
@@ -1,9 +1,9 @@
 import polars as pl
 
+from polars_utils.expressions import is_not_care_home
 from projects._03_independent_cqc._06_estimate_filled_posts.fargate.utils.models.utils import (
     join_model_predictions,
 )
-from polars_utils.expressions import is_not_care_home
 from utils.column_names.ind_cqc_pipeline_columns import IndCqcColumns as IndCqc
 from utils.column_names.ind_cqc_pipeline_columns import (
     NonResWithAndWithoutDormancyCombinedColumns as TempColumns,

--- a/projects/_03_independent_cqc/_06_estimate_filled_posts/tests/fargate/utils/models/test_estimate_ind_cqc_filled_posts_models_utils.py
+++ b/projects/_03_independent_cqc/_06_estimate_filled_posts/tests/fargate/utils/models/test_estimate_ind_cqc_filled_posts_models_utils.py
@@ -1,5 +1,6 @@
 import unittest
 from unittest.mock import ANY, Mock, patch
+
 import polars as pl
 import polars.testing as pl_testing
 

--- a/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/_04_estimate.py
+++ b/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/_04_estimate.py
@@ -1,10 +1,10 @@
 import polars as pl
 
 import projects._03_independent_cqc._07_estimate_filled_posts_by_job_role.fargate.utils.estimate_utils as eUtils
+from polars_utils import utils
 from projects._03_independent_cqc._07_estimate_filled_posts_by_job_role.fargate.utils.utils import (
     add_job_role_groups_column,
 )
-from polars_utils import utils
 from utils.column_names.ind_cqc_pipeline_columns import IndCqcColumns as IndCQC
 from utils.column_names.ind_cqc_pipeline_columns import PartitionKeys as Keys
 from utils.column_values.categorical_column_values import MainJobRoleLabels

--- a/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/validate_02_clean.py
+++ b/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/validate_02_clean.py
@@ -11,10 +11,10 @@ from projects._03_independent_cqc._07_estimate_filled_posts_by_job_role.fargate.
     CategoricalColumnTypes,
 )
 from utils.column_names.ind_cqc_pipeline_columns import IndCqcColumns
+from utils.column_values.categorical_column_values import JobRoleFilteringRule
 from utils.column_values.categorical_columns_by_dataset import (
     EstimatedIndCQCFilledPostsByJobRoleCategoricalValues as CatValues,
 )
-from utils.column_values.categorical_column_values import JobRoleFilteringRule
 
 VALIDATION_COLS_TO_IMPORT = [
     IndCqcColumns.id_per_locationid_import_date,

--- a/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/validate_04_estimates.py
+++ b/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/validate_04_estimates.py
@@ -1,6 +1,7 @@
 import sys
-import polars as pl
+
 import pointblank as pb
+import polars as pl
 
 from polars_utils import utils
 from polars_utils.validation import actions as vl

--- a/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/tests/fargate/test_01_merge.py
+++ b/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/tests/fargate/test_01_merge.py
@@ -2,6 +2,7 @@ import unittest
 from unittest.mock import ANY, Mock, call, patch
 
 import polars as pl
+
 import projects._03_independent_cqc._07_estimate_filled_posts_by_job_role.fargate._01_merge as job
 
 PATCH_PATH = "projects._03_independent_cqc._07_estimate_filled_posts_by_job_role.fargate._01_merge"

--- a/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/tests/fargate/test_validate_04_estimates.py
+++ b/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/tests/fargate/test_validate_04_estimates.py
@@ -1,14 +1,14 @@
 import json
 import unittest
-from unittest.mock import Mock, patch
 from datetime import date
+from unittest.mock import Mock, patch
 
 import polars as pl
 import polars.testing as pl_testing
 import pytest
 
-from utils.column_names.ind_cqc_pipeline_columns import IndCqcColumns
 import projects._03_independent_cqc._07_estimate_filled_posts_by_job_role.fargate.validate_04_estimates as job
+from utils.column_names.ind_cqc_pipeline_columns import IndCqcColumns
 from utils.column_values.categorical_column_values import (
     JobGroupLabels,
     MainJobRoleLabels,

--- a/projects/_03_independent_cqc/unittest_data/ind_cqc_test_file_data.py
+++ b/projects/_03_independent_cqc/unittest_data/ind_cqc_test_file_data.py
@@ -2,7 +2,6 @@ import math
 from dataclasses import dataclass
 from datetime import date
 
-
 from utils.column_names.ind_cqc_pipeline_columns import IndCqcColumns as IndCQC
 from utils.column_values.categorical_column_values import (
     CareHome,

--- a/projects/_03_independent_cqc/utils/tests/imputation/test_interpolation.py
+++ b/projects/_03_independent_cqc/utils/tests/imputation/test_interpolation.py
@@ -11,7 +11,6 @@ from projects._03_independent_cqc.unittest_data.polars_ind_cqc_test_file_data im
 from projects._03_independent_cqc.unittest_data.polars_ind_cqc_test_file_schemas import (
     InterpolationSchema as Schemas,
 )
-
 from utils.column_names.ind_cqc_pipeline_columns import IndCqcColumns as IndCqc
 
 PATCH_PATH: str = (

--- a/projects/_04_direct_payment_recipients/fargate/utils/models/extrapolation_ratio.py
+++ b/projects/_04_direct_payment_recipients/fargate/utils/models/extrapolation_ratio.py
@@ -1,4 +1,5 @@
 import polars as pl
+
 from projects._04_direct_payment_recipients.direct_payments_column_names import (
     DirectPaymentColumnNames as DP,
 )

--- a/projects/_04_direct_payment_recipients/tests/fargate/utils/models/test_extrapolation_ratio.py
+++ b/projects/_04_direct_payment_recipients/tests/fargate/utils/models/test_extrapolation_ratio.py
@@ -1,4 +1,5 @@
 import unittest
+
 import polars as pl
 import polars.testing as pl_testing
 

--- a/projects/_04_direct_payment_recipients/tests/fargate/utils/test_calculate_remaining_variables.py
+++ b/projects/_04_direct_payment_recipients/tests/fargate/utils/test_calculate_remaining_variables.py
@@ -1,4 +1,5 @@
 import unittest
+
 import polars as pl
 import polars.testing as pl_testing
 

--- a/projects/utils/unittest_data/utils_test_file_data.py
+++ b/projects/utils/unittest_data/utils_test_file_data.py
@@ -1,6 +1,5 @@
 from datetime import date
 
-
 calculate_new_column_rows = [
     ("1-001", 10.0, 2.5),
     ("1-002", 2.0, 4.0),

--- a/schemas/cqc_location_schema.py
+++ b/schemas/cqc_location_schema.py
@@ -1,9 +1,9 @@
 from pyspark.sql.types import (
-    StructField,
-    StructType,
-    StringType,
     ArrayType,
     IntegerType,
+    StringType,
+    StructField,
+    StructType,
 )
 
 from utils.column_names.raw_data_files.cqc_location_api_columns import (
@@ -11,13 +11,13 @@ from utils.column_names.raw_data_files.cqc_location_api_columns import (
 )
 
 """
-This schema (and the data in s3) has been updated to match changes which were announced 
-to be taking place on 30/1/25. The three new columns added are highlighted below. This 
+This schema (and the data in s3) has been updated to match changes which were announced
+to be taking place on 30/1/25. The three new columns added are highlighted below. This
 update to the API has now been postponed and no new launch date has been communicated as
 yet. We are leaving these columns in the schema for now, as they do not affect the pipeline.
 If another API schema change happens before these columns are added, they may need removing.
 
-The changes were made in PR #680: Update location api schema. Note that reversing this PR will 
+The changes were made in PR #680: Update location api schema. Note that reversing this PR will
 also roll back the version number for the CQC locations data in s3. The data in s3 and the
 version number in s3 will need reverting separately.
 """

--- a/schemas/cqc_pir_schema.py
+++ b/schemas/cqc_pir_schema.py
@@ -1,14 +1,11 @@
 from pyspark.sql.types import (
+    IntegerType,
+    StringType,
     StructField,
     StructType,
-    StringType,
-    IntegerType,
 )
 
-from utils.column_names.raw_data_files.cqc_pir_columns import (
-    CqcPirColumns as ColNames,
-)
-
+from utils.column_names.raw_data_files.cqc_pir_columns import CqcPirColumns as ColNames
 
 PIR_SCHEMA = StructType(
     fields=[

--- a/schemas/cqc_provider_schema.py
+++ b/schemas/cqc_provider_schema.py
@@ -1,8 +1,8 @@
 from pyspark.sql.types import (
+    ArrayType,
+    StringType,
     StructField,
     StructType,
-    StringType,
-    ArrayType,
 )
 
 from utils.column_names.raw_data_files.cqc_provider_api_columns import (

--- a/schemas/cqc_provider_schema_polars.py
+++ b/schemas/cqc_provider_schema_polars.py
@@ -1,8 +1,8 @@
 import polars as pl
+
 from utils.column_names.raw_data_files.cqc_provider_api_columns import (
     CqcProviderApiColumns as ColNames,
 )
-
 
 POLARS_PROVIDER_SCHEMA = {
     ColNames.provider_id: pl.Utf8,

--- a/schemas/direct_payment_data_schema.py
+++ b/schemas/direct_payment_data_schema.py
@@ -1,9 +1,9 @@
 from pyspark.sql.types import (
-    StructField,
-    StructType,
-    StringType,
     FloatType,
     IntegerType,
+    StringType,
+    StructField,
+    StructType,
 )
 
 EXTERNAL_DATA = StructType(

--- a/schemas/spss_job_estimates_schema.py
+++ b/schemas/spss_job_estimates_schema.py
@@ -1,11 +1,10 @@
 from pyspark.sql.types import (
-    StructField,
-    StructType,
-    StringType,
     FloatType,
     IntegerType,
+    StringType,
+    StructField,
+    StructType,
 )
-
 
 SPSS_JOBS_ESTIMATES = StructType(
     fields=[

--- a/tests/test_polars_utils/test_expressions.py
+++ b/tests/test_polars_utils/test_expressions.py
@@ -6,11 +6,11 @@ import pytest
 
 from polars_utils.expressions import (
     has_value,
+    is_care_home,
+    is_dormant,
+    is_not_care_home,
     percentage_share,
     str_length_cols,
-    is_care_home,
-    is_not_care_home,
-    is_dormant,
 )
 
 


### PR DESCRIPTION
## Description
Trello ticket [1643](https://trello.com/c/P3q4h5DA)

Ran isort profile black against whole repository.

## Testing
- [x] Successful [Step Function run](https://eu-west-2.console.aws.amazon.com/states/home?region=eu-west-2#/v2/executions/details/arn:aws:states:eu-west-2:856699698263:execution:1643-fix-isort-Ind-CQC-Filled-Post-Estimates:b5c3643a-d3ed-4a67-87c8-b1f276e03075)
- [x] Outputs checked in Athena

See Trello ticket for comparison query and sum of filled posts outputs.

## Reviewer checklist
- [ ] PR solves the Trello ticket requirements
- [ ] Outputs appear reasonable and understandable
- [ ] The overall approach is appropriate and not over-engineered
- [ ] No obvious scalability, performance or interdependency concerns
- [ ] Tests appropriately cover the main behaviour/edge cases
- [ ] Naming and structure are broadly understandable and consistent
- [ ] Docstrings are sufficient for future maintenance
- [ ] Docstrings cover non-obvious behaviour
