### PR TITLE
1649 Remove small locations from job group filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,8 @@ All notable changes to this project will be documented in this file.
 
 - Refactored job role estimates validation to remove aggregated table.
 
+- Removed small locations from job group filter
+
 ### Fixed
 - Raw and cleaned ascwds worker validation scripts so they raise exceptions on failure.
 

--- a/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/utils/clean_utils.py
+++ b/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/utils/clean_utils.py
@@ -51,12 +51,12 @@ def filter_job_role_group_outliers(
 ) -> pl.LazyFrame:
     """
     Null job role counts at locations where job group distribution is out of bounds and
-    locations have more than 50 workers.
+    locations have the same or more workers than the threshold.
 
     This function nulls outliers based on a locations job group distribution. Their
     distribution is calculated per location and import date, then upper/lower percentile
     bounds are calculated per service type for each job group across all periods. Values
-    are nulled where there are more than 50 workers at a location and either:
+    are nulled where there are the same or more workers than the threshold at a location and either:
 
     - direct care outside upper or lower percentile
     - managers/regulated professions/other outside upper percentile
@@ -64,7 +64,7 @@ def filter_job_role_group_outliers(
     The steps are as follows:
     1. Pivot table and aggregate to job group
     2. Calculate total ASCWDS count for location, service type and date
-    3. Drop rows with 50 or fewer workers
+    3. Drop rows for small locations
     4. Calculate job group percentage of total ASCWDS count for location, service type and date
     5. Calculate upper and lower percentile bounds of job group percentages for each job group and primary service type
     6. Flag where job role percentage is outside bounds
@@ -106,13 +106,15 @@ def filter_job_role_group_outliers(
         .with_columns(  # 2. Calculate total ASCWDS count for location, service type and date.
             Exprs.location_sum_expr
         )
-        .filter(pl.col(Exprs.temp_location_sum) > small_location_threshold)
-        .with_columns(  # 3. Calculate job group percentage of total ASCWDS count for location, service type and date.
+        .filter(
+            pl.col(Exprs.temp_location_sum) > small_location_threshold
+        )  # 3. Drop rows for small locations
+        .with_columns(  # 4. Calculate job group percentage of total ASCWDS count for location, service type and date.
             Exprs.job_group_percentage_expr
         )
     )
 
-    # 4. Calculate upper and lower percentile bounds of job group percentages for each job group and primary service type.
+    # 5. Calculate upper and lower percentile bounds of job group percentages for each job group and primary service type.
     bounds_lf = piv_lf.group_by(IndCQC.primary_service_type).agg(
         Exprs.upper_bounds_expr,
         Exprs.lower_bounds_expr,
@@ -124,7 +126,7 @@ def filter_job_role_group_outliers(
             on=IndCQC.primary_service_type,
             how="left",
         )
-        # 5. Flag where job role percentage is outside bounds.
+        # 6. Flag where job role percentage is outside bounds.
         .with_columns(Exprs.evaluation_expr.alias(temp_out_of_bounds_col)).select(
             IndCQC.id_per_locationid_import_date, temp_out_of_bounds_col
         )
@@ -132,7 +134,7 @@ def filter_job_role_group_outliers(
 
     lf = (
         lf.join(piv_lf, on=IndCQC.id_per_locationid_import_date, how="left")
-        .with_columns(  # 6. Null ascwds_job_role_counts_column
+        .with_columns(  # 7. Null ascwds_job_role_counts_column
             pl.when(pl.col(temp_out_of_bounds_col))
             .then(None)
             .otherwise(pl.col(IndCQC.ascwds_job_role_counts))
@@ -141,7 +143,7 @@ def filter_job_role_group_outliers(
         .drop(temp_out_of_bounds_col)
     )
 
-    lf = update_filtering_rule(  # 7. Add filtering rule
+    lf = update_filtering_rule(  # 8. Add filtering rule
         lf,
         filter_rule_col_name=IndCQC.job_role_filtering_rule,
         raw_col_name=IndCQC.ascwds_job_role_counts,

--- a/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/utils/clean_utils.py
+++ b/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/utils/clean_utils.py
@@ -61,16 +61,6 @@ def filter_job_role_group_outliers(
     - direct care outside upper or lower percentile
     - managers/regulated professions/other outside upper percentile
 
-    The steps are as follows:
-    1. Pivot table and aggregate to job group
-    2. Calculate total ASCWDS count for location, service type and date
-    3. Drop rows for small locations
-    4. Calculate job group percentage of total ASCWDS count for location, service type and date
-    5. Calculate upper and lower percentile bounds of job group percentages for each job group and primary service type
-    6. Flag where job role percentage is outside bounds
-    7. Null ascwds_job_role_counts_column
-    8. Update filtering rule
-
     Args:
         lf (pl.LazyFrame): The estimated filled post by job role LazyFrame.
         upper_percentile_bound (float): Upper bound for percentile filtering. Defaults to 0.999.
@@ -94,7 +84,6 @@ def filter_job_role_group_outliers(
         IndCQC.id_per_locationid_import_date,
     ]
 
-    # 1. Pivot table and aggregate to job group
     piv_lf = (
         lf.pivot(
             on=IndCQC.main_job_group_labelled,
@@ -103,18 +92,11 @@ def filter_job_role_group_outliers(
             values=IndCQC.ascwds_job_role_counts,
             aggregate_function="sum",
         )
-        .with_columns(  # 2. Calculate total ASCWDS count for location, service type and date.
-            Exprs.location_sum_expr
-        )
-        .filter(
-            pl.col(Exprs.temp_location_sum) > small_location_threshold
-        )  # 3. Drop rows for small locations
-        .with_columns(  # 4. Calculate job group percentage of total ASCWDS count for location, service type and date.
-            Exprs.job_group_percentage_expr
-        )
+        .with_columns(Exprs.location_sum_expr)
+        .filter(pl.col(Exprs.temp_location_sum) > small_location_threshold)
+        .with_columns(Exprs.job_group_percentage_expr)
     )
 
-    # 5. Calculate upper and lower percentile bounds of job group percentages for each job group and primary service type.
     bounds_lf = piv_lf.group_by(IndCQC.primary_service_type).agg(
         Exprs.upper_bounds_expr,
         Exprs.lower_bounds_expr,
@@ -126,15 +108,13 @@ def filter_job_role_group_outliers(
             on=IndCQC.primary_service_type,
             how="left",
         )
-        # 6. Flag where job role percentage is outside bounds.
-        .with_columns(Exprs.evaluation_expr.alias(temp_out_of_bounds_col)).select(
-            IndCQC.id_per_locationid_import_date, temp_out_of_bounds_col
-        )
+        .with_columns(Exprs.evaluation_expr.alias(temp_out_of_bounds_col))
+        .select(IndCQC.id_per_locationid_import_date, temp_out_of_bounds_col)
     )
 
     lf = (
         lf.join(piv_lf, on=IndCQC.id_per_locationid_import_date, how="left")
-        .with_columns(  # 7. Null ascwds_job_role_counts_column
+        .with_columns(
             pl.when(pl.col(temp_out_of_bounds_col))
             .then(None)
             .otherwise(pl.col(IndCQC.ascwds_job_role_counts))
@@ -143,7 +123,7 @@ def filter_job_role_group_outliers(
         .drop(temp_out_of_bounds_col)
     )
 
-    lf = update_filtering_rule(  # 8. Add filtering rule
+    lf = update_filtering_rule(
         lf,
         filter_rule_col_name=IndCQC.job_role_filtering_rule,
         raw_col_name=IndCQC.ascwds_job_role_counts,

--- a/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/utils/clean_utils.py
+++ b/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/utils/clean_utils.py
@@ -102,10 +102,11 @@ def filter_job_role_group_outliers(
             index=splits_for_pivot,
             values=IndCQC.ascwds_job_role_counts,
             aggregate_function="sum",
-        ).with_columns(  # 2. Calculate total ASCWDS count for location, service type and date.
+        )
+        .with_columns(  # 2. Calculate total ASCWDS count for location, service type and date.
             Exprs.location_sum_expr
         )
-        # .filter(pl.col(Exprs.temp_location_sum) > small_location_threshold)
+        .filter(pl.col(Exprs.temp_location_sum) > small_location_threshold)
         .with_columns(  # 3. Calculate job group percentage of total ASCWDS count for location, service type and date.
             Exprs.job_group_percentage_expr
         )

--- a/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/utils/clean_utils.py
+++ b/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/utils/clean_utils.py
@@ -47,14 +47,16 @@ def filter_job_role_group_outliers(
     lf: pl.LazyFrame,
     upper_percentile_bound: float = 0.999,
     lower_percentile_bound: float = 0.001,
+    small_location_threshold: int = 50,
 ) -> pl.LazyFrame:
     """
-    Null job role counts at locations where job group distribution is out of bounds.
+    Null job role counts at locations where job group distribution is out of bounds and
+    locations have more than 50 workers.
 
     This function nulls outliers based on a locations job group distribution. Their
     distribution is calculated per location and import date, then upper/lower percentile
     bounds are calculated per service type for each job group across all periods. Values
-    are nulled where:
+    are nulled where there are more than 50 workers at a location and either:
 
     - direct care outside upper or lower percentile
     - managers/regulated professions/other outside upper percentile
@@ -62,16 +64,18 @@ def filter_job_role_group_outliers(
     The steps are as follows:
     1. Pivot table and aggregate to job group
     2. Calculate total ASCWDS count for location, service type and date
-    3. Calculate job group percentage of total ASCWDS count for location, service type and date
-    4. Calculate upper and lower percentile bounds of job group percentages for each job group and primary service type
-    5. Flag where job role percentage is outside bounds
-    6. Null ascwds_job_role_counts_column
-    7. Update filtering rule
+    3. Drop rows with 50 or fewer workers
+    4. Calculate job group percentage of total ASCWDS count for location, service type and date
+    5. Calculate upper and lower percentile bounds of job group percentages for each job group and primary service type
+    6. Flag where job role percentage is outside bounds
+    7. Null ascwds_job_role_counts_column
+    8. Update filtering rule
 
     Args:
         lf (pl.LazyFrame): The estimated filled post by job role LazyFrame.
         upper_percentile_bound (float): Upper bound for percentile filtering. Defaults to 0.999.
         lower_percentile_bound (float): Lower bound for percentile filtering. Defaults to 0.001.
+        small_location_threshold (int): Minimum number of workers at a location to be included in filtering. Defaults to 50.
 
     Returns:
         pl.LazyFrame: LazyFrame with outliers in job role groups filtered.
@@ -98,10 +102,10 @@ def filter_job_role_group_outliers(
             index=splits_for_pivot,
             values=IndCQC.ascwds_job_role_counts,
             aggregate_function="sum",
-        )
-        .with_columns(  # 2. Calculate total ASCWDS count for location, service type and date.
+        ).with_columns(  # 2. Calculate total ASCWDS count for location, service type and date.
             Exprs.location_sum_expr
         )
+        # .filter(pl.col(Exprs.temp_location_sum) > small_location_threshold)
         .with_columns(  # 3. Calculate job group percentage of total ASCWDS count for location, service type and date.
             Exprs.job_group_percentage_expr
         )

--- a/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/tests/fargate/utils/test_clean_utils.py
+++ b/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/tests/fargate/utils/test_clean_utils.py
@@ -89,7 +89,7 @@ class TestFilterAscwdsJobRoleCountWhenJobGroupRatiosOutsidePercentileBounds:
         )
 
         returned_lf = job.filter_job_role_group_outliers(
-            test_lf, case.upper_bound, case.lower_bound
+            test_lf, case.upper_bound, case.lower_bound, case.small_location_threshold
         )
 
         pl_testing.assert_frame_equal(

--- a/projects/_03_independent_cqc/unittest_data/polars_ind_cqc_test_file_data.py
+++ b/projects/_03_independent_cqc/unittest_data/polars_ind_cqc_test_file_data.py
@@ -2882,7 +2882,7 @@ class EstimateFilledPostsByJobRoleCleanUtilsData:
             ],
             upper_bound=0.8,
             lower_bound=0.2,
-            small_location_threshold=5,
+            small_location_threshold=1,
         ),
         EstimateFilledPostsByJobRoleCleanUtilsTestCase(
             id="when_multiple_job_role_per_job_group",
@@ -2924,7 +2924,7 @@ class EstimateFilledPostsByJobRoleCleanUtilsData:
             ],
             upper_bound=0.8,
             lower_bound=0.2,
-            small_location_threshold=5,
+            small_location_threshold=1,
         ),
         EstimateFilledPostsByJobRoleCleanUtilsTestCase(
             id="when_ratio_is exactly_on_bound",
@@ -2938,7 +2938,7 @@ class EstimateFilledPostsByJobRoleCleanUtilsData:
             ],
             upper_bound=0.8,
             lower_bound=0.2,
-            small_location_threshold=5,
+            small_location_threshold=1,
         ),
         EstimateFilledPostsByJobRoleCleanUtilsTestCase(
             id="when_multiple_primary_service_types_present",
@@ -2972,7 +2972,7 @@ class EstimateFilledPostsByJobRoleCleanUtilsData:
             ],
             upper_bound=0.8,
             lower_bound=0.2,
-            small_location_threshold=5,
+            small_location_threshold=1,
         ),
         EstimateFilledPostsByJobRoleCleanUtilsTestCase(
             id="when_multiple_locations_and_dates_present",
@@ -3006,7 +3006,7 @@ class EstimateFilledPostsByJobRoleCleanUtilsData:
             ],
             upper_bound=0.8,
             lower_bound=0.2,
-            small_location_threshold=5,
+            small_location_threshold=1,
         ),
         EstimateFilledPostsByJobRoleCleanUtilsTestCase(
             id="when_null_values_present",
@@ -3048,23 +3048,23 @@ class EstimateFilledPostsByJobRoleCleanUtilsData:
             ],
             upper_bound=0.8,
             lower_bound=0.2,
-            small_location_threshold=5,
+            small_location_threshold=1,
         ),
         EstimateFilledPostsByJobRoleCleanUtilsTestCase(
             id="when_small_location_outside_bounds",
             test_data=[
-                (1,"loc1", date(2024, 1, 1), PrimaryServiceType.care_home_only, MainJobRoleLabels.care_worker, JobGroupLabels.direct_care, 20, JobRoleFilteringRule.populated), # Loc 1 direct care over upper bound
-                (1, "loc1", date(2024, 1, 1), PrimaryServiceType.care_home_only, MainJobRoleLabels.registered_nurse, JobGroupLabels.regulated_professions, 1, JobRoleFilteringRule.populated),
-                (1, "loc1", date(2024, 1, 1), PrimaryServiceType.care_home_only, MainJobRoleLabels.registered_manager, JobGroupLabels.managers, 1, JobRoleFilteringRule.populated),
-                (1, "loc1", date(2024, 1, 1), PrimaryServiceType.care_home_only, MainJobRoleLabels.other_non_care_related_staff, JobGroupLabels.other, 1, JobRoleFilteringRule.populated),
-                (2, "loc2", date(2024, 1, 1), PrimaryServiceType.care_home_only, MainJobRoleLabels.care_worker, JobGroupLabels.direct_care, 20, JobRoleFilteringRule.populated), # Loc 2 within bounds
-                (2, "loc2", date(2024, 1, 1), PrimaryServiceType.care_home_only, MainJobRoleLabels.registered_nurse, JobGroupLabels.regulated_professions, 2, JobRoleFilteringRule.populated),
-                (2, "loc2", date(2024, 1, 1), PrimaryServiceType.care_home_only, MainJobRoleLabels.registered_manager, JobGroupLabels.managers, 1, JobRoleFilteringRule.populated),
-                (2, "loc2", date(2024, 1, 1), PrimaryServiceType.care_home_only, MainJobRoleLabels.other_non_care_related_staff, JobGroupLabels.other, 1, JobRoleFilteringRule.populated),
-                (3, "loc3", date(2024, 1, 1), PrimaryServiceType.care_home_only, MainJobRoleLabels.care_worker, JobGroupLabels.direct_care, 1, JobRoleFilteringRule.populated), # Loc 3 direct care below lower bound, others above upper bound
-                (3, "loc3", date(2024, 1, 1), PrimaryServiceType.care_home_only, MainJobRoleLabels.registered_nurse, JobGroupLabels.regulated_professions, 1, JobRoleFilteringRule.populated),
-                (3, "loc3", date(2024, 1, 1), PrimaryServiceType.care_home_only, MainJobRoleLabels.registered_manager, JobGroupLabels.managers, 1, JobRoleFilteringRule.populated),
-                (3, "loc3", date(2024, 1, 1), PrimaryServiceType.care_home_only, MainJobRoleLabels.other_non_care_related_staff, JobGroupLabels.other, 1, JobRoleFilteringRule.populated),
+                (1,"loc1", date(2024, 1, 1), PrimaryServiceType.care_home_only, MainJobRoleLabels.care_worker, JobGroupLabels.direct_care, 200, JobRoleFilteringRule.populated), # Loc 1 direct care over upper bound
+                (1, "loc1", date(2024, 1, 1), PrimaryServiceType.care_home_only, MainJobRoleLabels.registered_nurse, JobGroupLabels.regulated_professions, 10, JobRoleFilteringRule.populated),
+                (1, "loc1", date(2024, 1, 1), PrimaryServiceType.care_home_only, MainJobRoleLabels.registered_manager, JobGroupLabels.managers, 10, JobRoleFilteringRule.populated),
+                (1, "loc1", date(2024, 1, 1), PrimaryServiceType.care_home_only, MainJobRoleLabels.other_non_care_related_staff, JobGroupLabels.other, 10, JobRoleFilteringRule.populated),
+                (2, "loc2", date(2024, 1, 1), PrimaryServiceType.care_home_only, MainJobRoleLabels.care_worker, JobGroupLabels.direct_care, 200, JobRoleFilteringRule.populated), # Loc 2 within bounds
+                (2, "loc2", date(2024, 1, 1), PrimaryServiceType.care_home_only, MainJobRoleLabels.registered_nurse, JobGroupLabels.regulated_professions, 20, JobRoleFilteringRule.populated),
+                (2, "loc2", date(2024, 1, 1), PrimaryServiceType.care_home_only, MainJobRoleLabels.registered_manager, JobGroupLabels.managers, 10, JobRoleFilteringRule.populated),
+                (2, "loc2", date(2024, 1, 1), PrimaryServiceType.care_home_only, MainJobRoleLabels.other_non_care_related_staff, JobGroupLabels.other, 10, JobRoleFilteringRule.populated),
+                (3, "loc3", date(2024, 1, 1), PrimaryServiceType.care_home_only, MainJobRoleLabels.care_worker, JobGroupLabels.direct_care, 10, JobRoleFilteringRule.populated), # Loc 3 direct care below lower bound, others above upper bound
+                (3, "loc3", date(2024, 1, 1), PrimaryServiceType.care_home_only, MainJobRoleLabels.registered_nurse, JobGroupLabels.regulated_professions, 10, JobRoleFilteringRule.populated),
+                (3, "loc3", date(2024, 1, 1), PrimaryServiceType.care_home_only, MainJobRoleLabels.registered_manager, JobGroupLabels.managers, 10, JobRoleFilteringRule.populated),
+                (3, "loc3", date(2024, 1, 1), PrimaryServiceType.care_home_only, MainJobRoleLabels.other_non_care_related_staff, JobGroupLabels.other, 10, JobRoleFilteringRule.populated),
                 (4, "loc4", date(2024, 1, 1), PrimaryServiceType.care_home_only, MainJobRoleLabels.care_worker, JobGroupLabels.direct_care, 1, JobRoleFilteringRule.populated), # Loc 4 small location with direct care below lower bound but others above upper bound
                 (4, "loc4", date(2024, 1, 1), PrimaryServiceType.care_home_only, MainJobRoleLabels.registered_nurse, JobGroupLabels.regulated_professions, 1, JobRoleFilteringRule.populated),
                 (4, "loc4", date(2024, 1, 1), PrimaryServiceType.care_home_only, MainJobRoleLabels.registered_manager, JobGroupLabels.managers, 1, JobRoleFilteringRule.populated),
@@ -3075,10 +3075,10 @@ class EstimateFilledPostsByJobRoleCleanUtilsData:
                 (1, "loc1", date(2024, 1, 1), PrimaryServiceType.care_home_only, MainJobRoleLabels.registered_nurse, JobGroupLabels.regulated_professions, None, JobRoleFilteringRule.job_role_group_is_outlier),
                 (1, "loc1", date(2024, 1, 1), PrimaryServiceType.care_home_only, MainJobRoleLabels.registered_manager, JobGroupLabels.managers, None, JobRoleFilteringRule.job_role_group_is_outlier),
                 (1, "loc1", date(2024, 1, 1), PrimaryServiceType.care_home_only, MainJobRoleLabels.other_non_care_related_staff, JobGroupLabels.other, None, JobRoleFilteringRule.job_role_group_is_outlier),
-                (2, "loc2", date(2024, 1, 1), PrimaryServiceType.care_home_only, MainJobRoleLabels.care_worker, JobGroupLabels.direct_care, 20, JobRoleFilteringRule.populated),
-                (2, "loc2", date(2024, 1, 1), PrimaryServiceType.care_home_only, MainJobRoleLabels.registered_nurse, JobGroupLabels.regulated_professions, 2, JobRoleFilteringRule.populated),
-                (2, "loc2", date(2024, 1, 1), PrimaryServiceType.care_home_only, MainJobRoleLabels.registered_manager, JobGroupLabels.managers, 1, JobRoleFilteringRule.populated),
-                (2, "loc2", date(2024, 1, 1), PrimaryServiceType.care_home_only, MainJobRoleLabels.other_non_care_related_staff, JobGroupLabels.other, 1, JobRoleFilteringRule.populated),
+                (2, "loc2", date(2024, 1, 1), PrimaryServiceType.care_home_only, MainJobRoleLabels.care_worker, JobGroupLabels.direct_care, 200, JobRoleFilteringRule.populated),
+                (2, "loc2", date(2024, 1, 1), PrimaryServiceType.care_home_only, MainJobRoleLabels.registered_nurse, JobGroupLabels.regulated_professions, 20, JobRoleFilteringRule.populated),
+                (2, "loc2", date(2024, 1, 1), PrimaryServiceType.care_home_only, MainJobRoleLabels.registered_manager, JobGroupLabels.managers, 10, JobRoleFilteringRule.populated),
+                (2, "loc2", date(2024, 1, 1), PrimaryServiceType.care_home_only, MainJobRoleLabels.other_non_care_related_staff, JobGroupLabels.other, 10, JobRoleFilteringRule.populated),
                 (3, "loc3", date(2024, 1, 1), PrimaryServiceType.care_home_only, MainJobRoleLabels.care_worker, JobGroupLabels.direct_care, None, JobRoleFilteringRule.job_role_group_is_outlier),
                 (3, "loc3", date(2024, 1, 1), PrimaryServiceType.care_home_only, MainJobRoleLabels.registered_nurse, JobGroupLabels.regulated_professions, None, JobRoleFilteringRule.job_role_group_is_outlier),
                 (3, "loc3", date(2024, 1, 1), PrimaryServiceType.care_home_only, MainJobRoleLabels.registered_manager, JobGroupLabels.managers, None, JobRoleFilteringRule.job_role_group_is_outlier),

--- a/projects/_03_independent_cqc/unittest_data/polars_ind_cqc_test_file_data.py
+++ b/projects/_03_independent_cqc/unittest_data/polars_ind_cqc_test_file_data.py
@@ -2927,7 +2927,7 @@ class EstimateFilledPostsByJobRoleCleanUtilsData:
             small_location_threshold=1,
         ),
         EstimateFilledPostsByJobRoleCleanUtilsTestCase(
-            id="retains_values_when_ratio_is exactly_on_bound",
+            id="retains_values_when_ratio_is_exactly_on_bound",
             test_data=[
                 (1, "loc1", date(2024, 1, 1), PrimaryServiceType.care_home_only, MainJobRoleLabels.care_worker, JobGroupLabels.direct_care, 5, JobRoleFilteringRule.populated),
                 (1, "loc1", date(2024, 1, 1), PrimaryServiceType.care_home_only, MainJobRoleLabels.registered_nurse, JobGroupLabels.regulated_professions, 5, JobRoleFilteringRule.populated),

--- a/projects/_03_independent_cqc/unittest_data/polars_ind_cqc_test_file_data.py
+++ b/projects/_03_independent_cqc/unittest_data/polars_ind_cqc_test_file_data.py
@@ -2844,6 +2844,7 @@ class EstimateFilledPostsByJobRoleCleanUtilsTestCase:
     expected_data: list[Any]
     upper_bound: Optional[float] = None
     lower_bound: Optional[float] = None
+    small_location_threshold: Optional[int] = None
 
 
 @dataclass
@@ -2881,6 +2882,7 @@ class EstimateFilledPostsByJobRoleCleanUtilsData:
             ],
             upper_bound=0.8,
             lower_bound=0.2,
+            small_location_threshold=5,
         ),
         EstimateFilledPostsByJobRoleCleanUtilsTestCase(
             id="when_multiple_job_role_per_job_group",
@@ -2922,6 +2924,7 @@ class EstimateFilledPostsByJobRoleCleanUtilsData:
             ],
             upper_bound=0.8,
             lower_bound=0.2,
+            small_location_threshold=5,
         ),
         EstimateFilledPostsByJobRoleCleanUtilsTestCase(
             id="when_ratio_is exactly_on_bound",
@@ -2935,6 +2938,7 @@ class EstimateFilledPostsByJobRoleCleanUtilsData:
             ],
             upper_bound=0.8,
             lower_bound=0.2,
+            small_location_threshold=5,
         ),
         EstimateFilledPostsByJobRoleCleanUtilsTestCase(
             id="when_multiple_primary_service_types_present",
@@ -2968,6 +2972,7 @@ class EstimateFilledPostsByJobRoleCleanUtilsData:
             ],
             upper_bound=0.8,
             lower_bound=0.2,
+            small_location_threshold=5,
         ),
         EstimateFilledPostsByJobRoleCleanUtilsTestCase(
             id="when_multiple_locations_and_dates_present",
@@ -3001,6 +3006,7 @@ class EstimateFilledPostsByJobRoleCleanUtilsData:
             ],
             upper_bound=0.8,
             lower_bound=0.2,
+            small_location_threshold=5,
         ),
         EstimateFilledPostsByJobRoleCleanUtilsTestCase(
             id="when_null_values_present",
@@ -3042,6 +3048,49 @@ class EstimateFilledPostsByJobRoleCleanUtilsData:
             ],
             upper_bound=0.8,
             lower_bound=0.2,
+            small_location_threshold=5,
+        ),
+        EstimateFilledPostsByJobRoleCleanUtilsTestCase(
+            id="when_small_location_outside_bounds",
+            test_data=[
+                (1,"loc1", date(2024, 1, 1), PrimaryServiceType.care_home_only, MainJobRoleLabels.care_worker, JobGroupLabels.direct_care, 20, JobRoleFilteringRule.populated), # Loc 1 direct care over upper bound
+                (1, "loc1", date(2024, 1, 1), PrimaryServiceType.care_home_only, MainJobRoleLabels.registered_nurse, JobGroupLabels.regulated_professions, 1, JobRoleFilteringRule.populated),
+                (1, "loc1", date(2024, 1, 1), PrimaryServiceType.care_home_only, MainJobRoleLabels.registered_manager, JobGroupLabels.managers, 1, JobRoleFilteringRule.populated),
+                (1, "loc1", date(2024, 1, 1), PrimaryServiceType.care_home_only, MainJobRoleLabels.other_non_care_related_staff, JobGroupLabels.other, 1, JobRoleFilteringRule.populated),
+                (2, "loc2", date(2024, 1, 1), PrimaryServiceType.care_home_only, MainJobRoleLabels.care_worker, JobGroupLabels.direct_care, 20, JobRoleFilteringRule.populated), # Loc 2 within bounds
+                (2, "loc2", date(2024, 1, 1), PrimaryServiceType.care_home_only, MainJobRoleLabels.registered_nurse, JobGroupLabels.regulated_professions, 2, JobRoleFilteringRule.populated),
+                (2, "loc2", date(2024, 1, 1), PrimaryServiceType.care_home_only, MainJobRoleLabels.registered_manager, JobGroupLabels.managers, 1, JobRoleFilteringRule.populated),
+                (2, "loc2", date(2024, 1, 1), PrimaryServiceType.care_home_only, MainJobRoleLabels.other_non_care_related_staff, JobGroupLabels.other, 1, JobRoleFilteringRule.populated),
+                (3, "loc3", date(2024, 1, 1), PrimaryServiceType.care_home_only, MainJobRoleLabels.care_worker, JobGroupLabels.direct_care, 1, JobRoleFilteringRule.populated), # Loc 3 direct care below lower bound, others above upper bound
+                (3, "loc3", date(2024, 1, 1), PrimaryServiceType.care_home_only, MainJobRoleLabels.registered_nurse, JobGroupLabels.regulated_professions, 1, JobRoleFilteringRule.populated),
+                (3, "loc3", date(2024, 1, 1), PrimaryServiceType.care_home_only, MainJobRoleLabels.registered_manager, JobGroupLabels.managers, 1, JobRoleFilteringRule.populated),
+                (3, "loc3", date(2024, 1, 1), PrimaryServiceType.care_home_only, MainJobRoleLabels.other_non_care_related_staff, JobGroupLabels.other, 1, JobRoleFilteringRule.populated),
+                (4, "loc4", date(2024, 1, 1), PrimaryServiceType.care_home_only, MainJobRoleLabels.care_worker, JobGroupLabels.direct_care, 1, JobRoleFilteringRule.populated), # Loc 4 small location with direct care below lower bound but others above upper bound
+                (4, "loc4", date(2024, 1, 1), PrimaryServiceType.care_home_only, MainJobRoleLabels.registered_nurse, JobGroupLabels.regulated_professions, 1, JobRoleFilteringRule.populated),
+                (4, "loc4", date(2024, 1, 1), PrimaryServiceType.care_home_only, MainJobRoleLabels.registered_manager, JobGroupLabels.managers, 1, JobRoleFilteringRule.populated),
+                (4, "loc4", date(2024, 1, 1), PrimaryServiceType.care_home_only, MainJobRoleLabels.other_non_care_related_staff, JobGroupLabels.other, 1, JobRoleFilteringRule.populated),
+            ],
+            expected_data=[
+                (1, "loc1", date(2024, 1, 1), PrimaryServiceType.care_home_only, MainJobRoleLabels.care_worker, JobGroupLabels.direct_care, None, JobRoleFilteringRule.job_role_group_is_outlier),
+                (1, "loc1", date(2024, 1, 1), PrimaryServiceType.care_home_only, MainJobRoleLabels.registered_nurse, JobGroupLabels.regulated_professions, None, JobRoleFilteringRule.job_role_group_is_outlier),
+                (1, "loc1", date(2024, 1, 1), PrimaryServiceType.care_home_only, MainJobRoleLabels.registered_manager, JobGroupLabels.managers, None, JobRoleFilteringRule.job_role_group_is_outlier),
+                (1, "loc1", date(2024, 1, 1), PrimaryServiceType.care_home_only, MainJobRoleLabels.other_non_care_related_staff, JobGroupLabels.other, None, JobRoleFilteringRule.job_role_group_is_outlier),
+                (2, "loc2", date(2024, 1, 1), PrimaryServiceType.care_home_only, MainJobRoleLabels.care_worker, JobGroupLabels.direct_care, 20, JobRoleFilteringRule.populated),
+                (2, "loc2", date(2024, 1, 1), PrimaryServiceType.care_home_only, MainJobRoleLabels.registered_nurse, JobGroupLabels.regulated_professions, 2, JobRoleFilteringRule.populated),
+                (2, "loc2", date(2024, 1, 1), PrimaryServiceType.care_home_only, MainJobRoleLabels.registered_manager, JobGroupLabels.managers, 1, JobRoleFilteringRule.populated),
+                (2, "loc2", date(2024, 1, 1), PrimaryServiceType.care_home_only, MainJobRoleLabels.other_non_care_related_staff, JobGroupLabels.other, 1, JobRoleFilteringRule.populated),
+                (3, "loc3", date(2024, 1, 1), PrimaryServiceType.care_home_only, MainJobRoleLabels.care_worker, JobGroupLabels.direct_care, None, JobRoleFilteringRule.job_role_group_is_outlier),
+                (3, "loc3", date(2024, 1, 1), PrimaryServiceType.care_home_only, MainJobRoleLabels.registered_nurse, JobGroupLabels.regulated_professions, None, JobRoleFilteringRule.job_role_group_is_outlier),
+                (3, "loc3", date(2024, 1, 1), PrimaryServiceType.care_home_only, MainJobRoleLabels.registered_manager, JobGroupLabels.managers, None, JobRoleFilteringRule.job_role_group_is_outlier),
+                (3, "loc3", date(2024, 1, 1), PrimaryServiceType.care_home_only, MainJobRoleLabels.other_non_care_related_staff, JobGroupLabels.other, None, JobRoleFilteringRule.job_role_group_is_outlier),
+                (4, "loc4", date(2024, 1, 1), PrimaryServiceType.care_home_only, MainJobRoleLabels.care_worker, JobGroupLabels.direct_care, 1, JobRoleFilteringRule.populated),
+                (4, "loc4", date(2024, 1, 1), PrimaryServiceType.care_home_only, MainJobRoleLabels.registered_nurse, JobGroupLabels.regulated_professions, 1, JobRoleFilteringRule.populated),
+                (4, "loc4", date(2024, 1, 1), PrimaryServiceType.care_home_only, MainJobRoleLabels.registered_manager, JobGroupLabels.managers, 1, JobRoleFilteringRule.populated),
+                (4, "loc4", date(2024, 1, 1), PrimaryServiceType.care_home_only, MainJobRoleLabels.other_non_care_related_staff, JobGroupLabels.other, 1, JobRoleFilteringRule.populated),
+            ],
+            upper_bound=0.8,
+            lower_bound=0.2,
+            small_location_threshold=5,
         ),
     ] # fmt: skip
 

--- a/projects/_03_independent_cqc/unittest_data/polars_ind_cqc_test_file_data.py
+++ b/projects/_03_independent_cqc/unittest_data/polars_ind_cqc_test_file_data.py
@@ -3092,6 +3092,48 @@ class EstimateFilledPostsByJobRoleCleanUtilsData:
             lower_bound=0.2,
             small_location_threshold=5,
         ),
+        EstimateFilledPostsByJobRoleCleanUtilsTestCase(
+            id="when_small_location_outside_bounds_and_on_small_location_threshold",
+            test_data=[
+                (1,"loc1", date(2024, 1, 1), PrimaryServiceType.care_home_only, MainJobRoleLabels.care_worker, JobGroupLabels.direct_care, 200, JobRoleFilteringRule.populated), # Loc 1 direct care over upper bound
+                (1, "loc1", date(2024, 1, 1), PrimaryServiceType.care_home_only, MainJobRoleLabels.registered_nurse, JobGroupLabels.regulated_professions, 10, JobRoleFilteringRule.populated),
+                (1, "loc1", date(2024, 1, 1), PrimaryServiceType.care_home_only, MainJobRoleLabels.registered_manager, JobGroupLabels.managers, 10, JobRoleFilteringRule.populated),
+                (1, "loc1", date(2024, 1, 1), PrimaryServiceType.care_home_only, MainJobRoleLabels.other_non_care_related_staff, JobGroupLabels.other, 10, JobRoleFilteringRule.populated),
+                (2, "loc2", date(2024, 1, 1), PrimaryServiceType.care_home_only, MainJobRoleLabels.care_worker, JobGroupLabels.direct_care, 200, JobRoleFilteringRule.populated), # Loc 2 within bounds
+                (2, "loc2", date(2024, 1, 1), PrimaryServiceType.care_home_only, MainJobRoleLabels.registered_nurse, JobGroupLabels.regulated_professions, 20, JobRoleFilteringRule.populated),
+                (2, "loc2", date(2024, 1, 1), PrimaryServiceType.care_home_only, MainJobRoleLabels.registered_manager, JobGroupLabels.managers, 10, JobRoleFilteringRule.populated),
+                (2, "loc2", date(2024, 1, 1), PrimaryServiceType.care_home_only, MainJobRoleLabels.other_non_care_related_staff, JobGroupLabels.other, 10, JobRoleFilteringRule.populated),
+                (3, "loc3", date(2024, 1, 1), PrimaryServiceType.care_home_only, MainJobRoleLabels.care_worker, JobGroupLabels.direct_care, 10, JobRoleFilteringRule.populated), # Loc 3 direct care below lower bound, others above upper bound
+                (3, "loc3", date(2024, 1, 1), PrimaryServiceType.care_home_only, MainJobRoleLabels.registered_nurse, JobGroupLabels.regulated_professions, 10, JobRoleFilteringRule.populated),
+                (3, "loc3", date(2024, 1, 1), PrimaryServiceType.care_home_only, MainJobRoleLabels.registered_manager, JobGroupLabels.managers, 10, JobRoleFilteringRule.populated),
+                (3, "loc3", date(2024, 1, 1), PrimaryServiceType.care_home_only, MainJobRoleLabels.other_non_care_related_staff, JobGroupLabels.other, 10, JobRoleFilteringRule.populated),
+                (4, "loc4", date(2024, 1, 1), PrimaryServiceType.care_home_only, MainJobRoleLabels.care_worker, JobGroupLabels.direct_care, 1, JobRoleFilteringRule.populated), # Loc 4 small location with direct care below lower bound but others above upper bound
+                (4, "loc4", date(2024, 1, 1), PrimaryServiceType.care_home_only, MainJobRoleLabels.registered_nurse, JobGroupLabels.regulated_professions, 1, JobRoleFilteringRule.populated),
+                (4, "loc4", date(2024, 1, 1), PrimaryServiceType.care_home_only, MainJobRoleLabels.registered_manager, JobGroupLabels.managers, 1, JobRoleFilteringRule.populated),
+                (4, "loc4", date(2024, 1, 1), PrimaryServiceType.care_home_only, MainJobRoleLabels.other_non_care_related_staff, JobGroupLabels.other, 1, JobRoleFilteringRule.populated),
+            ],
+            expected_data=[
+                (1, "loc1", date(2024, 1, 1), PrimaryServiceType.care_home_only, MainJobRoleLabels.care_worker, JobGroupLabels.direct_care, None, JobRoleFilteringRule.job_role_group_is_outlier),
+                (1, "loc1", date(2024, 1, 1), PrimaryServiceType.care_home_only, MainJobRoleLabels.registered_nurse, JobGroupLabels.regulated_professions, None, JobRoleFilteringRule.job_role_group_is_outlier),
+                (1, "loc1", date(2024, 1, 1), PrimaryServiceType.care_home_only, MainJobRoleLabels.registered_manager, JobGroupLabels.managers, None, JobRoleFilteringRule.job_role_group_is_outlier),
+                (1, "loc1", date(2024, 1, 1), PrimaryServiceType.care_home_only, MainJobRoleLabels.other_non_care_related_staff, JobGroupLabels.other, None, JobRoleFilteringRule.job_role_group_is_outlier),
+                (2, "loc2", date(2024, 1, 1), PrimaryServiceType.care_home_only, MainJobRoleLabels.care_worker, JobGroupLabels.direct_care, 200, JobRoleFilteringRule.populated),
+                (2, "loc2", date(2024, 1, 1), PrimaryServiceType.care_home_only, MainJobRoleLabels.registered_nurse, JobGroupLabels.regulated_professions, 20, JobRoleFilteringRule.populated),
+                (2, "loc2", date(2024, 1, 1), PrimaryServiceType.care_home_only, MainJobRoleLabels.registered_manager, JobGroupLabels.managers, 10, JobRoleFilteringRule.populated),
+                (2, "loc2", date(2024, 1, 1), PrimaryServiceType.care_home_only, MainJobRoleLabels.other_non_care_related_staff, JobGroupLabels.other, 10, JobRoleFilteringRule.populated),
+                (3, "loc3", date(2024, 1, 1), PrimaryServiceType.care_home_only, MainJobRoleLabels.care_worker, JobGroupLabels.direct_care, None, JobRoleFilteringRule.job_role_group_is_outlier),
+                (3, "loc3", date(2024, 1, 1), PrimaryServiceType.care_home_only, MainJobRoleLabels.registered_nurse, JobGroupLabels.regulated_professions, None, JobRoleFilteringRule.job_role_group_is_outlier),
+                (3, "loc3", date(2024, 1, 1), PrimaryServiceType.care_home_only, MainJobRoleLabels.registered_manager, JobGroupLabels.managers, None, JobRoleFilteringRule.job_role_group_is_outlier),
+                (3, "loc3", date(2024, 1, 1), PrimaryServiceType.care_home_only, MainJobRoleLabels.other_non_care_related_staff, JobGroupLabels.other, None, JobRoleFilteringRule.job_role_group_is_outlier),
+                (4, "loc4", date(2024, 1, 1), PrimaryServiceType.care_home_only, MainJobRoleLabels.care_worker, JobGroupLabels.direct_care, 1, JobRoleFilteringRule.populated),
+                (4, "loc4", date(2024, 1, 1), PrimaryServiceType.care_home_only, MainJobRoleLabels.registered_nurse, JobGroupLabels.regulated_professions, 1, JobRoleFilteringRule.populated),
+                (4, "loc4", date(2024, 1, 1), PrimaryServiceType.care_home_only, MainJobRoleLabels.registered_manager, JobGroupLabels.managers, 1, JobRoleFilteringRule.populated),
+                (4, "loc4", date(2024, 1, 1), PrimaryServiceType.care_home_only, MainJobRoleLabels.other_non_care_related_staff, JobGroupLabels.other, 1, JobRoleFilteringRule.populated),
+            ],
+            upper_bound=0.8,
+            lower_bound=0.2,
+            small_location_threshold=4,
+        ),
     ] # fmt: skip
 
     test_location_sum_expr_rows = [

--- a/projects/_03_independent_cqc/unittest_data/polars_ind_cqc_test_file_data.py
+++ b/projects/_03_independent_cqc/unittest_data/polars_ind_cqc_test_file_data.py
@@ -2851,7 +2851,7 @@ class EstimateFilledPostsByJobRoleCleanUtilsTestCase:
 class EstimateFilledPostsByJobRoleCleanUtilsData:
     filter_when_job_group_ratio_outside_percentile_bounds_test_cases = [
         EstimateFilledPostsByJobRoleCleanUtilsTestCase(
-            id="when_one_job_role_per_job_group",
+            id="filters_locations_outside_bounds_when_one_job_role_per_job_group",
             test_data=[
                 (1,"loc1", date(2024, 1, 1), PrimaryServiceType.care_home_only, MainJobRoleLabels.care_worker, JobGroupLabels.direct_care, 20, JobRoleFilteringRule.populated), # Loc 1 direct care over upper bound
                 (1, "loc1", date(2024, 1, 1), PrimaryServiceType.care_home_only, MainJobRoleLabels.registered_nurse, JobGroupLabels.regulated_professions, 1, JobRoleFilteringRule.populated),
@@ -2885,7 +2885,7 @@ class EstimateFilledPostsByJobRoleCleanUtilsData:
             small_location_threshold=1,
         ),
         EstimateFilledPostsByJobRoleCleanUtilsTestCase(
-            id="when_multiple_job_role_per_job_group",
+            id="filters_locations_outside_bounds_when_multiple_job_role_per_job_group",
             test_data=[
                 (1,"loc1", date(2024, 1, 1), PrimaryServiceType.care_home_only, MainJobRoleLabels.care_worker, JobGroupLabels.direct_care, 20, JobRoleFilteringRule.populated), # Loc 1 direct care over upper bound
                 (1, "loc1", date(2024, 1, 1), PrimaryServiceType.care_home_only, MainJobRoleLabels.registered_nurse, JobGroupLabels.regulated_professions, 1, JobRoleFilteringRule.populated),
@@ -2927,7 +2927,7 @@ class EstimateFilledPostsByJobRoleCleanUtilsData:
             small_location_threshold=1,
         ),
         EstimateFilledPostsByJobRoleCleanUtilsTestCase(
-            id="when_ratio_is exactly_on_bound",
+            id="retains_values_when_ratio_is exactly_on_bound",
             test_data=[
                 (1, "loc1", date(2024, 1, 1), PrimaryServiceType.care_home_only, MainJobRoleLabels.care_worker, JobGroupLabels.direct_care, 5, JobRoleFilteringRule.populated),
                 (1, "loc1", date(2024, 1, 1), PrimaryServiceType.care_home_only, MainJobRoleLabels.registered_nurse, JobGroupLabels.regulated_professions, 5, JobRoleFilteringRule.populated),
@@ -2941,7 +2941,7 @@ class EstimateFilledPostsByJobRoleCleanUtilsData:
             small_location_threshold=1,
         ),
         EstimateFilledPostsByJobRoleCleanUtilsTestCase(
-            id="when_multiple_primary_service_types_present",
+            id="filters_locations_outside_bounds_when_multiple_primary_service_types_present",
             test_data=[
                 (1, "loc1", date(2024, 1, 1), PrimaryServiceType.care_home_only, MainJobRoleLabels.care_worker, JobGroupLabels.direct_care, 20, JobRoleFilteringRule.populated), # Loc 1 direct care over upper bound
                 (1, "loc1", date(2024, 1, 1), PrimaryServiceType.care_home_only, MainJobRoleLabels.registered_nurse, JobGroupLabels.regulated_professions, 1, JobRoleFilteringRule.populated),
@@ -2975,7 +2975,7 @@ class EstimateFilledPostsByJobRoleCleanUtilsData:
             small_location_threshold=1,
         ),
         EstimateFilledPostsByJobRoleCleanUtilsTestCase(
-            id="when_multiple_locations_and_dates_present",
+            id="filters_locations_outside_bounds_when_multiple_locations_and_dates_present",
             test_data=[
                 (1, "loc1", date(2024, 1, 1), PrimaryServiceType.care_home_only, MainJobRoleLabels.care_worker, JobGroupLabels.direct_care, 20, JobRoleFilteringRule.populated), # Loc 1 in 2024 Direct care above upper bound
                 (1, "loc1", date(2024, 1, 1), PrimaryServiceType.care_home_only, MainJobRoleLabels.registered_nurse, JobGroupLabels.regulated_professions, 1, JobRoleFilteringRule.populated),
@@ -3009,7 +3009,7 @@ class EstimateFilledPostsByJobRoleCleanUtilsData:
             small_location_threshold=1,
         ),
         EstimateFilledPostsByJobRoleCleanUtilsTestCase(
-            id="when_null_values_present",
+            id="filters_locations_outside_bounds_when_null_values_present",
             test_data=[
                 (1,"loc1", date(2024, 1, 1), PrimaryServiceType.care_home_only, MainJobRoleLabels.care_worker, JobGroupLabels.direct_care, 20, JobRoleFilteringRule.populated),
                 (1, "loc1", date(2024, 1, 1), PrimaryServiceType.care_home_only, MainJobRoleLabels.registered_nurse, JobGroupLabels.regulated_professions, 1, JobRoleFilteringRule.populated),
@@ -3051,7 +3051,7 @@ class EstimateFilledPostsByJobRoleCleanUtilsData:
             small_location_threshold=1,
         ),
         EstimateFilledPostsByJobRoleCleanUtilsTestCase(
-            id="when_small_location_outside_bounds",
+            id="small_locations_not_filtered_when_outside_bounds",
             test_data=[
                 (1,"loc1", date(2024, 1, 1), PrimaryServiceType.care_home_only, MainJobRoleLabels.care_worker, JobGroupLabels.direct_care, 200, JobRoleFilteringRule.populated), # Loc 1 direct care over upper bound
                 (1, "loc1", date(2024, 1, 1), PrimaryServiceType.care_home_only, MainJobRoleLabels.registered_nurse, JobGroupLabels.regulated_professions, 10, JobRoleFilteringRule.populated),
@@ -3093,7 +3093,7 @@ class EstimateFilledPostsByJobRoleCleanUtilsData:
             small_location_threshold=5,
         ),
         EstimateFilledPostsByJobRoleCleanUtilsTestCase(
-            id="when_small_location_outside_bounds_and_on_small_location_threshold",
+            id="small_locations_not_filtered_when_outside_bounds_and_on_small_location_threshold",
             test_data=[
                 (1,"loc1", date(2024, 1, 1), PrimaryServiceType.care_home_only, MainJobRoleLabels.care_worker, JobGroupLabels.direct_care, 200, JobRoleFilteringRule.populated), # Loc 1 direct care over upper bound
                 (1, "loc1", date(2024, 1, 1), PrimaryServiceType.care_home_only, MainJobRoleLabels.registered_nurse, JobGroupLabels.regulated_professions, 10, JobRoleFilteringRule.populated),


### PR DESCRIPTION
## Description
Trello ticket [#1649](https://trello.com/c/y0kz7rmP/1649-jr-filtering-1-apply-the-job-group-filter-to-locations-with-50-staff)

Remove locations with fewer than 50 workers from the filtering

## Testing
- [x] Unit tests passing
- [x] Successful [Step Function run](https://eu-west-2.console.aws.amazon.com/states/home?region=eu-west-2#/v2/executions/details/arn:aws:states:eu-west-2:856699698263:execution:1649-jrf1-50plus-Ind-CQC-Filled-Post-Estimates-By-Role:57d32b2a-dfdb-4768-9682-4400ceb160b8)
- [x] Outputs checked in Athena

Case study outputs in athena. None of the small locations had data removed by filter.

## Checklist (delete if not relevant)
- [x] Unit tests added/amended
- [x] Docstrings added/updated
- [x] Updated CHANGELOG
- [x] Code reviewed by AI
- [x] Moved Trello ticket to PR column

## Reviewer checklist
- [ ] PR solves the Trello ticket requirements
- [ ] Outputs appear reasonable and understandable
- [ ] The overall approach is appropriate and not over-engineered
- [ ] No obvious scalability, performance or interdependency concerns
- [ ] Tests appropriately cover the main behaviour/edge cases
- [ ] Naming and structure are broadly understandable and consistent
- [ ] Docstrings are sufficient for future maintenance
- [ ] Docstrings cover non-obvious behaviour
