### PR TITLE
1652 - Add Providerid and Brandid columns to clean job within Estimates by job role Pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ All notable changes to this project will be documented in this file.
 
 - Added `--delete` to all sws s3 sync commands to ensure that the files present in the destination bucket but no longer present in the source bucket are removed during sync.
 
+- Added `providerid` and `brandid` columns to the clean job within Estimates by Job Role Pipeline.
+
 ### Changed
 - Renamed replace_care_navigator_with_care_coordinator to remap_mainjrid_codes for clarity and optimised implementation to use dictionary-based replacements targeting the main_job_role_clean column and updated corresponding test data names. Added Technician Job Role('22') in the dictionary to replace it with Other non-care-providing job roles ('27').
 

--- a/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/_01_merge.py
+++ b/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/_01_merge.py
@@ -15,7 +15,8 @@ pl.Config.set_streaming_chunk_size(50000)
 
 metadata_columns = {
     IndCQC.name: str,
-    IndCQC.provider_id: str,
+    IndCQC.provider_id: CatColType.ProviderCatType,
+    IndCQC.brand_id: CatColType.BrandCatType,
     IndCQC.services_offered: pl.List(str),
     IndCQC.primary_service_type_second_level: pl.Categorical,
     IndCQC.care_home: pl.Categorical,

--- a/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/_02_clean.py
+++ b/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/_02_clean.py
@@ -63,7 +63,7 @@ def main(
     )
     print("Merged Metadata LazyFrame read in")
     print(
-        f"estimated_job_role_posts_lf_TotalRecords before join: {estimated_job_role_posts_lf.count()}"
+        f"estimated_job_role_posts_lf_TotalRecords before join: {estimated_job_role_posts_lf.select(IndCQC.id_per_locationid_import_date).collect().height}"
     )
     # add metadata columns to estimated_job_role_posts_lf
     estimated_job_role_posts_lf = estimated_job_role_posts_lf.join(
@@ -73,7 +73,7 @@ def main(
     )
 
     print(
-        f"estimated_job_role_posts_lf_TotalRecords after join: {estimated_job_role_posts_lf.count()}"
+        f"estimated_job_role_posts_lf_TotalRecords after join: {estimated_job_role_posts_lf.select(IndCQC.id_per_locationid_import_date).collect().height}"
     )
 
     estimated_job_role_posts_lf = estimated_job_role_posts_lf.with_row_index(

--- a/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/_02_clean.py
+++ b/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/_02_clean.py
@@ -62,18 +62,12 @@ def main(
         utils.cast_to_schema(metadata_columns_to_import_schema)
     )
     print("Merged Metadata LazyFrame read in")
-    print(
-        f"estimated_job_role_posts_lf_TotalRecords before join: {estimated_job_role_posts_lf.select(IndCQC.id_per_locationid_import_date).collect().height}"
-    )
+
     # add metadata columns to estimated_job_role_posts_lf
     estimated_job_role_posts_lf = estimated_job_role_posts_lf.join(
         merged_metadata_lf,
         on=IndCQC.id_per_locationid_import_date,
         how="left",
-    )
-
-    print(
-        f"estimated_job_role_posts_lf_TotalRecords after join: {estimated_job_role_posts_lf.select(IndCQC.id_per_locationid_import_date).collect().height}"
     )
 
     estimated_job_role_posts_lf = estimated_job_role_posts_lf.with_row_index(

--- a/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/_02_clean.py
+++ b/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/_02_clean.py
@@ -62,12 +62,18 @@ def main(
         utils.cast_to_schema(metadata_columns_to_import_schema)
     )
     print("Merged Metadata LazyFrame read in")
-
+    print(
+        f"estimated_job_role_posts_lf_TotalRecords before join: {estimated_job_role_posts_lf.count()}"
+    )
     # add metadata columns to estimated_job_role_posts_lf
     estimated_job_role_posts_lf = estimated_job_role_posts_lf.join(
         merged_metadata_lf,
         on=IndCQC.id_per_locationid_import_date,
         how="left",
+    )
+
+    print(
+        f"estimated_job_role_posts_lf_TotalRecords after join: {estimated_job_role_posts_lf.count()}"
     )
 
     estimated_job_role_posts_lf = estimated_job_role_posts_lf.with_row_index(

--- a/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/_02_clean.py
+++ b/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/_02_clean.py
@@ -31,9 +31,16 @@ estimates_by_job_role_schema = {
     IndCQC.ascwds_job_role_counts: pl.Int16,
 }
 
+metadata_columns_to_import_schema = {
+    IndCQC.id_per_locationid_import_date: pl.UInt32,
+    IndCQC.provider_id: CatColType.ProviderCatType,
+    IndCQC.brand_id: CatColType.BrandCatType,
+}
+
 
 def main(
     merged_data_source: str,
+    merged_metadata_source: str,
     cleaned_data_destination: str,
 ) -> None:
     """
@@ -41,6 +48,7 @@ def main(
 
     Args:
         merged_data_source (str): path to the merged data
+        merged_metadata_source (str): path to the merged metadata
         cleaned_data_destination (str): destination for output
     """
     print("Cleaning merged_ind_cqc dataset...")
@@ -49,6 +57,19 @@ def main(
         utils.cast_to_schema(estimates_by_job_role_schema)
     )
     print("Merged LazyFrame read in")
+
+    merged_metadata_lf = utils.scan_parquet(merged_metadata_source).with_columns(
+        utils.cast_to_schema(metadata_columns_to_import_schema)
+    )
+    print("Merged Metadata LazyFrame read in")
+
+    # add metadata columns to estimated_job_role_posts_lf
+    estimated_job_role_posts_lf = estimated_job_role_posts_lf.join(
+        merged_metadata_lf,
+        on=IndCQC.id_per_locationid_import_date,
+        how="left",
+    )
+
     estimated_job_role_posts_lf = estimated_job_role_posts_lf.with_row_index(
         IndCQC.id_per_locationid_import_date_job_role
     )
@@ -82,8 +103,11 @@ def main(
     )
 
     # Drop job role group as this will be reallocated in later job
+    # Drop providerid and brandid which are just used for filtering and not needed for impute and estimate steps.
     estimated_job_role_posts_lf = estimated_job_role_posts_lf.drop(
-        IndCQC.main_job_group_labelled
+        IndCQC.main_job_group_labelled,
+        IndCQC.provider_id,
+        IndCQC.brand_id,
     )
 
     utils.sink_to_parquet(
@@ -99,9 +123,14 @@ if __name__ == "__main__":
             "--merged_data_source",
             "Source s3 directory for merged data",
         ),
+        (
+            "--merged_metadata_source",
+            "Source s3 directory for merged metadata",
+        ),
         ("--cleaned_data_destination", "Destination s3 directory for cleaned data"),
     )
     main(
         merged_data_source=args.merged_data_source,
+        merged_metadata_source=args.merged_metadata_source,
         cleaned_data_destination=args.cleaned_data_destination,
     )

--- a/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/utils/utils.py
+++ b/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/utils/utils.py
@@ -122,6 +122,10 @@ class CategoricalColumnTypes:
     EstablishmentCatType = pl.Categorical(
         pl.Categories("establishment", namespace="filled_posts")
     )
+    ProviderCatType = pl.Categorical(
+        pl.Categories("provider", namespace="filled_posts")
+    )
+    BrandCatType = pl.Categorical(pl.Categories("brand", namespace="filled_posts"))
     JobRoleEnumType = pl.Enum(AscwdsWorkerValueLabelsJobGroup.all_roles())
     JobGroupEnumType = pl.Enum(AscwdsWorkerValueLabelsJobGroup.all_job_groups())
     EstimatesFilledPostSourceEnumType = pl.Enum(

--- a/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/validate_01_merge_metadata.py
+++ b/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/validate_01_merge_metadata.py
@@ -135,7 +135,7 @@ def main(
         # Schema check
         .col_schema_match(
             schema=EXPECTED_SCHEMA,
-            brief="Dataset schema {} should match the expected schema",
+            brief="Dataset schema should match the expected schema",
         )
         # Dataset size
         .row_count_match(

--- a/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/validate_01_merge_metadata.py
+++ b/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/validate_01_merge_metadata.py
@@ -65,7 +65,8 @@ EXPECTED_SCHEMA = pb.Schema(
     columns={
         IndCqcColumns.id_per_locationid_import_date: "UInt32",
         IndCqcColumns.name: "String",
-        IndCqcColumns.provider_id: "String",
+        IndCqcColumns.provider_id: str(CategoricalColumnTypes.ProviderCatType),
+        IndCqcColumns.brand_id: str(CategoricalColumnTypes.BrandCatType),
         IndCqcColumns.primary_service_type_second_level: "Categorical",
         IndCqcColumns.care_home: "Categorical",
         IndCqcColumns.dormancy: "Categorical",

--- a/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/validate_01_merge_metadata.py
+++ b/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/validate_01_merge_metadata.py
@@ -31,6 +31,7 @@ VALIDATION_COLS_TO_IMPORT = [
     IndCqcColumns.id_per_locationid_import_date,
     IndCqcColumns.name,
     IndCqcColumns.provider_id,
+    IndCqcColumns.brand_id,
     IndCqcColumns.services_offered,
     IndCqcColumns.primary_service_type_second_level,
     IndCqcColumns.care_home,
@@ -133,7 +134,8 @@ def main(
         )
         # Schema check
         .col_schema_match(
-            schema=EXPECTED_SCHEMA, brief="Dataset should match the expected schema"
+            schema=EXPECTED_SCHEMA,
+            brief="Dataset schema {} should match the expected schema",
         )
         # Dataset size
         .row_count_match(

--- a/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/tests/fargate/test_02_clean.py
+++ b/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/tests/fargate/test_02_clean.py
@@ -17,6 +17,7 @@ PATCH_PATH = "projects._03_independent_cqc._07_estimate_filled_posts_by_job_role
 
 class MainTests(unittest.TestCase):
     MERGED_DATA_SOURCE = "some/source"
+    MERGED_METADATA_SOURCE = "some/metadata/source"
     CLEANED_DATA_DESTINATION = "some/destination"
 
     mock_estimated_job_role_posts_lf = pl.LazyFrame()
@@ -26,6 +27,7 @@ class MainTests(unittest.TestCase):
         Data.expected_data,
         Schemas.expected_schema,
     )
+    metadata_lf = pl.LazyFrame(Data.metadata, Schemas.metadata_schema)
 
     @patch(f"{PATCH_PATH}.utils.sink_to_parquet")
     @patch(f"{PATCH_PATH}.cUtils.filter_job_role_group_outliers")
@@ -35,7 +37,7 @@ class MainTests(unittest.TestCase):
     @patch(f"{PATCH_PATH}.cUtils.nullify_job_role_count_when_source_not_ascwds")
     @patch(
         f"{PATCH_PATH}.utils.scan_parquet",
-        side_effect=[mock_estimated_job_role_posts_lf],
+        side_effect=[mock_estimated_job_role_posts_lf, metadata_lf],
     )
     def test_main_runs(
         self,
@@ -47,13 +49,18 @@ class MainTests(unittest.TestCase):
         filter_job_role_group_outliers_mock: Mock,
         sink_to_parquet_mock: Mock,
     ):
-        job.main(self.MERGED_DATA_SOURCE, self.CLEANED_DATA_DESTINATION)
+        job.main(
+            self.MERGED_DATA_SOURCE,
+            self.MERGED_METADATA_SOURCE,
+            self.CLEANED_DATA_DESTINATION,
+        )
 
-        self.assertEqual(scan_parquet_mock.call_count, 1)
+        self.assertEqual(scan_parquet_mock.call_count, 2)
         scan_parquet_mock.assert_has_calls(
             [
                 call(self.MERGED_DATA_SOURCE),
-            ]
+                call(self.MERGED_METADATA_SOURCE),
+            ],
         )
 
         nullify_job_role_count_when_source_not_ascwds_mock.assert_called_once()
@@ -71,14 +78,18 @@ class MainTests(unittest.TestCase):
     @patch(f"{PATCH_PATH}.utils.sink_to_parquet")
     @patch(
         f"{PATCH_PATH}.utils.scan_parquet",
-        side_effect=[test_estimated_job_role_posts_lf],
+        side_effect=[test_estimated_job_role_posts_lf, metadata_lf],
     )
     def test_main_runs_with_data(
         self,
         scan_parquet_mock: Mock,
         sink_to_parquet_mock: Mock,
     ):
-        job.main(self.MERGED_DATA_SOURCE, self.CLEANED_DATA_DESTINATION)
+        job.main(
+            self.MERGED_DATA_SOURCE,
+            self.MERGED_METADATA_SOURCE,
+            self.CLEANED_DATA_DESTINATION,
+        )
 
         pltesting.assert_frame_equal(
             sink_to_parquet_mock.call_args.kwargs["lazy_df"],

--- a/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/tests/fargate/test_validate_01_merge_metadata.py
+++ b/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/tests/fargate/test_validate_01_merge_metadata.py
@@ -22,6 +22,7 @@ class ValidateJobRoleEstimatesTests(unittest.TestCase):
             IndCqcColumns.id_per_locationid_import_date: pl.UInt32,
             IndCqcColumns.name: pl.String,
             IndCqcColumns.provider_id: pl.String,
+            IndCqcColumns.brand_id: pl.String,
             IndCqcColumns.care_home: pl.String,
             IndCqcColumns.primary_service_type_second_level: pl.String,
             IndCqcColumns.imputed_registration_date: pl.Date,
@@ -46,8 +47,8 @@ class ValidateJobRoleEstimatesTests(unittest.TestCase):
             CQCLVal.services_offered_is_not_null: pl.Int64,
         }
         source_rows = [
-            ("1-001", date(2025, 1, 1), 1, "name1", "1-001", "Y", "something", date(2023, 1, 1), date(2022, 1, 1), "FilteringRule A", date(2023, 1, 2), "CSSR A", "Region A", "ICB A", "RUI A", "LSOA A", "MSOA A", "Estimate Source A", 10.0, 5.0, 7.0, 50.0, 100.0, "Not Dormant", 8.0, 1, 1),
-            ("2-002", date(2025, 1, 2), 2, "name2", "2-002", "N", "something", date(2023, 1, 2), date(2022, 1, 2), "FilteringRule B", date(2023, 1, 2), "CSSR B", "Region B", "ICB B", "RUI B", "LSOA B", "MSOA B", "Estimate Source B", 15.0, 10.0, 12.0, 60.0, 120.0, "Dormant", 13.0, 1, 1),
+            ("1-001", date(2025, 1, 1), 1, "name1", "1-001", "1-001", "Y", "something", date(2023, 1, 1), date(2022, 1, 1), "FilteringRule A", date(2023, 1, 2), "CSSR A", "Region A", "ICB A", "RUI A", "LSOA A", "MSOA A", "Estimate Source A", 10.0, 5.0, 7.0, 50.0, 100.0, "Not Dormant", 8.0, 1, 1),
+            ("2-002", date(2025, 1, 2), 2, "name2", "2-002", None, "N", "something", date(2023, 1, 2), date(2022, 1, 2), "FilteringRule B", date(2023, 1, 2), "CSSR B", "Region B", "ICB B", "RUI B", "LSOA B", "MSOA B", "Estimate Source B", 15.0, 10.0, 12.0, 60.0, 120.0, "Dormant", 13.0, 1, 1),
         ]  # fmt: skip
         self.source_df = pl.DataFrame(source_rows, source_schema, orient="row")
         self.compare_df = self.source_df.select(

--- a/projects/_03_independent_cqc/unittest_data/polars_ind_cqc_test_file_data.py
+++ b/projects/_03_independent_cqc/unittest_data/polars_ind_cqc_test_file_data.py
@@ -3350,7 +3350,7 @@ class EstimateFilledPostsByJobRoleCleanData:
     }
 
     metadata = {
-        IndCQC.id_per_locationid_import_date: [1] * 4,
-        IndCQC.provider_id: ["provider1"] * 4,
-        IndCQC.brand_id: ["brand1"] * 4,
+        IndCQC.id_per_locationid_import_date: [1],
+        IndCQC.provider_id: ["provider1"],
+        IndCQC.brand_id: ["brand1"],
     }

--- a/projects/_03_independent_cqc/unittest_data/polars_ind_cqc_test_file_data.py
+++ b/projects/_03_independent_cqc/unittest_data/polars_ind_cqc_test_file_data.py
@@ -3348,3 +3348,9 @@ class EstimateFilledPostsByJobRoleCleanData:
         IndCQC.registered_manager_names: [["Manager 1", "Manager 2"]] * 4,
         IndCQC.job_role_filtering_rule: [JobRoleFilteringRule.populated] * 4,
     }
+
+    metadata = {
+        IndCQC.id_per_locationid_import_date: [1] * 4,
+        IndCQC.provider_id: ["provider1"] * 4,
+        IndCQC.brand_id: ["brand1"] * 4,
+    }

--- a/projects/_03_independent_cqc/unittest_data/polars_ind_cqc_test_file_schemas.py
+++ b/projects/_03_independent_cqc/unittest_data/polars_ind_cqc_test_file_schemas.py
@@ -1773,3 +1773,9 @@ class EstimateFilledPostsByJobRoleCleanSchemas:
         IndCQC.registered_manager_names: pl.List(str),
         IndCQC.job_role_filtering_rule: CatColType.JobRoleFilteringRuleCatType,
     }
+
+    metadata_schema = {
+        IndCQC.id_per_locationid_import_date: pl.UInt32,
+        IndCQC.provider_id: CatColType.ProviderCatType,
+        IndCQC.brand_id: CatColType.BrandCatType,
+    }

--- a/terraform/pipeline/step-functions/dynamic/Ind-CQC-Filled-Post-Estimates-By-Role.json
+++ b/terraform/pipeline/step-functions/dynamic/Ind-CQC-Filled-Post-Estimates-By-Role.json
@@ -96,6 +96,7 @@
                               "Command": [
                                 "_02_clean.py",
                                 "--merged_data_source", "${dataset_bucket_uri}/domain=ind_cqc_filled_posts/dataset=ind_cqc_07_01_merge_job_roles/",
+                                "--merged_metadata_source", "${dataset_bucket_uri}/domain=ind_cqc_filled_posts/dataset=ind_cqc_07_01_merge_metadata_job_roles/",
                                 "--cleaned_data_destination", "${dataset_bucket_uri}/domain=ind_cqc_filled_posts/dataset=ind_cqc_07_02_clean_job_roles/"
                               ]
                             }

--- a/terraform/pipeline/step-functions/dynamic/Ind-CQC-Filled-Post-Estimates.json
+++ b/terraform/pipeline/step-functions/dynamic/Ind-CQC-Filled-Post-Estimates.json
@@ -964,6 +964,7 @@
                                     "Command": [
                                       "_02_clean.py",
                                       "--merged_data_source", "${dataset_bucket_uri}/domain=ind_cqc_filled_posts/dataset=ind_cqc_07_01_merge_job_roles/",
+                                      "--merged_metadata_source", "${dataset_bucket_uri}/domain=ind_cqc_filled_posts/dataset=ind_cqc_07_01_merge_metadata_job_roles/",
                                       "--cleaned_data_destination", "${dataset_bucket_uri}/domain=ind_cqc_filled_posts/dataset=ind_cqc_07_02_clean_job_roles/"
                                     ]
                                   }


### PR DESCRIPTION
## Description
Trello ticket [#1652](https://trello.com/c/TZnDZHAs/1652-jr-filtering-4-pull-in-provider-id-and-brand-id-columns-in-clean-job)

Added provider and brand id columns. They are joined in from the metadata and dropped at the end of the clean job.

## Testing
- [x] Unit tests passing
- [x] Successful [Step Function run](https://eu-west-2.console.aws.amazon.com/states/home?region=eu-west-2#/v2/executions/details/arn:aws:states:eu-west-2:856699698263:execution:1652-jr-cln-add-cols-Ind-CQC-Filled-Post-Estimates-By-Role:466536f1-bf20-439b-80c1-0f3ad834498a)
- [x] Outputs checked in Athena

[Add any additional testing information here - add screenshot if relevant]

## Checklist (delete if not relevant)
- [x] Unit tests added/amended
- [x] Docstrings added/updated
- [x] Updated CHANGELOG
- [x] Code reviewed by AI
- [x] Moved Trello ticket to PR column

## Reviewer checklist
- [ ] PR solves the Trello ticket requirements
- [ ] Outputs appear reasonable and understandable
- [ ] The overall approach is appropriate and not over-engineered
- [ ] No obvious scalability, performance or interdependency concerns
- [ ] Tests appropriately cover the main behaviour/edge cases
- [ ] Naming and structure are broadly understandable and consistent
- [ ] Docstrings are sufficient for future maintenance
- [ ] Docstrings cover non-obvious behaviour
