### PR TITLE
1647 cnv imptn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ All notable changes to this project will be documented in this file.
 
 - Added validations for cleaned data within Estimates by Job Roles Pipeline.
 
+- Converted model_imputation function and called in imputation and estimates job scripts where possible. Unworkable calls are added but commented out.
+
 ### Changed
 - Renamed replace_care_navigator_with_care_coordinator to remap_mainjrid_codes for clarity and optimised implementation to use dictionary-based replacements targeting the main_job_role_clean column and updated corresponding test data names. Added Technician Job Role('22') in the dictionary to replace it with Other non-care-providing job roles ('27').
 

--- a/projects/_03_independent_cqc/_03_impute/fargate/impute_ind_cqc_ascwds_and_pir.py
+++ b/projects/_03_independent_cqc/_03_impute/fargate/impute_ind_cqc_ascwds_and_pir.py
@@ -136,12 +136,13 @@ def main(cleaned_ind_cqc_source: str, destination: str) -> None:
         extrapolation_method="ratio",
     )
 
-    lf = utils.nullify_ct_values_previous_to_first_submission(
-        lf,
-        [
-            IndCQC.ct_care_home_total_employed_imputed,
-            IndCQC.ct_non_res_care_workers_employed_imputed,
-        ],
+    lf = lf.with_columns(
+        utils.nullify_ct_values_previous_to_first_submission(
+            [
+                IndCQC.ct_care_home_total_employed_imputed,
+                IndCQC.ct_non_res_care_workers_employed_imputed,
+            ],
+        )
     )
 
     print(f"Exporting as parquet to {destination}")

--- a/projects/_03_independent_cqc/_03_impute/fargate/impute_ind_cqc_ascwds_and_pir.py
+++ b/projects/_03_independent_cqc/_03_impute/fargate/impute_ind_cqc_ascwds_and_pir.py
@@ -135,7 +135,13 @@ def main(cleaned_ind_cqc_source: str, destination: str) -> None:
         extrapolation_method="ratio",
     )
 
-    # nullify_ct_values_previous_to_first_submission
+    lf = utils.nullify_ct_values_previous_to_first_submission(
+        lf,
+        [
+            IndCQC.ct_care_home_total_employed_imputed,
+            IndCQC.ct_non_res_care_workers_employed_imputed,
+        ],
+    )
 
     print(f"Exporting as parquet to {destination}")
 

--- a/projects/_03_independent_cqc/_03_impute/fargate/impute_ind_cqc_ascwds_and_pir.py
+++ b/projects/_03_independent_cqc/_03_impute/fargate/impute_ind_cqc_ascwds_and_pir.py
@@ -2,17 +2,19 @@ from dataclasses import dataclass
 
 import polars as pl
 
-from polars_utils import utils, cleaning_utils as cUtils
+from polars_utils import cleaning_utils as cUtils
+from polars_utils import utils
 from polars_utils.expressions import is_care_home
-from projects._03_independent_cqc._03_impute.fargate.utils.primary_service_rate_of_change import (
-    model_primary_service_rate_of_change_trendline,
-)
 from projects._03_independent_cqc._03_impute.fargate.utils.convert_pir_people_to_filled_posts import (
     convert_pir_to_filled_posts,
 )
 from projects._03_independent_cqc._03_impute.fargate.utils.forward_fill_latest_known_value import (
     forward_fill_latest_known_value,
 )
+from projects._03_independent_cqc._03_impute.fargate.utils.primary_service_rate_of_change import (
+    model_primary_service_rate_of_change_trendline,
+)
+from projects._03_independent_cqc.utils.imputation.imputation import model_imputation
 from utils.column_names.ind_cqc_pipeline_columns import IndCqcColumns as IndCQC
 
 
@@ -63,9 +65,23 @@ def main(cleaned_ind_cqc_source: str, destination: str) -> None:
 
     # merge_ascwds_and_pir_filled_post_submissions
 
-    # model_imputation_with_extrapolation_and_interpolation - imputed_filled_post_model
+    lf = model_imputation(
+        lf,
+        IndCQC.ascwds_pir_merged,
+        IndCQC.ascwds_rate_of_change_trendline_model,
+        IndCQC.imputed_filled_post_model,
+        care_home=False,
+        extrapolation_method="ratio",
+    )
 
-    # model_imputation_with_extrapolation_and_interpolation - imputed_filled_posts_per_bed_ratio_model
+    lf = model_imputation(
+        lf,
+        IndCQC.filled_posts_per_bed_ratio,
+        IndCQC.ascwds_rate_of_change_trendline_model,
+        IndCQC.imputed_filled_posts_per_bed_ratio_model,
+        care_home=True,
+        extrapolation_method="ratio",
+    )
 
     # model_calculate_rolling_average - posts_rolling_average_model
 
@@ -101,9 +117,23 @@ def main(cleaned_ind_cqc_source: str, destination: str) -> None:
         max_days_between_submissions=NumericalValues.max_number_of_days_to_interpolate_between,
     )
 
-    # model_imputation_with_extrapolation_and_interpolation - ct_care_home_total_employed_imputed
+    lf = model_imputation(
+        lf,
+        IndCQC.ct_care_home_total_employed_cleaned,
+        IndCQC.ct_combined_care_home_and_non_res_rate_of_change_trendline,
+        IndCQC.ct_care_home_total_employed_imputed,
+        care_home=True,
+        extrapolation_method="ratio",
+    )
 
-    # model_imputation_with_extrapolation_and_interpolation - ct_non_res_care_workers_employed_imputed
+    lf = model_imputation(
+        lf,
+        IndCQC.ct_non_res_care_workers_employed_cleaned,
+        IndCQC.ct_combined_care_home_and_non_res_rate_of_change_trendline,
+        IndCQC.ct_non_res_care_workers_employed_imputed,
+        care_home=False,
+        extrapolation_method="ratio",
+    )
 
     # nullify_ct_values_previous_to_first_submission
 

--- a/projects/_03_independent_cqc/_03_impute/fargate/impute_ind_cqc_ascwds_and_pir.py
+++ b/projects/_03_independent_cqc/_03_impute/fargate/impute_ind_cqc_ascwds_and_pir.py
@@ -65,14 +65,15 @@ def main(cleaned_ind_cqc_source: str, destination: str) -> None:
 
     # merge_ascwds_and_pir_filled_post_submissions
 
-    lf = model_imputation(
-        lf,
-        IndCQC.ascwds_pir_merged,
-        IndCQC.ascwds_rate_of_change_trendline_model,
-        IndCQC.imputed_filled_post_model,
-        care_home=False,
-        extrapolation_method="ratio",
-    )
+    # Uncomment this call when merge_ascwds_and_pir_filled_post_submissions is converted to polars.
+    # lf = model_imputation(
+    #     lf,
+    #     IndCQC.ascwds_pir_merged,
+    #     IndCQC.ascwds_rate_of_change_trendline_model,
+    #     IndCQC.imputed_filled_post_model,
+    #     care_home=False,
+    #     extrapolation_method="ratio",
+    # )
 
     lf = model_imputation(
         lf,

--- a/projects/_03_independent_cqc/_03_impute/tests/fargate/test_impute_ind_cqc_ascwds_and_pir.py
+++ b/projects/_03_independent_cqc/_03_impute/tests/fargate/test_impute_ind_cqc_ascwds_and_pir.py
@@ -25,6 +25,7 @@ class ImputeIndCqcAscwdsAndPirTests(unittest.TestCase):
     mock_data = Mock(name="data")
 
     @patch(f"{PATCH_PATH}.utils.sink_to_parquet")
+    @patch(f"{PATCH_PATH}.model_imputation")
     @patch(f"{PATCH_PATH}.convert_pir_to_filled_posts")
     @patch(f"{PATCH_PATH}.model_primary_service_rate_of_change_trendline")
     @patch(f"{PATCH_PATH}.cUtils.calculate_filled_posts_per_bed_ratio")
@@ -37,6 +38,7 @@ class ImputeIndCqcAscwdsAndPirTests(unittest.TestCase):
         calculate_filled_posts_per_bed_ratio_mock: Mock,
         model_roc_trendline_mock: Mock,
         convert_pir_to_filled_posts_mock: Mock,
+        model_imputation_mock: Mock,
         sink_to_parquet_mock: Mock,
     ):
 
@@ -50,6 +52,7 @@ class ImputeIndCqcAscwdsAndPirTests(unittest.TestCase):
         calculate_filled_posts_per_bed_ratio_mock.assert_called_once()
         self.assertEqual(model_roc_trendline_mock.call_count, 2)
         convert_pir_to_filled_posts_mock.assert_called_once()
+        self.assertEqual(model_imputation_mock.call_count, 4)
         sink_to_parquet_mock.assert_called_once_with(
             ANY,
             self.TEST_DESTINATION,

--- a/projects/_03_independent_cqc/_03_impute/tests/fargate/test_impute_ind_cqc_ascwds_and_pir.py
+++ b/projects/_03_independent_cqc/_03_impute/tests/fargate/test_impute_ind_cqc_ascwds_and_pir.py
@@ -25,6 +25,7 @@ class ImputeIndCqcAscwdsAndPirTests(unittest.TestCase):
     mock_data = Mock(name="data")
 
     @patch(f"{PATCH_PATH}.utils.sink_to_parquet")
+    @patch(f"{PATCH_PATH}.utils.nullify_ct_values_previous_to_first_submission")
     @patch(f"{PATCH_PATH}.model_imputation")
     @patch(f"{PATCH_PATH}.convert_pir_to_filled_posts")
     @patch(f"{PATCH_PATH}.model_primary_service_rate_of_change_trendline")
@@ -39,6 +40,7 @@ class ImputeIndCqcAscwdsAndPirTests(unittest.TestCase):
         model_roc_trendline_mock: Mock,
         convert_pir_to_filled_posts_mock: Mock,
         model_imputation_mock: Mock,
+        nullify_ct_values_previous_to_first_submission_mock: Mock,
         sink_to_parquet_mock: Mock,
     ):
 
@@ -53,6 +55,7 @@ class ImputeIndCqcAscwdsAndPirTests(unittest.TestCase):
         self.assertEqual(model_roc_trendline_mock.call_count, 2)
         convert_pir_to_filled_posts_mock.assert_called_once()
         self.assertEqual(model_imputation_mock.call_count, 4)
+        nullify_ct_values_previous_to_first_submission_mock.assert_called_once()
         sink_to_parquet_mock.assert_called_once_with(
             ANY,
             self.TEST_DESTINATION,

--- a/projects/_03_independent_cqc/_03_impute/tests/fargate/test_impute_ind_cqc_ascwds_and_pir.py
+++ b/projects/_03_independent_cqc/_03_impute/tests/fargate/test_impute_ind_cqc_ascwds_and_pir.py
@@ -54,7 +54,7 @@ class ImputeIndCqcAscwdsAndPirTests(unittest.TestCase):
         calculate_filled_posts_per_bed_ratio_mock.assert_called_once()
         self.assertEqual(model_roc_trendline_mock.call_count, 2)
         convert_pir_to_filled_posts_mock.assert_called_once()
-        self.assertEqual(model_imputation_mock.call_count, 4)
+        self.assertEqual(model_imputation_mock.call_count, 3)
         nullify_ct_values_previous_to_first_submission_mock.assert_called_once()
         sink_to_parquet_mock.assert_called_once_with(
             ANY,

--- a/projects/_03_independent_cqc/_06_estimate_filled_posts/fargate/estimate_ind_cqc_filled_posts.py
+++ b/projects/_03_independent_cqc/_06_estimate_filled_posts/fargate/estimate_ind_cqc_filled_posts.py
@@ -5,6 +5,7 @@ from projects._03_independent_cqc._06_estimate_filled_posts.fargate.utils.models
 from projects._03_independent_cqc._06_estimate_filled_posts.fargate.utils.models.utils import (
     enrich_with_model_predictions,
 )
+from projects._03_independent_cqc.utils.imputation.imputation import model_imputation
 from utils.column_names.ind_cqc_pipeline_columns import IndCqcColumns as IndCQC
 
 ind_cqc_columns = [
@@ -96,11 +97,32 @@ def main(
 
     lf = combine_non_res_with_and_without_dormancy_models(lf)
 
-    # model_imputation_with_extrapolation_and_interpolation - imputed_posts_care_home_model
+    lf = model_imputation(
+        lf,
+        IndCQC.ascwds_pir_merged,
+        IndCQC.care_home_model,
+        IndCQC.imputed_posts_care_home_model,
+        care_home=True,
+        extrapolation_method="nominal",
+    )
 
-    # model_imputation_with_extrapolation_and_interpolation - imputed_posts_non_res_combined_model
+    lf = model_imputation(
+        lf,
+        IndCQC.ascwds_pir_merged,
+        IndCQC.non_res_combined_model,
+        IndCQC.imputed_posts_non_res_combined_model,
+        care_home=False,
+        extrapolation_method="nominal",
+    )
 
-    # model_imputation_with_extrapolation_and_interpolation - imputed_pir_filled_posts_model
+    lf = model_imputation(
+        lf,
+        IndCQC.pir_filled_posts_model,
+        IndCQC.non_res_combined_model,
+        IndCQC.imputed_pir_filled_posts_model,
+        care_home=False,
+        extrapolation_method="nominal",
+    )
 
     # merge_columns_in_order
 

--- a/projects/_03_independent_cqc/_06_estimate_filled_posts/fargate/estimate_ind_cqc_filled_posts.py
+++ b/projects/_03_independent_cqc/_06_estimate_filled_posts/fargate/estimate_ind_cqc_filled_posts.py
@@ -97,23 +97,24 @@ def main(
 
     lf = combine_non_res_with_and_without_dormancy_models(lf)
 
-    lf = model_imputation(
-        lf,
-        IndCQC.ascwds_pir_merged,
-        IndCQC.care_home_model,
-        IndCQC.imputed_posts_care_home_model,
-        care_home=True,
-        extrapolation_method="nominal",
-    )
+    # Uncommented these call when ascwds_pir_merged has been converted to polars.
+    # lf = model_imputation(
+    #     lf,
+    #     IndCQC.ascwds_pir_merged,
+    #     IndCQC.care_home_model,
+    #     IndCQC.imputed_posts_care_home_model,
+    #     care_home=True,
+    #     extrapolation_method="nominal",
+    # )
 
-    lf = model_imputation(
-        lf,
-        IndCQC.ascwds_pir_merged,
-        IndCQC.non_res_combined_model,
-        IndCQC.imputed_posts_non_res_combined_model,
-        care_home=False,
-        extrapolation_method="nominal",
-    )
+    # lf = model_imputation(
+    #     lf,
+    #     IndCQC.ascwds_pir_merged,
+    #     IndCQC.non_res_combined_model,
+    #     IndCQC.imputed_posts_non_res_combined_model,
+    #     care_home=False,
+    #     extrapolation_method="nominal",
+    # )
 
     lf = model_imputation(
         lf,

--- a/projects/_03_independent_cqc/_06_estimate_filled_posts/tests/fargate/test_estimate_ind_cqc_filled_posts.py
+++ b/projects/_03_independent_cqc/_06_estimate_filled_posts/tests/fargate/test_estimate_ind_cqc_filled_posts.py
@@ -39,7 +39,7 @@ class EstimateIndCQCFilledPostsTests(unittest.TestCase):
         )
         self.assertEqual(enrich_with_model_predictions_mock.call_count, 3)
         combine_non_res_with_and_without_dormancy_models_mcok.assert_called_once()
-        self.assertEqual(model_imputation.call_count, 3)
+        self.assertEqual(model_imputation.call_count, 1)
         sink_to_parquet_mock.assert_called_once_with(
             ANY,
             self.TEST_DESTINATION,

--- a/projects/_03_independent_cqc/_06_estimate_filled_posts/tests/fargate/test_estimate_ind_cqc_filled_posts.py
+++ b/projects/_03_independent_cqc/_06_estimate_filled_posts/tests/fargate/test_estimate_ind_cqc_filled_posts.py
@@ -14,6 +14,7 @@ class EstimateIndCQCFilledPostsTests(unittest.TestCase):
     mock_data = Mock(name="data")
 
     @patch(f"{PATCH_PATH}.utils.sink_to_parquet")
+    @patch(f"{PATCH_PATH}.model_imputation")
     @patch(f"{PATCH_PATH}.combine_non_res_with_and_without_dormancy_models")
     @patch(f"{PATCH_PATH}.enrich_with_model_predictions")
     @patch(f"{PATCH_PATH}.utils.scan_parquet", return_value=mock_data)
@@ -22,6 +23,7 @@ class EstimateIndCQCFilledPostsTests(unittest.TestCase):
         scan_parquet_mock: Mock,
         enrich_with_model_predictions_mock: Mock,
         combine_non_res_with_and_without_dormancy_models_mcok: Mock,
+        model_imputation: Mock,
         sink_to_parquet_mock: Mock,
     ):
 
@@ -37,6 +39,7 @@ class EstimateIndCQCFilledPostsTests(unittest.TestCase):
         )
         self.assertEqual(enrich_with_model_predictions_mock.call_count, 3)
         combine_non_res_with_and_without_dormancy_models_mcok.assert_called_once()
+        self.assertEqual(model_imputation.call_count, 3)
         sink_to_parquet_mock.assert_called_once_with(
             ANY,
             self.TEST_DESTINATION,

--- a/projects/_03_independent_cqc/_06_estimate_filled_posts/utils/models/imputation_with_extrapolation_and_interpolation.py
+++ b/projects/_03_independent_cqc/_06_estimate_filled_posts/utils/models/imputation_with_extrapolation_and_interpolation.py
@@ -13,6 +13,7 @@ from utils.column_names.ind_cqc_pipeline_columns import IndCqcColumns as IndCqc
 from utils.column_values.categorical_column_values import CareHome
 
 
+# converted to polars -> projects\_03_independent_cqc\utils\imputation\imputation.py
 def model_imputation_with_extrapolation_and_interpolation(
     df: DataFrame,
     column_with_null_values: str,
@@ -85,6 +86,7 @@ def model_imputation_with_extrapolation_and_interpolation(
     return combined_df
 
 
+# converted to polars -> projects\_03_independent_cqc\utils\imputation\imputation.py
 def split_dataset_for_imputation(
     df: DataFrame, care_home: bool
 ) -> Tuple[DataFrame, DataFrame]:
@@ -120,6 +122,7 @@ def split_dataset_for_imputation(
     return imputation_df, non_imputation_df
 
 
+# Not required in polars version.
 def identify_locations_with_a_non_null_submission(
     df: DataFrame, column_with_null_values: str
 ) -> DataFrame:
@@ -150,6 +153,7 @@ def identify_locations_with_a_non_null_submission(
     return df
 
 
+# Not required in polars version.
 def model_imputation(
     df: DataFrame, column_with_null_values: str, imputation_model_column_name: str
 ) -> DataFrame:

--- a/projects/_03_independent_cqc/unittest_data/polars_ind_cqc_test_file_data.py
+++ b/projects/_03_independent_cqc/unittest_data/polars_ind_cqc_test_file_data.py
@@ -2655,18 +2655,6 @@ class ModelImputation:
     model_column_name: str = "trend_model"
     imputed_values_column_name: str = "imputed_values"
 
-    imputed_rows = [
-        ("1-002", date(2023, 1, 1), CareHome.not_care_home, None, 1.0, 19.0),
-        ("1-002", date(2023, 2, 1), CareHome.not_care_home, 20.0, 2.0, 20.0),
-        ("1-002", date(2023, 3, 1), CareHome.not_care_home, None, 3.0, 21.0),
-    ] # fmt: skip
-    non_imputed_rows = [
-        ("1-001", date(2023, 1, 1), CareHome.care_home, 10.0, 1.0, None),
-        ("1-001", date(2023, 2, 1), CareHome.care_home, None, 2.0, None),
-        ("1-001", date(2023, 3, 1), CareHome.care_home, 30.0, 3.0, None),
-        ("1-003", date(2023, 3, 1), CareHome.not_care_home, None, 1.0, None),
-    ] # fmt: skip
-
     expected_model_imputation_test_cases = [
         ModelImputationTestCase(
             id="when_values_will_be_extrapolated",

--- a/projects/_03_independent_cqc/unittest_data/polars_ind_cqc_test_file_data.py
+++ b/projects/_03_independent_cqc/unittest_data/polars_ind_cqc_test_file_data.py
@@ -2696,9 +2696,9 @@ class ModelImputation:
         ModelImputationTestCase(
             id="when_values_will_not_be_imputed_because_all_present",
             expected_data=[
-                ("1-001", date(2023, 1, 1), CareHome.not_care_home, 30.0, 1.0, None),
-                ("1-001", date(2023, 2, 1), CareHome.not_care_home, 31.0, 2.0, None),
-                ("1-001", date(2023, 3, 1), CareHome.not_care_home, 32.0, 3.0, None),
+                ("1-001", date(2023, 1, 1), CareHome.not_care_home, 30.0, 1.0, 30.0),
+                ("1-001", date(2023, 2, 1), CareHome.not_care_home, 31.0, 2.0, 31.0),
+                ("1-001", date(2023, 3, 1), CareHome.not_care_home, 32.0, 3.0, 32.0),
             ],
         ),
         ModelImputationTestCase(

--- a/projects/_03_independent_cqc/unittest_data/polars_ind_cqc_test_file_data.py
+++ b/projects/_03_independent_cqc/unittest_data/polars_ind_cqc_test_file_data.py
@@ -2640,6 +2640,79 @@ class ModelExtrapolation:
 
 
 @dataclass
+class ModelImputationTestCase:
+    id: str
+    data: list[Any]
+
+    def as_pytest_param(self):
+        """Return test case as pytest ParameterSet."""
+        return pytest.param(self.data, id=self.id)
+
+
+@dataclass
+class ModelImputation:
+    column_with_null_values_name: str = "null_values"
+    model_column_name: str = "trend_model"
+    imputed_values_column_name: str = "imputed_values"
+
+    imputed_rows = [
+        ("1-002", date(2023, 1, 1), CareHome.not_care_home, None, 1.0, 19.0),
+        ("1-002", date(2023, 2, 1), CareHome.not_care_home, 20.0, 2.0, 20.0),
+        ("1-002", date(2023, 3, 1), CareHome.not_care_home, None, 3.0, 21.0),
+    ] # fmt: skip
+    non_imputed_rows = [
+        ("1-001", date(2023, 1, 1), CareHome.care_home, 10.0, 1.0, None),
+        ("1-001", date(2023, 2, 1), CareHome.care_home, None, 2.0, None),
+        ("1-001", date(2023, 3, 1), CareHome.care_home, 30.0, 3.0, None),
+        ("1-003", date(2023, 3, 1), CareHome.not_care_home, None, 1.0, None),
+    ] # fmt: skip
+
+    expected_model_imputation_rows = [
+        ExtrapolationTestCase(
+            id="when_values_will_be_extrapolated",
+            data=[
+                ("1-001", date(2023, 1, 1), CareHome.not_care_home, None, 1.0, 19.0),
+                ("1-001", date(2023, 2, 1), CareHome.not_care_home, 20.0, 2.0, 20.0),
+                ("1-001", date(2023, 3, 1), CareHome.not_care_home, None, 3.0, 21.0),
+            ],
+        ),
+        ExtrapolationTestCase(
+            id="when_values_will_be_interpolated",
+            data=[
+                ("1-001", date(2023, 1, 1), CareHome.not_care_home, 20.0, 1.0, 20.0),
+                ("1-001", date(2023, 2, 1), CareHome.not_care_home, None, 2.0, 21.0),
+                ("1-001", date(2023, 3, 1), CareHome.not_care_home, 22.0, 3.0, 22.0),
+            ],
+        ),
+        ExtrapolationTestCase(
+            id="when_values_will_be_extrapolated_and_interpolated",
+            data=[
+                ("1-001", date(2023, 1, 1), CareHome.not_care_home, 20.0, 1.0, 20.0),
+                ("1-001", date(2023, 2, 1), CareHome.not_care_home, None, 2.0, 21.0),
+                ("1-001", date(2023, 3, 1), CareHome.not_care_home, 22.0, 3.0, 22.0),
+                ("1-001", date(2023, 4, 1), CareHome.not_care_home, None, 4.0, 23.0),
+            ],
+        ),
+        ExtrapolationTestCase(
+            id="when_values_will_not_be_imputed_because_all_present",
+            data=[
+                ("1-001", date(2023, 1, 1), CareHome.not_care_home, 30.0, 1.0, None),
+                ("1-001", date(2023, 2, 1), CareHome.not_care_home, 31.0, 2.0, None),
+                ("1-001", date(2023, 3, 1), CareHome.not_care_home, 32.0, 3.0, None),
+            ],
+        ),
+        ExtrapolationTestCase(
+            id="when_values_will_not_be_imputed_because_all_null",
+            data=[
+                ("1-001", date(2023, 1, 1), CareHome.not_care_home, None, 1.0, None),
+                ("1-001", date(2023, 2, 1), CareHome.not_care_home, None, 2.0, None),
+                ("1-001", date(2023, 3, 1), CareHome.not_care_home, None, 3.0, None),
+            ],
+        ),
+    ] # fmt: skip
+
+
+@dataclass
 class ModelRateOfChangeInputOutputTestCase:
     id: str
     input_data: list[Any]

--- a/projects/_03_independent_cqc/unittest_data/polars_ind_cqc_test_file_data.py
+++ b/projects/_03_independent_cqc/unittest_data/polars_ind_cqc_test_file_data.py
@@ -2697,6 +2697,17 @@ class ModelImputation:
                 ("1-001", date(2023, 3, 1), CareHome.not_care_home, None, 3.0, None),
             ],
         ),
+        ModelImputationTestCase(
+            id="when_given_multiple_service_types_only_non_res_gets_imputed_due_to_function_argument",
+            expected_data=[
+                ("1-001", date(2023, 1, 1), CareHome.not_care_home, None, 1.0, 19.0),
+                ("1-001", date(2023, 2, 1), CareHome.not_care_home, 20.0, 2.0, 20.0),
+                ("1-001", date(2023, 3, 1), CareHome.not_care_home, None, 3.0, 21.0),
+                ("1-002", date(2023, 1, 1), CareHome.care_home, None, 1.0, None),
+                ("1-002", date(2023, 2, 1), CareHome.care_home, 20.0, 2.0, None),
+                ("1-002", date(2023, 3, 1), CareHome.care_home, None, 3.0, None),
+            ],
+        ),
     ] # fmt: skip
 
 

--- a/projects/_03_independent_cqc/unittest_data/polars_ind_cqc_test_file_data.py
+++ b/projects/_03_independent_cqc/unittest_data/polars_ind_cqc_test_file_data.py
@@ -2642,11 +2642,11 @@ class ModelExtrapolation:
 @dataclass
 class ModelImputationTestCase:
     id: str
-    data: list[Any]
+    expected_data: list[Any]
 
     def as_pytest_param(self):
         """Return test case as pytest ParameterSet."""
-        return pytest.param(self.data, id=self.id)
+        return pytest.param(self.expected_data, id=self.id)
 
 
 @dataclass
@@ -2667,43 +2667,43 @@ class ModelImputation:
         ("1-003", date(2023, 3, 1), CareHome.not_care_home, None, 1.0, None),
     ] # fmt: skip
 
-    expected_model_imputation_rows = [
-        ExtrapolationTestCase(
+    expected_model_imputation_test_cases = [
+        ModelImputationTestCase(
             id="when_values_will_be_extrapolated",
-            data=[
+            expected_data=[
                 ("1-001", date(2023, 1, 1), CareHome.not_care_home, None, 1.0, 19.0),
                 ("1-001", date(2023, 2, 1), CareHome.not_care_home, 20.0, 2.0, 20.0),
                 ("1-001", date(2023, 3, 1), CareHome.not_care_home, None, 3.0, 21.0),
             ],
         ),
-        ExtrapolationTestCase(
+        ModelImputationTestCase(
             id="when_values_will_be_interpolated",
-            data=[
+            expected_data=[
                 ("1-001", date(2023, 1, 1), CareHome.not_care_home, 20.0, 1.0, 20.0),
                 ("1-001", date(2023, 2, 1), CareHome.not_care_home, None, 2.0, 21.0),
                 ("1-001", date(2023, 3, 1), CareHome.not_care_home, 22.0, 3.0, 22.0),
             ],
         ),
-        ExtrapolationTestCase(
+        ModelImputationTestCase(
             id="when_values_will_be_extrapolated_and_interpolated",
-            data=[
+            expected_data=[
                 ("1-001", date(2023, 1, 1), CareHome.not_care_home, 20.0, 1.0, 20.0),
                 ("1-001", date(2023, 2, 1), CareHome.not_care_home, None, 2.0, 21.0),
                 ("1-001", date(2023, 3, 1), CareHome.not_care_home, 22.0, 3.0, 22.0),
                 ("1-001", date(2023, 4, 1), CareHome.not_care_home, None, 4.0, 23.0),
             ],
         ),
-        ExtrapolationTestCase(
+        ModelImputationTestCase(
             id="when_values_will_not_be_imputed_because_all_present",
-            data=[
+            expected_data=[
                 ("1-001", date(2023, 1, 1), CareHome.not_care_home, 30.0, 1.0, None),
                 ("1-001", date(2023, 2, 1), CareHome.not_care_home, 31.0, 2.0, None),
                 ("1-001", date(2023, 3, 1), CareHome.not_care_home, 32.0, 3.0, None),
             ],
         ),
-        ExtrapolationTestCase(
+        ModelImputationTestCase(
             id="when_values_will_not_be_imputed_because_all_null",
-            data=[
+            expected_data=[
                 ("1-001", date(2023, 1, 1), CareHome.not_care_home, None, 1.0, None),
                 ("1-001", date(2023, 2, 1), CareHome.not_care_home, None, 2.0, None),
                 ("1-001", date(2023, 3, 1), CareHome.not_care_home, None, 3.0, None),

--- a/projects/_03_independent_cqc/unittest_data/polars_ind_cqc_test_file_schemas.py
+++ b/projects/_03_independent_cqc/unittest_data/polars_ind_cqc_test_file_schemas.py
@@ -1621,7 +1621,7 @@ class ModelImputation:
         IndCQC.care_home: pl.String,
         "null_values": pl.Float32,
         "trend_model": pl.Float32,
-        "imputed_values": pl.Float64,
+        "imputed_values": pl.Float32,
     }
 
     input_split_dataset_for_imputation_schema = {

--- a/projects/_03_independent_cqc/unittest_data/polars_ind_cqc_test_file_schemas.py
+++ b/projects/_03_independent_cqc/unittest_data/polars_ind_cqc_test_file_schemas.py
@@ -1614,6 +1614,18 @@ class ModelExtrapolation:
 
 
 @dataclass
+class ModelImputation:
+    expected_model_imputation_schema = {
+        IndCQC.location_id: pl.String,
+        IndCQC.cqc_location_import_date: pl.Date,
+        IndCQC.care_home: pl.String,
+        "null_values": pl.Float32,
+        "trend_model": pl.Float32,
+        "imputed_values": pl.Float64,
+    }
+
+
+@dataclass
 class ModelRateOfChangeSchemas:
     expected_model_roc_trendline_schema = {
         IndCQC.location_id: pl.String,

--- a/projects/_03_independent_cqc/unittest_data/polars_ind_cqc_test_file_schemas.py
+++ b/projects/_03_independent_cqc/unittest_data/polars_ind_cqc_test_file_schemas.py
@@ -1624,6 +1624,12 @@ class ModelImputation:
         "imputed_values": pl.Float64,
     }
 
+    input_split_dataset_for_imputation_schema = {
+        IndCQC.location_id: pl.String,
+        IndCQC.care_home: pl.String,
+        "null_values": pl.Float32,
+    }
+
 
 @dataclass
 class ModelRateOfChangeSchemas:

--- a/projects/_03_independent_cqc/unittest_data/polars_ind_cqc_test_file_schemas.py
+++ b/projects/_03_independent_cqc/unittest_data/polars_ind_cqc_test_file_schemas.py
@@ -1625,6 +1625,7 @@ class ModelImputation:
     }
 
     input_split_dataset_for_imputation_schema = {
+        "row_id": pl.Int8,
         IndCQC.location_id: pl.String,
         IndCQC.care_home: pl.String,
         "null_values": pl.Float32,

--- a/projects/_03_independent_cqc/utils/imputation/imputation.py
+++ b/projects/_03_independent_cqc/utils/imputation/imputation.py
@@ -70,7 +70,9 @@ def model_imputation(
             column_with_null_values,
             IndCqc.extrapolation_model,
             IndCqc.interpolation_model,
-        ).alias(imputed_column_name)
+        )
+        .cast(pl.Float32)
+        .alias(imputed_column_name)
     ).drop(
         IndCqc.extrapolation_forwards,
         IndCqc.extrapolation_model,
@@ -108,21 +110,17 @@ def split_dataset_for_imputation(
     else:
         care_home_filter_value: str = CareHome.not_care_home
 
-    locs_with_nulls_expr = (
-        pl.when(
-            (
-                pl.col(column_with_null_values)
-                .count()
-                .over([IndCqc.location_id, IndCqc.care_home])
-                > 0
-            )
-            & (pl.col(IndCqc.care_home) == care_home_filter_value)
-        )
-        .then(True)
-        .otherwise(False)
-    )
+    locs_with_values_expr = (
+        pl.col(column_with_null_values)
+        .count()
+        .over([IndCqc.location_id, IndCqc.care_home])
+        > 0
+    ) & (pl.col(IndCqc.care_home) == care_home_filter_value)
 
-    imputation_lf = lf.filter(locs_with_nulls_expr == True)
-    non_imputation_lf = lf.filter(locs_with_nulls_expr == False)
+    temp_bool = "temp_bool"
+    lf = lf.with_columns(locs_with_values_expr.alias(temp_bool))
+
+    imputation_lf = lf.filter(pl.col(temp_bool) == True).drop(temp_bool)
+    non_imputation_lf = lf.filter(pl.col(temp_bool) == False).drop(temp_bool)
 
     return (imputation_lf, non_imputation_lf)

--- a/projects/_03_independent_cqc/utils/imputation/imputation.py
+++ b/projects/_03_independent_cqc/utils/imputation/imputation.py
@@ -112,10 +112,7 @@ def split_dataset_for_imputation(
         > 0
     ) & (pl.col(IndCqc.care_home) == care_home_filter_value)
 
-    temp_bool = "temp_bool"
-    lf = lf.with_columns(locs_with_values_expr.alias(temp_bool))
-
-    imputation_lf = lf.filter(pl.col(temp_bool) == True).drop(temp_bool)
-    non_imputation_lf = lf.filter(pl.col(temp_bool) == False).drop(temp_bool)
+    imputation_lf = lf.filter(locs_with_values_expr == True)
+    non_imputation_lf = lf.filter(locs_with_values_expr == False)
 
     return (imputation_lf, non_imputation_lf)

--- a/projects/_03_independent_cqc/utils/imputation/imputation.py
+++ b/projects/_03_independent_cqc/utils/imputation/imputation.py
@@ -2,6 +2,7 @@ from typing import Tuple
 
 import polars as pl
 
+from polars_utils.expressions import is_care_home, is_not_care_home
 from projects._03_independent_cqc.utils.imputation.extrapolation import (
     model_extrapolation,
 )
@@ -101,16 +102,16 @@ def split_dataset_for_imputation(
             - non_imputation_lf: LazyFrame with rows not meeting the criteria.
     """
     if care_home:
-        care_home_filter_value: str = CareHome.care_home
+        care_home_filter_expr: pl.Expr = is_care_home()
     else:
-        care_home_filter_value: str = CareHome.not_care_home
+        care_home_filter_expr: pl.Expr = is_not_care_home()
 
     locs_with_values_expr = (
         pl.col(column_with_null_values)
         .count()
         .over([IndCqc.location_id, IndCqc.care_home])
         > 0
-    ) & (pl.col(IndCqc.care_home) == care_home_filter_value)
+    ) & (care_home_filter_expr)
 
     imputation_lf = lf.filter(locs_with_values_expr == True)
     non_imputation_lf = lf.filter(locs_with_values_expr == False)

--- a/projects/_03_independent_cqc/utils/imputation/imputation.py
+++ b/projects/_03_independent_cqc/utils/imputation/imputation.py
@@ -1,0 +1,128 @@
+from typing import Tuple
+
+import polars as pl
+
+from projects._03_independent_cqc.utils.imputation.extrapolation import (
+    model_extrapolation,
+)
+from projects._03_independent_cqc.utils.imputation.interpolation import (
+    model_interpolation,
+)
+from utils.column_names.ind_cqc_pipeline_columns import IndCqcColumns as IndCqc
+from utils.column_values.categorical_column_values import CareHome
+
+
+def model_imputation(
+    lf: pl.LazyFrame,
+    column_with_null_values: str,
+    model_column_name: str,
+    imputed_column_name: str,
+    care_home: bool,
+    extrapolation_method: str,
+) -> pl.LazyFrame:
+    """
+    Create a new column of imputed values based on known values and null values
+    being extrapolated and interpolated.
+
+    This function first splits the dataset into two, one which is relevant for
+    imputation (based on the care_home status of the location and only for
+    locations who have at least one non-null value) and another which includes
+    all other rows not relevant to imputation.
+
+    The imputation model is carried out in two steps, extrapolation and
+    interpolation, which both populate null values based on the rate of change
+    of values in '<model_column_name>'.
+
+    Args:
+        lf (pl.LazyFrame): The input LazyFrame containing the columns to be
+            extrapolated and interpolated.
+        column_with_null_values (str): The name of the column containing null
+            values to be extrapolated and interpolated.
+        model_column_name (str): The name of the column containing the model
+            values used for extrapolation and interpolation.
+        imputed_column_name (str): The name of the new imputated column.
+        care_home (bool): True if imputation is for care homes, False if it is
+            for non residential.
+        extrapolation_method (str): The choice of method.
+            Must be either 'nominal' or 'ratio'.
+
+    Returns:
+        pl.LazyFrame: The LazyFrame with the added column for imputed values.
+    """
+    imputed_lf, non_imputed_lf = split_dataset_for_imputation(lf, care_home)
+
+    imputed_lf = model_extrapolation(
+        imputed_lf,
+        column_with_null_values,
+        model_column_name,
+        extrapolation_method,
+    )
+    imputed_lf = model_interpolation(
+        imputed_lf,
+        column_with_null_values,
+        method="trend",
+    )
+
+    imputed_lf = imputed_lf.with_columns(
+        pl.coalesce(
+            column_with_null_values,
+            IndCqc.extrapolation_model,
+            IndCqc.interpolation_model,
+        ).alias(imputed_column_name)
+    ).drop(
+        IndCqc.extrapolation_backwards,
+        IndCqc.extrapolation_forwards,
+        IndCqc.extrapolation_model,
+        IndCqc.interpolation_model,
+        IndCqc.has_non_null_value,
+    )
+
+    return pl.concat([imputed_lf, non_imputed_lf])
+
+
+def split_dataset_for_imputation(
+    lf: pl.LazyFrame, column_with_null_values: str, care_home: bool
+) -> Tuple[pl.LazyFrame, pl.LazyFrame]:
+    """
+    Splits the LazyFrame into two based on whether or not the rows meet the
+    criteria for imputation.
+
+    Splits the LazyFrame into two based on the presence of non-null values in a
+    specified column and whether the care_home column matches the provided
+    argument.
+
+    Args:
+        lf (pl.LazyFrame): The input LazyFrame.
+        column_with_null_values (str): The name of the column to check for
+            non-null values.
+        care_home (bool): True if imputation is for care homes, False if it is
+            for non residential.
+
+    Returns:
+        Tuple[pl.LazyFrame, pl.LazyFrame]: A tuple containing two LazyFrames:
+            - imputation_lf: LazyFrame with rows meeting the criteria for imputation.
+            - non_imputation_lf: LazyFrame with rows not meeting the criteria.
+    """
+    if care_home:
+        care_home_filter_value: str = CareHome.care_home
+    else:
+        care_home_filter_value: str = CareHome.not_care_home
+
+    locs_with_nulls_expr = (
+        pl.when(
+            (
+                pl.col(column_with_null_values)
+                .null_count()
+                .over([IndCqc.location_id, IndCqc.care_home])
+                > 0
+            )
+            & (pl.col(IndCqc.care_home) == care_home_filter_value)
+        )
+        .then(True)
+        .otherwise(False)
+    )
+
+    imputation_df = lf.filter(locs_with_nulls_expr == True)
+    non_imputation_df = lf.filter(locs_with_nulls_expr == False)
+
+    return imputation_df, non_imputation_df

--- a/projects/_03_independent_cqc/utils/imputation/imputation.py
+++ b/projects/_03_independent_cqc/utils/imputation/imputation.py
@@ -49,7 +49,9 @@ def model_imputation(
     Returns:
         pl.LazyFrame: The LazyFrame with the added column for imputed values.
     """
-    imputed_lf, non_imputed_lf = split_dataset_for_imputation(lf, care_home)
+    imputed_lf, non_imputed_lf = split_dataset_for_imputation(
+        lf, column_with_null_values, care_home
+    )
 
     imputed_lf = model_extrapolation(
         imputed_lf,
@@ -70,14 +72,12 @@ def model_imputation(
             IndCqc.interpolation_model,
         ).alias(imputed_column_name)
     ).drop(
-        IndCqc.extrapolation_backwards,
         IndCqc.extrapolation_forwards,
         IndCqc.extrapolation_model,
         IndCqc.interpolation_model,
-        IndCqc.has_non_null_value,
     )
 
-    return pl.concat([imputed_lf, non_imputed_lf])
+    return pl.concat([imputed_lf, non_imputed_lf], how="diagonal")
 
 
 def split_dataset_for_imputation(
@@ -122,7 +122,7 @@ def split_dataset_for_imputation(
         .otherwise(False)
     )
 
-    imputation_df = lf.filter(locs_with_nulls_expr == True)
-    non_imputation_df = lf.filter(locs_with_nulls_expr == False)
+    imputation_lf = lf.filter(locs_with_nulls_expr == True)
+    non_imputation_lf = lf.filter(locs_with_nulls_expr == False)
 
-    return imputation_df, non_imputation_df
+    return (imputation_lf, non_imputation_lf)

--- a/projects/_03_independent_cqc/utils/imputation/imputation.py
+++ b/projects/_03_independent_cqc/utils/imputation/imputation.py
@@ -112,7 +112,7 @@ def split_dataset_for_imputation(
         pl.when(
             (
                 pl.col(column_with_null_values)
-                .null_count()
+                .count()
                 .over([IndCqc.location_id, IndCqc.care_home])
                 > 0
             )

--- a/projects/_03_independent_cqc/utils/imputation/imputation.py
+++ b/projects/_03_independent_cqc/utils/imputation/imputation.py
@@ -34,12 +34,11 @@ def model_imputation(
     of values in '<model_column_name>'.
 
     Args:
-        lf (pl.LazyFrame): The input LazyFrame containing the columns to be
-            extrapolated and interpolated.
+        lf (pl.LazyFrame): The input LazyFrame containing the column_with_null_values.
         column_with_null_values (str): The name of the column containing null
-            values to be extrapolated and interpolated.
+            values to be imputed.
         model_column_name (str): The name of the column containing the model
-            values used for extrapolation and interpolation.
+            values used for imputation.
         imputed_column_name (str): The name of the new imputated column.
         care_home (bool): True if imputation is for care homes, False if it is
             for non residential.
@@ -47,7 +46,7 @@ def model_imputation(
             Must be either 'nominal' or 'ratio'.
 
     Returns:
-        pl.LazyFrame: The LazyFrame with the added column for imputed values.
+        pl.LazyFrame: The LazyFrame with the added column imputed_column_name.
     """
     imputed_lf, non_imputed_lf = split_dataset_for_imputation(
         lf, column_with_null_values, care_home
@@ -86,12 +85,8 @@ def split_dataset_for_imputation(
     lf: pl.LazyFrame, column_with_null_values: str, care_home: bool
 ) -> Tuple[pl.LazyFrame, pl.LazyFrame]:
     """
-    Splits the LazyFrame into two based on whether or not the rows meet the
-    criteria for imputation.
-
     Splits the LazyFrame into two based on the presence of non-null values in a
-    specified column and whether the care_home column matches the provided
-    argument.
+    column_with_null_values and whether care_home is True or False.
 
     Args:
         lf (pl.LazyFrame): The input LazyFrame.

--- a/projects/_03_independent_cqc/utils/tests/imputation/test_imputation.py
+++ b/projects/_03_independent_cqc/utils/tests/imputation/test_imputation.py
@@ -107,14 +107,14 @@ class SplitDatasetForImputationTests(unittest.TestCase):
             schema=Schemas.input_split_dataset_for_imputation_schema,
             orient="row",
         )
-        returned_inputed_when_care_home, returned_non_inputed_when_care_home = (
+        returned_imputed_when_care_home, returned_non_imputed_when_care_home = (
             job.split_dataset_for_imputation(
                 input_lf,
                 Data.column_with_null_values_name,
                 care_home=True,
             )
         )
-        returned_inputed_when_not_care_home, returned_non_inputed_when_not_care_home = (
+        returned_imputed_when_not_care_home, returned_non_imputed_when_not_care_home = (
             job.split_dataset_for_imputation(
                 input_lf,
                 Data.column_with_null_values_name,
@@ -123,28 +123,28 @@ class SplitDatasetForImputationTests(unittest.TestCase):
         )
 
         self.assertEqual(
-            returned_inputed_when_care_home.select(IndCQC.location_id)
+            returned_imputed_when_care_home.select(IndCQC.location_id)
             .collect()
             .to_series()
             .to_list(),
             ["1-001", "1-001", "1-002"],
         )
         self.assertEqual(
-            returned_non_inputed_when_care_home.select(IndCQC.location_id)
+            returned_non_imputed_when_care_home.select(IndCQC.location_id)
             .collect()
             .to_series()
             .to_list(),
             ["1-003", "1-003", "1-004", "1-004", "1-005", "1-006", "1-006"],
         )
         self.assertEqual(
-            returned_inputed_when_not_care_home.select(IndCQC.location_id)
+            returned_imputed_when_not_care_home.select(IndCQC.location_id)
             .collect()
             .to_series()
             .to_list(),
             ["1-004", "1-004", "1-005"],
         )
         self.assertEqual(
-            returned_non_inputed_when_not_care_home.select(IndCQC.location_id)
+            returned_non_imputed_when_not_care_home.select(IndCQC.location_id)
             .collect()
             .to_series()
             .to_list(),

--- a/projects/_03_independent_cqc/utils/tests/imputation/test_imputation.py
+++ b/projects/_03_independent_cqc/utils/tests/imputation/test_imputation.py
@@ -21,12 +21,12 @@ PATCH_PATH = "projects._03_independent_cqc.utils.imputation.imputation"
 class TestModelImputationFunctionality(unittest.TestCase):
     def setUp(self):
         self.imputed_lf = pl.LazyFrame(
-            Data.imputed_rows,
+            [],
             Schemas.expected_model_imputation_schema,
             orient="row",
         )
         self.non_imputed_lf = pl.LazyFrame(
-            Data.non_imputed_rows,
+            [],
             Schemas.expected_model_imputation_schema,
             orient="row",
         )

--- a/projects/_03_independent_cqc/utils/tests/imputation/test_imputation.py
+++ b/projects/_03_independent_cqc/utils/tests/imputation/test_imputation.py
@@ -93,16 +93,16 @@ class SplitDatasetForImputationTests(unittest.TestCase):
 
         input_lf = pl.LazyFrame(
             data=[
-                ("1-001", CareHome.care_home, 10.0),
-                ("1-001", CareHome.care_home, None),
-                ("1-002", CareHome.care_home, 10.0),
-                ("1-003", CareHome.care_home, None),
-                ("1-003", CareHome.care_home, None),
-                ("1-004", CareHome.not_care_home, 10.0),
-                ("1-004", CareHome.not_care_home, None),
-                ("1-005", CareHome.not_care_home, 10.0),
-                ("1-006", CareHome.not_care_home, None),
-                ("1-006", CareHome.not_care_home, None),
+                (1, "1-001", CareHome.care_home, 10.0),
+                (2, "1-001", CareHome.care_home, None),
+                (3, "1-002", CareHome.care_home, 10.0),
+                (4, "1-003", CareHome.care_home, None),
+                (5, "1-003", CareHome.care_home, None),
+                (6, "1-004", CareHome.not_care_home, 10.0),
+                (7, "1-004", CareHome.not_care_home, None),
+                (8, "1-005", CareHome.not_care_home, 10.0),
+                (9, "1-006", CareHome.not_care_home, None),
+                (10, "1-006", CareHome.not_care_home, None),
             ],
             schema=Schemas.input_split_dataset_for_imputation_schema,
             orient="row",
@@ -122,31 +122,32 @@ class SplitDatasetForImputationTests(unittest.TestCase):
             )
         )
 
+        row_id = "row_id"
         self.assertEqual(
-            returned_imputed_when_care_home.select(IndCQC.location_id)
+            returned_imputed_when_care_home.select(row_id)
             .collect()
             .to_series()
             .to_list(),
-            ["1-001", "1-001", "1-002"],
+            [1, 2, 3],
         )
         self.assertEqual(
-            returned_non_imputed_when_care_home.select(IndCQC.location_id)
+            returned_non_imputed_when_care_home.select(row_id)
             .collect()
             .to_series()
             .to_list(),
-            ["1-003", "1-003", "1-004", "1-004", "1-005", "1-006", "1-006"],
+            [4, 5, 6, 7, 8, 9, 10],
         )
         self.assertEqual(
-            returned_imputed_when_not_care_home.select(IndCQC.location_id)
+            returned_imputed_when_not_care_home.select(row_id)
             .collect()
             .to_series()
             .to_list(),
-            ["1-004", "1-004", "1-005"],
+            [6, 7, 8],
         )
         self.assertEqual(
-            returned_non_imputed_when_not_care_home.select(IndCQC.location_id)
+            returned_non_imputed_when_not_care_home.select(row_id)
             .collect()
             .to_series()
             .to_list(),
-            ["1-001", "1-001", "1-002", "1-003", "1-003", "1-006", "1-006"],
+            [1, 2, 3, 4, 5, 9, 10],
         )

--- a/projects/_03_independent_cqc/utils/tests/imputation/test_imputation.py
+++ b/projects/_03_independent_cqc/utils/tests/imputation/test_imputation.py
@@ -12,6 +12,8 @@ from projects._03_independent_cqc.unittest_data.polars_ind_cqc_test_file_data im
 from projects._03_independent_cqc.unittest_data.polars_ind_cqc_test_file_schemas import (
     ModelImputation as Schemas,
 )
+from utils.column_names.ind_cqc_pipeline_columns import IndCqcColumns as IndCQC
+from utils.column_values.categorical_column_values import CareHome
 
 PATCH_PATH = "projects._03_independent_cqc.utils.imputation.imputation"
 
@@ -61,7 +63,7 @@ class TestModelImputationFunctionality(unittest.TestCase):
 class TestModelImputationResults:
     @pytest.mark.parametrize(
         "model_imputation_data",
-        [case.as_pytest_param() for case in Data.expected_model_imputation_rows],
+        [case.as_pytest_param() for case in Data.expected_model_imputation_test_cases],
     )
     def test_function_returns_expected_data(self, model_imputation_data):
         expected_lf = pl.LazyFrame(
@@ -83,4 +85,68 @@ class TestModelImputationResults:
             returned_lf,
             expected_lf,
             check_row_order=False,
+        )
+
+
+class SplitDatasetForImputationTests(unittest.TestCase):
+    def test_function_returns_expected_data(self):
+
+        input_lf = pl.LazyFrame(
+            data=[
+                ("1-001", CareHome.care_home, 10.0),
+                ("1-001", CareHome.care_home, None),
+                ("1-002", CareHome.care_home, 10.0),
+                ("1-003", CareHome.care_home, None),
+                ("1-003", CareHome.care_home, None),
+                ("1-004", CareHome.not_care_home, 10.0),
+                ("1-004", CareHome.not_care_home, None),
+                ("1-005", CareHome.not_care_home, 10.0),
+                ("1-006", CareHome.not_care_home, None),
+                ("1-006", CareHome.not_care_home, None),
+            ],
+            schema=Schemas.input_split_dataset_for_imputation_schema,
+            orient="row",
+        )
+        returned_inputed_when_care_home, returned_non_inputed_when_care_home = (
+            job.split_dataset_for_imputation(
+                input_lf,
+                Data.column_with_null_values_name,
+                care_home=True,
+            )
+        )
+        returned_inputed_when_not_care_home, returned_non_inputed_when_not_care_home = (
+            job.split_dataset_for_imputation(
+                input_lf,
+                Data.column_with_null_values_name,
+                care_home=False,
+            )
+        )
+
+        self.assertEqual(
+            returned_inputed_when_care_home.select(IndCQC.location_id)
+            .collect()
+            .to_series()
+            .to_list(),
+            ["1-001", "1-001", "1-002"],
+        )
+        self.assertEqual(
+            returned_non_inputed_when_care_home.select(IndCQC.location_id)
+            .collect()
+            .to_series()
+            .to_list(),
+            ["1-003", "1-003", "1-004", "1-004", "1-005", "1-006", "1-006"],
+        )
+        self.assertEqual(
+            returned_inputed_when_not_care_home.select(IndCQC.location_id)
+            .collect()
+            .to_series()
+            .to_list(),
+            ["1-004", "1-004", "1-005"],
+        )
+        self.assertEqual(
+            returned_non_inputed_when_not_care_home.select(IndCQC.location_id)
+            .collect()
+            .to_series()
+            .to_list(),
+            ["1-001", "1-001", "1-002", "1-003", "1-003", "1-006", "1-006"],
         )

--- a/projects/_03_independent_cqc/utils/tests/imputation/test_imputation.py
+++ b/projects/_03_independent_cqc/utils/tests/imputation/test_imputation.py
@@ -1,0 +1,86 @@
+import unittest
+from unittest.mock import Mock, patch
+
+import polars as pl
+import polars.testing as pl_testing
+import pytest
+
+import projects._03_independent_cqc.utils.imputation.imputation as job
+from projects._03_independent_cqc.unittest_data.polars_ind_cqc_test_file_data import (
+    ModelImputation as Data,
+)
+from projects._03_independent_cqc.unittest_data.polars_ind_cqc_test_file_schemas import (
+    ModelImputation as Schemas,
+)
+
+PATCH_PATH = "projects._03_independent_cqc.utils.imputation.imputation"
+
+
+class TestModelImputationFunctionality(unittest.TestCase):
+    def setUp(self):
+        self.imputed_lf = pl.LazyFrame(
+            Data.imputed_rows,
+            Schemas.expected_model_imputation_schema,
+            orient="row",
+        )
+        self.non_imputed_lf = pl.LazyFrame(
+            Data.non_imputed_rows,
+            Schemas.expected_model_imputation_schema,
+            orient="row",
+        )
+
+    @patch(f"{PATCH_PATH}.model_interpolation")
+    @patch(f"{PATCH_PATH}.model_extrapolation")
+    @patch(f"{PATCH_PATH}.split_dataset_for_imputation")
+    def test_function_has_expected_calls(
+        self,
+        split_dataset_for_imputation_mock: Mock,
+        model_extrapolation_mock: Mock,
+        model_interpolation_mock: Mock,
+    ):
+        split_dataset_for_imputation_mock.return_value = (
+            self.imputed_lf,
+            self.non_imputed_lf,
+        )
+        model_extrapolation_mock.return_value = self.imputed_lf
+        model_interpolation_mock.return_value = self.imputed_lf
+        job.model_imputation(
+            Mock(name="input_lf"),
+            Data.column_with_null_values_name,
+            Data.model_column_name,
+            Data.imputed_values_column_name,
+            care_home=False,
+            extrapolation_method="nominal",
+        )
+
+        split_dataset_for_imputation_mock.assert_called_once()
+        model_extrapolation_mock.assert_called_once()
+        model_interpolation_mock.assert_called_once()
+
+
+class TestModelImputationResults:
+    @pytest.mark.parametrize(
+        "model_imputation_data",
+        [case.as_pytest_param() for case in Data.expected_model_imputation_rows],
+    )
+    def test_function_returns_expected_data(self, model_imputation_data):
+        expected_lf = pl.LazyFrame(
+            model_imputation_data,
+            Schemas.expected_model_imputation_schema,
+            orient="row",
+        )
+        input_lf = expected_lf.drop(Data.imputed_values_column_name)
+        returned_lf = job.model_imputation(
+            input_lf,
+            Data.column_with_null_values_name,
+            Data.model_column_name,
+            Data.imputed_values_column_name,
+            care_home=False,
+            extrapolation_method="nominal",
+        )
+
+        pl_testing.assert_frame_equal(
+            returned_lf,
+            expected_lf,
+            check_row_order=False,
+        )


### PR DESCRIPTION
## Description
Trello ticket [1647](https://trello.com/c/o3JvBglE)

Converted the util function model_imputation_with_extrapolation_and_interpolation to polars as model_imputation.

Called the function 3/4 times in imputation job script (waiting for ascwds_pir_merged to b converted to polars).
Call the function 1/3 times in estimates job script (same issue).

## Testing
- [x] Unit tests passing
- [x] Successful [Job / Step Function run](https://eu-west-2.console.aws.amazon.com/states/home?region=eu-west-2#/v2/executions/details/arn:aws:states:eu-west-2:856699698263:execution:1647-cnv-imptn-Ind-CQC-Filled-Post-Estimates:6b6eadf3-38b6-4e28-9b30-41e6936432bb)
- [x] Outputs checked in Athena
- [ ] Outputs compared using [SageMaker script](https://eu-west-2.console.aws.amazon.com/sagemaker/home?region=eu-west-2#/notebook-instances/data-engineering-notebook)
      - Notebook name: compare_outputs.ipynb
- [x] Output Screenshots added to Trello ticket

See Trello ticket. I ran the dataset comparison query, and then got the variable sums for polars/pyspark versions of the datasets.

For the variables I could create, their values are within 0.5 at row level. The sums are slightly different because I made the variable type Float 32 instead of Float64.

## Migration to polars checklist
- [x] Check that similar utils functions don't already exist, or if one can be created
- [x] Check that utils are being saved in the appropriate place
- [x] Used LazyFrame option for test data
- [x] Unit tests added
- [x] Docstrings added
- [x] Added comment to pyspark functions which have been migrated with the link to the new location
      `# converted to polars -> filepath.py`
- [x] Use new file structure when saving to S3
      `{dataset}_{sub_dataset_if_relevant}_{order_of_process_if_relevant}_{very_brief_description}`
- [x] Updated CHANGELOG
- [x] Code reviewed by AI
- [x] Moved Trello ticket to PR column

## Reviewer checklist
- [x] PR solves the Trello ticket requirements
- [x] Outputs appear reasonable and understandable
- [x] The overall approach is appropriate and not over-engineered
- [x] No obvious scalability, performance or interdependency concerns
- [x] Tests appropriately cover the main behaviour/edge cases
- [x] Naming and structure are broadly understandable and consistent
- [x] Docstrings are sufficient for future maintenance
- [x] Docstrings cover non-obvious behaviour
