### PR TITLE
1658 Handle 400 error when caused by lowercase id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Added
-
+- Added error handling to CQC API call for 400 errors due to the location id being lowercase instead of uppercase.
 
 ### Changed
 

--- a/projects/_01_ingest/cqc_api/tests/utils/test_cqc_api.py
+++ b/projects/_01_ingest/cqc_api/tests/utils/test_cqc_api.py
@@ -177,10 +177,16 @@ class CallApiTests(CqcApiTests):
 
         response_json = cqc.call_api(
             self.test_url,
-            self.test_location_id,
+            self.test_lc_location_id,
             {"test": "body"},
             headers_dict={"some": "header"},
         )
+
+        expected_call_args = [
+            call("test_urllower", params={"test": "body"}, headers={"some": "header"}),
+            call("test_urlLOWER", params={"test": "body"}, headers={"some": "header"}),
+        ]
+        get_mock.assert_has_calls(expected_call_args)
         self.assertEqual(response_json, {})
 
     @patch("requests.Session.get")

--- a/projects/_01_ingest/cqc_api/tests/utils/test_cqc_api.py
+++ b/projects/_01_ingest/cqc_api/tests/utils/test_cqc_api.py
@@ -253,7 +253,7 @@ class CallApiTests(CqcApiTests):
         # When
         result = cqc.call_api(
             url="https://api.service.cqc.org.uk/test",
-            location_id=self.test_location_id,
+            id=self.test_location_id,
             query_params={"param": "value"},
         )
         # Then
@@ -294,7 +294,7 @@ class CallApiTests(CqcApiTests):
         with self.assertRaises(Exception) as context:
             result = cqc.call_api(
                 url="https://api.service.cqc.org.uk/test",
-                location_id=self.test_location_id,
+                id=self.test_location_id,
                 query_params={"param": "value"},
             )
             # Then

--- a/projects/_01_ingest/cqc_api/tests/utils/test_cqc_api.py
+++ b/projects/_01_ingest/cqc_api/tests/utils/test_cqc_api.py
@@ -26,6 +26,8 @@ PATCHED_CQC_ADAPTER = HTTPAdapter(
 class CqcApiTests(unittest.TestCase):
     def setUp(self) -> None:
         self.test_url = "test_url"
+        self.test_location_id = "1-001"
+        self.test_lc_location_id = "lower"
         self.location_object_type = "locations"
         self.test_column = "test_column"
         self.value_examples = ["value_1", "value_2", "value_3"]
@@ -134,7 +136,10 @@ class CallApiTests(CqcApiTests):
         get_mock.return_value = test_response
 
         response_json = cqc.call_api(
-            self.test_url, {"test": "body"}, headers_dict={"some": "header"}
+            self.test_url,
+            self.test_location_id,
+            {"test": "body"},
+            headers_dict={"some": "header"},
         )
         self.assertEqual(response_json, {})
 
@@ -145,18 +150,38 @@ class CallApiTests(CqcApiTests):
 
         with self.assertRaisesRegex(Exception, "^API response: 500 -.*"):
             cqc.call_api(
-                self.test_url, {"test": "body"}, headers_dict={"some": "header"}
+                self.test_url,
+                self.test_location_id,
+                {"test": "body"},
+                headers_dict={"some": "header"},
             )
 
     @patch("requests.Session.get")
-    def test_call_api_handles_400(self, get_mock: Mock):
+    def test_call_api_handles_400_when_not_lowercase_id(self, get_mock: Mock):
         test_response = TestResponse(400, {})
         get_mock.return_value = test_response
 
         with self.assertRaisesRegex(Exception, "^API response: 400 -.*"):
             cqc.call_api(
-                self.test_url, {"test": "body"}, headers_dict={"some": "header"}
+                self.test_url,
+                self.test_location_id,
+                {"test": "body"},
+                headers_dict={"some": "header"},
             )
+
+    @patch("requests.Session.get")
+    def test_call_api_handles_400_when_lowercase_id(self, get_mock: Mock):
+        test_response_success = TestResponse(200, {})
+        test_response_fail = TestResponse(400, {})
+        get_mock.side_effect = [test_response_fail, test_response_success]
+
+        response_json = cqc.call_api(
+            self.test_url,
+            self.test_location_id,
+            {"test": "body"},
+            headers_dict={"some": "header"},
+        )
+        self.assertEqual(response_json, {})
 
     @patch("requests.Session.get")
     def test_call_api_handles_404(self, get_mock: Mock):
@@ -167,7 +192,10 @@ class CallApiTests(CqcApiTests):
             cqc.NoProviderOrLocationException, "^API response: 404 -.*"
         ):
             cqc.call_api(
-                self.test_url, {"test": "body"}, headers_dict={"some": "header"}
+                self.test_url,
+                self.test_location_id,
+                {"test": "body"},
+                headers_dict={"some": "header"},
             )
 
     @patch("requests.Session.get")
@@ -177,7 +205,10 @@ class CallApiTests(CqcApiTests):
 
         with self.assertRaisesRegex(Exception, "^API response: 403 -.*"):
             cqc.call_api(
-                self.test_url, {"test": "body"}, headers_dict={"some": "header"}
+                self.test_url,
+                self.test_location_id,
+                {"test": "body"},
+                headers_dict={"some": "header"},
             )
 
     @patch("requests.Session.get")
@@ -186,7 +217,12 @@ class CallApiTests(CqcApiTests):
         get_mock.return_value = test_response
 
         with self.assertRaises(Exception) as context:
-            cqc.call_api(self.test_url, {"test": "body"}, headers_dict=None)
+            cqc.call_api(
+                self.test_url,
+                self.test_location_id,
+                {"test": "body"},
+                headers_dict=None,
+            )
 
         self.assertTrue(
             "API response: 403, ensure you have set a User-Agent header"
@@ -217,6 +253,7 @@ class CallApiTests(CqcApiTests):
         # When
         result = cqc.call_api(
             url="https://api.service.cqc.org.uk/test",
+            location_id=self.test_location_id,
             query_params={"param": "value"},
         )
         # Then
@@ -257,6 +294,7 @@ class CallApiTests(CqcApiTests):
         with self.assertRaises(Exception) as context:
             result = cqc.call_api(
                 url="https://api.service.cqc.org.uk/test",
+                location_id=self.test_location_id,
                 query_params={"param": "value"},
             )
             # Then

--- a/projects/_01_ingest/cqc_api/tests/utils/test_cqc_api.py
+++ b/projects/_01_ingest/cqc_api/tests/utils/test_cqc_api.py
@@ -101,7 +101,7 @@ class GetPageObjectsTests(CqcApiTests):
 
         mock_call_api.assert_called_once_with(
             self.test_url,
-            {"page": 1, "perPage": 500},
+            query_params={"page": 1, "perPage": 500},
             headers_dict={
                 "User-Agent": "SkillsForCare",
                 "Ocp-Apim-Subscription-Key": self.cqc_api_primary_key_stub,

--- a/projects/_01_ingest/cqc_api/utils/cqc_api.py
+++ b/projects/_01_ingest/cqc_api/utils/cqc_api.py
@@ -55,7 +55,11 @@ def call_api(
     with requests.Session() as session:
         try:
             session.mount(CQC_API_BASE_URL, CQC_ADAPTER)
-            response = session.get(url + id, params=query_params, headers=headers_dict)
+            if id:
+                full_url = url + id
+            else:
+                full_url = url
+            response = session.get(full_url, params=query_params, headers=headers_dict)
         except (MaxRetryError, ResponseError) as e:
             raise Exception("Max retries exceeded: {}".format(e))
 
@@ -72,10 +76,11 @@ def call_api(
 
     if (response.status_code == 400) & (id is not None):
         try:
-            uc_id = id.upper()
-            response = session.get(
-                url + uc_id, params=query_params, headers=headers_dict
-            )
+            if id:
+                full_url = url + id.upper()
+            else:
+                full_url = url
+            response = session.get(full_url, params=query_params, headers=headers_dict)
         except:
             raise Exception(
                 "API response: {} - {}".format(response.status_code, response.text)

--- a/projects/_01_ingest/cqc_api/utils/cqc_api.py
+++ b/projects/_01_ingest/cqc_api/utils/cqc_api.py
@@ -194,6 +194,7 @@ def get_updated_objects(
             try:
                 # return each object within a generator
                 yield get_object(id, object_type, cqc_api_primary_key)
+                print(f"Getting changes for {id}")
             except NoProviderOrLocationException as err:
                 # CQC API changes URL returns unfetchable IDs
                 print(f"{err}: {id}")

--- a/projects/_01_ingest/cqc_api/utils/cqc_api.py
+++ b/projects/_01_ingest/cqc_api/utils/cqc_api.py
@@ -33,7 +33,7 @@ CQC_ADAPTER = HTTPAdapter(max_retries=RETRY_STRATEGY)
 @limits(calls=RATE_LIMIT, period=ONE_MINUTE)
 def call_api(
     url: str,
-    id: str,
+    id: str | None = None,
     query_params: dict | None = None,
     headers_dict: dict | None = None,
 ) -> dict:
@@ -41,7 +41,7 @@ def call_api(
     Calls an API and returns the json response
     Args:
         url (str): the api url
-        id (str): the location id to request data for
+        id (str | None): the location id to request data for
         query_params (dict | None): the parameters to pass to the api
         headers_dict (dict | None): headers to pass to the api
 
@@ -70,7 +70,7 @@ def call_api(
             f"API response: {response.status_code} - {response.json().get('message')}"
         )
 
-    if response.status_code == 400:
+    if response.status_code == 400 & id:
         try:
             uc_id = id.upper()
             response = session.get(

--- a/projects/_01_ingest/cqc_api/utils/cqc_api.py
+++ b/projects/_01_ingest/cqc_api/utils/cqc_api.py
@@ -70,7 +70,7 @@ def call_api(
             f"API response: {response.status_code} - {response.json().get('message')}"
         )
 
-    if response.status_code == 400 & id:
+    if (response.status_code == 400) & (id is not None):
         try:
             uc_id = id.upper()
             response = session.get(

--- a/projects/_01_ingest/cqc_api/utils/cqc_api.py
+++ b/projects/_01_ingest/cqc_api/utils/cqc_api.py
@@ -74,7 +74,7 @@ def call_api(
             f"API response: {response.status_code} - {response.json().get('message')}"
         )
 
-    if (response.status_code == 400) & (id is not None):
+    if (response.status_code == 400) and (id is not None) and (id != id.upper()):
         try:
             if id:
                 full_url = url + id.upper()
@@ -157,12 +157,12 @@ def get_object(id: str, object_type: str, cqc_api_primary_key: str) -> dict:
     Calls the API for a given object.
 
     Constructs the correct URL and API call for a given provider or
-    locaiton id.
+    location id.
 
     Args:
         id(str): provider or location id to request data on
         object_type(str): whether the object is a provider or location
-        cqc_api_primary_key(str): key requeired to access API
+        cqc_api_primary_key(str): key required to access API
 
     Returns:
         dict: a python dictionary contianing the json response from the API

--- a/projects/_01_ingest/cqc_api/utils/cqc_api.py
+++ b/projects/_01_ingest/cqc_api/utils/cqc_api.py
@@ -32,12 +32,16 @@ CQC_ADAPTER = HTTPAdapter(max_retries=RETRY_STRATEGY)
 @sleep_and_retry
 @limits(calls=RATE_LIMIT, period=ONE_MINUTE)
 def call_api(
-    url: str, query_params: dict | None = None, headers_dict: dict | None = None
+    url: str,
+    location_id: str,
+    query_params: dict | None = None,
+    headers_dict: dict | None = None,
 ) -> dict:
     """
     Calls an API and returns the json response
     Args:
         url (str): the api url
+        location_id (str): the location id to request data for
         query_params (dict | None): the parameters to pass to the api
         headers_dict (dict | None): headers to pass to the api
 
@@ -51,7 +55,9 @@ def call_api(
     with requests.Session() as session:
         try:
             session.mount(CQC_API_BASE_URL, CQC_ADAPTER)
-            response = session.get(url, params=query_params, headers=headers_dict)
+            response = session.get(
+                url + location_id, params=query_params, headers=headers_dict
+            )
         except (MaxRetryError, ResponseError) as e:
             raise Exception("Max retries exceeded: {}".format(e))
 
@@ -65,6 +71,17 @@ def call_api(
         raise NoProviderOrLocationException(
             f"API response: {response.status_code} - {response.json().get('message')}"
         )
+
+    if response.status_code == 400:
+        try:
+            uc_location_id = location_id.upper()
+            response = session.get(
+                url + uc_location_id, params=query_params, headers=headers_dict
+            )
+        except:
+            raise Exception(
+                "API response: {} - {}".format(response.status_code, response.text)
+            )
 
     if response.status_code != 200:
         raise Exception(
@@ -135,7 +152,8 @@ def get_page_objects(
 def get_object(cqc_location_id, object_type, cqc_api_primary_key) -> dict:
     url = f"{CQC_API_BASE_URL}/public/{CQC_API_VERSION}/{object_type}/"
     response = call_api(
-        url + cqc_location_id,
+        url,
+        cqc_location_id,
         query_params=None,
         headers_dict={
             "User-Agent": USER_AGENT,

--- a/projects/_01_ingest/cqc_api/utils/cqc_api.py
+++ b/projects/_01_ingest/cqc_api/utils/cqc_api.py
@@ -33,7 +33,7 @@ CQC_ADAPTER = HTTPAdapter(max_retries=RETRY_STRATEGY)
 @limits(calls=RATE_LIMIT, period=ONE_MINUTE)
 def call_api(
     url: str,
-    location_id: str,
+    id: str,
     query_params: dict | None = None,
     headers_dict: dict | None = None,
 ) -> dict:
@@ -41,7 +41,7 @@ def call_api(
     Calls an API and returns the json response
     Args:
         url (str): the api url
-        location_id (str): the location id to request data for
+        id (str): the location id to request data for
         query_params (dict | None): the parameters to pass to the api
         headers_dict (dict | None): headers to pass to the api
 
@@ -55,9 +55,7 @@ def call_api(
     with requests.Session() as session:
         try:
             session.mount(CQC_API_BASE_URL, CQC_ADAPTER)
-            response = session.get(
-                url + location_id, params=query_params, headers=headers_dict
-            )
+            response = session.get(url + id, params=query_params, headers=headers_dict)
         except (MaxRetryError, ResponseError) as e:
             raise Exception("Max retries exceeded: {}".format(e))
 
@@ -74,9 +72,9 @@ def call_api(
 
     if response.status_code == 400:
         try:
-            uc_location_id = location_id.upper()
+            uc_id = id.upper()
             response = session.get(
-                url + uc_location_id, params=query_params, headers=headers_dict
+                url + uc_id, params=query_params, headers=headers_dict
             )
         except:
             raise Exception(
@@ -153,7 +151,7 @@ def get_object(cqc_location_id, object_type, cqc_api_primary_key) -> dict:
     url = f"{CQC_API_BASE_URL}/public/{CQC_API_VERSION}/{object_type}/"
     response = call_api(
         url,
-        cqc_location_id,
+        id=cqc_location_id,
         query_params=None,
         headers_dict={
             "User-Agent": USER_AGENT,

--- a/projects/_01_ingest/cqc_api/utils/cqc_api.py
+++ b/projects/_01_ingest/cqc_api/utils/cqc_api.py
@@ -229,7 +229,6 @@ def get_updated_objects(
             try:
                 # return each object within a generator
                 yield get_object(id, object_type, cqc_api_primary_key)
-                print(f"Getting changes for {id}")
             except NoProviderOrLocationException as err:
                 # CQC API changes URL returns unfetchable IDs
                 print(f"{err}: {id}")

--- a/projects/_01_ingest/cqc_api/utils/cqc_api.py
+++ b/projects/_01_ingest/cqc_api/utils/cqc_api.py
@@ -104,7 +104,7 @@ def get_all_objects(
 
     total_pages = call_api(
         url,
-        {
+        query_params={
             "perPage": per_page,
         },
         headers_dict={
@@ -136,7 +136,7 @@ def get_page_objects(
     page_objects = []
     response_body = call_api(
         url,
-        {"page": page_number, "perPage": per_page},
+        query_params={"page": page_number, "perPage": per_page},
         headers_dict={
             "User-Agent": USER_AGENT,
             "Ocp-Apim-Subscription-Key": cqc_api_primary_key,

--- a/projects/_01_ingest/cqc_api/utils/cqc_api.py
+++ b/projects/_01_ingest/cqc_api/utils/cqc_api.py
@@ -41,7 +41,7 @@ def call_api(
     Calls an API and returns the json response
     Args:
         url (str): the api url
-        id (str | None): the location id to request data for
+        id (str | None): the id to request data for
         query_params (dict | None): the parameters to pass to the api
         headers_dict (dict | None): headers to pass to the api
 

--- a/projects/_01_ingest/cqc_api/utils/cqc_api.py
+++ b/projects/_01_ingest/cqc_api/utils/cqc_api.py
@@ -147,11 +147,25 @@ def get_page_objects(
     return page_objects
 
 
-def get_object(cqc_location_id, object_type, cqc_api_primary_key) -> dict:
+def get_object(id: str, object_type: str, cqc_api_primary_key: str) -> dict:
+    """
+    Calls the API for a given object.
+
+    Constructs the correct URL and API call for a given provider or
+    locaiton id.
+
+    Args:
+        id(str): provider or location id to request data on
+        object_type(str): whether the object is a provider or location
+        cqc_api_primary_key(str): key requeired to access API
+
+    Returns:
+        dict: a python dictionary contianing the json response from the API
+    """
     url = f"{CQC_API_BASE_URL}/public/{CQC_API_VERSION}/{object_type}/"
     response = call_api(
         url,
-        id=cqc_location_id,
+        id=id,
         query_params=None,
         headers_dict={
             "User-Agent": USER_AGENT,


### PR DESCRIPTION
## Description
Trello ticket [#1658](https://trello.com/c/xa6LuvvX/1658-cqc-api-bug-fix-400-bad-request-error-on-locations-delta-call)

Adds logic to handles a 400 API error when caused by a location id being lowercase instead of uppercase
Have also emailed CQC syndication with error

## Testing
- [x] Unit tests passing
- [x] Successful [Step Function run](https://eu-west-2.console.aws.amazon.com/states/home?region=eu-west-2#/v2/executions/details/arn:aws:states:eu-west-2:856699698263:execution:1658-cqc-api-fix-Ingest-CQC-API-Delta:5f55fc58-5e1e-4097-baae-803aee15387f)
- [x] Outputs checked in Athena

Final test will be to re-run main pipeline

## Checklist (delete if not relevant)
- [x] Unit tests added/amended
- [x] Docstrings added/updated
- [x] Updated CHANGELOG
- [x] Code reviewed by AI
- [x] Moved Trello ticket to PR column

## Reviewer checklist
- [ ] PR solves the Trello ticket requirements
- [ ] Outputs appear reasonable and understandable
- [ ] The overall approach is appropriate and not over-engineered
- [ ] No obvious scalability, performance or interdependency concerns
- [ ] Tests appropriately cover the main behaviour/edge cases
- [ ] Naming and structure are broadly understandable and consistent
- [ ] Docstrings are sufficient for future maintenance
- [ ] Docstrings cover non-obvious behaviour
