### PR TITLE
1660 - Add reduced data filter while getting data in merge job within Estimates by Job Role pipeline

### DIFF
--- a/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/_01_merge.py
+++ b/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/_01_merge.py
@@ -1,3 +1,5 @@
+from datetime import date
+
 import polars as pl
 
 from polars_utils import utils
@@ -73,9 +75,34 @@ def main(
         merged_data_destination (str): destination for merged output
         metadata_destination (str): destination for metadata
     """
+    today = date.today()
+
+    # ---- FY boundary (1 April logic) ----
+    fy_year = today.year if today.month >= 4 else today.year - 1
+    current_fy_start = date(fy_year, 4, 1)
+
+    # ---- monthly window (last 2 FY years) ----
+    monthly_start = date(current_fy_start.year - 2, 4, 1)
+
+    quarter_months = [1, 4, 7, 10]
+
     combined_schema = transformation_columns | metadata_columns
     full_estimates_lf = (
         utils.scan_parquet(estimates_source)
+        .filter(
+            # FULL monthly data for last 2 years
+            (pl.col(IndCQC.cqc_location_import_date) >= monthly_start)
+            |
+            # quarterly sampling BEFORE that
+            (
+                (pl.col(IndCQC.cqc_location_import_date) < monthly_start)
+                & (
+                    pl.col(IndCQC.cqc_location_import_date)
+                    .dt.month()
+                    .is_in(quarter_months)
+                )
+            )
+        )
         .select(list(combined_schema))
         .with_row_index(name=IndCQC.id_per_locationid_import_date)
         .with_columns(utils.cast_to_schema(combined_schema))

--- a/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/_01_merge.py
+++ b/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/_01_merge.py
@@ -1,10 +1,9 @@
-from datetime import date
-
 import polars as pl
 
 from polars_utils import utils
 from projects._03_independent_cqc._07_estimate_filled_posts_by_job_role.fargate.utils.merge_utils import (
     join_estimates_to_ascwds,
+    reduced_data_filter_expr,
 )
 from projects._03_independent_cqc._07_estimate_filled_posts_by_job_role.fargate.utils.utils import (
     CategoricalColumnTypes as CatColType,
@@ -75,34 +74,10 @@ def main(
         merged_data_destination (str): destination for merged output
         metadata_destination (str): destination for metadata
     """
-    today = date.today()
-
-    # ---- FY boundary (1 April logic) ----
-    fy_year = today.year if today.month >= 4 else today.year - 1
-    current_fy_start = date(fy_year, 4, 1)
-
-    # ---- monthly window (last 2 FY years) ----
-    monthly_start = date(current_fy_start.year - 2, 4, 1)
-
-    quarter_months = [1, 4, 7, 10]
-
     combined_schema = transformation_columns | metadata_columns
     full_estimates_lf = (
         utils.scan_parquet(estimates_source)
-        .filter(
-            # FULL monthly data for last 2 years
-            (pl.col(IndCQC.cqc_location_import_date) >= monthly_start)
-            |
-            # quarterly sampling BEFORE that
-            (
-                (pl.col(IndCQC.cqc_location_import_date) < monthly_start)
-                & (
-                    pl.col(IndCQC.cqc_location_import_date)
-                    .dt.month()
-                    .is_in(quarter_months)
-                )
-            )
-        )
+        .filter(reduced_data_filter_expr())
         .select(list(combined_schema))
         .with_row_index(name=IndCQC.id_per_locationid_import_date)
         .with_columns(utils.cast_to_schema(combined_schema))

--- a/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/utils/merge_utils.py
+++ b/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/utils/merge_utils.py
@@ -64,7 +64,7 @@ def reduced_data_filter_expr(
     fy_start_month: int = 4,
     lookback_fy_years: int = 2,
     quarter_months: tuple[int, ...] = (1, 4, 7, 10),
-    col: str = "cqc_location_import_date",
+    date_col: str = "cqc_location_import_date",
 ) -> pl.Expr:
     """
     Build a Polars expression for filtering a reduced dataset using financial-year
@@ -94,9 +94,9 @@ def reduced_data_filter_expr(
             applying sampling.
 
         quarter_months (tuple[int, ...]): Months considered valid for quarterly sampling
-            of historical data.
+            of historical data (Defaults to Jan, Apr, Jul, and Oct).
 
-        col (str): Name of the date column the filter is applied to.
+        date_col (str): Name of the date column the filter is applied to.
 
     Returns:
         pl.Expr: A Polars boolean expression that can be used inside `.filter()` or
@@ -105,11 +105,10 @@ def reduced_data_filter_expr(
     today = today or date.today()
 
     fy_year = today.year if today.month >= fy_start_month else today.year - 1
-    current_fy_start = date(fy_year, fy_start_month, 1)
 
-    monthly_start = date(current_fy_start.year - lookback_fy_years, fy_start_month, 1)
+    monthly_start = date(fy_year - lookback_fy_years, fy_start_month, 1)
 
-    dt = pl.col(col)
+    dt = pl.col(date_col)
 
     return (dt >= monthly_start) | (
         (dt < monthly_start) & (dt.dt.month().is_in(quarter_months))

--- a/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/utils/merge_utils.py
+++ b/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/utils/merge_utils.py
@@ -1,3 +1,5 @@
+from datetime import date
+
 import polars as pl
 
 from utils.column_names.ind_cqc_pipeline_columns import IndCqcColumns as IndCQC
@@ -55,3 +57,25 @@ def join_estimates_to_ascwds(
         on=IndCQC.id_per_locationid_import_date,
         how="right",
     ).drop(join_keys)
+
+
+def reduced_data_filter_expr(
+    today: date | None = None,
+    fy_start_month: int = 4,
+    lookback_fy_years: int = 2,
+    quarter_months=(1, 4, 7, 10),
+    col: str = "cqc_location_import_date",
+) -> pl.Expr:
+
+    today = today or date.today()
+
+    fy_year = today.year if today.month >= fy_start_month else today.year - 1
+    current_fy_start = date(fy_year, fy_start_month, 1)
+
+    monthly_start = date(current_fy_start.year - lookback_fy_years, fy_start_month, 1)
+
+    dt = pl.col(col)
+
+    return (dt >= monthly_start) | (
+        (dt < monthly_start) & (dt.dt.month().is_in(quarter_months))
+    )

--- a/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/utils/merge_utils.py
+++ b/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/utils/merge_utils.py
@@ -63,10 +63,45 @@ def reduced_data_filter_expr(
     today: date | None = None,
     fy_start_month: int = 4,
     lookback_fy_years: int = 2,
-    quarter_months=(1, 4, 7, 10),
+    quarter_months: tuple[int, ...] = (1, 4, 7, 10),
     col: str = "cqc_location_import_date",
 ) -> pl.Expr:
+    """
+    Build a Polars expression for filtering a reduced dataset using financial-year
+    windowing with quarterly sampling for older data.
 
+    The filter implements a two-tier retention strategy:
+
+    1. Full retention window:
+       Rows with dates greater than or equal to the start of the current financial
+       year minus `lookback_fy_years` are always included.
+
+    2. Historical sampling window:
+       Rows older than the full retention window are only included if their month
+       falls within `quarter_months` (e.g. quarterly snapshots).
+
+    This allows recent data to be fully retained while reducing storage and
+    processing cost for older data via periodic sampling.
+
+    Args:
+        today (date | None): Reference date used to compute financial year boundaries.
+            If None, defaults to the current system date.
+
+        fy_start_month (int): Month in which the financial year starts
+            (default is 4 for April).
+
+        lookback_fy_years (int): Number of financial years to retain in full before
+            applying sampling.
+
+        quarter_months (tuple[int, ...]): Months considered valid for quarterly sampling
+            of historical data.
+
+        col (str): Name of the date column the filter is applied to.
+
+    Returns:
+        pl.Expr: A Polars boolean expression that can be used inside `.filter()` or
+            `.with_columns()` to select rows based on the reduced data strategy.
+    """
     today = today or date.today()
 
     fy_year = today.year if today.month >= fy_start_month else today.year - 1

--- a/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/utils/merge_utils.py
+++ b/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/utils/merge_utils.py
@@ -102,7 +102,7 @@ def reduced_data_filter_expr(
         pl.Expr: A Polars boolean expression that can be used inside `.filter()` or
             `.with_columns()` to select rows based on the reduced data strategy.
     """
-    today = today or date.today()
+    today: date = today or date.today()
 
     fy_year = today.year if today.month >= fy_start_month else today.year - 1
 

--- a/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/validate_01_merge.py
+++ b/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/validate_01_merge.py
@@ -7,6 +7,9 @@ import polars as pl
 from polars_utils import utils
 from polars_utils.validation import actions as vl
 from polars_utils.validation.constants import GLOBAL_ACTIONS, GLOBAL_THRESHOLDS
+from projects._03_independent_cqc._07_estimate_filled_posts_by_job_role.fargate.utils.merge_utils import (
+    reduced_data_filter_expr,
+)
 from projects._03_independent_cqc._07_estimate_filled_posts_by_job_role.fargate.utils.utils import (
     CategoricalColumnTypes,
 )
@@ -32,6 +35,7 @@ VALIDATION_COLS_TO_IMPORT = [
 
 IND_CQC_ESTIMATES_COLS_TO_IMPORT = [
     IndCqcColumns.location_id,
+    IndCqcColumns.cqc_location_import_date,
 ]
 
 CQC_EARLIEST_IMPORT_DATE = date(2013, 3, 1)
@@ -78,7 +82,7 @@ def main(
     compare_df = utils.read_parquet(
         source=f"s3://{bucket_name}/{compare_path}",
         selected_columns=IND_CQC_ESTIMATES_COLS_TO_IMPORT,
-    )
+    ).filter(reduced_data_filter_expr())
     expected_row_count = compare_df.height * len(
         AscwdsWorkerValueLabelsJobGroup.all_roles()
     )

--- a/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/validate_01_merge_metadata.py
+++ b/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/validate_01_merge_metadata.py
@@ -10,6 +10,9 @@ from polars_utils.validation.actions import (
     add_list_column_validation_check_flags,
 )
 from polars_utils.validation.constants import GLOBAL_ACTIONS, GLOBAL_THRESHOLDS
+from projects._03_independent_cqc._07_estimate_filled_posts_by_job_role.fargate.utils.merge_utils import (
+    reduced_data_filter_expr,
+)
 from projects._03_independent_cqc._07_estimate_filled_posts_by_job_role.fargate.utils.utils import (
     CategoricalColumnTypes,
 )
@@ -116,7 +119,7 @@ def main(
     compare_df = utils.read_parquet(
         source=f"s3://{bucket_name}/{compare_path}",
         selected_columns=IND_CQC_ESTIMATES_COLS_TO_IMPORT,
-    )
+    ).filter(reduced_data_filter_expr())
 
     source_df = add_list_column_validation_check_flags(
         source_df, [IndCqcColumns.services_offered]

--- a/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/validate_01_merge_metadata.py
+++ b/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/validate_01_merge_metadata.py
@@ -21,6 +21,7 @@ from utils.column_names.cleaned_data_files.cqc_location_cleaned import (
 )
 from utils.column_names.ind_cqc_pipeline_columns import IndCqcColumns
 from utils.column_values.categorical_column_values import (
+    AscwdsFilteringRule,
     NumericTrueFalse,
 )
 from utils.column_values.categorical_columns_by_dataset import (
@@ -197,7 +198,8 @@ def main(
         )
         .col_vals_in_set(
             IndCqcColumns.ascwds_filtering_rule,
-            CatValues.ascwds_filtering_rule_column_values.categorical_values,
+            CatValues.ascwds_filtering_rule_column_values.categorical_values
+            - {AscwdsFilteringRule.contained_invalid_missing_data_code},
         )
         .col_vals_in_set(
             IndCqcColumns.current_cssr,
@@ -273,7 +275,8 @@ def main(
         .specially(
             vl.is_unique_count_equal(
                 IndCqcColumns.ascwds_filtering_rule,
-                CatValues.ascwds_filtering_rule_column_values.count_of_categorical_values,
+                CatValues.ascwds_filtering_rule_column_values.count_of_categorical_values
+                - 1,
             ),
             brief=f"{IndCqcColumns.ascwds_filtering_rule} should have exactly {CatValues.ascwds_filtering_rule_column_values.count_of_categorical_values} distinct values",
         )

--- a/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/validate_01_merge_metadata.py
+++ b/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/validate_01_merge_metadata.py
@@ -128,6 +128,12 @@ def main(
 
     print(f"source df schema: {source_df.schema}")
 
+    allowed_ascwds_filtering_rule_column_values = [
+        v
+        for v in CatValues.ascwds_filtering_rule_column_values.categorical_values
+        if v != AscwdsFilteringRule.contained_invalid_missing_data_code
+    ]
+
     validation = (
         pb.Validate(
             data=source_df,
@@ -198,8 +204,7 @@ def main(
         )
         .col_vals_in_set(
             IndCqcColumns.ascwds_filtering_rule,
-            CatValues.ascwds_filtering_rule_column_values.categorical_values
-            - {AscwdsFilteringRule.contained_invalid_missing_data_code},
+            allowed_ascwds_filtering_rule_column_values,
         )
         .col_vals_in_set(
             IndCqcColumns.current_cssr,
@@ -275,10 +280,9 @@ def main(
         .specially(
             vl.is_unique_count_equal(
                 IndCqcColumns.ascwds_filtering_rule,
-                CatValues.ascwds_filtering_rule_column_values.count_of_categorical_values
-                - 1,
+                len(allowed_ascwds_filtering_rule_column_values),
             ),
-            brief=f"{IndCqcColumns.ascwds_filtering_rule} should have exactly {CatValues.ascwds_filtering_rule_column_values.count_of_categorical_values} distinct values",
+            brief=f"{IndCqcColumns.ascwds_filtering_rule} should have exactly {len(allowed_ascwds_filtering_rule_column_values)} distinct values",
         )
         .specially(
             vl.is_unique_count_equal(

--- a/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/validate_01_merge_metadata.py
+++ b/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/validate_01_merge_metadata.py
@@ -128,6 +128,10 @@ def main(
 
     print(f"source df schema: {source_df.schema}")
 
+    # With the reduced data, validation of ascwds_filtering_rule was failing as the data now did not have records with
+    # ascwds_filtering_rule column set to 'contained_invalid_missing_data_code'. So this is now handled by subtracting
+    # it in allowed_ascwds_filtering_rule_column_values. the dataclass 'AscwdsFilteringRule'is not updated directly as
+    # 'contained_invalid_missing_data_code' value is still needed in IND CQC pipeline.
     allowed_ascwds_filtering_rule_column_values = [
         v
         for v in CatValues.ascwds_filtering_rule_column_values.categorical_values

--- a/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/validate_04_estimates.py
+++ b/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/validate_04_estimates.py
@@ -311,10 +311,10 @@ def other_validation(
         )
         .col_vals_between(
             columns=IndCqcColumns.difference_estimate_filled_posts_and_from_all_job_roles,
-            left=-0.0001,
+            left=-0.0002,
             right=1,
             na_pass=True,
-            brief="Difference between estimate_filled_posts and estimate_filled_posts_from_all_job_roles should be between -0.0001 and 1 where present",
+            brief="Difference between estimate_filled_posts and estimate_filled_posts_from_all_job_roles should be between -0.0002 and 1 where present",
         )
         # Date plausibility
         .col_vals_ge(

--- a/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/tests/fargate/test_validate_01_merge.py
+++ b/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/tests/fargate/test_validate_01_merge.py
@@ -36,7 +36,9 @@ class ValidateJobRoleEstimatesTests(unittest.TestCase):
             (1, "1-001", date(2026, 1, 1), PrimaryServiceType.non_residential, 10.0, EstimateFilledPostsSource.ascwds_pir_merged, MainJobRoleLabels.care_worker, 5.0, 10),
         ]  # fmt: skip
         self.source_df = pl.DataFrame(source_rows, source_schema, orient="row")
-        self.compare_df = self.source_df.select([IndCqcColumns.location_id])
+        self.compare_df = self.source_df.select(
+            [IndCqcColumns.location_id, IndCqcColumns.cqc_location_import_date]
+        )
 
     @patch(f"{PATCH_PATH}.vl.write_reports")
     @patch(f"{PATCH_PATH}.utils.read_parquet")

--- a/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/tests/fargate/utils/test_merge_utils.py
+++ b/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/tests/fargate/utils/test_merge_utils.py
@@ -95,7 +95,7 @@ class TestReducedDataFilterExpr(unittest.TestCase):
                     date(2023, 6, 1),   # within range -> included
                     date(2021, 4, 1),   # old FY but quarterly rule matches -> included
                     date(2021, 5, 1),   # old FY, non-quarter -> excluded
-                ] #fmt: skip
+                ] # fmt: skip
             }
         )
 

--- a/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/tests/fargate/utils/test_merge_utils.py
+++ b/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/tests/fargate/utils/test_merge_utils.py
@@ -9,6 +9,9 @@ import projects._03_independent_cqc._07_estimate_filled_posts_by_job_role.fargat
 from projects._03_independent_cqc.unittest_data.polars_ind_cqc_test_file_data import (
     TestJoinEstimatesToAscwds as Data,
 )
+from projects._03_independent_cqc.unittest_data.polars_ind_cqc_test_file_data import (
+    TestReducedDataFilter as ReducedDataFilterdata,
+)
 from projects._03_independent_cqc.unittest_data.polars_ind_cqc_test_file_schemas import (
     TestJoinEstimatesToAscwds as Schemas,
 )
@@ -69,40 +72,27 @@ class TestJoinEstimatesToAscwds:
         assert result_lf.collect().height == expected_rows
 
 
-class TestReducedDataFilterExpr(unittest.TestCase):
-    def test_expr_function_filters_rows_correctly(self):
-        # Given
-        today = date(2024, 6, 15)
-        fy_start_month = 4
-        lookback_fy_years = 2
-        quarter_months = (1, 4, 7, 10)
-        col = "cqc_location_import_date"
+class TestReducedDataFilterExpr:
+    @pytest.mark.parametrize(
+        "case",
+        [
+            pytest.param(case, id=case.id)
+            for case in ReducedDataFilterdata.reduced_data_filter_test_cases
+        ],
+    )
+    def test_function_returns_expected_values(self, case):
+        date_col = "cqc_location_import_date"
 
         expr = job.reduced_data_filter_expr(
-            today=today,
-            fy_start_month=fy_start_month,
-            lookback_fy_years=lookback_fy_years,
-            quarter_months=quarter_months,
-            col=col,
+            today=case.today,
+            fy_start_month=case.fy_start_month,
+            lookback_fy_years=case.lookback_fy_years,
+            quarter_months=case.quarter_months,
+            date_col=date_col,
         )
 
-        # Create test data around boundary
-        df = pl.DataFrame(
-            {
-                col: [
-                    date(2022, 3, 31),  # before monthly_start and quarterly rule does not match -> excluded
-                    date(2022, 4, 1),   # boundary -> included (monthly_start)
-                    date(2023, 6, 1),   # within range -> included
-                    date(2021, 4, 1),   # old FY but quarterly rule matches -> included
-                    date(2021, 5, 1),   # old FY, non-quarter -> excluded
-                ] # fmt: skip
-            }
-        )
+        df = pl.DataFrame({date_col: case.input_data})
 
-        # When
         result = df.with_columns(expr.alias("keep"))
 
-        # Then
-        expected = [False, True, True, True, False]
-
-        assert result["keep"].to_list() == expected
+        assert result["keep"].to_list() == case.expected

--- a/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/tests/fargate/utils/test_merge_utils.py
+++ b/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/tests/fargate/utils/test_merge_utils.py
@@ -1,3 +1,6 @@
+import unittest
+from datetime import date
+
 import polars as pl
 import polars.testing as pl_testing
 import pytest
@@ -64,3 +67,42 @@ class TestJoinEstimatesToAscwds:
         # Sanity check: correct expansion
         expected_rows = len(case.estimates_data) * 2  # mocked roles
         assert result_lf.collect().height == expected_rows
+
+
+class TestReducedDataFilterExpr(unittest.TestCase):
+    def test_expr_function_filters_rows_correctly(self):
+        # Given
+        today = date(2024, 6, 15)
+        fy_start_month = 4
+        lookback_fy_years = 2
+        quarter_months = (1, 4, 7, 10)
+        col = "cqc_location_import_date"
+
+        expr = job.reduced_data_filter_expr(
+            today=today,
+            fy_start_month=fy_start_month,
+            lookback_fy_years=lookback_fy_years,
+            quarter_months=quarter_months,
+            col=col,
+        )
+
+        # Create test data around boundary
+        df = pl.DataFrame(
+            {
+                col: [
+                    date(2022, 3, 31),  # before monthly_start and quarterly rule does not match -> excluded
+                    date(2022, 4, 1),   # boundary -> included (monthly_start)
+                    date(2023, 6, 1),   # within range -> included
+                    date(2021, 4, 1),   # old FY but quarterly rule matches -> included
+                    date(2021, 5, 1),   # old FY, non-quarter -> excluded
+                ] #fmt: skip
+            }
+        )
+
+        # When
+        result = df.with_columns(expr.alias("keep"))
+
+        # Then
+        expected = [False, True, True, True, False]
+
+        assert result["keep"].to_list() == expected

--- a/projects/_03_independent_cqc/unittest_data/polars_ind_cqc_test_file_data.py
+++ b/projects/_03_independent_cqc/unittest_data/polars_ind_cqc_test_file_data.py
@@ -1838,6 +1838,66 @@ class TestJoinEstimatesToAscwds:
 
 
 @dataclass
+class ReducedDataFilterCase:
+    id: str
+    today: date | None
+    fy_start_month: int
+    lookback_fy_years: int
+    quarter_months: tuple[int, ...]
+    input_data: list[date]
+    expected: list[bool]
+
+
+@dataclass
+class TestReducedDataFilter:
+    reduced_data_filter_test_cases = [
+        ReducedDataFilterCase(
+            id="test reduced_data_filter with default args",
+            today=date(2024, 6, 15),
+            fy_start_month=4,
+            lookback_fy_years=2,
+            quarter_months=(1, 4, 7, 10),
+            input_data=[
+                date(2021, 4, 1), # before monthly_start but quarterly rule matches -> included
+                date(2021, 5, 1), # before monthly_start, non-quarter -> excluded
+                date(2022, 3, 31), # before monthly_start and quarterly rule does not match -> excluded
+                date(2022, 4, 1), # at boundary (monthly_start) -> included
+                date(2023, 6, 1), # within range -> included
+            ],
+            expected=[True, False, False, True, True],
+        ),
+        ReducedDataFilterCase(
+            id="test reduced_data_filter with non-default args",
+            today=date(2024, 6, 15),
+            fy_start_month=1,
+            lookback_fy_years=1,
+            quarter_months=(3, 6, 9, 12),
+            input_data=[
+                date(2022, 1, 1), # before monthly_start, non-quarter -> excluded
+                date(2022, 2, 1), # before monthly_start, non-quarter -> excluded
+                date(2022, 12, 1), # before monthly_start but quarterly rule matches -> included
+                date(2023, 3, 1), # before monthly_start and quarterly rule matches -> included
+                date(2024, 6, 1), # within range -> included
+            ],
+            expected=[False, False, True, True, True],
+        ),
+        ReducedDataFilterCase(
+            id="test reduced_data_filter with today=None",
+            today=None,
+            fy_start_month=4,
+            lookback_fy_years=2,
+            quarter_months=(1, 4, 7, 10),
+            input_data=[
+                date.today(),  # should be included as it's the current date
+                date(2021, 4, 1), # before monthly_start but quarterly rule matches -> included
+                date(2021, 5, 1), # before monthly_start, non-quarter -> excluded
+            ],
+            expected=[True, True, False],
+        ),
+    ]  # fmt: skip
+
+
+@dataclass
 class ImputeJobRoleTestCase:
     id: str
     data: list[Any]


### PR DESCRIPTION
## Description
Trello ticket [#1660](https://trello.com/c/1LzmUu8U/1660-add-filter-for-reduced-dataset-for-job-role-pipeline)

Added a reduced data filter while getting data in merge job within Estimates by Job Role pipeline. The data is filtered based in `cqc_location_import_date` column. monthly data for last 2 years is taken and only quarterly data before that. 

With the reduced data, validation of merged metadata was failing as the data now did not have records with `ascwds_filtering_rule` set to 'contained_invalid_missing_data_code'. So this is now handled by subtracting it while validation of merged metadata. the dataclass is not updated directly as this is still needed in IND CQC pipeline.

## Testing
- [x] Unit tests passing
- [x] Successful [Step Function run](https://eu-west-2.console.aws.amazon.com/states/home?region=eu-west-2#/v2/executions/details/arn:aws:states:eu-west-2:856699698263:execution:1660-jr-reduced-data-Ind-CQC-Filled-Post-Estimates-By-Role:f2e1c11e-46b5-4c31-bd8e-2c562a87ba2e)
- [x] Outputs checked in Athena

Outputs to compare branch and main are attached to the trello ticket.

## Checklist (delete if not relevant)
- [x] Unit tests added/amended
- [x] Docstrings added/updated
- [x] Updated CHANGELOG
- [x] Code reviewed by AI
- [x] Moved Trello ticket to PR column

## Reviewer checklist
- [ ] PR solves the Trello ticket requirements
- [ ] Outputs appear reasonable and understandable
- [ ] The overall approach is appropriate and not over-engineered
- [ ] No obvious scalability, performance or interdependency concerns
- [ ] Tests appropriately cover the main behaviour/edge cases
- [ ] Naming and structure are broadly understandable and consistent
- [ ] Docstrings are sufficient for future maintenance
- [ ] Docstrings cover non-obvious behaviour
