### PR TITLE
1674 replace-allroles-class-method-and-alljobgroups-class-method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to this project will be documented in this file.
 - Refactored job group filter to use magic numbers for outlier bounds.
 
 ### Fixed
+- Replace the all roles and all job groups functions with the appropriate categorical values attribute.
 
 
 ## [v2026.05.0] - 12/06/2026

--- a/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/utils/estimate_utils.py
+++ b/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/utils/estimate_utils.py
@@ -6,8 +6,8 @@ from projects._03_independent_cqc._07_estimate_filled_posts_by_job_role.fargate.
 )
 from utils.column_names.ind_cqc_pipeline_columns import IndCqcColumns as IndCQC
 from utils.column_values.categorical_column_values import MainJobRoleLabels
-from utils.value_labels.ascwds_worker.ascwds_worker_jobgroup_dictionary import (
-    AscwdsWorkerValueLabelsJobGroup,
+from utils.column_values.categorical_columns_by_dataset import (
+    EstimatedIndCQCFilledPostsByJobRoleCategoricalValues as CatVals,
 )
 
 
@@ -90,7 +90,7 @@ def reallocate_historical_filled_posts_by_job_role(lf: pl.LazyFrame) -> pl.LazyF
     if null_count > 0:
         raise ValueError("Error: Estimate filled posts by job role column has nulls")
 
-    all_job_roles = AscwdsWorkerValueLabelsJobGroup.all_roles()
+    all_job_roles = CatVals.main_job_role_labels_column_values
     lf_adjusted = lf.pivot(
         on=IndCQC.main_job_role_clean_labelled,
         on_columns=all_job_roles,

--- a/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/utils/estimate_utils.py
+++ b/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/utils/estimate_utils.py
@@ -90,7 +90,7 @@ def reallocate_historical_filled_posts_by_job_role(lf: pl.LazyFrame) -> pl.LazyF
     if null_count > 0:
         raise ValueError("Error: Estimate filled posts by job role column has nulls")
 
-    all_job_roles = CatVals.main_job_role_labels_column_values
+    all_job_roles = CatVals.main_job_role_labels_column_values.categorical_values
     lf_adjusted = lf.pivot(
         on=IndCQC.main_job_role_clean_labelled,
         on_columns=all_job_roles,

--- a/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/utils/merge_utils.py
+++ b/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/utils/merge_utils.py
@@ -7,7 +7,7 @@ from utils.column_values.categorical_columns_by_dataset import (
     EstimatedIndCQCFilledPostsByJobRoleCategoricalValues as CatVals,
 )
 
-JobRoleEnumType = pl.Enum(CatVals.main_job_role_labels_column_values)
+JobRoleEnumType = pl.Enum(CatVals.main_job_role_labels_column_values.categorical_values)
 
 
 def join_estimates_to_ascwds(
@@ -39,7 +39,10 @@ def join_estimates_to_ascwds(
     )
 
     roles_lf = pl.LazyFrame(
-        data=[(role,) for role in CatVals.main_job_role_labels_column_values],
+        data=[
+            (role,)
+            for role in CatVals.main_job_role_labels_column_values.categorical_values
+        ],
         schema={job_role_labels: JobRoleEnumType},
         orient="row",
     )

--- a/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/utils/merge_utils.py
+++ b/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/utils/merge_utils.py
@@ -3,11 +3,11 @@ from datetime import date
 import polars as pl
 
 from utils.column_names.ind_cqc_pipeline_columns import IndCqcColumns as IndCQC
-from utils.value_labels.ascwds_worker.ascwds_worker_jobgroup_dictionary import (
-    AscwdsWorkerValueLabelsJobGroup,
+from utils.column_values.categorical_columns_by_dataset import (
+    EstimatedIndCQCFilledPostsByJobRoleCategoricalValues as CatVals,
 )
 
-JobRoleEnumType = pl.Enum(AscwdsWorkerValueLabelsJobGroup.all_roles())
+JobRoleEnumType = pl.Enum(CatVals.main_job_role_labels_column_values)
 
 
 def join_estimates_to_ascwds(
@@ -39,7 +39,7 @@ def join_estimates_to_ascwds(
     )
 
     roles_lf = pl.LazyFrame(
-        data=[(role,) for role in AscwdsWorkerValueLabelsJobGroup.all_roles()],
+        data=[(role,) for role in CatVals.main_job_role_labels_column_values],
         schema={job_role_labels: JobRoleEnumType},
         orient="row",
     )

--- a/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/utils/merge_utils.py
+++ b/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/utils/merge_utils.py
@@ -54,7 +54,13 @@ def join_estimates_to_ascwds(
     ).drop(join_keys)
 
 
-def create_job_role_lazyframe():
+def create_job_role_lazyframe() -> pl.LazyFrame:
+    """
+    Creates a LazyFrame with one column containing a row per job role label.
+
+    Returns:
+        pl.LazyFrame: A LazyFrame of job role labels.
+    """
     roles_lf = pl.LazyFrame(
         data=CatVals.main_job_role_labels_column_values.categorical_values,
         schema={

--- a/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/utils/merge_utils.py
+++ b/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/utils/merge_utils.py
@@ -8,6 +8,8 @@ from utils.column_values.categorical_columns_by_dataset import (
 )
 
 job_role_labels = IndCQC.main_job_role_clean_labelled
+# Cache the stable, ordered list of job role labels for reuse and determinism.
+MAIN_JOB_ROLE_VALUES = CatVals.main_job_role_labels_column_values.categorical_values
 
 
 def join_estimates_to_ascwds(
@@ -61,17 +63,14 @@ def create_job_role_lazyframe() -> pl.LazyFrame:
     Returns:
         pl.LazyFrame: A LazyFrame of job role labels.
     """
-    roles_lf = pl.LazyFrame(
-        data=CatVals.main_job_role_labels_column_values.categorical_values,
-        schema={
-            job_role_labels: pl.Enum(
-                CatVals.main_job_role_labels_column_values.categorical_values
-            ),
-        },
+    values = MAIN_JOB_ROLE_VALUES
+    # Build explicit 1-tuple rows so Polars interprets each string as a single column value.
+    rows = [(v,) for v in values]
+    return pl.LazyFrame(
+        data=rows,
+        schema={job_role_labels: pl.Enum(values)},
         orient="row",
     )
-
-    return roles_lf
 
 
 def reduced_data_filter_expr(

--- a/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/utils/merge_utils.py
+++ b/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/utils/merge_utils.py
@@ -7,7 +7,7 @@ from utils.column_values.categorical_columns_by_dataset import (
     EstimatedIndCQCFilledPostsByJobRoleCategoricalValues as CatVals,
 )
 
-JobRoleEnumType = pl.Enum(CatVals.main_job_role_labels_column_values.categorical_values)
+job_role_labels = IndCQC.main_job_role_clean_labelled
 
 
 def join_estimates_to_ascwds(
@@ -32,20 +32,12 @@ def join_estimates_to_ascwds(
         IndCQC.ascwds_workplace_import_date,
         IndCQC.establishment_id,
     ]
-    job_role_labels = IndCQC.main_job_role_clean_labelled
 
     narrow_keys_lf = estimates_lf.select(
         [IndCQC.id_per_locationid_import_date] + join_keys
     )
 
-    roles_lf = pl.LazyFrame(
-        data=[
-            (role,)
-            for role in CatVals.main_job_role_labels_column_values.categorical_values
-        ],
-        schema={job_role_labels: JobRoleEnumType},
-        orient="row",
-    )
+    roles_lf = create_job_role_lazyframe()
 
     expanded_keys_lf = narrow_keys_lf.join(roles_lf, how="cross")
 
@@ -60,6 +52,20 @@ def join_estimates_to_ascwds(
         on=IndCQC.id_per_locationid_import_date,
         how="right",
     ).drop(join_keys)
+
+
+def create_job_role_lazyframe():
+    roles_lf = pl.LazyFrame(
+        data=CatVals.main_job_role_labels_column_values.categorical_values,
+        schema={
+            job_role_labels: pl.Enum(
+                CatVals.main_job_role_labels_column_values.categorical_values
+            ),
+        },
+        orient="row",
+    )
+
+    return roles_lf
 
 
 def reduced_data_filter_expr(

--- a/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/utils/utils.py
+++ b/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/utils/utils.py
@@ -9,6 +9,9 @@ from utils.column_values.categorical_column_values import (
     MainJobRoleLabels,
     PrimaryServiceType,
 )
+from utils.column_values.categorical_columns_by_dataset import (
+    EstimatedIndCQCFilledPostsByJobRoleCategoricalValues as CatVals,
+)
 from utils.value_labels.ascwds_worker.ascwds_worker_jobgroup_dictionary import (
     AscwdsWorkerValueLabelsJobGroup,
 )
@@ -126,7 +129,7 @@ class CategoricalColumnTypes:
         pl.Categories("provider", namespace="filled_posts")
     )
     BrandCatType = pl.Categorical(pl.Categories("brand", namespace="filled_posts"))
-    JobRoleEnumType = pl.Enum(AscwdsWorkerValueLabelsJobGroup.all_roles())
+    JobRoleEnumType = pl.Enum(CatVals.main_job_role_labels_column_values)
     JobGroupEnumType = pl.Enum(AscwdsWorkerValueLabelsJobGroup.all_job_groups())
     EstimatesFilledPostSourceEnumType = pl.Enum(
         [

--- a/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/utils/utils.py
+++ b/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/utils/utils.py
@@ -129,8 +129,12 @@ class CategoricalColumnTypes:
         pl.Categories("provider", namespace="filled_posts")
     )
     BrandCatType = pl.Categorical(pl.Categories("brand", namespace="filled_posts"))
-    JobRoleEnumType = pl.Enum(CatVals.main_job_role_labels_column_values)
-    JobGroupEnumType = pl.Enum(CatVals.main_job_group_labels_column_values)
+    JobRoleEnumType = pl.Enum(
+        CatVals.main_job_role_labels_column_values.categorical_values
+    )
+    JobGroupEnumType = pl.Enum(
+        CatVals.main_job_group_labels_column_values.categorical_values
+    )
     EstimatesFilledPostSourceEnumType = pl.Enum(
         [
             EstimateFilledPostsSource.imputed_pir_filled_posts_model,

--- a/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/utils/utils.py
+++ b/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/utils/utils.py
@@ -130,7 +130,7 @@ class CategoricalColumnTypes:
     )
     BrandCatType = pl.Categorical(pl.Categories("brand", namespace="filled_posts"))
     JobRoleEnumType = pl.Enum(CatVals.main_job_role_labels_column_values)
-    JobGroupEnumType = pl.Enum(AscwdsWorkerValueLabelsJobGroup.all_job_groups())
+    JobGroupEnumType = pl.Enum(CatVals.main_job_group_labels_column_values)
     EstimatesFilledPostSourceEnumType = pl.Enum(
         [
             EstimateFilledPostsSource.imputed_pir_filled_posts_model,

--- a/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/validate_01_merge.py
+++ b/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/validate_01_merge.py
@@ -17,9 +17,6 @@ from utils.column_names.ind_cqc_pipeline_columns import IndCqcColumns
 from utils.column_values.categorical_columns_by_dataset import (
     EstimatedIndCQCFilledPostsByJobRoleCategoricalValues as CatValues,
 )
-from utils.value_labels.ascwds_worker.ascwds_worker_jobgroup_dictionary import (
-    AscwdsWorkerValueLabelsJobGroup,
-)
 
 VALIDATION_COLS_TO_IMPORT = [
     IndCqcColumns.id_per_locationid_import_date,
@@ -84,7 +81,7 @@ def main(
         selected_columns=IND_CQC_ESTIMATES_COLS_TO_IMPORT,
     ).filter(reduced_data_filter_expr())
     expected_row_count = compare_df.height * len(
-        AscwdsWorkerValueLabelsJobGroup.all_roles()
+        CatValues.main_job_role_labels_column_values
     )
 
     validation = (

--- a/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/validate_01_merge.py
+++ b/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/validate_01_merge.py
@@ -81,7 +81,7 @@ def main(
         selected_columns=IND_CQC_ESTIMATES_COLS_TO_IMPORT,
     ).filter(reduced_data_filter_expr())
     expected_row_count = compare_df.height * len(
-        CatValues.main_job_role_labels_column_values
+        CatValues.main_job_role_labels_column_values.categorical_values
     )
 
     validation = (

--- a/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/tests/fargate/utils/test_merge_utils.py
+++ b/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/tests/fargate/utils/test_merge_utils.py
@@ -13,10 +13,11 @@ from projects._03_independent_cqc.unittest_data.polars_ind_cqc_test_file_schemas
     TestJoinEstimatesToAscwds as Schemas,
 )
 
+roles = ["role_a", "role_b"]
+
 
 @pytest.fixture(autouse=True)
 def mock_roles(monkeypatch):
-    roles = ["role_a", "role_b"]
 
     monkeypatch.setattr(
         job,
@@ -66,21 +67,13 @@ class TestJoinEstimatesToAscwds:
 
 
 class TestCreateJobRoleLazyFrame:
-    def test_create_job_role_lazyframe_schema_rowcount_and_order():
-        lf = job.create_job_role_lazyframe()
-        df = lf.collect()
+    def test_create_job_role_lazyframe_schema_rowcount_and_order(self):
+        expected_lf = pl.LazyFrame(
+            roles, {job.job_role_labels: pl.Enum(roles)}, orient="row"
+        )
+        returned_lf = job.create_job_role_lazyframe()
 
-        # Column name
-        assert job.job_role_labels in df.columns
-
-        # Row count matches the authoritative values
-        expected = job.MAIN_JOB_ROLE_VALUES
-        assert df.height == len(expected)
-
-        # Values are strings and in the exact expected order
-        values = df[job.job_role_labels].to_list()
-        assert all(isinstance(v, str) for v in values)
-        assert values == expected
+        pl_testing.assert_frame_equal(expected_lf, returned_lf)
 
 
 class TestReducedDataFilterExpr:

--- a/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/tests/fargate/utils/test_merge_utils.py
+++ b/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/tests/fargate/utils/test_merge_utils.py
@@ -22,15 +22,11 @@ def mock_roles(monkeypatch):
     roles = ["role_a", "role_b"]
 
     monkeypatch.setattr(
-        job.AscwdsWorkerValueLabelsJobGroup,
-        "all_roles",
-        lambda: roles,
-    )
-
-    monkeypatch.setattr(
         job,
-        "JobRoleEnumType",
-        pl.Enum(roles),
+        "create_job_role_lazyframe",
+        lambda: pl.LazyFrame(
+            roles, {job.job_role_labels: pl.Enum(roles)}, orient="row"
+        ),
     )
 
 

--- a/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/tests/fargate/utils/test_merge_utils.py
+++ b/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/tests/fargate/utils/test_merge_utils.py
@@ -1,6 +1,3 @@
-import unittest
-from datetime import date
-
 import polars as pl
 import polars.testing as pl_testing
 import pytest
@@ -66,6 +63,24 @@ class TestJoinEstimatesToAscwds:
         # Sanity check: correct expansion
         expected_rows = len(case.estimates_data) * 2  # mocked roles
         assert result_lf.collect().height == expected_rows
+
+
+class TestCreateJobRoleLazyFrame:
+    def test_create_job_role_lazyframe_schema_rowcount_and_order():
+        lf = job.create_job_role_lazyframe()
+        df = lf.collect()
+
+        # Column name
+        assert job.job_role_labels in df.columns
+
+        # Row count matches the authoritative values
+        expected = job.MAIN_JOB_ROLE_VALUES
+        assert df.height == len(expected)
+
+        # Values are strings and in the exact expected order
+        values = df[job.job_role_labels].to_list()
+        assert all(isinstance(v, str) for v in values)
+        assert values == expected
 
 
 class TestReducedDataFilterExpr:

--- a/projects/_03_independent_cqc/unittest_data/polars_ind_cqc_test_file_schemas.py
+++ b/projects/_03_independent_cqc/unittest_data/polars_ind_cqc_test_file_schemas.py
@@ -49,6 +49,9 @@ from utils.column_values.categorical_column_values import (
     JobGroupLabels,
     JobRoleFilteringRule,
 )
+from utils.column_values.categorical_columns_by_dataset import (
+    EstimatedIndCQCFilledPostsByJobRoleCategoricalValues as CatVals,
+)
 from utils.value_labels.ascwds_worker.ascwds_worker_jobgroup_dictionary import (
     AscwdsWorkerValueLabelsJobGroup,
 )
@@ -1462,7 +1465,7 @@ class EstimateFilledPostsByJobRoleEstimateUtilsSchemas:
         {
             IndCQC.id_per_locationid_import_date: pl.Int32,
             IndCQC.main_job_role_clean_labelled: pl.Enum(
-                AscwdsWorkerValueLabelsJobGroup.all_roles()
+                CatVals.main_job_role_labels_column_values
             ),
             IndCQC.estimate_filled_posts_by_job_role_historically_reallocated: pl.Float32,
             IndCQC.registered_manager_count: pl.Float32,
@@ -1472,7 +1475,7 @@ class EstimateFilledPostsByJobRoleEstimateUtilsSchemas:
         {
             IndCQC.id_per_locationid_import_date: pl.Int32,
             IndCQC.main_job_role_clean_labelled: pl.Enum(
-                AscwdsWorkerValueLabelsJobGroup.all_roles()
+                CatVals.main_job_role_labels_column_values
             ),
             IndCQC.estimate_filled_posts_by_job_role_historically_reallocated: pl.Float32,
             IndCQC.estimate_filled_posts_by_job_role_manager_adjusted: pl.Float32,
@@ -1483,7 +1486,7 @@ class EstimateFilledPostsByJobRoleEstimateUtilsSchemas:
         {
             IndCQC.id_per_locationid_import_date: pl.Int32,
             IndCQC.main_job_role_clean_labelled: pl.Enum(
-                AscwdsWorkerValueLabelsJobGroup.all_roles()
+                CatVals.main_job_role_labels_column_values
             ),
             IndCQC.estimate_filled_posts_by_job_role_historically_reallocated: pl.Float32,
             IndCQC.registered_manager_count: pl.Float32,
@@ -1495,7 +1498,7 @@ class EstimateFilledPostsByJobRoleEstimateUtilsSchemas:
         {
             IndCQC.id_per_locationid_import_date: pl.Int32,
             IndCQC.main_job_role_clean_labelled: pl.Enum(
-                AscwdsWorkerValueLabelsJobGroup.all_roles()
+                CatVals.main_job_role_labels_column_values
             ),
             IndCQC.estimate_filled_posts_by_job_role_historically_reallocated: pl.Float32,
             IndCQC.proportion_of_non_rm_managerial_estimated_filled_posts_by_role: pl.Float32,
@@ -1506,7 +1509,7 @@ class EstimateFilledPostsByJobRoleEstimateUtilsSchemas:
         {
             IndCQC.id_per_locationid_import_date: pl.Int32,
             IndCQC.main_job_role_clean_labelled: pl.Enum(
-                AscwdsWorkerValueLabelsJobGroup.all_roles()
+                CatVals.main_job_role_labels_column_values
             ),
             IndCQC.estimate_filled_posts_by_job_role_historically_reallocated: pl.Float32,
             IndCQC.registered_manager_count: pl.Int32,
@@ -1521,7 +1524,7 @@ class EstimateFilledPostsByJobRoleEstimateUtilsSchemas:
             IndCQC.id_per_locationid_import_date: pl.Int32,
             IndCQC.estimate_filled_posts: pl.Float32,
             IndCQC.main_job_role_clean_labelled: pl.Enum(
-                AscwdsWorkerValueLabelsJobGroup.all_roles()
+                CatVals.main_job_role_labels_column_values
             ),
             IndCQC.estimate_filled_posts_by_job_role_manager_adjusted: pl.Float32,
             IndCQC.estimate_filled_posts_from_all_job_roles: pl.Float32,
@@ -1535,7 +1538,7 @@ class EstimateFilledPostsByJobRoleEstimateUtilsSchemas:
             IndCQC.location_id: pl.String,
             IndCQC.cqc_location_import_date: pl.Date,
             IndCQC.main_job_role_clean_labelled: pl.Enum(
-                AscwdsWorkerValueLabelsJobGroup.all_roles()
+                CatVals.main_job_role_labels_column_values
             ),
             IndCQC.estimate_filled_posts_by_job_role: pl.Float32,
             IndCQC.estimate_filled_posts_by_job_role_historically_reallocated: pl.Float32,

--- a/projects/_03_independent_cqc/unittest_data/polars_ind_cqc_test_file_schemas.py
+++ b/projects/_03_independent_cqc/unittest_data/polars_ind_cqc_test_file_schemas.py
@@ -52,9 +52,6 @@ from utils.column_values.categorical_column_values import (
 from utils.column_values.categorical_columns_by_dataset import (
     EstimatedIndCQCFilledPostsByJobRoleCategoricalValues as CatVals,
 )
-from utils.value_labels.ascwds_worker.ascwds_worker_jobgroup_dictionary import (
-    AscwdsWorkerValueLabelsJobGroup,
-)
 
 
 @dataclass
@@ -1465,7 +1462,7 @@ class EstimateFilledPostsByJobRoleEstimateUtilsSchemas:
         {
             IndCQC.id_per_locationid_import_date: pl.Int32,
             IndCQC.main_job_role_clean_labelled: pl.Enum(
-                CatVals.main_job_role_labels_column_values
+                CatVals.main_job_role_labels_column_values.categorical_values
             ),
             IndCQC.estimate_filled_posts_by_job_role_historically_reallocated: pl.Float32,
             IndCQC.registered_manager_count: pl.Float32,
@@ -1475,7 +1472,7 @@ class EstimateFilledPostsByJobRoleEstimateUtilsSchemas:
         {
             IndCQC.id_per_locationid_import_date: pl.Int32,
             IndCQC.main_job_role_clean_labelled: pl.Enum(
-                CatVals.main_job_role_labels_column_values
+                CatVals.main_job_role_labels_column_values.categorical_values
             ),
             IndCQC.estimate_filled_posts_by_job_role_historically_reallocated: pl.Float32,
             IndCQC.estimate_filled_posts_by_job_role_manager_adjusted: pl.Float32,
@@ -1486,7 +1483,7 @@ class EstimateFilledPostsByJobRoleEstimateUtilsSchemas:
         {
             IndCQC.id_per_locationid_import_date: pl.Int32,
             IndCQC.main_job_role_clean_labelled: pl.Enum(
-                CatVals.main_job_role_labels_column_values
+                CatVals.main_job_role_labels_column_values.categorical_values
             ),
             IndCQC.estimate_filled_posts_by_job_role_historically_reallocated: pl.Float32,
             IndCQC.registered_manager_count: pl.Float32,
@@ -1498,7 +1495,7 @@ class EstimateFilledPostsByJobRoleEstimateUtilsSchemas:
         {
             IndCQC.id_per_locationid_import_date: pl.Int32,
             IndCQC.main_job_role_clean_labelled: pl.Enum(
-                CatVals.main_job_role_labels_column_values
+                CatVals.main_job_role_labels_column_values.categorical_values
             ),
             IndCQC.estimate_filled_posts_by_job_role_historically_reallocated: pl.Float32,
             IndCQC.proportion_of_non_rm_managerial_estimated_filled_posts_by_role: pl.Float32,
@@ -1509,7 +1506,7 @@ class EstimateFilledPostsByJobRoleEstimateUtilsSchemas:
         {
             IndCQC.id_per_locationid_import_date: pl.Int32,
             IndCQC.main_job_role_clean_labelled: pl.Enum(
-                CatVals.main_job_role_labels_column_values
+                CatVals.main_job_role_labels_column_values.categorical_values
             ),
             IndCQC.estimate_filled_posts_by_job_role_historically_reallocated: pl.Float32,
             IndCQC.registered_manager_count: pl.Int32,
@@ -1524,7 +1521,7 @@ class EstimateFilledPostsByJobRoleEstimateUtilsSchemas:
             IndCQC.id_per_locationid_import_date: pl.Int32,
             IndCQC.estimate_filled_posts: pl.Float32,
             IndCQC.main_job_role_clean_labelled: pl.Enum(
-                CatVals.main_job_role_labels_column_values
+                CatVals.main_job_role_labels_column_values.categorical_values
             ),
             IndCQC.estimate_filled_posts_by_job_role_manager_adjusted: pl.Float32,
             IndCQC.estimate_filled_posts_from_all_job_roles: pl.Float32,
@@ -1538,7 +1535,7 @@ class EstimateFilledPostsByJobRoleEstimateUtilsSchemas:
             IndCQC.location_id: pl.String,
             IndCQC.cqc_location_import_date: pl.Date,
             IndCQC.main_job_role_clean_labelled: pl.Enum(
-                CatVals.main_job_role_labels_column_values
+                CatVals.main_job_role_labels_column_values.categorical_values
             ),
             IndCQC.estimate_filled_posts_by_job_role: pl.Float32,
             IndCQC.estimate_filled_posts_by_job_role_historically_reallocated: pl.Float32,
@@ -1700,7 +1697,7 @@ class EstimateFilledPostsByJobRoleCleanUtilsSchemas:
         IndCQC.primary_service_type: CatColType.PrimaryServiceEnumType,
         IndCQC.main_job_role_clean_labelled: CatColType.JobRoleEnumType,
         IndCQC.main_job_group_labelled: pl.Enum(
-            CatVals.main_job_group_labels_column_values
+            CatVals.main_job_group_labels_column_values.categorical_values
         ),
         IndCQC.ascwds_job_role_counts: pl.Int64,
         IndCQC.job_role_filtering_rule: CatColType.JobRoleFilteringRuleCatType,
@@ -1712,7 +1709,7 @@ class EstimateFilledPostsByJobRoleCleanUtilsSchemas:
         IndCQC.primary_service_type: CatColType.PrimaryServiceEnumType,
         IndCQC.main_job_role_clean_labelled: CatColType.JobRoleEnumType,
         IndCQC.main_job_group_labelled: pl.Enum(
-            CatVals.main_job_group_labels_column_values
+            CatVals.main_job_group_labels_column_values.categorical_values
         ),
         IndCQC.ascwds_job_role_counts: pl.Int64,
         IndCQC.job_role_filtering_rule: CatColType.JobRoleFilteringRuleCatType,

--- a/projects/_03_independent_cqc/unittest_data/polars_ind_cqc_test_file_schemas.py
+++ b/projects/_03_independent_cqc/unittest_data/polars_ind_cqc_test_file_schemas.py
@@ -1700,7 +1700,7 @@ class EstimateFilledPostsByJobRoleCleanUtilsSchemas:
         IndCQC.primary_service_type: CatColType.PrimaryServiceEnumType,
         IndCQC.main_job_role_clean_labelled: CatColType.JobRoleEnumType,
         IndCQC.main_job_group_labelled: pl.Enum(
-            AscwdsWorkerValueLabelsJobGroup.all_job_groups()
+            CatVals.main_job_group_labels_column_values
         ),
         IndCQC.ascwds_job_role_counts: pl.Int64,
         IndCQC.job_role_filtering_rule: CatColType.JobRoleFilteringRuleCatType,
@@ -1712,7 +1712,7 @@ class EstimateFilledPostsByJobRoleCleanUtilsSchemas:
         IndCQC.primary_service_type: CatColType.PrimaryServiceEnumType,
         IndCQC.main_job_role_clean_labelled: CatColType.JobRoleEnumType,
         IndCQC.main_job_group_labelled: pl.Enum(
-            AscwdsWorkerValueLabelsJobGroup.all_job_groups()
+            CatVals.main_job_group_labels_column_values
         ),
         IndCQC.ascwds_job_role_counts: pl.Int64,
         IndCQC.job_role_filtering_rule: CatColType.JobRoleFilteringRuleCatType,

--- a/utils/value_labels/ascwds_worker/ascwds_worker_jobgroup_dictionary.py
+++ b/utils/value_labels/ascwds_worker/ascwds_worker_jobgroup_dictionary.py
@@ -67,11 +67,6 @@ class AscwdsWorkerValueLabelsJobGroup:
         return cls.filter_roles(JobGroupLabels.managers)
 
     @classmethod
-    def all_roles(cls) -> list[str]:
-        """Return all job roles."""
-        return list(cls.job_role_to_job_group_dict)
-
-    @classmethod
     def all_job_groups(cls) -> list[str]:
         """Return all job groups."""
         return sorted(list(set(cls.job_role_to_job_group_dict.values())))

--- a/utils/value_labels/ascwds_worker/ascwds_worker_jobgroup_dictionary.py
+++ b/utils/value_labels/ascwds_worker/ascwds_worker_jobgroup_dictionary.py
@@ -65,8 +65,3 @@ class AscwdsWorkerValueLabelsJobGroup:
     def manager_roles(cls) -> list[str]:
         """Return a list of roles in the "managers" job group."""
         return cls.filter_roles(JobGroupLabels.managers)
-
-    @classmethod
-    def all_job_groups(cls) -> list[str]:
-        """Return all job groups."""
-        return sorted(list(set(cls.job_role_to_job_group_dict.values())))


### PR DESCRIPTION
## Description
Trello ticket [#1674](https://trello.com/c/klWwY8fi/1674-s-replace-allroles-class-method-and-alljobgroups-class-method-with-categorical-values-attributes-and-remove-class-methods)

Replace the all roles and all job groups functions with the appropriate categorical values attribute

## Testing
- [x] Unit tests passing
- [x] Successful [Step Function run](https://eu-west-2.console.aws.amazon.com/states/home?region=eu-west-2#/v2/executions/details/arn:aws:states:eu-west-2:856699698263:execution:1674-rm-dup-func-Ind-CQC-Filled-Post-Estimates-By-Role:234ba9ba-77a2-4780-a9ce-b27284aedc64)
- [ ] Outputs checked in Athena

## Checklist (delete if not relevant)
- [x] Updated CHANGELOG
- [x] AI review
- [x] Moved Trello ticket to PR column

## Reviewer checklist
- [ ] PR solves the Trello ticket requirements
- [ ] Outputs appear reasonable and understandable
- [ ] The overall approach is appropriate and not over-engineered
- [ ] No obvious scalability, performance or interdependency concerns
- [ ] Tests appropriately cover the main behaviour/edge cases
- [ ] Naming and structure are broadly understandable and consistent
- [ ] Docstrings are sufficient for future maintenance
- [ ] Docstrings cover non-obvious behaviour
