### PR TITLE
1688 hist jr fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ All notable changes to this project will be documented in this file.
 ### Changed
 - Refactored job group filter to use magic numbers for outlier bounds.
 
+- Changed _04_estimate job role filled posts so historical reallocation is called after manager adjustment.
+
 ### Fixed
 
 

--- a/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/_04_estimate.py
+++ b/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/_04_estimate.py
@@ -41,13 +41,13 @@ def main(
 
     lf = eUtils.calculate_estimated_filled_posts_by_job_role(lf)
 
-    lf = eUtils.reallocate_historical_filled_posts_by_job_role(lf)
-
     lf = lf.with_columns(
         eUtils.has_rm_in_cqc_rm_name_list_flag().alias(IndCQC.registered_manager_count)
     )
 
     lf = eUtils.adjust_managerial_roles(lf, non_rm_manager_roles)
+
+    lf = eUtils.reallocate_historical_filled_posts_by_job_role(lf)
 
     lf = eUtils.calc_diff_estimate_filled_posts_and_from_all_job_roles(lf)
 

--- a/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/utils/estimate_utils.py
+++ b/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/utils/estimate_utils.py
@@ -232,9 +232,9 @@ def calculate_reg_man_difference(lf: pl.LazyFrame) -> pl.LazyFrame:
     return lf.with_columns(
         (
             (
-                pl.col(
-                    IndCQC.estimate_filled_posts_by_job_role_historically_reallocated
-                ).sub(pl.col(IndCQC.registered_manager_count))
+                pl.col(IndCQC.estimate_filled_posts_by_job_role).sub(
+                    pl.col(IndCQC.registered_manager_count)
+                )
             )
             .filter(
                 pl.col(IndCQC.main_job_role_clean_labelled)
@@ -265,7 +265,7 @@ def calculate_non_rm_managerial_distribution(
             'proportion_of_non_rm_managerial_estimated_filled_posts_by_role'.
     """
     sum_non_rm_managerial_posts_expr = (
-        pl.col(IndCQC.estimate_filled_posts_by_job_role_historically_reallocated)
+        pl.col(IndCQC.estimate_filled_posts_by_job_role)
         .filter(non_rm_manager_condition)
         .sum()
         .over(IndCQC.id_per_locationid_import_date)
@@ -289,9 +289,7 @@ def calculate_non_rm_managerial_distribution(
                     .cast(pl.Float32)
                 )
                 .otherwise(
-                    pl.col(
-                        IndCQC.estimate_filled_posts_by_job_role_historically_reallocated
-                    )
+                    pl.col(IndCQC.estimate_filled_posts_by_job_role)
                     .truediv(sum_non_rm_managerial_posts_expr)
                     .cast(pl.Float32)
                 )
@@ -327,9 +325,7 @@ def distribute_rm_difference(
         pl.LazyFrame: The input LazyFrame with column
             'estimate_filled_posts_by_job_role_manager_adjusted'.
     """
-    redistribution_expr = pl.col(
-        IndCQC.estimate_filled_posts_by_job_role_historically_reallocated
-    ).add(
+    redistribution_expr = pl.col(IndCQC.estimate_filled_posts_by_job_role).add(
         pl.col(IndCQC.difference_between_estimate_and_cqc_registered_managers).mul(
             pl.col(
                 IndCQC.proportion_of_non_rm_managerial_estimated_filled_posts_by_role
@@ -345,9 +341,7 @@ def distribute_rm_difference(
             == MainJobRoleLabels.registered_manager
         )
         .then(pl.col(IndCQC.registered_manager_count).cast(pl.Float32))
-        .otherwise(
-            pl.col(IndCQC.estimate_filled_posts_by_job_role_historically_reallocated)
-        )
+        .otherwise(pl.col(IndCQC.estimate_filled_posts_by_job_role))
         .alias(IndCQC.estimate_filled_posts_by_job_role_manager_adjusted)
     )
 
@@ -362,14 +356,16 @@ def calc_diff_estimate_filled_posts_and_from_all_job_roles(
 
     Args:
         lf (pl.LazyFrame): A LazyFrame with 'estimate_filled_posts' and
-            'estimate_filled_posts_by_job_role_manager_adjusted'.
+            'estimate_filled_posts_by_job_role_historically_reallocated'.
 
     Returns:
         pl.LazyFrame: A LazyFrame with new columns
             'estimate_filled_posts_from_all_job_roles' and
             'difference_estimate_filled_posts_and_from_all_job_roles'.
     """
-    posts_by_job_role_col = IndCQC.estimate_filled_posts_by_job_role_manager_adjusted
+    posts_by_job_role_col = (
+        IndCQC.estimate_filled_posts_by_job_role_historically_reallocated
+    )
 
     sum_expr = (
         pl.when(

--- a/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/utils/estimate_utils.py
+++ b/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/utils/estimate_utils.py
@@ -71,7 +71,7 @@ def reallocate_historical_filled_posts_by_job_role(lf: pl.LazyFrame) -> pl.LazyF
 
     Args:
         lf (pl.LazyFrame): The input LazyFrame with column
-            'estimate_filled_posts_by_job_role'.
+            'estimate_filled_posts_by_job_role_manager_adjusted'.
 
     Returns:
         pl.LazyFrame: The input LazyFrame with new column
@@ -81,9 +81,13 @@ def reallocate_historical_filled_posts_by_job_role(lf: pl.LazyFrame) -> pl.LazyF
         ValueError: If estimate filled posts by job role column has nulls.
     """
 
-    # Raise error if there are nulls in job role filled post columns.
+    # Raise error if there are nulls in job role filled post column.
     null_count = (
-        lf.select(pl.col(IndCQC.estimate_filled_posts_by_job_role).null_count())
+        lf.select(
+            pl.col(
+                IndCQC.estimate_filled_posts_by_job_role_manager_adjusted
+            ).null_count()
+        )
         .collect()
         .item()
     )
@@ -95,7 +99,7 @@ def reallocate_historical_filled_posts_by_job_role(lf: pl.LazyFrame) -> pl.LazyF
         on=IndCQC.main_job_role_clean_labelled,
         on_columns=all_job_roles,
         index=[IndCQC.id_per_locationid_import_date, IndCQC.cqc_location_import_date],
-        values=IndCQC.estimate_filled_posts_by_job_role,
+        values=IndCQC.estimate_filled_posts_by_job_role_manager_adjusted,
         aggregate_function="sum",
     )
 

--- a/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/utils/utils.py
+++ b/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/utils/utils.py
@@ -67,6 +67,18 @@ def add_job_role_groups_column(
 
 
 class HistoricJobRoleAdjustmentConfig:
+    """
+    A dictionary in which keys are dates before which we reallocate job roles.
+        Date: {
+            historic role to reallocate: {
+                receiving role: amount to receive,
+            },
+        }
+
+    Please note the registered manager role must not be a receiving role due to
+    the order of functions in _04_estimate job roles script. This role is taken
+    from CQC counts and therefore must be that count thereafter.
+    """
 
     adjustment_dict = {
         date(2023, 8, 1): {

--- a/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/utils/utils.py
+++ b/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/utils/utils.py
@@ -76,8 +76,9 @@ class HistoricJobRoleAdjustmentConfig:
         }
 
     Please note the registered manager role must not be a receiving role due to
-    the order of functions in _04_estimate job roles script. This role is taken
-    from CQC counts and therefore must be that count thereafter.
+    the order of functions in _04_estimate job roles script (historical reallocation
+    happens after RM reassignment). This role is taken from CQC counts and therefore
+    must be that count thereafter.
     """
 
     adjustment_dict = {

--- a/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/validate_04_estimates.py
+++ b/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/validate_04_estimates.py
@@ -84,7 +84,7 @@ EXPECTED_SCHEMA = pb.Schema(
         IndCqcColumns.ascwds_job_role_ratios_merged: "Float32",
         IndCqcColumns.ascwds_job_role_ratios_merged_source: "String",
         IndCqcColumns.estimate_filled_posts_by_job_role: "Float32",
-        IndCqcColumns.estimate_filled_posts_by_job_role_historically_reallocated: "Float32",
+        IndCqcColumns.estimate_filled_posts_by_job_role_historically_reallocated: "Float64",
         IndCqcColumns.estimate_filled_posts_by_job_role_manager_adjusted: "Float64",
         IndCqcColumns.estimate_filled_posts_from_all_job_roles: "Float64",
         IndCqcColumns.difference_estimate_filled_posts_and_from_all_job_roles: "Float64",

--- a/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/tests/fargate/test_04_estimate.py
+++ b/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/tests/fargate/test_04_estimate.py
@@ -18,18 +18,18 @@ class TestMain(unittest.TestCase):
     @patch(
         f"{PATCH_PATH}.eUtils.calc_diff_estimate_filled_posts_and_from_all_job_roles"
     )
+    @patch(f"{PATCH_PATH}.eUtils.reallocate_historical_filled_posts_by_job_role")
     @patch(f"{PATCH_PATH}.eUtils.adjust_managerial_roles")
     @patch(f"{PATCH_PATH}.eUtils.has_rm_in_cqc_rm_name_list_flag")
-    @patch(f"{PATCH_PATH}.eUtils.reallocate_historical_filled_posts_by_job_role")
     @patch(f"{PATCH_PATH}.eUtils.calculate_estimated_filled_posts_by_job_role")
     @patch(f"{PATCH_PATH}.utils.scan_parquet")
     def test_main_succeeds(
         self,
         scan_parquet_mock: Mock,
         calculate_estimated_filled_posts_by_job_role_mock: Mock,
-        reallocate_historical_filled_posts_by_job_role: Mock,
         has_rm_in_cqc_rm_name_list_flag_mock: Mock,
         adjust_managerial_roles_mock: Mock,
+        reallocate_historical_filled_posts_by_job_role: Mock,
         calc_diff_estimate_filled_posts_and_from_all_job_roles_mock: Mock,
         sink_to_parquet_mock: Mock,
     ):
@@ -40,9 +40,9 @@ class TestMain(unittest.TestCase):
 
         scan_parquet_mock.assert_called_once()
         calculate_estimated_filled_posts_by_job_role_mock.assert_called_once()
-        reallocate_historical_filled_posts_by_job_role.assert_called_once()
         has_rm_in_cqc_rm_name_list_flag_mock.assert_called_once()
         adjust_managerial_roles_mock.assert_called_once()
+        reallocate_historical_filled_posts_by_job_role.assert_called_once()
         calc_diff_estimate_filled_posts_and_from_all_job_roles_mock.assert_called_once()
         sink_to_parquet_mock.assert_called_once_with(
             lazy_df=ANY,

--- a/projects/_03_independent_cqc/unittest_data/polars_ind_cqc_test_file_schemas.py
+++ b/projects/_03_independent_cqc/unittest_data/polars_ind_cqc_test_file_schemas.py
@@ -1537,7 +1537,7 @@ class EstimateFilledPostsByJobRoleEstimateUtilsSchemas:
             IndCQC.main_job_role_clean_labelled: pl.Enum(
                 AscwdsWorkerValueLabelsJobGroup.all_roles()
             ),
-            IndCQC.estimate_filled_posts_by_job_role: pl.Float32,
+            IndCQC.estimate_filled_posts_by_job_role_manager_adjusted: pl.Float32,
             IndCQC.estimate_filled_posts_by_job_role_historically_reallocated: pl.Float32,
         }
     )

--- a/projects/_03_independent_cqc/unittest_data/polars_ind_cqc_test_file_schemas.py
+++ b/projects/_03_independent_cqc/unittest_data/polars_ind_cqc_test_file_schemas.py
@@ -1464,7 +1464,7 @@ class EstimateFilledPostsByJobRoleEstimateUtilsSchemas:
             IndCQC.main_job_role_clean_labelled: pl.Enum(
                 AscwdsWorkerValueLabelsJobGroup.all_roles()
             ),
-            IndCQC.estimate_filled_posts_by_job_role_historically_reallocated: pl.Float32,
+            IndCQC.estimate_filled_posts_by_job_role: pl.Float32,
             IndCQC.registered_manager_count: pl.Float32,
         }
     )
@@ -1474,7 +1474,7 @@ class EstimateFilledPostsByJobRoleEstimateUtilsSchemas:
             IndCQC.main_job_role_clean_labelled: pl.Enum(
                 AscwdsWorkerValueLabelsJobGroup.all_roles()
             ),
-            IndCQC.estimate_filled_posts_by_job_role_historically_reallocated: pl.Float32,
+            IndCQC.estimate_filled_posts_by_job_role: pl.Float32,
             IndCQC.estimate_filled_posts_by_job_role_manager_adjusted: pl.Float32,
         }
     )
@@ -1485,7 +1485,7 @@ class EstimateFilledPostsByJobRoleEstimateUtilsSchemas:
             IndCQC.main_job_role_clean_labelled: pl.Enum(
                 AscwdsWorkerValueLabelsJobGroup.all_roles()
             ),
-            IndCQC.estimate_filled_posts_by_job_role_historically_reallocated: pl.Float32,
+            IndCQC.estimate_filled_posts_by_job_role: pl.Float32,
             IndCQC.registered_manager_count: pl.Float32,
             IndCQC.difference_between_estimate_and_cqc_registered_managers: pl.Float32,
         }
@@ -1497,7 +1497,7 @@ class EstimateFilledPostsByJobRoleEstimateUtilsSchemas:
             IndCQC.main_job_role_clean_labelled: pl.Enum(
                 AscwdsWorkerValueLabelsJobGroup.all_roles()
             ),
-            IndCQC.estimate_filled_posts_by_job_role_historically_reallocated: pl.Float32,
+            IndCQC.estimate_filled_posts_by_job_role: pl.Float32,
             IndCQC.proportion_of_non_rm_managerial_estimated_filled_posts_by_role: pl.Float32,
         }
     )
@@ -1508,7 +1508,7 @@ class EstimateFilledPostsByJobRoleEstimateUtilsSchemas:
             IndCQC.main_job_role_clean_labelled: pl.Enum(
                 AscwdsWorkerValueLabelsJobGroup.all_roles()
             ),
-            IndCQC.estimate_filled_posts_by_job_role_historically_reallocated: pl.Float32,
+            IndCQC.estimate_filled_posts_by_job_role: pl.Float32,
             IndCQC.registered_manager_count: pl.Int32,
             IndCQC.difference_between_estimate_and_cqc_registered_managers: pl.Float32,
             IndCQC.proportion_of_non_rm_managerial_estimated_filled_posts_by_role: pl.Float32,
@@ -1523,7 +1523,7 @@ class EstimateFilledPostsByJobRoleEstimateUtilsSchemas:
             IndCQC.main_job_role_clean_labelled: pl.Enum(
                 AscwdsWorkerValueLabelsJobGroup.all_roles()
             ),
-            IndCQC.estimate_filled_posts_by_job_role_manager_adjusted: pl.Float32,
+            IndCQC.estimate_filled_posts_by_job_role_historically_reallocated: pl.Float32,
             IndCQC.estimate_filled_posts_from_all_job_roles: pl.Float32,
             IndCQC.difference_estimate_filled_posts_and_from_all_job_roles: pl.Float32,
         }


### PR DESCRIPTION
## Description
Trello ticket [1688](https://trello.com/c/nfOs7IyL)

We make estimate_filled_posts_by_job_role, then recalculate to remove filled posts in roles from previous years, then recalculate to adjust for registered managers.

If a location only has RM's as their manager roles, and we redistribute an excess into the other manager roles, it gets spread evenly. This repopulates historic manager roles that should have 0 filled posts.

This PR moves the historic adjustment function to after manager adjustment. So estimate_filled_posts_by_job_role_historically_reallocated becomes the final estimate column for filled posts.

Registered manager role doesn't receive any posts from historic reallocation.


## Testing
- [x] Unit tests passing
- [x] Successful [Step Function run](https://eu-west-2.console.aws.amazon.com/states/home?region=eu-west-2#/v2/executions/details/arn:aws:states:eu-west-2:856699698263:execution:1688-hist-jr-fix-Ind-CQC-Filled-Post-Estimates-By-Role:4bfd601f-f9ad-42e7-81cf-29a544dbb757)
- [x] Outputs checked in Athena

Excel attached to Trello ticket compared branch and main. Note that the estimate column is now swapped from "manager adjusted" to "historically reallocated".

## Checklist (delete if not relevant)
- [x] Unit tests added/amended
- [x] Docstrings added/updated
- [x] Updated CHANGELOG
- [x] Code reviewed by AI
- [x] Moved Trello ticket to PR column

## Reviewer checklist
- [ ] PR solves the Trello ticket requirements
- [ ] Outputs appear reasonable and understandable
- [ ] The overall approach is appropriate and not over-engineered
- [ ] No obvious scalability, performance or interdependency concerns
- [ ] Tests appropriately cover the main behaviour/edge cases
- [ ] Naming and structure are broadly understandable and consistent
- [ ] Docstrings are sufficient for future maintenance
- [ ] Docstrings cover non-obvious behaviour
