### PR TITLE
1654 - Make lower bound magic number optional within filter_job_role_group_outliers function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ All notable changes to this project will be documented in this file.
 
 - Refactored job group filter to work for brands and providers as well as locations.
 
+- Refactored `filter_job_role_group_outliers` and `FilterJobRoleGroupExpressions` to accept an include_direct_care_lower_bound parameter, allowing the direct care lower bound check to be optionally excluded from outlier filtering.
+
 ### Fixed
 
 

--- a/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/_02_clean.py
+++ b/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/_02_clean.py
@@ -118,11 +118,11 @@ def main(
 
     # Drop job role group as this will be reallocated in later job
     # Drop providerid and brandid which are just used for filtering and not needed for impute and estimate steps.
-    # estimated_job_role_posts_lf = estimated_job_role_posts_lf.drop(
-    #     IndCQC.main_job_group_labelled,
-    #     IndCQC.provider_id,
-    #     IndCQC.brand_id,
-    # )
+    estimated_job_role_posts_lf = estimated_job_role_posts_lf.drop(
+        IndCQC.main_job_group_labelled,
+        IndCQC.provider_id,
+        IndCQC.brand_id,
+    )
 
     utils.sink_to_parquet(
         lazy_df=estimated_job_role_posts_lf,

--- a/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/_02_clean.py
+++ b/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/_02_clean.py
@@ -118,11 +118,11 @@ def main(
 
     # Drop job role group as this will be reallocated in later job
     # Drop providerid and brandid which are just used for filtering and not needed for impute and estimate steps.
-    estimated_job_role_posts_lf = estimated_job_role_posts_lf.drop(
-        IndCQC.main_job_group_labelled,
-        IndCQC.provider_id,
-        IndCQC.brand_id,
-    )
+    # estimated_job_role_posts_lf = estimated_job_role_posts_lf.drop(
+    #     IndCQC.main_job_group_labelled,
+    #     IndCQC.provider_id,
+    #     IndCQC.brand_id,
+    # )
 
     utils.sink_to_parquet(
         lazy_df=estimated_job_role_posts_lf,

--- a/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/_02_clean.py
+++ b/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/_02_clean.py
@@ -103,7 +103,9 @@ def main(
     )
 
     estimated_job_role_posts_lf = cUtils.filter_job_role_group_outliers(
-        estimated_job_role_posts_lf, id_column=IndCQC.brand_id
+        estimated_job_role_posts_lf,
+        id_column=IndCQC.brand_id,
+        include_direct_care_lower_bound=False,
     )
 
     estimated_job_role_posts_lf = cUtils.filter_job_role_group_outliers(

--- a/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/utils/clean_utils.py
+++ b/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/utils/clean_utils.py
@@ -85,7 +85,7 @@ def filter_job_role_group_outliers(
         raise ValueError(
             f"Value must be one of {IndCQC.brand_id}, {IndCQC.provider_id}, or {IndCQC.location_id}"
         )
-    temp_out_of_bounds_col: str = "out_of_bounds"
+    temp_out_of_bounds_col: str = f"{id_column}_out_of_bounds"
 
     Exprs = FilterJobRoleGroupExpressions(include_direct_care_lower_bound)
 
@@ -108,9 +108,13 @@ def filter_job_role_group_outliers(
             values=IndCQC.ascwds_job_role_counts,
             aggregate_function="sum",
         )
-        .with_columns(Exprs.id_column_sum_expr)
+        .with_columns(Exprs.id_column_sum_expr.alias(f"{id_column}_sum"))
         .filter(pl.col(Exprs.temp_id_column_sum) >= min_workers_threshold)
-        .with_columns(Exprs.job_group_percentage_expr)
+        .with_columns(
+            Exprs.job_group_percentage_expr.alias(
+                f"{id_column}_job_group_percentage_expr"
+            )
+        )
     )
 
     # Build a LazyFrame of the fixed bounds from the magic numbers dict
@@ -156,7 +160,8 @@ def filter_job_role_group_outliers(
         .then(None)
         .otherwise(pl.col(IndCQC.ascwds_job_role_counts))
         .alias(IndCQC.ascwds_job_role_counts)
-    ).drop(temp_out_of_bounds_col)
+    )
+    # .drop(temp_out_of_bounds_col)
 
     if id_column == IndCQC.brand_id:
         new_rule = JobRoleFilteringRule.job_role_group_is_outlier_at_brand_level

--- a/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/utils/clean_utils.py
+++ b/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/utils/clean_utils.py
@@ -108,19 +108,13 @@ def filter_job_role_group_outliers(
             values=IndCQC.ascwds_job_role_counts,
             aggregate_function="sum",
         )
-        .with_columns(
-            [
-                Exprs.id_column_sum_expr,
-                *[
-                    (pl.col(c) / pl.col(Exprs.temp_id_column_sum)).alias(
-                        f"{id_column}_{c}_pct"
-                    )
-                    for c in Exprs.job_group_cols
-                ],
-            ]
-        )
+        .with_columns(Exprs.id_column_sum_expr)
         .filter(pl.col(Exprs.temp_id_column_sum) >= min_workers_threshold)
-        .with_columns(Exprs.job_group_percentage_expr)
+        .with_columns(
+            Exprs.job_group_percentage_expr.alias(
+                f"{pl.col(IndCQC.main_job_group_labelled)}_percentage"
+            )
+        )
     )
 
     # Build a LazyFrame of the fixed bounds from the magic numbers dict
@@ -145,14 +139,11 @@ def filter_job_role_group_outliers(
     else:
         piv_lf = piv_lf.join(bounds_lf, how="cross")
 
-    piv_lf = piv_lf.with_columns(
-        Exprs.evaluation_expr.alias(temp_out_of_bounds_col)
-    ).select(
-        *splits_for_pivot,
-        temp_out_of_bounds_col,
-        Exprs.temp_id_column_sum,
-        *[f"{id_column}_{c}_pct" for c in Exprs.job_group_cols],
-    )
+    piv_lf = piv_lf.with_columns(Exprs.evaluation_expr.alias(temp_out_of_bounds_col))
+    # .select(
+    #     *splits_for_pivot,
+    #     temp_out_of_bounds_col,
+    # )
 
     lf = lf.join(
         piv_lf,

--- a/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/utils/clean_utils.py
+++ b/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/utils/clean_utils.py
@@ -112,7 +112,7 @@ def filter_job_role_group_outliers(
         .filter(pl.col(Exprs.temp_id_column_sum) >= min_workers_threshold)
         .with_columns(
             Exprs.job_group_percentage_expr.alias(
-                f"{pl.col(IndCQC.main_job_group_labelled)}_percentage"
+                f"{id_column}_{pl.col(IndCQC.main_job_group_labelled)}_percentage"
             )
         )
     )

--- a/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/utils/clean_utils.py
+++ b/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/utils/clean_utils.py
@@ -48,6 +48,7 @@ def filter_job_role_group_outliers(
     lf: pl.LazyFrame,
     id_column: str = IndCQC.location_id,
     min_workers_threshold: int = 50,
+    include_direct_care_lower_bound: bool = True,
 ) -> pl.LazyFrame:
     """
     Null job role counts at locations, providers or brands where job group distribution is
@@ -69,6 +70,8 @@ def filter_job_role_group_outliers(
         min_workers_threshold (int): Minimum number of workers at a location/ provider/
             brand to be included in filtering. If below this threshold, location/ provider/brand
             bypasses the filter and is automatically included. Defaults to 50.
+        include_direct_care_lower_bound (bool): Whether to include the lower bound for
+            direct care in the filtering. Defaults to True.
 
     Returns:
         pl.LazyFrame: LazyFrame with outliers in job role groups filtered.
@@ -83,7 +86,7 @@ def filter_job_role_group_outliers(
         )
     temp_out_of_bounds_col: str = "out_of_bounds"
 
-    Exprs = FilterJobRoleGroupExpressions()
+    Exprs = FilterJobRoleGroupExpressions(include_direct_care_lower_bound)
 
     if id_column == IndCQC.location_id:
         splits_for_pivot = [
@@ -208,7 +211,7 @@ class FilterJobRoleGroupExpressions:
     job_group_percentage_expr: pl.Expr
     evaluation_expr: pl.Expr
 
-    def __init__(self):
+    def __init__(self, include_direct_care_lower_bound: bool = True):
         self.temp_id_column_sum = "id_column_sum"
         self.job_group_cols = [
             JobGroupLabels.direct_care,
@@ -274,14 +277,11 @@ class FilterJobRoleGroupExpressions:
             )
             .otherwise(pl.lit(None).cast(pl.Float32))
         )
+
         self.evaluation_expr = (
             (
                 pl.col(JobGroupLabels.direct_care)
                 > pl.col(JobGroupLabels.direct_care + self.upper_bound_suffix)
-            )
-            | (
-                pl.col(JobGroupLabels.direct_care)
-                < pl.col(JobGroupLabels.direct_care + self.lower_bound_suffix)
             )
             | (
                 pl.col(JobGroupLabels.managers)
@@ -296,6 +296,13 @@ class FilterJobRoleGroupExpressions:
                 > pl.col(JobGroupLabels.other + self.upper_bound_suffix)
             )
         )
+
+        lower_bound_check = pl.col(JobGroupLabels.direct_care) < pl.col(
+            JobGroupLabels.direct_care + self.lower_bound_suffix
+        )
+
+        if include_direct_care_lower_bound:
+            self.evaluation_expr = self.evaluation_expr | lower_bound_check
 
 
 def filter_job_role_group_equal_zero(lf: pl.LazyFrame) -> pl.LazyFrame:

--- a/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/utils/clean_utils.py
+++ b/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/utils/clean_utils.py
@@ -85,7 +85,7 @@ def filter_job_role_group_outliers(
         raise ValueError(
             f"Value must be one of {IndCQC.brand_id}, {IndCQC.provider_id}, or {IndCQC.location_id}"
         )
-    temp_out_of_bounds_col: str = f"{id_column}_out_of_bounds"
+    temp_out_of_bounds_col: str = "out_of_bounds"
 
     Exprs = FilterJobRoleGroupExpressions(include_direct_care_lower_bound)
 
@@ -135,11 +135,12 @@ def filter_job_role_group_outliers(
     else:
         piv_lf = piv_lf.join(bounds_lf, how="cross")
 
-    piv_lf = piv_lf.with_columns(Exprs.evaluation_expr.alias(temp_out_of_bounds_col))
-    # .select(
-    #     *splits_for_pivot,
-    #     temp_out_of_bounds_col,
-    # )
+    piv_lf = piv_lf.with_columns(
+        Exprs.evaluation_expr.alias(temp_out_of_bounds_col)
+    ).select(
+        *splits_for_pivot,
+        temp_out_of_bounds_col,
+    )
 
     lf = lf.join(
         piv_lf,
@@ -155,8 +156,7 @@ def filter_job_role_group_outliers(
         .then(None)
         .otherwise(pl.col(IndCQC.ascwds_job_role_counts))
         .alias(IndCQC.ascwds_job_role_counts)
-    )
-    # .drop(temp_out_of_bounds_col)
+    ).drop(temp_out_of_bounds_col)
 
     if id_column == IndCQC.brand_id:
         new_rule = JobRoleFilteringRule.job_role_group_is_outlier_at_brand_level

--- a/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/utils/clean_utils.py
+++ b/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/utils/clean_utils.py
@@ -60,7 +60,8 @@ def filter_job_role_group_outliers(
     Values are nulled where there are the same or more workers than the min workers threshold
     and either:
 
-    - direct care is outside the upper or lower bound
+    - direct care is outside the upper bound, or outside the lower bound if
+      include_direct_care_lower_bound is True
     - managers, regulated professions, or other are outside their upper bound
 
     Args:
@@ -185,6 +186,10 @@ class FilterJobRoleGroupExpressions:
     group distributions. It also defines column names
     used by these expressions.
 
+    Args:
+        include_direct_care_lower_bound (bool): Whether to include the lower bound
+            for direct care in the evaluation expression.
+
     Attributes:
         temp_id_column_sum (str): Temporary column name for the total number of workers.
         job_group_cols (list[str]): List of job group column names.
@@ -212,13 +217,6 @@ class FilterJobRoleGroupExpressions:
     evaluation_expr: pl.Expr
 
     def __init__(self, include_direct_care_lower_bound: bool = True):
-        """
-        Initialise FilterJobRoleGroupExpressions.
-
-        Args:
-            include_direct_care_lower_bound (bool): Whether to include the lower bound
-                for direct care in the evaluation expression. Defaults to True.
-        """
         self.temp_id_column_sum = "id_column_sum"
         self.job_group_cols = [
             JobGroupLabels.direct_care,

--- a/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/utils/clean_utils.py
+++ b/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/utils/clean_utils.py
@@ -110,11 +110,7 @@ def filter_job_role_group_outliers(
         )
         .with_columns(Exprs.id_column_sum_expr)
         .filter(pl.col(Exprs.temp_id_column_sum) >= min_workers_threshold)
-        .with_columns(
-            Exprs.job_group_percentage_expr.alias(
-                f"{id_column}_{pl.col(IndCQC.main_job_group_labelled)}_percentage"
-            )
-        )
+        .with_columns(Exprs.job_group_percentage_expr)
     )
 
     # Build a LazyFrame of the fixed bounds from the magic numbers dict

--- a/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/utils/clean_utils.py
+++ b/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/utils/clean_utils.py
@@ -212,6 +212,13 @@ class FilterJobRoleGroupExpressions:
     evaluation_expr: pl.Expr
 
     def __init__(self, include_direct_care_lower_bound: bool = True):
+        """
+        Initialise FilterJobRoleGroupExpressions.
+
+        Args:
+            include_direct_care_lower_bound (bool): Whether to include the lower bound
+                for direct care in the evaluation expression. Defaults to True.
+        """
         self.temp_id_column_sum = "id_column_sum"
         self.job_group_cols = [
             JobGroupLabels.direct_care,

--- a/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/utils/clean_utils.py
+++ b/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/utils/clean_utils.py
@@ -108,13 +108,19 @@ def filter_job_role_group_outliers(
             values=IndCQC.ascwds_job_role_counts,
             aggregate_function="sum",
         )
-        .with_columns(Exprs.id_column_sum_expr.alias(f"{id_column}_sum"))
-        .filter(pl.col(Exprs.temp_id_column_sum) >= min_workers_threshold)
         .with_columns(
-            Exprs.job_group_percentage_expr.alias(
-                f"{id_column}_job_group_percentage_expr"
-            )
+            [
+                Exprs.id_column_sum_expr,
+                *[
+                    (pl.col(c) / pl.col(Exprs.temp_id_column_sum)).alias(
+                        f"{id_column}_{c}_pct"
+                    )
+                    for c in Exprs.job_group_cols
+                ],
+            ]
         )
+        .filter(pl.col(Exprs.temp_id_column_sum) >= min_workers_threshold)
+        .with_columns(Exprs.job_group_percentage_expr)
     )
 
     # Build a LazyFrame of the fixed bounds from the magic numbers dict
@@ -144,6 +150,8 @@ def filter_job_role_group_outliers(
     ).select(
         *splits_for_pivot,
         temp_out_of_bounds_col,
+        Exprs.temp_id_column_sum,
+        *[f"{id_column}_{c}_pct" for c in Exprs.job_group_cols],
     )
 
     lf = lf.join(

--- a/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/tests/fargate/test_02_clean.py
+++ b/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/tests/fargate/test_02_clean.py
@@ -70,7 +70,11 @@ class MainTests(unittest.TestCase):
         filter_job_role_group_equal_zero_mock.assert_called_once()
         filter_job_role_group_outliers_mock.assert_has_calls(
             [
-                call(ANY, id_column=IndCQC.brand_id),
+                call(
+                    ANY,
+                    id_column=IndCQC.brand_id,
+                    include_direct_care_lower_bound=False,
+                ),
                 call(ANY, id_column=IndCQC.provider_id),
                 call(ANY, id_column=IndCQC.location_id),
             ],

--- a/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/tests/fargate/utils/test_clean_utils.py
+++ b/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/tests/fargate/utils/test_clean_utils.py
@@ -333,6 +333,29 @@ class TestFilterJobRoleGroupExpressions:
 
         pl_testing.assert_frame_equal(returned_lf, expected_lf)
 
+    TestExprsNoLowerBound = job.FilterJobRoleGroupExpressions(
+        include_direct_care_lower_bound=False
+    )
+
+    def test_evaluation_expression_excludes_lower_bound_when_flag_is_false(self):
+        test_lf = pl.LazyFrame(
+            Data.test_evaluation_expr_rows,
+            Schemas.test_evaluation_expr_schema,
+            orient="row",
+        )
+        expected_lf = pl.LazyFrame(
+            Data.expected_evaluation_expr_rows_no_lower_bound,
+            Schemas.test_evaluation_expr_schema,
+            orient="row",
+        )
+        returned_lf = test_lf.with_columns(
+            pl.when(self.TestExprsNoLowerBound.evaluation_expr)
+            .then(None)
+            .otherwise(pl.col(IndCQC.ascwds_job_role_counts))
+            .alias(IndCQC.ascwds_job_role_counts)
+        )
+        pl_testing.assert_frame_equal(returned_lf, expected_lf)
+
 
 class TestFilterJobRoleGroupsEqualZero:
     @pytest.mark.parametrize(

--- a/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/tests/fargate/utils/test_clean_utils.py
+++ b/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/tests/fargate/utils/test_clean_utils.py
@@ -178,6 +178,7 @@ class TestFilterAscwdsJobRoleCountWhenJobGroupRatiosOutsidePercentileBounds:
             test_lf,
             id_column=IndCQC.brand_id,
             min_workers_threshold=case.min_workers_threshold,
+            include_direct_care_lower_bound=case.include_direct_care_lower_bound,
         )
 
         pl_testing.assert_frame_equal(

--- a/projects/_03_independent_cqc/unittest_data/polars_ind_cqc_test_file_data.py
+++ b/projects/_03_independent_cqc/unittest_data/polars_ind_cqc_test_file_data.py
@@ -2976,6 +2976,7 @@ class EstimateFilledPostsByJobRoleCleanUtilsTestCase:
     expected_data: list[Any]
     expected_brand_prov_data: Optional[list[Any]] = None
     min_workers_threshold: Optional[int] = None
+    include_direct_care_lower_bound: bool = True
 
     def __post_init__(self):
         if self.expected_brand_prov_data is None:
@@ -3180,6 +3181,29 @@ class EstimateFilledPostsByJobRoleCleanUtilsData:
                 ("loc3", date(2024, 1, 1), PrimaryServiceType.care_home_only, MainJobRoleLabels.registered_nurse, JobGroupLabels.regulated_professions, None, JobRoleFilteringRule.job_role_group_is_outlier_at_location_level),
             ],
             min_workers_threshold=1,
+        ),
+        EstimateFilledPostsByJobRoleCleanUtilsTestCase(
+            id="retains_values_when_below_direct_care_lower_bound_and_flag_is_false",
+            test_data=[
+                ("loc1", date(2024, 1, 1), PrimaryServiceType.care_home_only, MainJobRoleLabels.care_worker, JobGroupLabels.direct_care, 1, JobRoleFilteringRule.populated),
+                ("loc1", date(2024, 1, 1), PrimaryServiceType.care_home_only, MainJobRoleLabels.registered_manager, JobGroupLabels.managers, 2, JobRoleFilteringRule.populated),
+                ("loc1", date(2024, 1, 1), PrimaryServiceType.care_home_only, MainJobRoleLabels.registered_nurse, JobGroupLabels.regulated_professions, 1, JobRoleFilteringRule.populated),
+                ("loc1", date(2024, 1, 1), PrimaryServiceType.care_home_only, MainJobRoleLabels.admin_staff, JobGroupLabels.other, 5, JobRoleFilteringRule.populated),
+            ],
+            expected_data=[
+                ("loc1", date(2024, 1, 1), PrimaryServiceType.care_home_only, MainJobRoleLabels.care_worker, JobGroupLabels.direct_care, None, JobRoleFilteringRule.job_role_group_is_outlier_at_location_level),
+                ("loc1", date(2024, 1, 1), PrimaryServiceType.care_home_only, MainJobRoleLabels.registered_manager, JobGroupLabels.managers, None, JobRoleFilteringRule.job_role_group_is_outlier_at_location_level),
+                ("loc1", date(2024, 1, 1), PrimaryServiceType.care_home_only, MainJobRoleLabels.registered_nurse, JobGroupLabels.regulated_professions, None, JobRoleFilteringRule.job_role_group_is_outlier_at_location_level),
+                ("loc1", date(2024, 1, 1), PrimaryServiceType.care_home_only, MainJobRoleLabels.admin_staff, JobGroupLabels.other, None, JobRoleFilteringRule.job_role_group_is_outlier_at_location_level),
+            ],
+            expected_brand_prov_data=[
+                ("loc1", date(2024, 1, 1), PrimaryServiceType.care_home_only, MainJobRoleLabels.care_worker, JobGroupLabels.direct_care, 1, JobRoleFilteringRule.populated),
+                ("loc1", date(2024, 1, 1), PrimaryServiceType.care_home_only, MainJobRoleLabels.registered_manager, JobGroupLabels.managers, 2, JobRoleFilteringRule.populated),
+                ("loc1", date(2024, 1, 1), PrimaryServiceType.care_home_only, MainJobRoleLabels.registered_nurse, JobGroupLabels.regulated_professions, 1, JobRoleFilteringRule.populated),
+                ("loc1", date(2024, 1, 1), PrimaryServiceType.care_home_only, MainJobRoleLabels.admin_staff, JobGroupLabels.other, 5, JobRoleFilteringRule.populated),
+            ],
+            min_workers_threshold=1,
+            include_direct_care_lower_bound=False,
         ),
     ]  # fmt: skip
 

--- a/projects/_03_independent_cqc/unittest_data/polars_ind_cqc_test_file_data.py
+++ b/projects/_03_independent_cqc/unittest_data/polars_ind_cqc_test_file_data.py
@@ -3241,6 +3241,16 @@ class EstimateFilledPostsByJobRoleCleanUtilsData:
         (0.01, 0.3, 0.3, 0.3, 0.2, 0.2, 0.2, 0.2, 0.05, None), # All out of bounds
         (None, None, None, None, None, None, None, None, None, None), # Test handling of null values
     ] # fmt: skip
+    expected_evaluation_expr_rows_no_lower_bound = [
+        (0.1, 0.1, 0.1, 0.1, 0.2, 0.2, 0.2, 0.2, 0.05, 1),    # All within bounds - retained
+        (0.3, 0.1, 0.1, 0.1, 0.2, 0.2, 0.2, 0.2, 0.05, None),  # Direct care above upper bound - nulled
+        (0.1, 0.3, 0.1, 0.1, 0.2, 0.2, 0.2, 0.2, 0.05, None),  # Managers above upper bound - nulled
+        (0.1, 0.1, 0.3, 0.1, 0.2, 0.2, 0.2, 0.2, 0.05, None),  # Regulated professionals above upper bound - nulled
+        (0.1, 0.1, 0.1, 0.3, 0.2, 0.2, 0.2, 0.2, 0.05, None),  # Other above upper bound - nulled
+        (0.01, 0.1, 0.1, 0.1, 0.2, 0.2, 0.2, 0.2, 0.05, 1),    # Direct care below lower bound - retained (flag=False)
+        (0.01, 0.3, 0.3, 0.3, 0.2, 0.2, 0.2, 0.2, 0.05, None), # All out of bounds - nulled (upper bounds still apply)
+        (None, None, None, None, None, None, None, None, None, None), # Null values - retained
+    ]  # fmt: skip
 
     filter_job_role_group_equal_zero_test_cases = [
         EstimateFilledPostsByJobRoleCleanUtilsTestCase(


### PR DESCRIPTION
## Description
Trello ticket [#1654](https://trello.com/c/ehSLnOVw/1654-jr-filtering-6-optional-ticket-make-lower-bound-magic-number-optional)

Made lower bound magic number optional within filter_job_role_group_outliers function. I have added a optional parameter to include/not include the lower bound to flag outliers.

## Testing
- [x] Unit tests passing
- [x] Successful [Step Function run](https://eu-west-2.console.aws.amazon.com/states/home?region=eu-west-2#/v2/executions/details/arn:aws:states:eu-west-2:856699698263:execution:1654-jr-fltr-opt-prm-Ind-CQC-Filled-Post-Estimates-By-Role:950ca9a3-2003-4f79-a1ae-107c6853b2d5)
- [ ] Outputs checked in Athena

## Checklist (delete if not relevant)
- [x] Unit tests added/amended
- [x] Docstrings added/updated
- [x] Updated CHANGELOG
- [x] Code reviewed by AI
- [x] Moved Trello ticket to PR column

## Reviewer checklist
- [ ] PR solves the Trello ticket requirements
- [ ] Outputs appear reasonable and understandable
- [ ] The overall approach is appropriate and not over-engineered
- [ ] No obvious scalability, performance or interdependency concerns
- [ ] Tests appropriately cover the main behaviour/edge cases
- [ ] Naming and structure are broadly understandable and consistent
- [ ] Docstrings are sufficient for future maintenance
- [ ] Docstrings cover non-obvious behaviour
