### PR TITLE
1678 grp provs 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ All notable changes to this project will be documented in this file.
 
 - Changed _04_estimate job role filled posts so historical reallocation is called after manager adjustment.
 
+- Changed null_grouped_providers so that they are saved to s3 before being nulled.
+
 ### Fixed
 - Replace the all roles and all job groups functions with the appropriate categorical values attribute.
 

--- a/projects/_03_independent_cqc/_01_merge/fargate/merge_ind_cqc_data.py
+++ b/projects/_03_independent_cqc/_01_merge/fargate/merge_ind_cqc_data.py
@@ -67,6 +67,7 @@ cleaned_ascwds_workplace_columns_to_import = [
     AWPClean.organisation_id,
     AWPClean.total_staff_bounded,
     AWPClean.worker_records_bounded,
+    AWPClean.nmds_id,
 ]
 
 cleaned_cqc_pir_columns_to_import = [

--- a/projects/_03_independent_cqc/_02_clean/fargate/clean_ind_cqc_filled_posts.py
+++ b/projects/_03_independent_cqc/_02_clean/fargate/clean_ind_cqc_filled_posts.py
@@ -96,7 +96,8 @@ def main(
 
     locations_lf = calculate_care_home_status_count(locations_lf)
 
-    print(f"Exporting as parquet to {cleaned_ind_cqc_destination}")
+    print(f"Exporting cleaned data to {cleaned_ind_cqc_destination}")
+    print(f"Exporting grouped providers data to {grouped_providers_destination}")
 
     utils.sink_to_parquet(
         locations_lf,

--- a/projects/_03_independent_cqc/_02_clean/fargate/clean_ind_cqc_filled_posts.py
+++ b/projects/_03_independent_cqc/_02_clean/fargate/clean_ind_cqc_filled_posts.py
@@ -23,6 +23,9 @@ from projects._03_independent_cqc._02_clean.fargate.utils.clean_ind_cqc_filled_p
 from projects._03_independent_cqc._02_clean.fargate.utils.utils import (
     create_column_with_repeated_values_removed,
 )
+from utils.column_names.cleaned_data_files.ascwds_workplace_cleaned import (
+    AscwdsWorkplaceCleanedColumns as AWPClean,
+)
 from utils.column_names.ind_cqc_pipeline_columns import IndCqcColumns as IndCQC
 
 
@@ -80,6 +83,7 @@ def main(
     )
 
     locations_lf, grouped_providers = clean_ascwds_filled_post_outliers(locations_lf)
+    locations_lf = locations_lf.drop(AWPClean.nmds_id)
 
     locations_lf = cUtils.calculate_filled_posts_per_bed_ratio(
         locations_lf,

--- a/projects/_03_independent_cqc/_02_clean/fargate/clean_ind_cqc_filled_posts.py
+++ b/projects/_03_independent_cqc/_02_clean/fargate/clean_ind_cqc_filled_posts.py
@@ -108,7 +108,7 @@ def main(
     utils.sink_to_parquet(
         grouped_providers,
         grouped_providers_destination,
-        append=True,
+        append=False,
     )
 
 

--- a/projects/_03_independent_cqc/_02_clean/fargate/clean_ind_cqc_filled_posts.py
+++ b/projects/_03_independent_cqc/_02_clean/fargate/clean_ind_cqc_filled_posts.py
@@ -28,14 +28,16 @@ from utils.column_names.ind_cqc_pipeline_columns import IndCqcColumns as IndCQC
 
 def main(
     merged_ind_cqc_source: str,
-    destination: str,
+    cleaned_ind_cqc_destination: str,
+    grouped_providers_destination: str,
 ) -> None:
     """
     Cleans independent CQC locations data.
 
     Args:
         merged_ind_cqc_source (str): s3 path to the merged independent CQC location data
-        destination (str): s3 path to save cleaned independent CQC location data
+        cleaned_ind_cqc_destination (str): s3 path to save cleaned independent CQC location data
+        grouped_providers_destination (str): S3 path to save potential grouped providers data
     """
     print("Cleaning merged_ind_cqc dataset...")
 
@@ -77,7 +79,7 @@ def main(
         [0, 1, 3, 5, 10, 15, 20, 25, 50, float("Inf")],
     )
 
-    locations_lf = clean_ascwds_filled_post_outliers(locations_lf)
+    locations_lf, grouped_providers = clean_ascwds_filled_post_outliers(locations_lf)
 
     locations_lf = cUtils.calculate_filled_posts_per_bed_ratio(
         locations_lf,
@@ -90,12 +92,18 @@ def main(
 
     locations_lf = calculate_care_home_status_count(locations_lf)
 
-    print(f"Exporting as parquet to {destination}")
+    print(f"Exporting as parquet to {cleaned_ind_cqc_destination}")
 
     utils.sink_to_parquet(
         locations_lf,
-        destination,
+        cleaned_ind_cqc_destination,
         append=False,
+    )
+
+    utils.sink_to_parquet(
+        grouped_providers,
+        grouped_providers_destination,
+        append=True,
     )
 
 
@@ -108,14 +116,19 @@ if __name__ == "__main__":
             "S3 URI to read merged CQC location data from",
         ),
         (
-            "--destination",
+            "--cleaned_ind_cqc_destination",
             "S3 URI to save cleaned ind cqc data to",
+        ),
+        (
+            "--grouped_providers_destination",
+            "S3 URI to save potential grouped providers data to",
         ),
     )
 
     main(
         merged_ind_cqc_source=args.merged_ind_cqc_source,
-        destination=args.destination,
+        cleaned_ind_cqc_destination=args.cleaned_ind_cqc_destination,
+        grouped_providers_destination=args.grouped_providers_destination,
     )
 
     print("Finished Clean Independent CQC job")

--- a/projects/_03_independent_cqc/_02_clean/fargate/utils/clean_ascwds_filled_post_outliers/clean_ascwds_filled_post_outliers.py
+++ b/projects/_03_independent_cqc/_02_clean/fargate/utils/clean_ascwds_filled_post_outliers/clean_ascwds_filled_post_outliers.py
@@ -19,7 +19,9 @@ from utils.column_names.ind_cqc_pipeline_columns import IndCqcColumns as IndCQC
 from utils.column_values.categorical_column_values import AscwdsFilteringRule
 
 
-def clean_ascwds_filled_post_outliers(lf: pl.LazyFrame) -> pl.LazyFrame:
+def clean_ascwds_filled_post_outliers(
+    lf: pl.LazyFrame,
+) -> tuple[pl.LazyFrame, pl.LazyFrame]:
     """
     Creates a clean version of 'ascwds_filled_posts_dedup' column.
 
@@ -31,7 +33,8 @@ def clean_ascwds_filled_post_outliers(lf: pl.LazyFrame) -> pl.LazyFrame:
         lf (pl.LazyFrame): A polars LazyFrame containing 'ascwds_filled_posts_dedup'.
 
     Returns:
-        pl.LazyFrame: A polars LazyFrame containing 'ascwds_filled_posts_dedup_clean'.
+        tuple[pl.LazyFrame, pl.LazyFrame]: The input LazyFrame containing
+            'ascwds_filled_posts_dedup_clean' and a LazyFrame of potential grouped providers.
     """
     print("Cleaning ascwds_filled_posts_dedup...")
 
@@ -49,8 +52,8 @@ def clean_ascwds_filled_post_outliers(lf: pl.LazyFrame) -> pl.LazyFrame:
     )
 
     lf = null_filled_posts_where_locations_use_invalid_missing_data_code(lf)
-    lf = null_grouped_providers(lf)
+    lf, grouped_providers = null_grouped_providers(lf)
     lf = winsorize_care_home_filled_posts_per_bed_ratio_outliers(lf)
     lf = non_res_brand_id_filter(lf)
 
-    return lf
+    return lf, grouped_providers

--- a/projects/_03_independent_cqc/_02_clean/fargate/utils/clean_ascwds_filled_post_outliers/null_grouped_providers.py
+++ b/projects/_03_independent_cqc/_02_clean/fargate/utils/clean_ascwds_filled_post_outliers/null_grouped_providers.py
@@ -7,6 +7,9 @@ from polars_utils.expressions import is_care_home, is_not_care_home
 from polars_utils.filtering_utils import (
     update_filtering_rule,
 )
+from utils.column_names.cleaned_data_files.ascwds_workplace_cleaned import (
+    AscwdsWorkplaceCleanedColumns as AWPClean,
+)
 from utils.column_names.ind_cqc_pipeline_columns import IndCqcColumns as IndCQC
 from utils.column_names.ind_cqc_pipeline_columns import (
     NullGroupedProviderColumns as NGPcol,
@@ -312,6 +315,7 @@ def select_grouped_providers_on_latest_import(lf: pl.LazyFrame) -> pl.LazyFrame:
         IndCQC.location_id,
         IndCQC.provider_id,
         IndCQC.cqc_location_import_date,
+        AWPClean.nmds_id,
         NGPcol.potential_grouped_provider,
         IndCQC.ascwds_filled_posts_dedup_clean,
     ]

--- a/projects/_03_independent_cqc/_02_clean/fargate/utils/clean_ascwds_filled_post_outliers/null_grouped_providers.py
+++ b/projects/_03_independent_cqc/_02_clean/fargate/utils/clean_ascwds_filled_post_outliers/null_grouped_providers.py
@@ -321,23 +321,11 @@ def select_grouped_providers(lf: pl.LazyFrame) -> pl.LazyFrame:
         NGPcol.potential_grouped_provider,
         IndCQC.ascwds_filled_posts_dedup_clean,
     ]
+
+    date_col = pl.col(IndCQC.cqc_location_import_date)
     return (
         lf.select(cols_to_select)
-        .filter(
-            (pl.col(NGPcol.potential_grouped_provider) == True)
-            & (
-                pl.col(IndCQC.cqc_location_import_date).dt.year()
-                == pl.col(IndCQC.cqc_location_import_date).dt.year().max()
-            )
-            & (
-                pl.col(IndCQC.cqc_location_import_date).dt.month()
-                == pl.col(IndCQC.cqc_location_import_date).dt.month().max()
-            )
-        )
-        .filter(
-            (
-                pl.col(IndCQC.cqc_location_import_date).dt.day()
-                == pl.col(IndCQC.cqc_location_import_date).dt.day().min()
-            )
-        )
+        .filter(pl.col(NGPcol.potential_grouped_provider) == True)
+        .filter(date_col.dt.truncate("1mo") == date_col.dt.truncate("1mo").max())
+        .filter(date_col == date_col.min().over(date_col.dt.truncate("1mo")))
     )

--- a/projects/_03_independent_cqc/_02_clean/fargate/utils/clean_ascwds_filled_post_outliers/null_grouped_providers.py
+++ b/projects/_03_independent_cqc/_02_clean/fargate/utils/clean_ascwds_filled_post_outliers/null_grouped_providers.py
@@ -304,8 +304,8 @@ def select_grouped_providers(lf: pl.LazyFrame) -> pl.LazyFrame:
     """
     Filters the input LazyFrame to the following:
         - potential_grouped_provider is True
-        - cqc_location_import_date equal to max month across dataset.
-        - cqc_location_import_date equal to min day of the max month across dataset.
+        - cqc_location_import_date equal to max year/month across dataset.
+        - cqc_location_import_date equal to min day of the max year/month across dataset.
 
     Args:
         lf (pl.LazyFrame): A LazyFrame with potential_grouped_provider column.
@@ -325,6 +325,10 @@ def select_grouped_providers(lf: pl.LazyFrame) -> pl.LazyFrame:
         lf.select(cols_to_select)
         .filter(
             (pl.col(NGPcol.potential_grouped_provider) == True)
+            & (
+                pl.col(IndCQC.cqc_location_import_date).dt.year()
+                == pl.col(IndCQC.cqc_location_import_date).dt.year().max()
+            )
             & (
                 pl.col(IndCQC.cqc_location_import_date).dt.month()
                 == pl.col(IndCQC.cqc_location_import_date).dt.month().max()

--- a/projects/_03_independent_cqc/_02_clean/fargate/utils/clean_ascwds_filled_post_outliers/null_grouped_providers.py
+++ b/projects/_03_independent_cqc/_02_clean/fargate/utils/clean_ascwds_filled_post_outliers/null_grouped_providers.py
@@ -327,6 +327,5 @@ def select_grouped_providers(lf: pl.LazyFrame) -> pl.LazyFrame:
     return (
         lf.filter(pl.col(NGPcol.potential_grouped_provider))
         .filter(trunc_date_col == trunc_date_col.max())
-        .filter(date_col == date_col.min().over(trunc_date_col))
         .select(cols_to_select)
     )

--- a/projects/_03_independent_cqc/_02_clean/fargate/utils/clean_ascwds_filled_post_outliers/null_grouped_providers.py
+++ b/projects/_03_independent_cqc/_02_clean/fargate/utils/clean_ascwds_filled_post_outliers/null_grouped_providers.py
@@ -323,9 +323,10 @@ def select_grouped_providers(lf: pl.LazyFrame) -> pl.LazyFrame:
     ]
 
     date_col = pl.col(IndCQC.cqc_location_import_date)
+    trunc_date_col = date_col.dt.truncate("1mo")  # E.g. 2026-01-05 becomes 2026-01-01.
     return (
-        lf.select(cols_to_select)
-        .filter(pl.col(NGPcol.potential_grouped_provider) == True)
-        .filter(date_col.dt.truncate("1mo") == date_col.dt.truncate("1mo").max())
-        .filter(date_col == date_col.min().over(date_col.dt.truncate("1mo")))
+        lf.filter(pl.col(NGPcol.potential_grouped_provider))
+        .filter(trunc_date_col == trunc_date_col.max())
+        .filter(date_col == date_col.min().over(trunc_date_col))
+        .select(cols_to_select)
     )

--- a/projects/_03_independent_cqc/_02_clean/fargate/utils/clean_ascwds_filled_post_outliers/null_grouped_providers.py
+++ b/projects/_03_independent_cqc/_02_clean/fargate/utils/clean_ascwds_filled_post_outliers/null_grouped_providers.py
@@ -73,7 +73,7 @@ def null_grouped_providers(lf: pl.LazyFrame) -> tuple[pl.LazyFrame, pl.LazyFrame
 
     lf = identify_potential_grouped_providers(lf)
 
-    grouped_providers = select_grouped_providers_on_latest_import(lf)
+    grouped_providers = select_grouped_providers(lf)
 
     lf = null_care_home_grouped_providers(lf)
     lf = null_non_residential_grouped_providers(lf)
@@ -300,10 +300,12 @@ def null_non_residential_grouped_providers(lf: pl.LazyFrame) -> pl.LazyFrame:
     return lf
 
 
-def select_grouped_providers_on_latest_import(lf: pl.LazyFrame) -> pl.LazyFrame:
+def select_grouped_providers(lf: pl.LazyFrame) -> pl.LazyFrame:
     """
-    Filters LazyFrame where potential_grouped_provider is True and
-    cqc_location_import_date equal to max cqc_location_import_date.
+    Filters the input LazyFrame to the following:
+        - potential_grouped_provider is True
+        - cqc_location_import_date equal to max month across dataset.
+        - cqc_location_import_date equal to min day of the max month across dataset.
 
     Args:
         lf (pl.LazyFrame): A LazyFrame with potential_grouped_provider column.
@@ -319,10 +321,19 @@ def select_grouped_providers_on_latest_import(lf: pl.LazyFrame) -> pl.LazyFrame:
         NGPcol.potential_grouped_provider,
         IndCQC.ascwds_filled_posts_dedup_clean,
     ]
-    return lf.select(cols_to_select).filter(
-        (pl.col(NGPcol.potential_grouped_provider) == True)
-        & (
-            pl.col(IndCQC.cqc_location_import_date)
-            == pl.max(IndCQC.cqc_location_import_date)
+    return (
+        lf.select(cols_to_select)
+        .filter(
+            (pl.col(NGPcol.potential_grouped_provider) == True)
+            & (
+                pl.col(IndCQC.cqc_location_import_date).dt.month()
+                == pl.col(IndCQC.cqc_location_import_date).dt.month().max()
+            )
+        )
+        .filter(
+            (
+                pl.col(IndCQC.cqc_location_import_date).dt.day()
+                == pl.col(IndCQC.cqc_location_import_date).dt.day().min()
+            )
         )
     )

--- a/projects/_03_independent_cqc/_02_clean/fargate/utils/clean_ascwds_filled_post_outliers/null_grouped_providers.py
+++ b/projects/_03_independent_cqc/_02_clean/fargate/utils/clean_ascwds_filled_post_outliers/null_grouped_providers.py
@@ -42,10 +42,12 @@ class NullGroupedProvidersConfig:
     POSTS_PER_PIR_PROVIDER_THRESHOLD: pl.Float64 = 1.5
 
 
-def null_grouped_providers(lf: pl.LazyFrame) -> pl.LazyFrame:
+def null_grouped_providers(lf: pl.LazyFrame) -> tuple[pl.LazyFrame, pl.LazyFrame]:
     """
     Null ascwds_filled_posts_dedup_clean where a provider has multiple
     locations, all their ascwds is under one location.
+
+    These providers are returned in a separate LazyFrame before being nulled.
 
     Following analysis of ASCWDS data and contacting some providers, we
     discovered that some providers were submitting their entire workforce
@@ -61,11 +63,14 @@ def null_grouped_providers(lf: pl.LazyFrame) -> pl.LazyFrame:
         lf (pl.LazyFrame): A polars LazyFrame with independent cqc data.
 
     Returns:
-        pl.LazyFrame: A polars LazyFrame with grouped providers' data nulled.
+        tuple[pl.LazyFrame, pl.LazyFrame]: The input LazyFrame with grouped
+            providers' data nulled and a LazyFrame of potential grouped providers prior to nulling.
     """
     lf = calculate_data_for_grouped_provider_identification(lf)
 
     lf = identify_potential_grouped_providers(lf)
+
+    grouped_providers = select_grouped_providers_on_latest_import(lf)
 
     lf = null_care_home_grouped_providers(lf)
     lf = null_non_residential_grouped_providers(lf)
@@ -73,7 +78,7 @@ def null_grouped_providers(lf: pl.LazyFrame) -> pl.LazyFrame:
     columns_to_drop = [field.name for field in fields(NGPcol())]
     lf = lf.drop(*columns_to_drop)
 
-    return lf
+    return lf, grouped_providers
 
 
 def calculate_data_for_grouped_provider_identification(
@@ -290,3 +295,30 @@ def null_non_residential_grouped_providers(lf: pl.LazyFrame) -> pl.LazyFrame:
     )
 
     return lf
+
+
+def select_grouped_providers_on_latest_import(lf: pl.LazyFrame) -> pl.LazyFrame:
+    """
+    Filters LazyFrame where potential_grouped_provider is True and
+    cqc_location_import_date equal to max cqc_location_import_date.
+
+    Args:
+        lf (pl.LazyFrame): A LazyFrame with potential_grouped_provider column.
+
+    Returns:
+        pl.LazyFrame: The filtered input LazyFrame.
+    """
+    cols_to_select = [
+        IndCQC.location_id,
+        IndCQC.provider_id,
+        IndCQC.cqc_location_import_date,
+        NGPcol.potential_grouped_provider,
+        IndCQC.ascwds_filled_posts_dedup_clean,
+    ]
+    return lf.select(cols_to_select).filter(
+        (pl.col(NGPcol.potential_grouped_provider) == True)
+        & (
+            pl.col(IndCQC.cqc_location_import_date)
+            == pl.max(IndCQC.cqc_location_import_date)
+        )
+    )

--- a/projects/_03_independent_cqc/_02_clean/tests/fargate/test_clean_ind_cqc_filled_posts.py
+++ b/projects/_03_independent_cqc/_02_clean/tests/fargate/test_clean_ind_cqc_filled_posts.py
@@ -1,16 +1,7 @@
 import unittest
-import warnings
-from unittest.mock import ANY, Mock, patch
-
-import polars as pl
+from unittest.mock import ANY, Mock, call, patch
 
 import projects._03_independent_cqc._02_clean.fargate.clean_ind_cqc_filled_posts as job
-from projects._03_independent_cqc.unittest_data.polars_ind_cqc_test_file_data import (
-    CleanIndCQCData as Data,
-)
-from projects._03_independent_cqc.unittest_data.polars_ind_cqc_test_file_schemas import (
-    CleanIndCQCSchema as Schemas,
-)
 
 PATCH_PATH = "projects._03_independent_cqc._02_clean.fargate.clean_ind_cqc_filled_posts"
 
@@ -18,9 +9,7 @@ PATCH_PATH = "projects._03_independent_cqc._02_clean.fargate.clean_ind_cqc_fille
 class CleanIndFilledPostsTests(unittest.TestCase):
     MERGE_IND_CQC_SOURCE = "input_dir"
     CLEANED_IND_CQC_DESTINATION = "output_dir"
-
-    def setUp(self):
-        self.merge_ind_cqc_test_df = Mock(name="merge_ind_cqc_data")
+    GROUPED_PROVIDERS_DESTINATION = "another_dir"
 
 
 class MainTests(CleanIndFilledPostsTests):
@@ -59,11 +48,17 @@ class MainTests(CleanIndFilledPostsTests):
         calculate_care_home_status_count_mock: Mock,
         sink_to_parquet_mock: Mock,
     ):
-        scan_parquet_mock.return_value = self.merge_ind_cqc_test_df
+        scan_parquet_mock.return_value = Mock(name="merge_ind_cqc_data")
+
+        clean_ascwds_filled_post_outliers_mock.return_value = [
+            Mock(name="clean_ind_cqc_data"),
+            Mock(name="grouped_providers"),
+        ]
 
         job.main(
             self.MERGE_IND_CQC_SOURCE,
             self.CLEANED_IND_CQC_DESTINATION,
+            self.GROUPED_PROVIDERS_DESTINATION,
         )
 
         reduce_dataset_to_earliest_file_per_month_mock.assert_called_once()
@@ -81,10 +76,20 @@ class MainTests(CleanIndFilledPostsTests):
         clean_capacity_tracker_non_res_outliers_mock.assert_called_once()
         calculate_care_home_status_count_mock.assert_called_once()
 
-        sink_to_parquet_mock.assert_called_once_with(
-            ANY,
-            self.CLEANED_IND_CQC_DESTINATION,
-            append=False,
+        self.assertEqual(sink_to_parquet_mock.call_count, 2)
+        sink_to_parquet_mock.assert_has_calls(
+            [
+                call(
+                    ANY,
+                    self.CLEANED_IND_CQC_DESTINATION,
+                    append=False,
+                ),
+                call(
+                    ANY,
+                    self.GROUPED_PROVIDERS_DESTINATION,
+                    append=True,
+                ),
+            ]
         )
 
 

--- a/projects/_03_independent_cqc/_02_clean/tests/fargate/test_clean_ind_cqc_filled_posts.py
+++ b/projects/_03_independent_cqc/_02_clean/tests/fargate/test_clean_ind_cqc_filled_posts.py
@@ -87,7 +87,7 @@ class MainTests(CleanIndFilledPostsTests):
                 call(
                     ANY,
                     self.GROUPED_PROVIDERS_DESTINATION,
-                    append=True,
+                    append=False,
                 ),
             ]
         )

--- a/projects/_03_independent_cqc/_02_clean/tests/fargate/utils/clean_ascwds_filled_post_outliers/test_clean_ascwds_filled_post_outliers.py
+++ b/projects/_03_independent_cqc/_02_clean/tests/fargate/utils/clean_ascwds_filled_post_outliers/test_clean_ascwds_filled_post_outliers.py
@@ -39,6 +39,11 @@ class CleanAscwdsFilledPostOutliersTests(unittest.TestCase):
         null_filled_posts_where_locations_use_invalid_missing_data_code_mock: Mock,
         add_filtering_rule_column_mock: Mock,
     ):
+        null_grouped_provders_mock.return_value = [
+            Mock(name="clean_ind_cqc_data"),
+            Mock(name="grouped_providers"),
+        ]
+
         job.clean_ascwds_filled_post_outliers(self.unfiltered_ind_cqc_lf)
         winsorize_care_home_filled_posts_per_bed_ratio_outliers_mock.assert_called_once()
         null_grouped_provders_mock.assert_called_once()

--- a/projects/_03_independent_cqc/_02_clean/tests/fargate/utils/clean_ascwds_filled_post_outliers/test_null_grouped_providers.py
+++ b/projects/_03_independent_cqc/_02_clean/tests/fargate/utils/clean_ascwds_filled_post_outliers/test_null_grouped_providers.py
@@ -190,7 +190,7 @@ class NullNonResidentialGroupedProvidersTests(unittest.TestCase):
         pl_testing.assert_frame_equal(returned_lf.sort(IndCQC.location_id), test_lf)
 
 
-class SelectGroupedProvidersOnLatestImport(unittest.TestCase):
+class SelectGroupedProviders(unittest.TestCase):
     def test_function_returns_expected_rows(self):
         input_lf = pl.LazyFrame(
             Data.select_grouped_providers_rows,
@@ -203,4 +203,4 @@ class SelectGroupedProvidersOnLatestImport(unittest.TestCase):
             Schemas.select_grouped_providers_schema,
             orient="row",
         )
-        pl_testing.assert_frame_equal(returned_lf.sort(IndCQC.location_id), expected_lf)
+        pl_testing.assert_frame_equal(returned_lf, expected_lf)

--- a/projects/_03_independent_cqc/_02_clean/tests/fargate/utils/clean_ascwds_filled_post_outliers/test_null_grouped_providers.py
+++ b/projects/_03_independent_cqc/_02_clean/tests/fargate/utils/clean_ascwds_filled_post_outliers/test_null_grouped_providers.py
@@ -59,24 +59,32 @@ class MainTests(unittest.TestCase):
             Schemas.null_grouped_providers_schema,
             orient="row",
         )
-        self.returned_lf = job.null_grouped_providers(self.test_lf)
+        self.returned_lf, self.grouped_providers = job.null_grouped_providers(
+            self.test_lf
+        )
 
     def test_null_grouped_providers_runs(self):
         self.assertIsInstance(self.returned_lf, pl.LazyFrame)
+        self.assertIsInstance(self.grouped_providers, pl.LazyFrame)
 
     def test_null_grouped_providers_returns_same_number_of_rows(self):
         self.assertEqual(
             self.returned_lf.collect().height, self.test_lf.collect().height
         )
 
+    def test_null_grouped_providers_returns_expected_grouped_providers(self):
+        self.assertEqual(self.grouped_providers.collect().height, 2)
+
     @patch(f"{PATCH_PATH}.null_non_residential_grouped_providers")
     @patch(f"{PATCH_PATH}.null_care_home_grouped_providers")
+    @patch(f"{PATCH_PATH}.select_grouped_providers_on_latest_import")
     @patch(f"{PATCH_PATH}.identify_potential_grouped_providers")
     @patch(f"{PATCH_PATH}.calculate_data_for_grouped_provider_identification")
     def test_null_grouped_providers_calls_functions(
         self,
         calculate_data_for_grouped_provider_identification_mock: Mock,
         identify_potential_grouped_providers_mock: Mock,
+        select_grouped_providers_on_latest_import: Mock,
         null_care_home_grouped_providers_mock: Mock,
         null_non_residential_grouped_providers_mock: Mock,
     ):
@@ -86,6 +94,7 @@ class MainTests(unittest.TestCase):
             self.test_lf
         )
         identify_potential_grouped_providers_mock.assert_called_once()
+        select_grouped_providers_on_latest_import.assert_called_once()
         null_care_home_grouped_providers_mock.assert_called_once()
         null_non_residential_grouped_providers_mock.assert_called_once()
 
@@ -179,3 +188,20 @@ class NullNonResidentialGroupedProvidersTests(unittest.TestCase):
         returned_lf = job.null_non_residential_grouped_providers(test_lf)
 
         pl_testing.assert_frame_equal(returned_lf.sort(IndCQC.location_id), test_lf)
+
+
+class SelectGroupedProvidersOnLatestImport(unittest.TestCase):
+    def test_function_returns_expected_rows(self):
+        input_lf = pl.LazyFrame(
+            Data.select_grouped_providers_on_latest_import_rows,
+            Schemas.select_grouped_providers_on_latest_import_schema,
+            orient="row",
+        )
+        returned_lf = job.select_grouped_providers_on_latest_import(input_lf)
+        expected_lf = pl.LazyFrame(
+            Data.expected_select_grouped_providers_on_latest_import_rows,
+            Schemas.select_grouped_providers_on_latest_import_schema,
+            orient="row",
+        )
+
+        pl_testing.assert_frame_equal(returned_lf, expected_lf)

--- a/projects/_03_independent_cqc/_02_clean/tests/fargate/utils/clean_ascwds_filled_post_outliers/test_null_grouped_providers.py
+++ b/projects/_03_independent_cqc/_02_clean/tests/fargate/utils/clean_ascwds_filled_post_outliers/test_null_grouped_providers.py
@@ -67,12 +67,14 @@ class MainTests(unittest.TestCase):
         self.assertIsInstance(self.returned_lf, pl.LazyFrame)
         self.assertIsInstance(self.grouped_providers, pl.LazyFrame)
 
-    def test_null_grouped_providers_returns_same_number_of_rows(self):
+    def test_null_grouped_providers_returns_same_number_of_rows_in_locations_data(self):
         self.assertEqual(
             self.returned_lf.collect().height, self.test_lf.collect().height
         )
 
-    def test_null_grouped_providers_returns_expected_grouped_providers(self):
+    def test_null_grouped_providers_returns_expected_rows_in_grouped_providers_data(
+        self,
+    ):
         self.assertEqual(self.grouped_providers.collect().height, 2)
 
     @patch(f"{PATCH_PATH}.null_non_residential_grouped_providers")

--- a/projects/_03_independent_cqc/_02_clean/tests/fargate/utils/clean_ascwds_filled_post_outliers/test_null_grouped_providers.py
+++ b/projects/_03_independent_cqc/_02_clean/tests/fargate/utils/clean_ascwds_filled_post_outliers/test_null_grouped_providers.py
@@ -203,5 +203,4 @@ class SelectGroupedProvidersOnLatestImport(unittest.TestCase):
             Schemas.select_grouped_providers_schema,
             orient="row",
         )
-
         pl_testing.assert_frame_equal(returned_lf.sort(IndCQC.location_id), expected_lf)

--- a/projects/_03_independent_cqc/_02_clean/tests/fargate/utils/clean_ascwds_filled_post_outliers/test_null_grouped_providers.py
+++ b/projects/_03_independent_cqc/_02_clean/tests/fargate/utils/clean_ascwds_filled_post_outliers/test_null_grouped_providers.py
@@ -77,14 +77,14 @@ class MainTests(unittest.TestCase):
 
     @patch(f"{PATCH_PATH}.null_non_residential_grouped_providers")
     @patch(f"{PATCH_PATH}.null_care_home_grouped_providers")
-    @patch(f"{PATCH_PATH}.select_grouped_providers_on_latest_import")
+    @patch(f"{PATCH_PATH}.select_grouped_providers")
     @patch(f"{PATCH_PATH}.identify_potential_grouped_providers")
     @patch(f"{PATCH_PATH}.calculate_data_for_grouped_provider_identification")
     def test_null_grouped_providers_calls_functions(
         self,
         calculate_data_for_grouped_provider_identification_mock: Mock,
         identify_potential_grouped_providers_mock: Mock,
-        select_grouped_providers_on_latest_import: Mock,
+        select_grouped_providers: Mock,
         null_care_home_grouped_providers_mock: Mock,
         null_non_residential_grouped_providers_mock: Mock,
     ):
@@ -94,7 +94,7 @@ class MainTests(unittest.TestCase):
             self.test_lf
         )
         identify_potential_grouped_providers_mock.assert_called_once()
-        select_grouped_providers_on_latest_import.assert_called_once()
+        select_grouped_providers.assert_called_once()
         null_care_home_grouped_providers_mock.assert_called_once()
         null_non_residential_grouped_providers_mock.assert_called_once()
 
@@ -193,15 +193,15 @@ class NullNonResidentialGroupedProvidersTests(unittest.TestCase):
 class SelectGroupedProvidersOnLatestImport(unittest.TestCase):
     def test_function_returns_expected_rows(self):
         input_lf = pl.LazyFrame(
-            Data.select_grouped_providers_on_latest_import_rows,
-            Schemas.select_grouped_providers_on_latest_import_schema,
+            Data.select_grouped_providers_rows,
+            Schemas.select_grouped_providers_schema,
             orient="row",
         )
-        returned_lf = job.select_grouped_providers_on_latest_import(input_lf)
+        returned_lf = job.select_grouped_providers(input_lf)
         expected_lf = pl.LazyFrame(
-            Data.expected_select_grouped_providers_on_latest_import_rows,
-            Schemas.select_grouped_providers_on_latest_import_schema,
+            Data.expected_select_grouped_providers_rows,
+            Schemas.select_grouped_providers_schema,
             orient="row",
         )
 
-        pl_testing.assert_frame_equal(returned_lf, expected_lf)
+        pl_testing.assert_frame_equal(returned_lf.sort(IndCQC.location_id), expected_lf)

--- a/projects/_03_independent_cqc/unittest_data/polars_ind_cqc_test_file_data.py
+++ b/projects/_03_independent_cqc/unittest_data/polars_ind_cqc_test_file_data.py
@@ -1187,16 +1187,15 @@ class NullGroupedProvidersData:
     select_grouped_providers_rows = [
         ("1-001", "prov-1", date(2026, 1, 1), "nmdsid_1", True, 1.0), # Grouped provider but undesired import date.
         ("1-002", "prov-1", date(2026, 1, 1), "nmdsid_2", False, 1.0), # Not grouped provider and undesired import date.
-        ("1-003", "prov-1", date(2026, 2, 2), "nmdsid_3", False, 1.0), # Desired date but not grouped provider.
-        ("1-004", "prov-1", date(2026, 2, 2), "nmdsid_4", True, 1.0), # Keep
-        ("1-005", "prov-2", date(2026, 2, 2), "nmdsid_5", True, 1.0), # Keep (different provider)
-        ("1-006", "prov-1", date(2026, 2, 3), "nmdsid_6", True, 1.0), # Correct year/month but not min day.
-        ("1-007", "prov-1", date(2025, 1, 1), "nmdsid_7", True, 1.0), # Incorrect date with lower year and month than desired.
+        ("1-003", "prov-1", date(2026, 2, 1), "nmdsid_3", False, 1.0), # Desired date but not grouped provider.
+        ("1-004", "prov-1", date(2026, 2, 1), "nmdsid_4", True, 1.0), # Keep
+        ("1-005", "prov-2", date(2026, 2, 1), "nmdsid_5", True, 1.0), # Keep (different provider)
+        ("1-006", "prov-1", date(2025, 1, 1), "nmdsid_6", True, 1.0), # Incorrect date with lower year and month than desired.
         ("1-008", "prov-1", date(2025, 3, 1), "nmdsid_7", True, 1.0), # Incorrect date with lower year and higher month than desired.
     ] # fmt: skip
     expected_select_grouped_providers_rows = [
-        ("1-004", "prov-1", date(2026, 2, 2), "nmdsid_4", True, 1.0),
-        ("1-005", "prov-2", date(2026, 2, 2), "nmdsid_5", True, 1.0),
+        ("1-004", "prov-1", date(2026, 2, 1), "nmdsid_4", True, 1.0),
+        ("1-005", "prov-2", date(2026, 2, 1), "nmdsid_5", True, 1.0),
     ] # fmt: skip
 
 

--- a/projects/_03_independent_cqc/unittest_data/polars_ind_cqc_test_file_data.py
+++ b/projects/_03_independent_cqc/unittest_data/polars_ind_cqc_test_file_data.py
@@ -1090,8 +1090,8 @@ class NullGroupedProvidersData:
         ("loc 1", "prov 1", date(2024, 1, 1), "Y", "estab 1", "nmdsid_1", 13.0, 13.0, 4, 3.25, AscwdsFilteringRule.populated, 1.0),
         ("loc 2", "prov 1", date(2024, 1, 1), "Y", None, None, None,  None, 4, None, AscwdsFilteringRule.missing_data, 1.0),
         ("loc 3", "prov 1", date(2024, 1, 1), "Y", None, None, None, None, 4, None, AscwdsFilteringRule.missing_data, 1.0),
-        ("loc 1", "prov 1", date(2024, 1, 8), "Y", "estab 1", "nmdsid_1", 12.0, 12.0, 4, 3.0, AscwdsFilteringRule.populated, 1.0),
-        ("loc 2", "prov 1", date(2024, 1, 8), "Y", None, None, None, None, 4, None, AscwdsFilteringRule.missing_data, 1.0),
+        ("loc 1", "prov 1", date(2024, 2, 1), "Y", "estab 1", "nmdsid_1", 12.0, 12.0, 4, 3.0, AscwdsFilteringRule.populated, 1.0),
+        ("loc 2", "prov 1", date(2024, 2, 1), "Y", None, None, None, None, 4, None, AscwdsFilteringRule.missing_data, 1.0),
     ] # fmt: skip
 
     input_grouped_provider_rows = [
@@ -1184,16 +1184,17 @@ class NullGroupedProvidersData:
         ("1-008", CareHome.not_care_home, True, 50.0, None, 10.0, 2, 25.0, AscwdsFilteringRule.contained_invalid_missing_data_code),  # already filtered
     ] # fmt: skip
 
-    select_grouped_providers_on_latest_import_rows = [
+    select_grouped_providers_rows = [
         ("1-001", "prov-1", date(2026, 1, 1), "nmdsid_1", True, 1.0), # Grouped provider but not on latest import date.
         ("1-002", "prov-1", date(2026, 1, 1), "nmdsid_2", False, 1.0), # Not grouped provider and not on latest import date.
-        ("1-003", "prov-1", date(2026, 1, 2), "nmdsid_3", False, 1.0), # Latest import date but not grouped provider.
-        ("1-004", "prov-1", date(2026, 1, 2), "nmdsid_4", True, 1.0),
-        ("1-005", "prov-2", date(2026, 1, 2), "nmdsid_5", True, 1.0),
+        ("1-003", "prov-1", date(2026, 2, 2), "nmdsid_3", False, 1.0), # Latest import month and min day but not grouped provider.
+        ("1-004", "prov-1", date(2026, 2, 2), "nmdsid_4", True, 1.0), # Keep
+        ("1-005", "prov-2", date(2026, 2, 2), "nmdsid_5", True, 1.0), # Keep (different provider)
+        ("1-006", "prov-1", date(2026, 2, 3), "nmdsid_6", True, 1.0), # Latest import month but not min day.
     ] # fmt: skip
-    expected_select_grouped_providers_on_latest_import_rows = [
-        ("1-004", "prov-1", date(2026, 1, 2), "nmdsid_4", True, 1.0),
-        ("1-005", "prov-2", date(2026, 1, 2), "nmdsid_5", True, 1.0),
+    expected_select_grouped_providers_rows = [
+        ("1-004", "prov-1", date(2026, 2, 2), "nmdsid_4", True, 1.0),
+        ("1-005", "prov-2", date(2026, 2, 2), "nmdsid_5", True, 1.0),
     ] # fmt: skip
 
 

--- a/projects/_03_independent_cqc/unittest_data/polars_ind_cqc_test_file_data.py
+++ b/projects/_03_independent_cqc/unittest_data/polars_ind_cqc_test_file_data.py
@@ -1087,11 +1087,11 @@ class NullFilledPostsUsingInvalidMissingDataCodeData:
 class NullGroupedProvidersData:
 
     null_grouped_providers_rows = [
-        ("loc 1", "prov 1", date(2024, 1, 1), "Y", "estab 1", 13.0, 13.0, 4, 3.25, AscwdsFilteringRule.populated, 1.0),
-        ("loc 2", "prov 1", date(2024, 1, 1), "Y", None, None,  None, 4, None, AscwdsFilteringRule.missing_data, 1.0),
-        ("loc 3", "prov 1", date(2024, 1, 1), "Y", None, None, None, 4, None, AscwdsFilteringRule.missing_data, 1.0),
-        ("loc 1", "prov 1", date(2024, 1, 8), "Y", "estab 1", 12.0, 12.0, 4, 3.0, AscwdsFilteringRule.populated, 1.0),
-        ("loc 2", "prov 1", date(2024, 1, 8), "Y", None, None, None, 4, None, AscwdsFilteringRule.missing_data, 1.0),
+        ("loc 1", "prov 1", date(2024, 1, 1), "Y", "estab 1", "nmdsid_1", 13.0, 13.0, 4, 3.25, AscwdsFilteringRule.populated, 1.0),
+        ("loc 2", "prov 1", date(2024, 1, 1), "Y", None, None, None,  None, 4, None, AscwdsFilteringRule.missing_data, 1.0),
+        ("loc 3", "prov 1", date(2024, 1, 1), "Y", None, None, None, None, 4, None, AscwdsFilteringRule.missing_data, 1.0),
+        ("loc 1", "prov 1", date(2024, 1, 8), "Y", "estab 1", "nmdsid_1", 12.0, 12.0, 4, 3.0, AscwdsFilteringRule.populated, 1.0),
+        ("loc 2", "prov 1", date(2024, 1, 8), "Y", None, None, None, None, 4, None, AscwdsFilteringRule.missing_data, 1.0),
     ] # fmt: skip
 
     input_grouped_provider_rows = [
@@ -1185,15 +1185,15 @@ class NullGroupedProvidersData:
     ] # fmt: skip
 
     select_grouped_providers_on_latest_import_rows = [
-        ("1-001", "prov-1", date(2026, 1, 1), True, 1.0), # Grouped provider but not on latest import date.
-        ("1-002", "prov-1", date(2026, 1, 1), False, 1.0), # Not grouped provider and not on latest import date.
-        ("1-003", "prov-1", date(2026, 1, 2), False, 1.0), # Latest import date but not grouped provider.
-        ("1-004", "prov-1", date(2026, 1, 2), True, 1.0),
-        ("1-005", "prov-2", date(2026, 1, 2), True, 1.0),
+        ("1-001", "prov-1", date(2026, 1, 1), "nmdsid_1", True, 1.0), # Grouped provider but not on latest import date.
+        ("1-002", "prov-1", date(2026, 1, 1), "nmdsid_2", False, 1.0), # Not grouped provider and not on latest import date.
+        ("1-003", "prov-1", date(2026, 1, 2), "nmdsid_3", False, 1.0), # Latest import date but not grouped provider.
+        ("1-004", "prov-1", date(2026, 1, 2), "nmdsid_4", True, 1.0),
+        ("1-005", "prov-2", date(2026, 1, 2), "nmdsid_5", True, 1.0),
     ] # fmt: skip
     expected_select_grouped_providers_on_latest_import_rows = [
-        ("1-004", "prov-1", date(2026, 1, 2), True, 1.0),
-        ("1-005", "prov-2", date(2026, 1, 2), True, 1.0),
+        ("1-004", "prov-1", date(2026, 1, 2), "nmdsid_4", True, 1.0),
+        ("1-005", "prov-2", date(2026, 1, 2), "nmdsid_5", True, 1.0),
     ] # fmt: skip
 
 

--- a/projects/_03_independent_cqc/unittest_data/polars_ind_cqc_test_file_data.py
+++ b/projects/_03_independent_cqc/unittest_data/polars_ind_cqc_test_file_data.py
@@ -1185,12 +1185,13 @@ class NullGroupedProvidersData:
     ] # fmt: skip
 
     select_grouped_providers_rows = [
-        ("1-001", "prov-1", date(2026, 1, 1), "nmdsid_1", True, 1.0), # Grouped provider but not on latest import date.
-        ("1-002", "prov-1", date(2026, 1, 1), "nmdsid_2", False, 1.0), # Not grouped provider and not on latest import date.
-        ("1-003", "prov-1", date(2026, 2, 2), "nmdsid_3", False, 1.0), # Latest import month and min day but not grouped provider.
+        ("1-001", "prov-1", date(2026, 1, 1), "nmdsid_1", True, 1.0), # Grouped provider but undesired import date.
+        ("1-002", "prov-1", date(2026, 1, 1), "nmdsid_2", False, 1.0), # Not grouped provider and undesired import date.
+        ("1-003", "prov-1", date(2026, 2, 2), "nmdsid_3", False, 1.0), # Max month and min day but not grouped provider.
         ("1-004", "prov-1", date(2026, 2, 2), "nmdsid_4", True, 1.0), # Keep
         ("1-005", "prov-2", date(2026, 2, 2), "nmdsid_5", True, 1.0), # Keep (different provider)
-        ("1-006", "prov-1", date(2026, 2, 3), "nmdsid_6", True, 1.0), # Latest import month but not min day.
+        ("1-006", "prov-1", date(2026, 2, 3), "nmdsid_6", True, 1.0), # Max month but not min day.
+        ("1-007", "prov-1", date(2025, 2, 2), "nmdsid_6", True, 1.0), # Max month and min day but not max year.
     ] # fmt: skip
     expected_select_grouped_providers_rows = [
         ("1-004", "prov-1", date(2026, 2, 2), "nmdsid_4", True, 1.0),

--- a/projects/_03_independent_cqc/unittest_data/polars_ind_cqc_test_file_data.py
+++ b/projects/_03_independent_cqc/unittest_data/polars_ind_cqc_test_file_data.py
@@ -1184,6 +1184,18 @@ class NullGroupedProvidersData:
         ("1-008", CareHome.not_care_home, True, 50.0, None, 10.0, 2, 25.0, AscwdsFilteringRule.contained_invalid_missing_data_code),  # already filtered
     ] # fmt: skip
 
+    select_grouped_providers_on_latest_import_rows = [
+        ("1-001", "prov-1", date(2026, 1, 1), True, 1.0), # Grouped provider but not on latest import date.
+        ("1-002", "prov-1", date(2026, 1, 1), False, 1.0), # Not grouped provider and not on latest import date.
+        ("1-003", "prov-1", date(2026, 1, 2), False, 1.0), # Latest import date but not grouped provider.
+        ("1-004", "prov-1", date(2026, 1, 2), True, 1.0),
+        ("1-005", "prov-2", date(2026, 1, 2), True, 1.0),
+    ] # fmt: skip
+    expected_select_grouped_providers_on_latest_import_rows = [
+        ("1-004", "prov-1", date(2026, 1, 2), True, 1.0),
+        ("1-005", "prov-2", date(2026, 1, 2), True, 1.0),
+    ] # fmt: skip
+
 
 @dataclass
 class CleanAscwdsFilledPostOutliersData:

--- a/projects/_03_independent_cqc/unittest_data/polars_ind_cqc_test_file_data.py
+++ b/projects/_03_independent_cqc/unittest_data/polars_ind_cqc_test_file_data.py
@@ -1187,11 +1187,12 @@ class NullGroupedProvidersData:
     select_grouped_providers_rows = [
         ("1-001", "prov-1", date(2026, 1, 1), "nmdsid_1", True, 1.0), # Grouped provider but undesired import date.
         ("1-002", "prov-1", date(2026, 1, 1), "nmdsid_2", False, 1.0), # Not grouped provider and undesired import date.
-        ("1-003", "prov-1", date(2026, 2, 2), "nmdsid_3", False, 1.0), # Max month and min day but not grouped provider.
+        ("1-003", "prov-1", date(2026, 2, 2), "nmdsid_3", False, 1.0), # Desired date but not grouped provider.
         ("1-004", "prov-1", date(2026, 2, 2), "nmdsid_4", True, 1.0), # Keep
         ("1-005", "prov-2", date(2026, 2, 2), "nmdsid_5", True, 1.0), # Keep (different provider)
-        ("1-006", "prov-1", date(2026, 2, 3), "nmdsid_6", True, 1.0), # Max month but not min day.
-        ("1-007", "prov-1", date(2025, 2, 2), "nmdsid_6", True, 1.0), # Max month and min day but not max year.
+        ("1-006", "prov-1", date(2026, 2, 3), "nmdsid_6", True, 1.0), # Correct year/month but not min day.
+        ("1-007", "prov-1", date(2025, 1, 1), "nmdsid_7", True, 1.0), # Incorrect date with lower year and month than desired.
+        ("1-008", "prov-1", date(2025, 3, 1), "nmdsid_7", True, 1.0), # Incorrect date with lower year and higher month than desired.
     ] # fmt: skip
     expected_select_grouped_providers_rows = [
         ("1-004", "prov-1", date(2026, 2, 2), "nmdsid_4", True, 1.0),

--- a/projects/_03_independent_cqc/unittest_data/polars_ind_cqc_test_file_schemas.py
+++ b/projects/_03_independent_cqc/unittest_data/polars_ind_cqc_test_file_schemas.py
@@ -925,6 +925,7 @@ class NullGroupedProvidersSchema:
             (IndCQC.cqc_location_import_date, pl.Date()),
             (IndCQC.care_home, pl.String()),
             (IndCQC.establishment_id, pl.String()),
+            (AWPClean.nmds_id, pl.String()),
             (IndCQC.ascwds_filled_posts_dedup, pl.Float64()),
             (IndCQC.ascwds_filled_posts_dedup_clean, pl.Float64()),
             (IndCQC.number_of_beds, pl.Int64()),
@@ -1007,6 +1008,7 @@ class NullGroupedProvidersSchema:
             (IndCQC.location_id, pl.String()),
             (IndCQC.provider_id, pl.String()),
             (IndCQC.cqc_location_import_date, pl.Date()),
+            (AWPClean.nmds_id, pl.String()),
             (NGPcol.potential_grouped_provider, pl.Boolean()),
             (IndCQC.ascwds_filled_posts_dedup_clean, pl.Float64()),
         ]

--- a/projects/_03_independent_cqc/unittest_data/polars_ind_cqc_test_file_schemas.py
+++ b/projects/_03_independent_cqc/unittest_data/polars_ind_cqc_test_file_schemas.py
@@ -1003,7 +1003,7 @@ class NullGroupedProvidersSchema:
         ]
     )
 
-    select_grouped_providers_on_latest_import_schema = pl.Schema(
+    select_grouped_providers_schema = pl.Schema(
         [
             (IndCQC.location_id, pl.String()),
             (IndCQC.provider_id, pl.String()),

--- a/projects/_03_independent_cqc/unittest_data/polars_ind_cqc_test_file_schemas.py
+++ b/projects/_03_independent_cqc/unittest_data/polars_ind_cqc_test_file_schemas.py
@@ -1002,6 +1002,16 @@ class NullGroupedProvidersSchema:
         ]
     )
 
+    select_grouped_providers_on_latest_import_schema = pl.Schema(
+        [
+            (IndCQC.location_id, pl.String()),
+            (IndCQC.provider_id, pl.String()),
+            (IndCQC.cqc_location_import_date, pl.Date()),
+            (NGPcol.potential_grouped_provider, pl.Boolean()),
+            (IndCQC.ascwds_filled_posts_dedup_clean, pl.Float64()),
+        ]
+    )
+
 
 @dataclass
 class CleanAscwdsFilledPostOutliersSchema:

--- a/terraform/pipeline/step-functions/dynamic/Ind-CQC-Filled-Post-Estimates.json
+++ b/terraform/pipeline/step-functions/dynamic/Ind-CQC-Filled-Post-Estimates.json
@@ -1340,6 +1340,19 @@
           }
         },
         {
+          "StartAt": "Run SfC Crawler",
+          "States": {
+            "Run SfC Crawler": {
+              "Type": "Task",
+              "Resource": "arn:aws:states:::aws-sdk:glue:startCrawler",
+              "Parameters": {
+                "Name": "${sfc_crawler_name}"
+              },
+              "End": true
+            }
+          }
+        },
+        {
           "StartAt": "Run Validation Crawler",
           "States": {
             "Run Validation Crawler": {

--- a/terraform/pipeline/step-functions/dynamic/Ind-CQC-Filled-Post-Estimates.json
+++ b/terraform/pipeline/step-functions/dynamic/Ind-CQC-Filled-Post-Estimates.json
@@ -76,8 +76,10 @@
                                 "clean_ind_cqc_filled_posts.py",
                                 "--merged_ind_cqc_source",
                                 "${dataset_bucket_uri}/domain=ind_cqc_filled_posts/dataset=ind_cqc_01_merged_data/",
-                                "--destination",
-                                "${dataset_bucket_uri}/domain=ind_cqc_filled_posts/dataset=ind_cqc_02_cleaned_data/"
+                                "--cleaned_ind_cqc_destination",
+                                "${dataset_bucket_uri}/domain=ind_cqc_filled_posts/dataset=ind_cqc_02_cleaned_data/",
+                                "--grouped_providers_destination",
+                                "${dataset_bucket_uri}/domain=SfC/dataset=sfc_grouped_providers/"
                               ]
                             }
                           ]


### PR DESCRIPTION
## Description
Trello ticket [1678](https://trello.com/c/ylk9qCPY)

Added a function that filters to "potential grouped providers" in the latest import date and saves them to S3.
Part of the ticket was to add nmdsid to the output, so brought this into the merge job, but dropped it after grouped providers dataset is prepped.

At the moment, this is appending data because the intention is to add newly observed cases on future import dates. However, if this runs twice in a month then it will duplicate the same data.

The next ticket for this is to update it so it only adds newly discovered data.

## Testing
- [x] Unit tests passing
- [x] Successful [Step Function run](https://eu-west-2.console.aws.amazon.com/states/home?region=eu-west-2#/v2/executions/details/arn:aws:states:eu-west-2:856699698263:execution:1678-grp-provs-1-Ind-CQC-Filled-Post-Estimates:dc22cacc-087f-437a-b9d0-8f85c7636471)
- [x] Outputs checked in Athena

Found 163 locations and attached them to Trello ticket. The number of rows in cleaned dataset is same in branch as main.

## Checklist (delete if not relevant)
- [x] Unit tests added/amended
- [x] Docstrings added/updated
- [x] Updated CHANGELOG
- [x] Code reviewed by AI
- [x] Moved Trello ticket to PR column

## Reviewer checklist
- [ ] PR solves the Trello ticket requirements
- [ ] Outputs appear reasonable and understandable
- [ ] The overall approach is appropriate and not over-engineered
- [ ] No obvious scalability, performance or interdependency concerns
- [ ] Tests appropriately cover the main behaviour/edge cases
- [ ] Naming and structure are broadly understandable and consistent
- [ ] Docstrings are sufficient for future maintenance
- [ ] Docstrings cover non-obvious behaviour
