### PR TITLE
1691 - Updated jr estimate validation to use historically adjusted column

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ All notable changes to this project will be documented in this file.
 
 - Changed _04_estimate job role filled posts so historical reallocation is called after manager adjustment.
 
+- Changed validate_04_estimates to reflect that historical reallocation is called after manager adjustment.
+
 ### Fixed
 - Replace the all roles and all job groups functions with the appropriate categorical values attribute.
 

--- a/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/validate_04_estimates.py
+++ b/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/validate_04_estimates.py
@@ -46,8 +46,8 @@ OTHER_VALIDATION_COLS_TO_IMPORT = [
     IndCqcColumns.ascwds_job_role_ratios_merged,
     IndCqcColumns.ascwds_job_role_ratios_merged_source,
     IndCqcColumns.estimate_filled_posts_by_job_role,
-    IndCqcColumns.estimate_filled_posts_by_job_role_historically_reallocated,
     IndCqcColumns.estimate_filled_posts_by_job_role_manager_adjusted,
+    IndCqcColumns.estimate_filled_posts_by_job_role_historically_reallocated,
     IndCqcColumns.estimate_filled_posts_from_all_job_roles,
     IndCqcColumns.difference_estimate_filled_posts_and_from_all_job_roles,
     IndCqcColumns.main_job_group_labelled,
@@ -84,8 +84,8 @@ EXPECTED_SCHEMA = pb.Schema(
         IndCqcColumns.ascwds_job_role_ratios_merged: "Float32",
         IndCqcColumns.ascwds_job_role_ratios_merged_source: "String",
         IndCqcColumns.estimate_filled_posts_by_job_role: "Float32",
-        IndCqcColumns.estimate_filled_posts_by_job_role_historically_reallocated: "Float64",
         IndCqcColumns.estimate_filled_posts_by_job_role_manager_adjusted: "Float64",
+        IndCqcColumns.estimate_filled_posts_by_job_role_historically_reallocated: "Float64",
         IndCqcColumns.estimate_filled_posts_from_all_job_roles: "Float64",
         IndCqcColumns.difference_estimate_filled_posts_and_from_all_job_roles: "Float64",
         IndCqcColumns.main_job_group_labelled: str(
@@ -216,8 +216,8 @@ def other_validation(
                 IndCqcColumns.ascwds_job_role_ratios_merged,
                 IndCqcColumns.ascwds_job_role_ratios_merged_source,
                 IndCqcColumns.estimate_filled_posts_by_job_role,
-                IndCqcColumns.estimate_filled_posts_by_job_role_historically_reallocated,
                 IndCqcColumns.estimate_filled_posts_by_job_role_manager_adjusted,
+                IndCqcColumns.estimate_filled_posts_by_job_role_historically_reallocated,
                 IndCqcColumns.estimate_filled_posts_from_all_job_roles,
                 IndCqcColumns.difference_estimate_filled_posts_and_from_all_job_roles,
                 PartitionKeys.year,
@@ -292,8 +292,8 @@ def other_validation(
         .col_vals_ge(
             columns=[
                 IndCqcColumns.estimate_filled_posts_by_job_role,
-                IndCqcColumns.estimate_filled_posts_by_job_role_historically_reallocated,
                 IndCqcColumns.estimate_filled_posts_by_job_role_manager_adjusted,
+                IndCqcColumns.estimate_filled_posts_by_job_role_historically_reallocated,
             ],
             value=0,
             brief="ascwds_job_role_counts should be >= 0 where present",
@@ -478,12 +478,14 @@ def estimates_percentage_expressions(
         expr = (
             pl.when(pl.col(IndCqcColumns.main_job_role_clean_labelled) == name)
             .then(
-                pl.col(IndCqcColumns.estimate_filled_posts_by_job_role_manager_adjusted)
+                pl.col(
+                    IndCqcColumns.estimate_filled_posts_by_job_role_historically_reallocated
+                )
             )
             .otherwise(0)
             .sum()
             / pl.col(
-                IndCqcColumns.estimate_filled_posts_by_job_role_manager_adjusted
+                IndCqcColumns.estimate_filled_posts_by_job_role_historically_reallocated
             ).sum()
         )
 
@@ -491,12 +493,14 @@ def estimates_percentage_expressions(
         expr = (
             pl.when(pl.col(IndCqcColumns.main_job_group_labelled) == name)
             .then(
-                pl.col(IndCqcColumns.estimate_filled_posts_by_job_role_manager_adjusted)
+                pl.col(
+                    IndCqcColumns.estimate_filled_posts_by_job_role_historically_reallocated
+                )
             )
             .otherwise(0)
             .sum()
             / pl.col(
-                IndCqcColumns.estimate_filled_posts_by_job_role_manager_adjusted
+                IndCqcColumns.estimate_filled_posts_by_job_role_historically_reallocated
             ).sum()
         )
     return ((expr >= pcts[0]) & (expr <= pcts[1])).over(

--- a/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/validate_04_estimates.py
+++ b/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/validate_04_estimates.py
@@ -468,6 +468,9 @@ def estimates_percentage_expressions(
     Raises:
         ValueError: if role_or_group is not 'role' or 'group', or if pcts is not a list of two numbers
     """
+    job_role_estimate_col = pl.col(
+        IndCqcColumns.estimate_filled_posts_by_job_role_historically_reallocated
+    )
     if role_or_group not in ["role", "group"]:
         raise ValueError("role_or_group must be either 'role' or 'group'")
     if len(pcts) != 2 or not all(isinstance(pct, (int, float)) for pct in pcts):
@@ -477,31 +480,19 @@ def estimates_percentage_expressions(
     if role_or_group == "role":
         expr = (
             pl.when(pl.col(IndCqcColumns.main_job_role_clean_labelled) == name)
-            .then(
-                pl.col(
-                    IndCqcColumns.estimate_filled_posts_by_job_role_historically_reallocated
-                )
-            )
+            .then(job_role_estimate_col)
             .otherwise(0)
             .sum()
-            / pl.col(
-                IndCqcColumns.estimate_filled_posts_by_job_role_historically_reallocated
-            ).sum()
+            / job_role_estimate_col.sum()
         )
 
     elif role_or_group == "group":
         expr = (
             pl.when(pl.col(IndCqcColumns.main_job_group_labelled) == name)
-            .then(
-                pl.col(
-                    IndCqcColumns.estimate_filled_posts_by_job_role_historically_reallocated
-                )
-            )
+            .then(job_role_estimate_col)
             .otherwise(0)
             .sum()
-            / pl.col(
-                IndCqcColumns.estimate_filled_posts_by_job_role_historically_reallocated
-            ).sum()
+            / job_role_estimate_col.sum()
         )
     return ((expr >= pcts[0]) & (expr <= pcts[1])).over(
         pl.col(IndCqcColumns.cqc_location_import_date)

--- a/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/tests/fargate/test_validate_04_estimates.py
+++ b/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/tests/fargate/test_validate_04_estimates.py
@@ -49,8 +49,8 @@ class ValidateJobRoleEstimatesTests(unittest.TestCase):
             IndCqcColumns.ascwds_job_role_ratios_merged: pl.Float32,
             IndCqcColumns.ascwds_job_role_ratios_merged_source: pl.String,
             IndCqcColumns.estimate_filled_posts_by_job_role: pl.Float32,
-            IndCqcColumns.estimate_filled_posts_by_job_role_historically_reallocated: pl.Float32,
             IndCqcColumns.estimate_filled_posts_by_job_role_manager_adjusted: pl.Float32,
+            IndCqcColumns.estimate_filled_posts_by_job_role_historically_reallocated: pl.Float32,
             IndCqcColumns.estimate_filled_posts_from_all_job_roles: pl.Float32,
             IndCqcColumns.difference_estimate_filled_posts_and_from_all_job_roles: pl.Float32,
             IndCqcColumns.main_job_group_labelled: pl.String,
@@ -170,7 +170,7 @@ class TestEstimatesPercentageExpressions:
             IndCqcColumns.cqc_location_import_date: pl.Date,
             IndCqcColumns.main_job_role_clean_labelled: pl.String,
             IndCqcColumns.main_job_group_labelled: pl.String,
-            IndCqcColumns.estimate_filled_posts_by_job_role_manager_adjusted: pl.Float32,
+            IndCqcColumns.estimate_filled_posts_by_job_role_historically_reallocated: pl.Float32,
             "expression": pl.Boolean,
         },
         data=[


### PR DESCRIPTION
## Description
Trello ticket [1691](https://trello.com/c/uwFjd3Jo)

This should have been done as part of ticket [1688](https://trello.com/c/nfOs7IyL) but was missed. 

That ticket swapped the order of functions in the job role estimates, so "...historical adjustment" is now the final column created, before it was "... manager adjusted".

This PR swaps their order of appearance in the estimates validation script, and replaces "... manager adjusted" with "...historical adjustment" in the calculation of national job role/group percentages.

## Testing
- x ] Unit tests passing
- [x] Successful [Step Function run](https://eu-west-2.console.aws.amazon.com/states/home?region=eu-west-2#/v2/executions/details/arn:aws:states:eu-west-2:856699698263:execution:1691-jr-est-val-Ind-CQC-Filled-Post-Estimates-By-Role:55a429a1-ddad-42f3-a588-7defe4ad1dd5)
- [ ] Outputs checked in Athena

No outputs because this PR is validation changes.

## Checklist (delete if not relevant)
- [x] Unit tests added/amended
- [ ] Docstrings added/updated
- [x] Updated CHANGELOG
- [ ] Code reviewed by AI
- [x] Moved Trello ticket to PR column

## Reviewer checklist
- [ ] PR solves the Trello ticket requirements
- [ ] Outputs appear reasonable and understandable
- [ ] The overall approach is appropriate and not over-engineered
- [ ] No obvious scalability, performance or interdependency concerns
- [ ] Tests appropriately cover the main behaviour/edge cases
- [ ] Naming and structure are broadly understandable and consistent
- [ ] Docstrings are sufficient for future maintenance
- [ ] Docstrings cover non-obvious behaviour
