### PR TITLE
1676- Remove option to append from sink_to_parquet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ All notable changes to this project will be documented in this file.
 
 - Changed validate_04_estimates to reflect that historical reallocation is called after manager adjustment.
 
+- Removed `Append` option from `sink_to_parquet` function.
+
 ### Fixed
 - Replace the all roles and all job groups functions with the appropriate categorical values attribute.
 

--- a/polars_utils/utils.py
+++ b/polars_utils/utils.py
@@ -168,13 +168,6 @@ def sink_to_parquet(
         print("The provided LazyFrame was empty. No data was written.")
         return
 
-    # if append:
-    #     fname = f"{uuid.uuid4()}.parquet"
-    #     if isinstance(output_path, str):
-    #         output_path += fname
-    #     else:
-    #         output_path = output_path / fname
-
     try:
         if partition_cols:
             pad_cols = [col for col in partition_cols if col in ("day", "month")]

--- a/polars_utils/utils.py
+++ b/polars_utils/utils.py
@@ -149,7 +149,6 @@ def sink_to_parquet(
     lazy_df: pl.LazyFrame,
     output_path: str | Path,
     partition_cols: list[str] | None = None,
-    append: bool = True,
 ) -> None:
     """
     Sinks a Polars LazyFrame directly to Parquet using sink_parquet (fully lazy), with optional partitioning.
@@ -158,7 +157,6 @@ def sink_to_parquet(
         lazy_df (pl.LazyFrame): The Polars LazyFrame to write.
         output_path (str | Path): Directory path to sink Parquet files.
         partition_cols (list[str] | None): Columns to partition by. Defaults to None.
-        append (bool): Whether to append (True) or overwrite (False). Defaults to True.
 
     Returns:
         None: This function does not return any value.
@@ -170,12 +168,12 @@ def sink_to_parquet(
         print("The provided LazyFrame was empty. No data was written.")
         return
 
-    if append:
-        fname = f"{uuid.uuid4()}.parquet"
-        if isinstance(output_path, str):
-            output_path += fname
-        else:
-            output_path = output_path / fname
+    # if append:
+    #     fname = f"{uuid.uuid4()}.parquet"
+    #     if isinstance(output_path, str):
+    #         output_path += fname
+    #     else:
+    #         output_path = output_path / fname
 
     try:
         if partition_cols:

--- a/projects/_01_ingest/cqc_api/fargate/cqc_locations_2_delta_flatten.py
+++ b/projects/_01_ingest/cqc_api/fargate/cqc_locations_2_delta_flatten.py
@@ -73,7 +73,6 @@ def main(
         cqc_lf,
         cqc_locations_flattened_destination,
         partition_cols=cqc_partition_keys,
-        append=False,
     )
 
 

--- a/projects/_01_ingest/cqc_api/fargate/cqc_locations_4_full_clean.py
+++ b/projects/_01_ingest/cqc_api/fargate/cqc_locations_4_full_clean.py
@@ -113,7 +113,6 @@ def main(
     utils.sink_to_parquet(
         cqc_reg_lf,
         cqc_registered_locations_cleaned_destination,
-        append=False,
     )
 
 

--- a/projects/_01_ingest/cqc_api/fargate/cqc_providers_2_delta_flatten.py
+++ b/projects/_01_ingest/cqc_api/fargate/cqc_providers_2_delta_flatten.py
@@ -30,7 +30,6 @@ def main(delta_api_source: str, flattened_destination: str) -> None:
         cqc_lf,
         flattened_destination,
         partition_cols=cqc_partition_keys,
-        append=False,
     )
 
 

--- a/projects/_01_ingest/cqc_api/fargate/cqc_providers_4_full_clean.py
+++ b/projects/_01_ingest/cqc_api/fargate/cqc_providers_4_full_clean.py
@@ -35,7 +35,7 @@ def main(full_flattened_source: str, full_cleaned_destination: str) -> None:
         cqc_reg_lf, Keys.import_date, CQCPClean.cqc_provider_import_date
     ).drop(Keys.import_date)
 
-    utils.sink_to_parquet(cqc_reg_lf, full_cleaned_destination, append=False)
+    utils.sink_to_parquet(cqc_reg_lf, full_cleaned_destination)
 
 
 if __name__ == "__main__":

--- a/projects/_01_ingest/cqc_api/fargate/utils/cleaning_utils.py
+++ b/projects/_01_ingest/cqc_api/fargate/utils/cleaning_utils.py
@@ -51,7 +51,7 @@ def save_latest_full_snapshot(
         cqc_lf, CQCLClean.cqc_location_import_date
     )
 
-    utils.sink_to_parquet(cqc_lf, cqc_full_snapshot_destination, append=False)
+    utils.sink_to_parquet(cqc_lf, cqc_full_snapshot_destination)
 
 
 def clean_provider_id_column(cqc_lf: pl.LazyFrame) -> pl.LazyFrame:

--- a/projects/_01_ingest/cqc_api/fargate/utils/convert_delta_to_full.py
+++ b/projects/_01_ingest/cqc_api/fargate/utils/convert_delta_to_full.py
@@ -66,7 +66,6 @@ def convert_delta_to_full(
             merged_lf,
             full_destination,
             partition_cols=cqc_partition_keys,
-            append=False,
         )
 
         full_lf = merged_lf

--- a/projects/_01_ingest/cqc_api/tests/fargate/test_cqc_locations_2_delta_flatten.py
+++ b/projects/_01_ingest/cqc_api/tests/fargate/test_cqc_locations_2_delta_flatten.py
@@ -39,5 +39,4 @@ class CqcLocationsDeltaFlattenTests(unittest.TestCase):
             ANY,
             self.TEST_DESTINATION,
             partition_cols=self.partition_keys,
-            append=False,
         )

--- a/projects/_01_ingest/cqc_api/tests/fargate/test_cqc_locations_4_full_clean.py
+++ b/projects/_01_ingest/cqc_api/tests/fargate/test_cqc_locations_4_full_clean.py
@@ -80,6 +80,4 @@ class CqcLocationsFullCleanTests(unittest.TestCase):
         add_related_location_column_mock.assert_called_once()
         classify_specialisms_mock.assert_called_once()
         run_postcode_matching_mock.assert_called_once()
-        sink_to_parquet_mock.assert_called_once_with(
-            ANY, self.TEST_REG_DESTINATION, append=False
-        )
+        sink_to_parquet_mock.assert_called_once_with(ANY, self.TEST_REG_DESTINATION)

--- a/projects/_01_ingest/cqc_api/tests/fargate/test_cqc_providers_2_delta_flatten.py
+++ b/projects/_01_ingest/cqc_api/tests/fargate/test_cqc_providers_2_delta_flatten.py
@@ -28,5 +28,4 @@ class CqcProvidersDeltaFlattenTests(unittest.TestCase):
             ANY,
             self.TEST_DESTINATION,
             partition_cols=self.partition_keys,
-            append=False,
         )

--- a/projects/_01_ingest/cqc_api/tests/fargate/test_cqc_providers_4_full_clean.py
+++ b/projects/_01_ingest/cqc_api/tests/fargate/test_cqc_providers_4_full_clean.py
@@ -31,6 +31,4 @@ class CqcProvidersFullCleanTests(unittest.TestCase):
             selected_columns=job.cqc_provider_cols_to_import,
         )
         column_to_date_mock.assert_called_once()
-        sink_to_parquet_mock.assert_called_once_with(
-            ANY, self.TEST_CLEAN_DESTINATION, append=False
-        )
+        sink_to_parquet_mock.assert_called_once_with(ANY, self.TEST_CLEAN_DESTINATION)

--- a/projects/_01_ingest/cqc_api/tests/fargate/utils/test_cleaning_utils.py
+++ b/projects/_01_ingest/cqc_api/tests/fargate/utils/test_cleaning_utils.py
@@ -35,9 +35,7 @@ class SaveLatestFullSnapshotTests(unittest.TestCase):
         job.save_latest_full_snapshot(self.lf, self.destination_path)
 
         filter_to_max_mock.assert_called_once()
-        sink_to_parquet_mock.assert_called_once_with(
-            ANY, self.destination_path, append=False
-        )
+        sink_to_parquet_mock.assert_called_once_with(ANY, self.destination_path)
 
     @patch(f"{PATCH_PATH}.utils.sink_to_parquet")
     def test_expected_lazyframe_is_stored(self, sink_to_parquet_mock: Mock):

--- a/projects/_03_independent_cqc/_01_merge/fargate/merge_ind_cqc_data.py
+++ b/projects/_03_independent_cqc/_01_merge/fargate/merge_ind_cqc_data.py
@@ -182,7 +182,6 @@ def main(
     utils.sink_to_parquet(
         independent_cqc_lf,
         destination,
-        append=False,
     )
 
 

--- a/projects/_03_independent_cqc/_01_merge/fargate/prepare_job_role_counts.py
+++ b/projects/_03_independent_cqc/_01_merge/fargate/prepare_job_role_counts.py
@@ -48,7 +48,6 @@ def main(
     utils.sink_to_parquet(
         lazy_df=aggregated_worker_lf,
         output_path=prepared_ascwds_job_role_counts_destination,
-        append=False,
     )
 
 

--- a/projects/_03_independent_cqc/_01_merge/tests/fargate/test_merge_ind_cqc_data.py
+++ b/projects/_03_independent_cqc/_01_merge/tests/fargate/test_merge_ind_cqc_data.py
@@ -49,7 +49,6 @@ class IndCQCMergeTests(unittest.TestCase):
         sink_to_parquet_mock.assert_called_once_with(
             ANY,
             self.TEST_DESTINATION,
-            append=False,
         )
 
     @patch(f"{PATCH_PATH}.utils.sink_to_parquet")

--- a/projects/_03_independent_cqc/_01_merge/tests/fargate/test_prepare_job_role_counts.py
+++ b/projects/_03_independent_cqc/_01_merge/tests/fargate/test_prepare_job_role_counts.py
@@ -45,7 +45,6 @@ class MainTests(unittest.TestCase):
         sink_to_parquet_mock.assert_called_once_with(
             lazy_df=ANY,
             output_path=self.PREPARED_JOB_ROLE_COUNTS_DESTINATION,
-            append=False,
         )
 
 

--- a/projects/_03_independent_cqc/_02_clean/fargate/clean_ind_cqc_filled_posts.py
+++ b/projects/_03_independent_cqc/_02_clean/fargate/clean_ind_cqc_filled_posts.py
@@ -95,7 +95,6 @@ def main(
     utils.sink_to_parquet(
         locations_lf,
         destination,
-        append=False,
     )
 
 

--- a/projects/_03_independent_cqc/_02_clean/tests/fargate/test_clean_ind_cqc_filled_posts.py
+++ b/projects/_03_independent_cqc/_02_clean/tests/fargate/test_clean_ind_cqc_filled_posts.py
@@ -84,7 +84,6 @@ class MainTests(CleanIndFilledPostsTests):
         sink_to_parquet_mock.assert_called_once_with(
             ANY,
             self.CLEANED_IND_CQC_DESTINATION,
-            append=False,
         )
 
 

--- a/projects/_03_independent_cqc/_03_impute/fargate/impute_ind_cqc_ascwds_and_pir.py
+++ b/projects/_03_independent_cqc/_03_impute/fargate/impute_ind_cqc_ascwds_and_pir.py
@@ -150,7 +150,6 @@ def main(cleaned_ind_cqc_source: str, destination: str) -> None:
     utils.sink_to_parquet(
         lf,
         destination,
-        append=False,
     )
 
     print("Completed imputing independent CQC ASCWDS and PIR")

--- a/projects/_03_independent_cqc/_03_impute/tests/fargate/test_impute_ind_cqc_ascwds_and_pir.py
+++ b/projects/_03_independent_cqc/_03_impute/tests/fargate/test_impute_ind_cqc_ascwds_and_pir.py
@@ -59,7 +59,6 @@ class ImputeIndCqcAscwdsAndPirTests(unittest.TestCase):
         sink_to_parquet_mock.assert_called_once_with(
             ANY,
             self.TEST_DESTINATION,
-            append=False,
         )
 
 

--- a/projects/_03_independent_cqc/_04_model/fargate/model_01_features_care_home.py
+++ b/projects/_03_independent_cqc/_04_model/fargate/model_01_features_care_home.py
@@ -100,7 +100,6 @@ def main(bucket_name: str, model_name: str) -> None:
     utils.sink_to_parquet(
         features_lf,
         destination,
-        append=False,
     )
 
 

--- a/projects/_03_independent_cqc/_04_model/fargate/model_01_features_non_res_with_dormancy.py
+++ b/projects/_03_independent_cqc/_04_model/fargate/model_01_features_non_res_with_dormancy.py
@@ -126,7 +126,6 @@ def main(bucket_name: str, model_name: str) -> None:
     utils.sink_to_parquet(
         features_lf,
         destination,
-        append=False,
     )
 
 

--- a/projects/_03_independent_cqc/_04_model/fargate/model_01_features_non_res_without_dormancy.py
+++ b/projects/_03_independent_cqc/_04_model/fargate/model_01_features_non_res_without_dormancy.py
@@ -126,7 +126,6 @@ def main(bucket_name: str, model_name: str) -> None:
     utils.sink_to_parquet(
         features_lf,
         destination,
-        append=False,
     )
 
 

--- a/projects/_03_independent_cqc/_04_model/tests/fargate/test_model_01_features_care_home.py
+++ b/projects/_03_independent_cqc/_04_model/tests/fargate/test_model_01_features_care_home.py
@@ -53,4 +53,4 @@ class ModelFeaturesCareHomeTests(unittest.TestCase):
         self.assertEqual(cap_integer_at_max_value_mock.call_count, 2)
         self.assertEqual(expand_encode_and_extract_features_mock.call_count, 4)
         select_and_filter_features_data_mock.assert_called_once()
-        sink_to_parquet_mock.assert_called_once_with(ANY, ANY, append=False)
+        sink_to_parquet_mock.assert_called_once_with(ANY, ANY)

--- a/projects/_03_independent_cqc/_04_model/tests/fargate/test_model_01_features_non_res_with_dormancy.py
+++ b/projects/_03_independent_cqc/_04_model/tests/fargate/test_model_01_features_non_res_with_dormancy.py
@@ -57,4 +57,4 @@ class ModelFeaturesNonResWithoutDormancyTests(unittest.TestCase):
         group_rural_urban_sparse_categories_mock.assert_called_once()
         self.assertEqual(expand_encode_and_extract_features_mock.call_count, 5)
         select_and_filter_features_data_mock.assert_called_once()
-        sink_to_parquet_mock.assert_called_once_with(ANY, ANY, append=False)
+        sink_to_parquet_mock.assert_called_once_with(ANY, ANY)

--- a/projects/_03_independent_cqc/_04_model/tests/fargate/test_model_01_features_non_res_without_dormancy.py
+++ b/projects/_03_independent_cqc/_04_model/tests/fargate/test_model_01_features_non_res_without_dormancy.py
@@ -54,4 +54,4 @@ class ModelFeaturesNonResWithoutDormancyTests(unittest.TestCase):
         group_rural_urban_sparse_categories_mock.assert_called_once()
         self.assertEqual(expand_encode_and_extract_features_mock.call_count, 5)
         select_and_filter_features_data_mock.assert_called_once()
-        sink_to_parquet_mock.assert_called_once_with(ANY, ANY, append=False)
+        sink_to_parquet_mock.assert_called_once_with(ANY, ANY)

--- a/projects/_03_independent_cqc/_06_estimate_filled_posts/fargate/estimate_ind_cqc_filled_posts.py
+++ b/projects/_03_independent_cqc/_06_estimate_filled_posts/fargate/estimate_ind_cqc_filled_posts.py
@@ -134,7 +134,6 @@ def main(
     utils.sink_to_parquet(
         lf,
         destination,
-        append=False,
     )
 
 

--- a/projects/_03_independent_cqc/_06_estimate_filled_posts/tests/fargate/test_estimate_ind_cqc_filled_posts.py
+++ b/projects/_03_independent_cqc/_06_estimate_filled_posts/tests/fargate/test_estimate_ind_cqc_filled_posts.py
@@ -43,5 +43,4 @@ class EstimateIndCQCFilledPostsTests(unittest.TestCase):
         sink_to_parquet_mock.assert_called_once_with(
             ANY,
             self.TEST_DESTINATION,
-            append=False,
         )

--- a/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/_01_merge.py
+++ b/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/_01_merge.py
@@ -108,13 +108,11 @@ def main(
     utils.sink_to_parquet(
         lazy_df=estimated_job_role_posts_lf,
         output_path=merged_data_destination,
-        append=False,
     )
 
     utils.sink_to_parquet(
         lazy_df=metadata_lf,
         output_path=metadata_destination,
-        append=False,
     )
 
 

--- a/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/_02_clean.py
+++ b/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/_02_clean.py
@@ -125,7 +125,6 @@ def main(
     utils.sink_to_parquet(
         lazy_df=estimated_job_role_posts_lf,
         output_path=cleaned_data_destination,
-        append=False,
     )
 
 

--- a/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/_03_impute.py
+++ b/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/_03_impute.py
@@ -36,7 +36,6 @@ def main(
     utils.sink_to_parquet(
         lazy_df=estimated_job_role_posts_lf,
         output_path=imputed_data_destination,
-        append=False,
     )
 
 

--- a/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/_04_estimate.py
+++ b/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/_04_estimate.py
@@ -61,7 +61,6 @@ def main(
         lazy_df=lf,
         output_path=estimated_data_destination,
         partition_cols=[Keys.year],
-        append=False,
     )
 
 

--- a/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/tests/fargate/test_01_merge.py
+++ b/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/tests/fargate/test_01_merge.py
@@ -53,12 +53,10 @@ class MainTests(unittest.TestCase):
                 call(
                     lazy_df=ANY,
                     output_path=self.MERGED_DATA_DESTINATION,
-                    append=False,
                 ),
                 call(
                     lazy_df=ANY,
                     output_path=self.METADATA_DESTINATION,
-                    append=False,
                 ),
             ]
         )

--- a/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/tests/fargate/test_02_clean.py
+++ b/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/tests/fargate/test_02_clean.py
@@ -80,7 +80,6 @@ class MainTests(unittest.TestCase):
         sink_to_parquet_mock.assert_called_once_with(
             lazy_df=ANY,
             output_path=self.CLEANED_DATA_DESTINATION,
-            append=False,
         )
 
     @patch(f"{PATCH_PATH}.utils.sink_to_parquet")

--- a/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/tests/fargate/test_03_impute.py
+++ b/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/tests/fargate/test_03_impute.py
@@ -44,5 +44,4 @@ class MainTests(unittest.TestCase):
         sink_to_parquet_mock.assert_called_once_with(
             lazy_df=ANY,
             output_path=self.IMPUTED_DATA_DESTINATION,
-            append=False,
         )

--- a/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/tests/fargate/test_04_estimate.py
+++ b/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/tests/fargate/test_04_estimate.py
@@ -48,5 +48,4 @@ class TestMain(unittest.TestCase):
             lazy_df=ANY,
             output_path=self.TEST_DESTINATION,
             partition_cols=[Keys.year],
-            append=False,
         )

--- a/projects/_03_independent_cqc/_09_archive_estimates/fargate/archive_filled_posts_estimates.py
+++ b/projects/_03_independent_cqc/_09_archive_estimates/fargate/archive_filled_posts_estimates.py
@@ -90,7 +90,6 @@ def main(
         archive_lf,
         archive_ind_cqc_filled_posts_destination,
         partition_cols=partition_keys,
-        append=False,
     )
 
     print("Completed archive independent CQC filled posts")

--- a/projects/_03_independent_cqc/_09_archive_estimates/tests/fargate/test_archive_filled_posts_estimates.py
+++ b/projects/_03_independent_cqc/_09_archive_estimates/tests/fargate/test_archive_filled_posts_estimates.py
@@ -42,5 +42,4 @@ class IndCQCArchiveTests(unittest.TestCase):
             ANY,
             self.TEST_DESTINATION,
             partition_cols=self.partition_keys,
-            append=False,
         )

--- a/projects/_04_direct_payment_recipients/fargate/estimate_direct_payments.py
+++ b/projects/_04_direct_payment_recipients/fargate/estimate_direct_payments.py
@@ -56,13 +56,11 @@ def main(
     utils.sink_to_parquet(
         lf,
         destination,
-        append=False,
     )
 
     utils.sink_to_parquet(
         summary_lf,
         summary_destination,
-        append=False,
     )
 
 

--- a/projects/_04_direct_payment_recipients/tests/fargate/test_estimate_direct_payments.py
+++ b/projects/_04_direct_payment_recipients/tests/fargate/test_estimate_direct_payments.py
@@ -50,12 +50,10 @@ class EstimateDirectPaymentsTests(unittest.TestCase):
                 call(
                     ANY,
                     self.SOME_DESTINATION,
-                    append=False,
                 ),
                 call(
                     ANY,
                     self.SOME_OTHER_DESTINATION,
-                    append=False,
                 ),
             ]
         )

--- a/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/_01_merge.py
+++ b/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/_01_merge.py
@@ -17,7 +17,6 @@ def main(
     utils.sink_to_parquet(
         lazy_df=lf,
         output_path=merged_data_destination,
-        append=False,
     )
 
 

--- a/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/_02_clean.py
+++ b/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/_02_clean.py
@@ -17,7 +17,6 @@ def main(
     utils.sink_to_parquet(
         lazy_df=lf,
         output_path=cleaned_data_destination,
-        append=False,
     )
 
 

--- a/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/_03_impute.py
+++ b/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/_03_impute.py
@@ -17,7 +17,6 @@ def main(
     utils.sink_to_parquet(
         lazy_df=lf,
         output_path=imputed_data_destination,
-        append=False,
     )
 
 

--- a/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/tests/fargate/test_01_merge.py
+++ b/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/tests/fargate/test_01_merge.py
@@ -27,5 +27,4 @@ class MainTests(unittest.TestCase):
         sink_to_parquet_mock.assert_called_once_with(
             lazy_df=ANY,
             output_path=self.MERGED_DATA_DESTINATION,
-            append=False,
         )

--- a/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/tests/fargate/test_02_clean.py
+++ b/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/tests/fargate/test_02_clean.py
@@ -27,5 +27,4 @@ class MainTests(unittest.TestCase):
         sink_to_parquet_mock.assert_called_once_with(
             lazy_df=ANY,
             output_path=self.CLEANED_DATA_DESTINATION,
-            append=False,
         )

--- a/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/tests/fargate/test_03_impute.py
+++ b/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/tests/fargate/test_03_impute.py
@@ -27,5 +27,4 @@ class MainTests(unittest.TestCase):
         sink_to_parquet_mock.assert_called_once_with(
             lazy_df=ANY,
             output_path=self.IMPUTED_DATA_DESTINATION,
-            append=False,
         )

--- a/tests/test_polars_utils/test_utils.py
+++ b/tests/test_polars_utils/test_utils.py
@@ -209,7 +209,7 @@ class TestSinkParquet(TestUtils):
 
         f = io.StringIO()
         with redirect_stdout(f):
-            utils.sink_to_parquet(lazy_df, destination, None, append=False)
+            utils.sink_to_parquet(lazy_df, destination, None)
         output = f.getvalue()
 
         self.assertFalse(destination.exists())
@@ -221,25 +221,16 @@ class TestSinkParquet(TestUtils):
         df: pl.DataFrame = pl.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
         lazy_df = df.lazy()
         destination: str = str(self.temp_dir) + "/"
-        utils.sink_to_parquet(lazy_df, destination, append=True)
+        utils.sink_to_parquet(lazy_df, destination)
         files = glob(os.path.join(str(destination), "*.parquet"))
         self.assertEqual(len(files), 1)
-
-    def test_sink_parquet_writes_with_append(self):
-        df: pl.DataFrame = pl.DataFrame({"a": [1, 2, 1], "b": [4, 5, 6]})
-        lazy_df = df.lazy()
-        destination: str = str(self.temp_dir) + "/"
-        utils.sink_to_parquet(lazy_df, destination, append=True)
-        utils.sink_to_parquet(lazy_df, destination, append=True)
-        files = glob(os.path.join(destination, "*.parquet"))
-        self.assertEqual(len(files), 2)
 
     def test_sink_parquet_writes_with_overwrite(self):
         df: pl.DataFrame = pl.DataFrame({"a": [1, 2, 1], "b": [4, 5, 6]})
         lazy_df = df.lazy()
         destination = self.temp_dir / "test.parquet"
-        utils.sink_to_parquet(lazy_df, destination, append=False)
-        utils.sink_to_parquet(lazy_df, destination, append=False)
+        utils.sink_to_parquet(lazy_df, destination)
+        utils.sink_to_parquet(lazy_df, destination)
 
         files = glob(os.path.join(self.temp_dir, "*.parquet"))
         self.assertEqual(len(files), 1)
@@ -254,7 +245,6 @@ class TestSinkParquet(TestUtils):
             lazy_df,
             destination,
             partition_cols=["part"],
-            append=False,
         )
         partitions = [d.name for d in destination.iterdir() if d.is_dir()]
         self.assertTrue(set(partitions) == {"part=x", "part=y"})
@@ -277,7 +267,6 @@ class TestSinkParquet(TestUtils):
                 lazy_df,
                 output_path,
                 partition_cols=["year", "month", "day"],
-                append=False,
             )
 
             written_files = [str(p) for p in output_path.rglob("*.parquet")]


### PR DESCRIPTION
## Description
Trello ticket [#1676](https://trello.com/c/tTrEx8XA/1676-s-remove-option-to-append-from-sinktoparquet)

Removed option to append from sink_to_parquet function within Polars Utils. I updated all the ccalls where append = False we explicitly made (function and tests).

## Testing
- [x] Unit tests passing
- [x] Successful [Step Function run](https://eu-west-2.console.aws.amazon.com/states/home?region=eu-west-2#/v2/executions/details/arn:aws:states:eu-west-2:856699698263:execution:1676-rem-append-Ind-CQC-Filled-Post-Estimates:b1c055c0-d792-467a-a3b6-9e4e0ce94ab6)
- [x] Outputs checked in Athena

## Checklist (delete if not relevant)
- [x] Unit tests added/amended
- [x] Docstrings added/updated
- [x] Updated CHANGELOG
- [ ] Code reviewed by AI
- [x] Moved Trello ticket to PR column

## Reviewer checklist
- [ ] PR solves the Trello ticket requirements
- [ ] Outputs appear reasonable and understandable
- [ ] The overall approach is appropriate and not over-engineered
- [ ] No obvious scalability, performance or interdependency concerns
- [ ] Tests appropriately cover the main behaviour/edge cases
- [ ] Naming and structure are broadly understandable and consistent
- [ ] Docstrings are sufficient for future maintenance
- [ ] Docstrings cover non-obvious behaviour
