### PR TITLE
1677 - Inform about new grouped providers Part 2: Add functionality to check for new grouped providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,8 @@ All notable changes to this project will be documented in this file.
 
 - Added more datasets to SLV merge job.
 
+- Updated `select_grouped_providers` function and added a new `update_grouped_providers_history` function within `null_grouped_providers` function to get historic audit of grouped providers identified and fixed over time.
+
 ### Fixed
 - Replace the all roles and all job groups functions with the appropriate categorical values attribute.
 

--- a/projects/_03_independent_cqc/_02_clean/fargate/clean_ind_cqc_filled_posts.py
+++ b/projects/_03_independent_cqc/_02_clean/fargate/clean_ind_cqc_filled_posts.py
@@ -82,7 +82,12 @@ def main(
         [0, 1, 3, 5, 10, 15, 20, 25, 50, float("Inf")],
     )
 
-    locations_lf, grouped_providers = clean_ascwds_filled_post_outliers(locations_lf)
+    grouped_providers_lf = utils.scan_parquet(grouped_providers_destination)
+    print("Existing Grouped providers LazyFrame read in")
+
+    locations_lf, grouped_providers = clean_ascwds_filled_post_outliers(
+        locations_lf, grouped_providers_lf
+    )
     locations_lf = locations_lf.drop(AWPClean.nmds_id)
 
     locations_lf = cUtils.calculate_filled_posts_per_bed_ratio(

--- a/projects/_03_independent_cqc/_02_clean/fargate/clean_ind_cqc_filled_posts.py
+++ b/projects/_03_independent_cqc/_02_clean/fargate/clean_ind_cqc_filled_posts.py
@@ -25,13 +25,26 @@ from projects._03_independent_cqc._02_clean.fargate.utils.clean_ind_cqc_filled_p
 from projects._03_independent_cqc._02_clean.fargate.utils.utils import (
     create_column_with_repeated_values_removed,
 )
-from projects._03_independent_cqc.unittest_data.polars_ind_cqc_test_file_schemas import (
-    NullGroupedProvidersSchema as Schemas,
-)
 from utils.column_names.cleaned_data_files.ascwds_workplace_cleaned import (
     AscwdsWorkplaceCleanedColumns as AWPClean,
 )
 from utils.column_names.ind_cqc_pipeline_columns import IndCqcColumns as IndCQC
+from utils.column_names.ind_cqc_pipeline_columns import (
+    NullGroupedProviderColumns as NGPcol,
+)
+
+GROUPED_PROVIDER_SCHEMA = pl.Schema(
+    [
+        (IndCQC.location_id, pl.String()),
+        (IndCQC.provider_id, pl.String()),
+        (IndCQC.cqc_location_import_date, pl.Date()),
+        (AWPClean.nmds_id, pl.String()),
+        (NGPcol.potential_grouped_provider, pl.Boolean()),
+        (IndCQC.ascwds_filled_posts_dedup_clean, pl.Float64()),
+        (NGPcol.grouped_provider_status, pl.String()),
+        (NGPcol.last_update_date, pl.Date()),
+    ]
+)
 
 
 def main(
@@ -91,9 +104,7 @@ def main(
         grouped_providers_lf = utils.scan_parquet(grouped_providers_destination)
         print("Existing grouped providers read in")
     except FileNotFoundError:
-        grouped_providers_lf = pl.LazyFrame(
-            schema=Schemas.expected_select_grouped_providers_schema
-        )
+        grouped_providers_lf = pl.LazyFrame(schema=GROUPED_PROVIDER_SCHEMA)
         print("No existing grouped providers found, starting fresh")
 
     locations_lf, grouped_providers = clean_ascwds_filled_post_outliers(

--- a/projects/_03_independent_cqc/_02_clean/fargate/clean_ind_cqc_filled_posts.py
+++ b/projects/_03_independent_cqc/_02_clean/fargate/clean_ind_cqc_filled_posts.py
@@ -101,7 +101,9 @@ def main(
     )
 
     try:
-        grouped_providers_lf = utils.scan_parquet(grouped_providers_destination)
+        grouped_providers_lf = utils.scan_parquet(
+            source=grouped_providers_destination, schema=GROUPED_PROVIDER_SCHEMA
+        )
         print("Existing grouped providers read in")
     except FileNotFoundError:
         grouped_providers_lf = pl.LazyFrame(schema=GROUPED_PROVIDER_SCHEMA)

--- a/projects/_03_independent_cqc/_02_clean/fargate/clean_ind_cqc_filled_posts.py
+++ b/projects/_03_independent_cqc/_02_clean/fargate/clean_ind_cqc_filled_posts.py
@@ -1,3 +1,5 @@
+import polars as pl
+
 import polars_utils.cleaning_utils as cUtils
 from polars_utils import utils
 from projects._03_independent_cqc._02_clean.fargate.utils.ascwds_filled_posts_calculator import (
@@ -22,6 +24,9 @@ from projects._03_independent_cqc._02_clean.fargate.utils.clean_ind_cqc_filled_p
 )
 from projects._03_independent_cqc._02_clean.fargate.utils.utils import (
     create_column_with_repeated_values_removed,
+)
+from projects._03_independent_cqc.unittest_data.polars_ind_cqc_test_file_schemas import (
+    NullGroupedProvidersSchema as Schemas,
 )
 from utils.column_names.cleaned_data_files.ascwds_workplace_cleaned import (
     AscwdsWorkplaceCleanedColumns as AWPClean,
@@ -82,8 +87,14 @@ def main(
         [0, 1, 3, 5, 10, 15, 20, 25, 50, float("Inf")],
     )
 
-    grouped_providers_lf = utils.scan_parquet(grouped_providers_destination)
-    print("Existing Grouped providers LazyFrame read in")
+    try:
+        grouped_providers_lf = utils.scan_parquet(grouped_providers_destination)
+        print("Existing grouped providers read in")
+    except FileNotFoundError:
+        grouped_providers_lf = pl.LazyFrame(
+            schema=Schemas.expected_select_grouped_providers_schema
+        )
+        print("No existing grouped providers found, starting fresh")
 
     locations_lf, grouped_providers = clean_ascwds_filled_post_outliers(
         locations_lf, grouped_providers_lf

--- a/projects/_03_independent_cqc/_02_clean/fargate/clean_ind_cqc_filled_posts.py
+++ b/projects/_03_independent_cqc/_02_clean/fargate/clean_ind_cqc_filled_posts.py
@@ -42,7 +42,8 @@ GROUPED_PROVIDER_SCHEMA = pl.Schema(
         (NGPcol.potential_grouped_provider, pl.Boolean()),
         (IndCQC.ascwds_filled_posts_dedup_clean, pl.Float64()),
         (NGPcol.grouped_provider_status, pl.String()),
-        (NGPcol.last_update_date, pl.Date()),
+        (NGPcol.grp_prov_identified_date, pl.Date()),
+        (NGPcol.grp_prov_fixed_date, pl.Date()),
     ]
 )
 

--- a/projects/_03_independent_cqc/_02_clean/fargate/utils/clean_ascwds_filled_post_outliers/clean_ascwds_filled_post_outliers.py
+++ b/projects/_03_independent_cqc/_02_clean/fargate/utils/clean_ascwds_filled_post_outliers/clean_ascwds_filled_post_outliers.py
@@ -21,6 +21,7 @@ from utils.column_values.categorical_column_values import AscwdsFilteringRule
 
 def clean_ascwds_filled_post_outliers(
     lf: pl.LazyFrame,
+    grouped_providers_lf: pl.LazyFrame,
 ) -> tuple[pl.LazyFrame, pl.LazyFrame]:
     """
     Creates a clean version of 'ascwds_filled_posts_dedup' column.
@@ -31,6 +32,7 @@ def clean_ascwds_filled_post_outliers(
 
     Args:
         lf (pl.LazyFrame): A polars LazyFrame containing 'ascwds_filled_posts_dedup'.
+        grouped_providers_lf (pl.LazyFrame): A polars LazyFrame containing existing grouped providers.
 
     Returns:
         tuple[pl.LazyFrame, pl.LazyFrame]: The input LazyFrame containing
@@ -52,7 +54,7 @@ def clean_ascwds_filled_post_outliers(
     )
 
     lf = null_filled_posts_where_locations_use_invalid_missing_data_code(lf)
-    lf, grouped_providers = null_grouped_providers(lf)
+    lf, grouped_providers = null_grouped_providers(lf, grouped_providers_lf)
     lf = winsorize_care_home_filled_posts_per_bed_ratio_outliers(lf)
     lf = non_res_brand_id_filter(lf)
 

--- a/projects/_03_independent_cqc/_02_clean/fargate/utils/clean_ascwds_filled_post_outliers/null_grouped_providers.py
+++ b/projects/_03_independent_cqc/_02_clean/fargate/utils/clean_ascwds_filled_post_outliers/null_grouped_providers.py
@@ -81,7 +81,9 @@ def null_grouped_providers(
     lf = null_care_home_grouped_providers(lf)
     lf = null_non_residential_grouped_providers(lf)
 
-    columns_to_drop = [field.name for field in fields(NGPcol())]
+    ngp_cols = {field.name for field in fields(NGPcol())}
+    columns_to_drop = [c for c in lf.collect_schema().names() if c in ngp_cols]
+
     lf = lf.drop(*columns_to_drop)
 
     return lf, grouped_providers

--- a/projects/_03_independent_cqc/_02_clean/fargate/utils/clean_ascwds_filled_post_outliers/null_grouped_providers.py
+++ b/projects/_03_independent_cqc/_02_clean/fargate/utils/clean_ascwds_filled_post_outliers/null_grouped_providers.py
@@ -45,7 +45,9 @@ class NullGroupedProvidersConfig:
     POSTS_PER_PIR_PROVIDER_THRESHOLD: pl.Float64 = 1.5
 
 
-def null_grouped_providers(lf: pl.LazyFrame) -> tuple[pl.LazyFrame, pl.LazyFrame]:
+def null_grouped_providers(
+    lf: pl.LazyFrame, grouped_providers_lf: pl.LazyFrame
+) -> tuple[pl.LazyFrame, pl.LazyFrame]:
     """
     Null ascwds_filled_posts_dedup_clean where a provider has multiple
     locations, all their ascwds is under one location.
@@ -64,6 +66,7 @@ def null_grouped_providers(lf: pl.LazyFrame) -> tuple[pl.LazyFrame, pl.LazyFrame
 
     Args:
         lf (pl.LazyFrame): A polars LazyFrame with independent cqc data.
+        grouped_providers_lf (pl.LazyFrame): A polars LazyFrame containing existing grouped providers.
 
     Returns:
         tuple[pl.LazyFrame, pl.LazyFrame]: The input LazyFrame with grouped
@@ -73,7 +76,7 @@ def null_grouped_providers(lf: pl.LazyFrame) -> tuple[pl.LazyFrame, pl.LazyFrame
 
     lf = identify_potential_grouped_providers(lf)
 
-    grouped_providers = select_grouped_providers(lf)
+    grouped_providers = select_grouped_providers(lf, grouped_providers_lf)
 
     lf = null_care_home_grouped_providers(lf)
     lf = null_non_residential_grouped_providers(lf)
@@ -300,7 +303,9 @@ def null_non_residential_grouped_providers(lf: pl.LazyFrame) -> pl.LazyFrame:
     return lf
 
 
-def select_grouped_providers(lf: pl.LazyFrame) -> pl.LazyFrame:
+def select_grouped_providers(
+    lf: pl.LazyFrame, grouped_providers_lf: pl.LazyFrame
+) -> pl.LazyFrame:
     """
     Filters the input LazyFrame to the following:
         - potential_grouped_provider is True
@@ -309,6 +314,7 @@ def select_grouped_providers(lf: pl.LazyFrame) -> pl.LazyFrame:
 
     Args:
         lf (pl.LazyFrame): A LazyFrame with potential_grouped_provider column.
+        grouped_providers_lf (pl.LazyFrame): A LazyFrame containing existing grouped providers.
 
     Returns:
         pl.LazyFrame: The filtered input LazyFrame.
@@ -324,8 +330,22 @@ def select_grouped_providers(lf: pl.LazyFrame) -> pl.LazyFrame:
 
     date_col = pl.col(IndCQC.cqc_location_import_date)
     trunc_date_col = date_col.dt.truncate("1mo")  # E.g. 2026-01-05 becomes 2026-01-01.
-    return (
+
+    new_grouped_providers_lf = (
         lf.filter(pl.col(NGPcol.potential_grouped_provider))
         .filter(trunc_date_col == trunc_date_col.max())
         .select(cols_to_select)
+        .with_columns(
+            # add a new bool column to true for all newly identified grouped providers
+            pl.lit(True).alias("grouped_provider")
+        )
     )
+
+    # If the locationid is in the grouped_providers_lf but not in new_grouped_providers_lf then change their "grouped_provider" status in the grouped_providers_lf to False.
+    # Append the new_grouped_providers_lf to the grouped_providers_lf and remove duplicates on locationid and "grouped_provider".
+
+    grouped_providers_lf = grouped_providers_lf.join(
+        new_grouped_providers_lf, on=IndCQC.location_id, how="outer"
+    )
+
+    return grouped_providers_lf

--- a/projects/_03_independent_cqc/_02_clean/fargate/utils/clean_ascwds_filled_post_outliers/null_grouped_providers.py
+++ b/projects/_03_independent_cqc/_02_clean/fargate/utils/clean_ascwds_filled_post_outliers/null_grouped_providers.py
@@ -76,7 +76,10 @@ def null_grouped_providers(
 
     lf = identify_potential_grouped_providers(lf)
 
-    grouped_providers = select_grouped_providers(lf, grouped_providers_lf)
+    new_grouped_providers = select_grouped_providers(lf)
+    updated_grouped_providers_lf = update_grouped_providers_history(
+        new_grouped_providers, grouped_providers_lf
+    )
 
     lf = null_care_home_grouped_providers(lf)
     lf = null_non_residential_grouped_providers(lf)
@@ -86,7 +89,7 @@ def null_grouped_providers(
 
     lf = lf.drop(*columns_to_drop)
 
-    return lf, grouped_providers
+    return lf, updated_grouped_providers_lf
 
 
 def calculate_data_for_grouped_provider_identification(
@@ -305,32 +308,18 @@ def null_non_residential_grouped_providers(lf: pl.LazyFrame) -> pl.LazyFrame:
     return lf
 
 
-def select_grouped_providers(
-    lf: pl.LazyFrame, grouped_providers_lf: pl.LazyFrame
-) -> pl.LazyFrame:
+def select_grouped_providers(lf: pl.LazyFrame) -> pl.LazyFrame:
     """
-    Filters the input LazyFrame to the following and merges
-    with historical grouped provider records, updating status columns for locations
-    that have dropped off:
+    Filters the input LazyFrame to the following:
         - potential_grouped_provider is True
         - cqc_location_import_date equal to max year/month across dataset.
 
-    On first run (empty grouped_providers_lf), returns only the new snapshot.
-    On subsequent runs:
-        - Locations no longer in the new snapshot have grouped_provider_status set to
-            "fixed".
-        - Locations still active are retained as-is.
-        - Duplicates on (location_id, grouped_provider_status) are dropped, keeping the
-          oldest import date.
-
     Args:
-        lf (pl.LazyFrame): Input frame containing potential_grouped_provider column.
-        grouped_providers_lf (pl.LazyFrame): Historical grouped provider records.
-            May be empty on first run.
+        lf (pl.LazyFrame): A LazyFrame with potential_grouped_provider column.
 
     Returns:
-        pl.LazyFrame: Full history of grouped provider records with updated flags.
-            Unique on (location_id, grouped_provider_status).
+        pl.LazyFrame: The filtered input LazyFrame with `grouped_provider_status`
+            and `last_update_date` columns added.
     """
     cols_to_select = [
         IndCQC.location_id,
@@ -344,7 +333,7 @@ def select_grouped_providers(
     date_col = pl.col(IndCQC.cqc_location_import_date)
     trunc_date_col = date_col.dt.truncate("1mo")  # E.g. 2026-01-05 becomes 2026-01-01.
 
-    new_grouped_providers_lf = (
+    return (
         lf.filter(pl.col(NGPcol.potential_grouped_provider))
         .filter(trunc_date_col == trunc_date_col.max())
         .select(cols_to_select)
@@ -354,24 +343,63 @@ def select_grouped_providers(
         )
     )
 
+
+def update_grouped_providers_history(
+    new_grouped_providers_lf: pl.LazyFrame,
+    grouped_providers_lf: pl.LazyFrame,
+) -> pl.LazyFrame:
+    """
+    Merges newly identified grouped providers with the historical records,
+    updating status for locations that have dropped off.
+
+    On first run (empty grouped_providers_lf), returns only the new snapshot.
+    On subsequent runs:
+        - Locations no longer in the new snapshot have grouped_provider_status
+          set to "fixed" and last_update_date set to cqc_location_import_date.
+        - Locations still active are retained as-is with last_update_date unchanged.
+        - Duplicates on (location_id, grouped_provider_status) are dropped,
+          keeping the oldest import date.
+
+    Args:
+        new_grouped_providers_lf (pl.LazyFrame): Current snapshot of grouped
+            providers, as returned by select_grouped_providers function.
+        grouped_providers_lf (pl.LazyFrame): Historical grouped provider records.
+            May be empty on first run.
+
+    Returns:
+        pl.LazyFrame: Full history of grouped provider records with updated statuses.
+            Unique on (location_id, grouped_provider_status).
+    """
     if grouped_providers_lf.limit(1).collect().is_empty():
         return new_grouped_providers_lf
 
-    active_ids = new_grouped_providers_lf.select(IndCQC.location_id)
+    new_grouped_provider_ids = new_grouped_providers_lf.select(IndCQC.location_id)
 
-    dropped_ids_lf = grouped_providers_lf.join(
-        active_ids, on=IndCQC.location_id, how="anti"
-    ).with_columns(
-        pl.lit("fixed").alias(NGPcol.grouped_provider_status),
-        pl.col(IndCQC.cqc_location_import_date).alias(NGPcol.last_update_date),
+    snapshot_date = (
+        new_grouped_providers_lf.select(pl.col(IndCQC.cqc_location_import_date).max())
+        .collect()
+        .item()
     )
 
-    retained_lf = grouped_providers_lf.join(
-        active_ids, on=IndCQC.location_id, how="semi"
+    fixed_grouped_providers_lf = grouped_providers_lf.join(
+        new_grouped_provider_ids, on=IndCQC.location_id, how="anti"
+    ).with_columns(
+        pl.lit("fixed").alias(NGPcol.grouped_provider_status),
+        pl.lit(snapshot_date).alias(NGPcol.last_update_date),
+    )
+
+    active_grouped_providers_lf = grouped_providers_lf.join(
+        new_grouped_provider_ids, on=IndCQC.location_id, how="semi"
     )
 
     return (
-        pl.concat([retained_lf, dropped_ids_lf, new_grouped_providers_lf])
+        pl.concat(
+            [
+                active_grouped_providers_lf,
+                fixed_grouped_providers_lf,
+                new_grouped_providers_lf,
+            ]
+        )
         .sort(IndCQC.cqc_location_import_date, descending=False)
         .unique(
             subset=[IndCQC.location_id, NGPcol.grouped_provider_status],

--- a/projects/_03_independent_cqc/_02_clean/fargate/utils/clean_ascwds_filled_post_outliers/null_grouped_providers.py
+++ b/projects/_03_independent_cqc/_02_clean/fargate/utils/clean_ascwds_filled_post_outliers/null_grouped_providers.py
@@ -339,7 +339,10 @@ def select_grouped_providers(lf: pl.LazyFrame) -> pl.LazyFrame:
         .select(cols_to_select)
         .with_columns(
             pl.lit("problem").alias(NGPcol.grouped_provider_status),
-            pl.col(IndCQC.cqc_location_import_date).alias(NGPcol.last_update_date),
+            pl.col(IndCQC.cqc_location_import_date).alias(
+                NGPcol.grp_prov_identified_date
+            ),
+            pl.lit(None).cast(pl.Date).alias(NGPcol.grp_prov_fixed_date),
         )
     )
 
@@ -354,8 +357,8 @@ def update_grouped_providers_history(
 
     On first run (empty grouped_providers_lf), returns only the new snapshot.
     On subsequent runs:
-        - Locations no longer in the new snapshot have grouped_provider_status
-          set to "fixed" and last_update_date set to cqc_location_import_date.
+        - Locations no longer in the new snapshot have grouped_provider_status set to
+          "fixed" and grp_prov_fixed_date set to the snapshot's import date.
         - Locations still active are retained as-is with last_update_date unchanged.
         - Duplicates on (location_id, grouped_provider_status) are dropped,
           keeping the oldest import date.
@@ -385,7 +388,7 @@ def update_grouped_providers_history(
         new_grouped_provider_ids, on=IndCQC.location_id, how="anti"
     ).with_columns(
         pl.lit("fixed").alias(NGPcol.grouped_provider_status),
-        pl.lit(snapshot_date).alias(NGPcol.last_update_date),
+        pl.lit(snapshot_date).alias(NGPcol.grp_prov_fixed_date),
     )
 
     active_grouped_providers_lf = grouped_providers_lf.join(

--- a/projects/_03_independent_cqc/_02_clean/fargate/utils/clean_ascwds_filled_post_outliers/null_grouped_providers.py
+++ b/projects/_03_independent_cqc/_02_clean/fargate/utils/clean_ascwds_filled_post_outliers/null_grouped_providers.py
@@ -330,8 +330,6 @@ def select_grouped_providers(
         pl.LazyFrame: Full history of grouped provider records with updated flags.
             Unique on (location_id, grouped_provider_status).
     """
-    grouped_provider_status = "grouped_provider_status"  # New column to indicate the status of the grouped provider (problem/fixed).
-    last_update_date = "last_update_date"  # New column to indicate the last update date for the grouped provider status.
     cols_to_select = [
         IndCQC.location_id,
         IndCQC.provider_id,
@@ -349,8 +347,8 @@ def select_grouped_providers(
         .filter(trunc_date_col == trunc_date_col.max())
         .select(cols_to_select)
         .with_columns(
-            pl.lit("problem").alias(grouped_provider_status),
-            pl.col(IndCQC.cqc_location_import_date).alias(last_update_date),
+            pl.lit("problem").alias(NGPcol.grouped_provider_status),
+            pl.col(IndCQC.cqc_location_import_date).alias(NGPcol.last_update_date),
         )
     )
 
@@ -362,8 +360,8 @@ def select_grouped_providers(
     dropped_ids_lf = grouped_providers_lf.join(
         active_ids, on=IndCQC.location_id, how="anti"
     ).with_columns(
-        pl.lit("fixed").alias(grouped_provider_status),
-        pl.col(IndCQC.cqc_location_import_date).alias(last_update_date),
+        pl.lit("fixed").alias(NGPcol.grouped_provider_status),
+        pl.col(IndCQC.cqc_location_import_date).alias(NGPcol.last_update_date),
     )
 
     retained_lf = grouped_providers_lf.join(
@@ -374,7 +372,7 @@ def select_grouped_providers(
         pl.concat([retained_lf, dropped_ids_lf, new_grouped_providers_lf])
         .sort(IndCQC.cqc_location_import_date, descending=False)
         .unique(
-            subset=[IndCQC.location_id, grouped_provider_status],
+            subset=[IndCQC.location_id, NGPcol.grouped_provider_status],
             keep="first",
             maintain_order=True,
         )

--- a/projects/_03_independent_cqc/_02_clean/fargate/utils/clean_ascwds_filled_post_outliers/null_grouped_providers.py
+++ b/projects/_03_independent_cqc/_02_clean/fargate/utils/clean_ascwds_filled_post_outliers/null_grouped_providers.py
@@ -307,18 +307,31 @@ def select_grouped_providers(
     lf: pl.LazyFrame, grouped_providers_lf: pl.LazyFrame
 ) -> pl.LazyFrame:
     """
-    Filters the input LazyFrame to the following:
+    Filters the input LazyFrame to the following and merges
+    with historical grouped provider records, updating status columns for locations
+    that have dropped off:
         - potential_grouped_provider is True
         - cqc_location_import_date equal to max year/month across dataset.
-        - cqc_location_import_date equal to min day of the max year/month across dataset.
+
+    On first run (empty grouped_providers_lf), returns only the new snapshot.
+    On subsequent runs:
+        - Locations no longer in the new snapshot have grouped_provider_status set to
+            "fixed".
+        - Locations still active are retained as-is.
+        - Duplicates on (location_id, grouped_provider_status) are dropped, keeping the
+          oldest import date.
 
     Args:
-        lf (pl.LazyFrame): A LazyFrame with potential_grouped_provider column.
-        grouped_providers_lf (pl.LazyFrame): A LazyFrame containing existing grouped providers.
+        lf (pl.LazyFrame): Input frame containing potential_grouped_provider column.
+        grouped_providers_lf (pl.LazyFrame): Historical grouped provider records.
+            May be empty on first run.
 
     Returns:
-        pl.LazyFrame: The filtered input LazyFrame.
+        pl.LazyFrame: Full history of grouped provider records with updated flags.
+            Unique on (location_id, grouped_provider_status).
     """
+    grouped_provider_status = "grouped_provider_status"  # New column to indicate the status of the grouped provider (problem/fixed).
+    last_update_date = "last_update_date"  # New column to indicate the last update date for the grouped provider status.
     cols_to_select = [
         IndCQC.location_id,
         IndCQC.provider_id,
@@ -336,16 +349,33 @@ def select_grouped_providers(
         .filter(trunc_date_col == trunc_date_col.max())
         .select(cols_to_select)
         .with_columns(
-            # add a new bool column to true for all newly identified grouped providers
-            pl.lit(True).alias("grouped_provider")
+            pl.lit("problem").alias(grouped_provider_status),
+            pl.col(IndCQC.cqc_location_import_date).alias(last_update_date),
         )
     )
 
-    # If the locationid is in the grouped_providers_lf but not in new_grouped_providers_lf then change their "grouped_provider" status in the grouped_providers_lf to False.
-    # Append the new_grouped_providers_lf to the grouped_providers_lf and remove duplicates on locationid and "grouped_provider".
+    if grouped_providers_lf.limit(1).collect().is_empty():
+        return new_grouped_providers_lf
 
-    grouped_providers_lf = grouped_providers_lf.join(
-        new_grouped_providers_lf, on=IndCQC.location_id, how="outer"
+    active_ids = new_grouped_providers_lf.select(IndCQC.location_id)
+
+    dropped_ids_lf = grouped_providers_lf.join(
+        active_ids, on=IndCQC.location_id, how="anti"
+    ).with_columns(
+        pl.lit("fixed").alias(grouped_provider_status),
+        pl.col(IndCQC.cqc_location_import_date).alias(last_update_date),
     )
 
-    return grouped_providers_lf
+    retained_lf = grouped_providers_lf.join(
+        active_ids, on=IndCQC.location_id, how="semi"
+    )
+
+    return (
+        pl.concat([retained_lf, dropped_ids_lf, new_grouped_providers_lf])
+        .sort(IndCQC.cqc_location_import_date, descending=False)
+        .unique(
+            subset=[IndCQC.location_id, grouped_provider_status],
+            keep="first",
+            maintain_order=True,
+        )
+    )

--- a/projects/_03_independent_cqc/_02_clean/tests/fargate/utils/clean_ascwds_filled_post_outliers/test_clean_ascwds_filled_post_outliers.py
+++ b/projects/_03_independent_cqc/_02_clean/tests/fargate/utils/clean_ascwds_filled_post_outliers/test_clean_ascwds_filled_post_outliers.py
@@ -23,6 +23,7 @@ class CleanAscwdsFilledPostOutliersTests(unittest.TestCase):
             Schemas.unfiltered_ind_cqc_schema,
             orient="row",
         )
+        self.grouped_providers_lf = pl.LazyFrame()
 
     @patch(f"{PATCH_PATH}.add_filtering_rule_column")
     @patch(
@@ -44,7 +45,9 @@ class CleanAscwdsFilledPostOutliersTests(unittest.TestCase):
             Mock(name="grouped_providers"),
         ]
 
-        job.clean_ascwds_filled_post_outliers(self.unfiltered_ind_cqc_lf)
+        job.clean_ascwds_filled_post_outliers(
+            self.unfiltered_ind_cqc_lf, self.grouped_providers_lf
+        )
         winsorize_care_home_filled_posts_per_bed_ratio_outliers_mock.assert_called_once()
         null_grouped_provders_mock.assert_called_once()
         null_filled_posts_where_locations_use_invalid_missing_data_code_mock.assert_called_once()

--- a/projects/_03_independent_cqc/_02_clean/tests/fargate/utils/clean_ascwds_filled_post_outliers/test_null_grouped_providers.py
+++ b/projects/_03_independent_cqc/_02_clean/tests/fargate/utils/clean_ascwds_filled_post_outliers/test_null_grouped_providers.py
@@ -251,5 +251,5 @@ class UpdateGropupedProvidersHistory(unittest.TestCase):
         returned_lf = job.update_grouped_providers_history(
             new_grouped_providers_lf, historical_grouped_providers_lf
         )
-        expected_lf = new_grouped_providers_lf
-        pl_testing.assert_frame_equal(returned_lf, expected_lf)
+
+        pl_testing.assert_frame_equal(returned_lf, new_grouped_providers_lf)

--- a/projects/_03_independent_cqc/_02_clean/tests/fargate/utils/clean_ascwds_filled_post_outliers/test_null_grouped_providers.py
+++ b/projects/_03_independent_cqc/_02_clean/tests/fargate/utils/clean_ascwds_filled_post_outliers/test_null_grouped_providers.py
@@ -59,8 +59,9 @@ class MainTests(unittest.TestCase):
             Schemas.null_grouped_providers_schema,
             orient="row",
         )
+        self.grouped_providers_lf = pl.LazyFrame()
         self.returned_lf, self.grouped_providers = job.null_grouped_providers(
-            self.test_lf
+            self.test_lf, self.grouped_providers_lf
         )
 
     def test_null_grouped_providers_runs(self):
@@ -90,7 +91,7 @@ class MainTests(unittest.TestCase):
         null_care_home_grouped_providers_mock: Mock,
         null_non_residential_grouped_providers_mock: Mock,
     ):
-        job.null_grouped_providers(self.test_lf)
+        job.null_grouped_providers(self.test_lf, self.grouped_providers_lf)
 
         calculate_data_for_grouped_provider_identification_mock.assert_called_once_with(
             self.test_lf
@@ -193,16 +194,36 @@ class NullNonResidentialGroupedProvidersTests(unittest.TestCase):
 
 
 class SelectGroupedProviders(unittest.TestCase):
-    def test_function_returns_expected_rows(self):
+    def test_function_returns_expected_rows_when_grouped_providers_exist(self):
         input_lf = pl.LazyFrame(
             Data.select_grouped_providers_rows,
             Schemas.select_grouped_providers_schema,
             orient="row",
         )
-        returned_lf = job.select_grouped_providers(input_lf)
+        grouped_providers_lf = pl.LazyFrame(
+            Data.grouped_providers_rows,
+            Schemas.expected_select_grouped_providers_schema,
+            orient="row",
+        )
+        returned_lf = job.select_grouped_providers(input_lf, grouped_providers_lf)
         expected_lf = pl.LazyFrame(
             Data.expected_select_grouped_providers_rows,
+            Schemas.expected_select_grouped_providers_schema,
+            orient="row",
+        )
+        pl_testing.assert_frame_equal(returned_lf, expected_lf)
+
+    def test_function_returns_expected_rows_when_grouped_providers_does_not_exist(self):
+        input_lf = pl.LazyFrame(
+            Data.select_grouped_providers_rows,
             Schemas.select_grouped_providers_schema,
+            orient="row",
+        )
+        grouped_providers_lf = pl.LazyFrame()
+        returned_lf = job.select_grouped_providers(input_lf, grouped_providers_lf)
+        expected_lf = pl.LazyFrame(
+            Data.expected_first_run_rows,
+            Schemas.expected_select_grouped_providers_schema,
             orient="row",
         )
         pl_testing.assert_frame_equal(returned_lf, expected_lf)

--- a/projects/_03_independent_cqc/_02_clean/tests/fargate/utils/clean_ascwds_filled_post_outliers/test_null_grouped_providers.py
+++ b/projects/_03_independent_cqc/_02_clean/tests/fargate/utils/clean_ascwds_filled_post_outliers/test_null_grouped_providers.py
@@ -68,6 +68,13 @@ class MainTests(unittest.TestCase):
         self.assertIsInstance(self.returned_lf, pl.LazyFrame)
         self.assertIsInstance(self.grouped_providers, pl.LazyFrame)
 
+    def test_null_grouped_providers_returns_tuple_of_two_lazyframes(self):
+        result = job.null_grouped_providers(self.test_lf, self.grouped_providers_lf)
+        self.assertIsInstance(result, tuple)
+        self.assertEqual(len(result), 2)
+        self.assertIsInstance(result[0], pl.LazyFrame)
+        self.assertIsInstance(result[1], pl.LazyFrame)
+
     def test_null_grouped_providers_returns_same_number_of_rows_in_locations_data(self):
         self.assertEqual(
             self.returned_lf.collect().height, self.test_lf.collect().height
@@ -80,6 +87,7 @@ class MainTests(unittest.TestCase):
 
     @patch(f"{PATCH_PATH}.null_non_residential_grouped_providers")
     @patch(f"{PATCH_PATH}.null_care_home_grouped_providers")
+    @patch(f"{PATCH_PATH}.update_grouped_providers_history")
     @patch(f"{PATCH_PATH}.select_grouped_providers")
     @patch(f"{PATCH_PATH}.identify_potential_grouped_providers")
     @patch(f"{PATCH_PATH}.calculate_data_for_grouped_provider_identification")
@@ -87,7 +95,8 @@ class MainTests(unittest.TestCase):
         self,
         calculate_data_for_grouped_provider_identification_mock: Mock,
         identify_potential_grouped_providers_mock: Mock,
-        select_grouped_providers: Mock,
+        select_grouped_providers_mock: Mock,
+        update_grouped_providers_history_mock: Mock,
         null_care_home_grouped_providers_mock: Mock,
         null_non_residential_grouped_providers_mock: Mock,
     ):
@@ -97,7 +106,8 @@ class MainTests(unittest.TestCase):
             self.test_lf
         )
         identify_potential_grouped_providers_mock.assert_called_once()
-        select_grouped_providers.assert_called_once()
+        select_grouped_providers_mock.assert_called_once()
+        update_grouped_providers_history_mock.assert_called_once()
         null_care_home_grouped_providers_mock.assert_called_once()
         null_non_residential_grouped_providers_mock.assert_called_once()
 
@@ -194,36 +204,52 @@ class NullNonResidentialGroupedProvidersTests(unittest.TestCase):
 
 
 class SelectGroupedProviders(unittest.TestCase):
-    def test_function_returns_expected_rows_when_grouped_providers_exist(self):
+    def test_function_returns_expected_rows(self):
         input_lf = pl.LazyFrame(
             Data.select_grouped_providers_rows,
             Schemas.select_grouped_providers_schema,
             orient="row",
         )
-        grouped_providers_lf = pl.LazyFrame(
-            Data.grouped_providers_rows,
-            Schemas.expected_select_grouped_providers_schema,
-            orient="row",
-        )
-        returned_lf = job.select_grouped_providers(input_lf, grouped_providers_lf)
+        returned_lf = job.select_grouped_providers(input_lf)
         expected_lf = pl.LazyFrame(
             Data.expected_select_grouped_providers_rows,
-            Schemas.expected_select_grouped_providers_schema,
+            Schemas.final_grouped_providers_schema,
             orient="row",
         )
         pl_testing.assert_frame_equal(returned_lf, expected_lf)
 
-    def test_function_returns_expected_rows_when_grouped_providers_does_not_exist(self):
-        input_lf = pl.LazyFrame(
-            Data.select_grouped_providers_rows,
-            Schemas.select_grouped_providers_schema,
+
+class UpdateGropupedProvidersHistory(unittest.TestCase):
+    def test_function_returns_expected_rows_when_grouped_providers_exist(self):
+        new_grouped_providers_lf = pl.LazyFrame(
+            Data.new_grouped_providers_rows,
+            Schemas.final_grouped_providers_schema,
             orient="row",
         )
-        grouped_providers_lf = pl.LazyFrame()
-        returned_lf = job.select_grouped_providers(input_lf, grouped_providers_lf)
+        historical_grouped_providers_lf = pl.LazyFrame(
+            Data.historical_grouped_providers_rows,
+            Schemas.final_grouped_providers_schema,
+            orient="row",
+        )
+        returned_lf = job.update_grouped_providers_history(
+            new_grouped_providers_lf, historical_grouped_providers_lf
+        )
         expected_lf = pl.LazyFrame(
-            Data.expected_first_run_rows,
-            Schemas.expected_select_grouped_providers_schema,
+            Data.expected_update_grouped_providers_history_rows,
+            Schemas.final_grouped_providers_schema,
             orient="row",
         )
+        pl_testing.assert_frame_equal(returned_lf, expected_lf, check_row_order=False)
+
+    def test_function_returns_expected_rows_when_grouped_providers_does_not_exist(self):
+        new_grouped_providers_lf = pl.LazyFrame(
+            Data.new_grouped_providers_rows,
+            Schemas.final_grouped_providers_schema,
+            orient="row",
+        )
+        historical_grouped_providers_lf = pl.LazyFrame()
+        returned_lf = job.update_grouped_providers_history(
+            new_grouped_providers_lf, historical_grouped_providers_lf
+        )
+        expected_lf = new_grouped_providers_lf
         pl_testing.assert_frame_equal(returned_lf, expected_lf)

--- a/projects/_03_independent_cqc/unittest_data/polars_ind_cqc_test_file_data.py
+++ b/projects/_03_independent_cqc/unittest_data/polars_ind_cqc_test_file_data.py
@@ -1195,31 +1195,31 @@ class NullGroupedProvidersData:
     ] # fmt: skip
 
     expected_select_grouped_providers_rows = [
-        ("1-004", "prov-1", date(2026, 2, 1), "nmdsid_4", True, 1.0, "problem", date(2026, 2, 1)),
-        ("1-005", "prov-2", date(2026, 2, 1), "nmdsid_5", True, 1.0, "problem", date(2026, 2, 1)),
+        ("1-004", "prov-1", date(2026, 2, 1), "nmdsid_4", True, 1.0, "problem", date(2026, 2, 1), None),
+        ("1-005", "prov-2", date(2026, 2, 1), "nmdsid_5", True, 1.0, "problem", date(2026, 2, 1), None),
     ] # fmt: skip
 
     # All rows have grouped_provider_status = "problem" and last_update_date = their import date.
     new_grouped_providers_rows = [
-        ("1-001", "prov-1", date(2026, 2, 1), "nmds_1", True, 10.0, "problem", date(2026, 2, 1)),
-        ("1-003", "prov-2", date(2026, 2, 1), "nmds_3", True, 30.0, "problem", date(2026, 2, 1)),
-        ("1-004", "prov-3", date(2026, 2, 1), "nmds_4", True, 40.0, "problem", date(2026, 2, 1)),
+        ("1-001", "prov-1", date(2026, 2, 1), "nmds_1", True, 10.0, "problem", date(2026, 2, 1), None),
+        ("1-003", "prov-2", date(2026, 2, 1), "nmds_3", True, 30.0, "problem", date(2026, 2, 1), None),
+        ("1-004", "prov-3", date(2026, 2, 1), "nmds_4", True, 40.0, "problem", date(2026, 2, 1), None),
     ]  # fmt: skip
 
     # historical_grouped_providers_rows: what was previously saved to the grouped providers dataset.
     historical_grouped_providers_rows = [
-        ("1-001", "prov-1", date(2026, 1, 1), "nmds_1", True, 10.0, "problem", date(2026, 1, 1)), # Still active problem — should be retained as-is (oldest kept, last_update_date stays same).
-        ("1-002", "prov-1", date(2026, 1, 1), "nmds_2", True, 20.0, "problem", date(2026, 1, 1)), # Dropped off — not in new snapshot, should be flipped to "fixed".
-        ("1-003", "prov-2", date(2026, 1, 1), "nmds_3", True, 30.0, "fixed", date(2026, 1, 1)), # Re-appearing — was fixed, now back as "problem" in new snapshot; new row appended.
+        ("1-001", "prov-1", date(2026, 1, 1), "nmds_1", True, 10.0, "problem", date(2026, 1, 1), None), # Still active problem — should be retained as-is (oldest kept, last_update_date stays same).
+        ("1-002", "prov-1", date(2026, 1, 1), "nmds_2", True, 20.0, "problem", date(2026, 1, 1), None), # Dropped off — not in new snapshot, should be flipped to "fixed".
+        ("1-003", "prov-2", date(2026, 1, 1), "nmds_3", True, 30.0, "fixed", date(2026, 1, 1), date(2026, 1, 1)), # Re-appearing — was fixed, now back as "problem" in new snapshot; new row appended.
     ]  # fmt: skip
 
     # expected_update_grouped_providers_history_rows: full history after update.
     expected_update_grouped_providers_history_rows = [
-        ("1-001", "prov-1", date(2026, 1, 1), "nmds_1", True, 10.0, "problem", date(2026, 1, 1)), # Retained — oldest "problem" record kept, last_update_date unchanged.
-        ("1-002", "prov-1", date(2026, 1, 1), "nmds_2", True, 20.0, "fixed", date(2026, 2, 1)), # Flipped — was "problem", now "fixed" with last_update_date = new snapshot date.
-        ("1-003", "prov-2", date(2026, 1, 1), "nmds_3", True, 30.0, "fixed", date(2026, 1, 1)), # Preserved — old "fixed" row kept as part of full history.
-        ("1-003", "prov-2", date(2026, 2, 1), "nmds_3", True, 30.0, "problem", date(2026, 2, 1)), # Re-appeared — new "problem" row appended alongside the old "fixed" row.
-        ("1-004", "prov-3", date(2026, 2, 1), "nmds_4", True, 40.0, "problem", date(2026, 2, 1)), # New — first time seen, added with "problem" status.
+        ("1-001", "prov-1", date(2026, 1, 1), "nmds_1", True, 10.0, "problem", date(2026, 1, 1), None), # Retained — oldest "problem" record kept, last_update_date unchanged.
+        ("1-002", "prov-1", date(2026, 1, 1), "nmds_2", True, 20.0, "fixed", date(2026, 1, 1), date(2026, 2, 1)), # Flipped — was "problem", now "fixed" with last_update_date = new snapshot date.
+        ("1-003", "prov-2", date(2026, 1, 1), "nmds_3", True, 30.0, "fixed", date(2026, 1, 1), date(2026, 1, 1)), # Preserved — old "fixed" row kept as part of full history.
+        ("1-003", "prov-2", date(2026, 2, 1), "nmds_3", True, 30.0, "problem", date(2026, 2, 1), None), # Re-appeared — new "problem" row appended alongside the old "fixed" row.
+        ("1-004", "prov-3", date(2026, 2, 1), "nmds_4", True, 40.0, "problem", date(2026, 2, 1), None), # New — first time seen, added with "problem" status.
     ]  # fmt: skip
 
 

--- a/projects/_03_independent_cqc/unittest_data/polars_ind_cqc_test_file_data.py
+++ b/projects/_03_independent_cqc/unittest_data/polars_ind_cqc_test_file_data.py
@@ -1193,10 +1193,28 @@ class NullGroupedProvidersData:
         ("1-006", "prov-1", date(2025, 1, 1), "nmdsid_6", True, 1.0), # Incorrect date with lower year and month than desired.
         ("1-008", "prov-1", date(2025, 3, 1), "nmdsid_7", True, 1.0), # Incorrect date with lower year and higher month than desired.
     ] # fmt: skip
+
+    # Historical state: 1-004 and 1-005 active, 1-007 was active but drops off this run.
+    grouped_providers_rows = [
+        ("1-004", "prov-1", date(2026, 1, 1), "nmdsid_4", True, 1.0, "problem",  None),           # Still active — oldest record kept.
+        ("1-005", "prov-2", date(2026, 1, 1), "nmdsid_5", True, 1.0, "problem",  None),           # Still active — oldest record kept.
+        ("1-007", "prov-1", date(2026, 1, 1), "nmdsid_8", True, 1.0, "problem",  date(2026, 1, 1)),  # Drops off this run → flipped to "fixed".
+    ]  # fmt: skip
+
+    # Expected: 1-004 and 1-005 unchanged (oldest kept, update_date null),
+    #           1-007 flipped to False with update_date = snapshot date,
+    #           new True rows for 1-004 and 1-005 deduped away (same location_id + grouped_provider).
     expected_select_grouped_providers_rows = [
-        ("1-004", "prov-1", date(2026, 2, 1), "nmdsid_4", True, 1.0),
-        ("1-005", "prov-2", date(2026, 2, 1), "nmdsid_5", True, 1.0),
-    ] # fmt: skip
+        ("1-004", "prov-1", date(2026, 1, 1), "nmdsid_4", True, 1.0, "problem",  None),           # Oldest retained, unchanged.
+        ("1-005", "prov-2", date(2026, 1, 1), "nmdsid_5", True, 1.0, "problem",  None),           # Oldest retained, unchanged.
+        ("1-007", "prov-1", date(2026, 1, 1), "nmdsid_8", True, 1.0, "fixed", date(2026, 1, 1)),  # Flipped, last_update_date = snapshot date.
+    ]  # fmt: skip
+
+    # First run: no history, output equals filtered new snapshot only.
+    expected_first_run_rows = [
+        ("1-004", "prov-1", date(2026, 2, 1), "nmdsid_4", True, 1.0, "problem", date(2026, 2, 1)),
+        ("1-005", "prov-2", date(2026, 2, 1), "nmdsid_5", True, 1.0, "problem", date(2026, 2, 1)),
+    ]  # fmt: skip
 
 
 @dataclass

--- a/projects/_03_independent_cqc/unittest_data/polars_ind_cqc_test_file_data.py
+++ b/projects/_03_independent_cqc/unittest_data/polars_ind_cqc_test_file_data.py
@@ -1201,9 +1201,6 @@ class NullGroupedProvidersData:
         ("1-007", "prov-1", date(2026, 1, 1), "nmdsid_8", True, 1.0, "problem",  date(2026, 1, 1)),  # Drops off this run → flipped to "fixed".
     ]  # fmt: skip
 
-    # Expected: 1-004 and 1-005 unchanged (oldest kept, update_date null),
-    #           1-007 flipped to False with update_date = snapshot date,
-    #           new True rows for 1-004 and 1-005 deduped away (same location_id + grouped_provider).
     expected_select_grouped_providers_rows = [
         ("1-004", "prov-1", date(2026, 1, 1), "nmdsid_4", True, 1.0, "problem",  None),           # Oldest retained, unchanged.
         ("1-005", "prov-2", date(2026, 1, 1), "nmdsid_5", True, 1.0, "problem",  None),           # Oldest retained, unchanged.

--- a/projects/_03_independent_cqc/unittest_data/polars_ind_cqc_test_file_data.py
+++ b/projects/_03_independent_cqc/unittest_data/polars_ind_cqc_test_file_data.py
@@ -1194,23 +1194,32 @@ class NullGroupedProvidersData:
         ("1-008", "prov-1", date(2025, 3, 1), "nmdsid_7", True, 1.0), # Incorrect date with lower year and higher month than desired.
     ] # fmt: skip
 
-    # Historical state: 1-004 and 1-005 active, 1-007 was active but drops off this run.
-    grouped_providers_rows = [
-        ("1-004", "prov-1", date(2026, 1, 1), "nmdsid_4", True, 1.0, "problem",  None),           # Still active — oldest record kept.
-        ("1-005", "prov-2", date(2026, 1, 1), "nmdsid_5", True, 1.0, "problem",  None),           # Still active — oldest record kept.
-        ("1-007", "prov-1", date(2026, 1, 1), "nmdsid_8", True, 1.0, "problem",  date(2026, 1, 1)),  # Drops off this run → flipped to "fixed".
-    ]  # fmt: skip
-
     expected_select_grouped_providers_rows = [
-        ("1-004", "prov-1", date(2026, 1, 1), "nmdsid_4", True, 1.0, "problem",  None),           # Oldest retained, unchanged.
-        ("1-005", "prov-2", date(2026, 1, 1), "nmdsid_5", True, 1.0, "problem",  None),           # Oldest retained, unchanged.
-        ("1-007", "prov-1", date(2026, 1, 1), "nmdsid_8", True, 1.0, "fixed", date(2026, 1, 1)),  # Flipped, last_update_date = snapshot date.
-    ]  # fmt: skip
-
-    # First run: no history, output equals filtered new snapshot only.
-    expected_first_run_rows = [
         ("1-004", "prov-1", date(2026, 2, 1), "nmdsid_4", True, 1.0, "problem", date(2026, 2, 1)),
         ("1-005", "prov-2", date(2026, 2, 1), "nmdsid_5", True, 1.0, "problem", date(2026, 2, 1)),
+    ] # fmt: skip
+
+    # All rows have grouped_provider_status = "problem" and last_update_date = their import date.
+    new_grouped_providers_rows = [
+        ("1-001", "prov-1", date(2026, 2, 1), "nmds_1", True, 10.0, "problem", date(2026, 2, 1)),
+        ("1-003", "prov-2", date(2026, 2, 1), "nmds_3", True, 30.0, "problem", date(2026, 2, 1)),
+        ("1-004", "prov-3", date(2026, 2, 1), "nmds_4", True, 40.0, "problem", date(2026, 2, 1)),
+    ]  # fmt: skip
+
+    # historical_grouped_providers_rows: what was previously saved to the grouped providers dataset.
+    historical_grouped_providers_rows = [
+        ("1-001", "prov-1", date(2026, 1, 1), "nmds_1", True, 10.0, "problem", date(2026, 1, 1)), # Still active problem — should be retained as-is (oldest kept, last_update_date stays same).
+        ("1-002", "prov-1", date(2026, 1, 1), "nmds_2", True, 20.0, "problem", date(2026, 1, 1)), # Dropped off — not in new snapshot, should be flipped to "fixed".
+        ("1-003", "prov-2", date(2026, 1, 1), "nmds_3", True, 30.0, "fixed", date(2026, 1, 1)), # Re-appearing — was fixed, now back as "problem" in new snapshot; new row appended.
+    ]  # fmt: skip
+
+    # expected_update_grouped_providers_history_rows: full history after update.
+    expected_update_grouped_providers_history_rows = [
+        ("1-001", "prov-1", date(2026, 1, 1), "nmds_1", True, 10.0, "problem", date(2026, 1, 1)), # Retained — oldest "problem" record kept, last_update_date unchanged.
+        ("1-002", "prov-1", date(2026, 1, 1), "nmds_2", True, 20.0, "fixed", date(2026, 2, 1)), # Flipped — was "problem", now "fixed" with last_update_date = new snapshot date.
+        ("1-003", "prov-2", date(2026, 1, 1), "nmds_3", True, 30.0, "fixed", date(2026, 1, 1)), # Preserved — old "fixed" row kept as part of full history.
+        ("1-003", "prov-2", date(2026, 2, 1), "nmds_3", True, 30.0, "problem", date(2026, 2, 1)), # Re-appeared — new "problem" row appended alongside the old "fixed" row.
+        ("1-004", "prov-3", date(2026, 2, 1), "nmds_4", True, 40.0, "problem", date(2026, 2, 1)), # New — first time seen, added with "problem" status.
     ]  # fmt: skip
 
 

--- a/projects/_03_independent_cqc/unittest_data/polars_ind_cqc_test_file_schemas.py
+++ b/projects/_03_independent_cqc/unittest_data/polars_ind_cqc_test_file_schemas.py
@@ -1018,7 +1018,8 @@ class NullGroupedProvidersSchema:
         list(select_grouped_providers_schema.items())
         + [
             (NGPcol.grouped_provider_status, pl.String()),
-            (NGPcol.last_update_date, pl.Date()),
+            (NGPcol.grp_prov_identified_date, pl.Date()),
+            (NGPcol.grp_prov_fixed_date, pl.Date()),
         ]
     )
 

--- a/projects/_03_independent_cqc/unittest_data/polars_ind_cqc_test_file_schemas.py
+++ b/projects/_03_independent_cqc/unittest_data/polars_ind_cqc_test_file_schemas.py
@@ -1014,7 +1014,7 @@ class NullGroupedProvidersSchema:
         ]
     )
 
-    expected_select_grouped_providers_schema = pl.Schema(
+    final_grouped_providers_schema = pl.Schema(
         list(select_grouped_providers_schema.items())
         + [
             (NGPcol.grouped_provider_status, pl.String()),

--- a/projects/_03_independent_cqc/unittest_data/polars_ind_cqc_test_file_schemas.py
+++ b/projects/_03_independent_cqc/unittest_data/polars_ind_cqc_test_file_schemas.py
@@ -1014,6 +1014,14 @@ class NullGroupedProvidersSchema:
         ]
     )
 
+    expected_select_grouped_providers_schema = pl.Schema(
+        list(select_grouped_providers_schema.items())
+        + [
+            ("grouped_provider_status", pl.String()),
+            ("last_update_date", pl.Date()),
+        ]
+    )
+
 
 @dataclass
 class CleanAscwdsFilledPostOutliersSchema:

--- a/projects/_03_independent_cqc/unittest_data/polars_ind_cqc_test_file_schemas.py
+++ b/projects/_03_independent_cqc/unittest_data/polars_ind_cqc_test_file_schemas.py
@@ -1017,8 +1017,8 @@ class NullGroupedProvidersSchema:
     expected_select_grouped_providers_schema = pl.Schema(
         list(select_grouped_providers_schema.items())
         + [
-            ("grouped_provider_status", pl.String()),
-            ("last_update_date", pl.Date()),
+            (NGPcol.grouped_provider_status, pl.String()),
+            (NGPcol.last_update_date, pl.Date()),
         ]
     )
 

--- a/utils/column_names/ind_cqc_pipeline_columns.py
+++ b/utils/column_names/ind_cqc_pipeline_columns.py
@@ -399,7 +399,8 @@ class NullGroupedProviderColumns:
     provider_pir_count: str = "provider_pir_count"
     provider_pir_sum: str = "provider_pir_sum"
     grouped_provider_status: str = "grouped_provider_status"
-    last_update_date: str = "last_update_date"
+    grp_prov_identified_date: str = "grouped_provider_identified_date"
+    grp_prov_fixed_date: str = "grouped_provider_fixed_date"
 
 
 @dataclass

--- a/utils/column_names/ind_cqc_pipeline_columns.py
+++ b/utils/column_names/ind_cqc_pipeline_columns.py
@@ -398,6 +398,8 @@ class NullGroupedProviderColumns:
     potential_grouped_provider: str = "potential_grouped_provider"
     provider_pir_count: str = "provider_pir_count"
     provider_pir_sum: str = "provider_pir_sum"
+    grouped_provider_status: str = "grouped_provider_status"
+    last_update_date: str = "last_update_date"
 
 
 @dataclass


### PR DESCRIPTION
## Description
Trello ticket [#1677](https://trello.com/c/uqRyvfPX/1677-minform-about-new-grouped-providers-part-2-add-functionality-to-check-for-new-grouped-providers)

This PR updates the grouped provider selection process to maintain a historical log of grouped provider issues across monthly runs.

A new status flag is added to selected grouped providers, with newly identified rows marked as problem. The process now reads the previous month's grouped provider data and compares it against the current run. Any location_id that existed previously but is no longer identified in the current run is updated to fixed.

The current and historical datasets are then combined and deduplicated by location_id and status, allowing us to retain a growing audit trail of grouped provider issues and resolutions over time.

## Testing
- [x] Unit tests passing
- [x] Successful [Step Function run](https://eu-west-2.console.aws.amazon.com/states/home?region=eu-west-2#/v2/executions/details/arn:aws:states:eu-west-2:856699698263:execution:1677-grp-provs-2-Ind-CQC-Filled-Post-Estimates:6ae20fea-8be9-4d0f-97a5-adbf4c258c36)
- [x] Outputs checked in Athena

[Add any additional testing information here - add screenshot if relevant]

## Checklist (delete if not relevant)
- [ ] Unit tests added/amended
- [ ] Docstrings added/updated
- [ ] Updated CHANGELOG
- [ ] Code reviewed by AI
- [ ] Moved Trello ticket to PR column

## Reviewer checklist
- [x] PR solves the Trello ticket requirements
- [ ] Outputs appear reasonable and understandable
- [ ] The overall approach is appropriate and not over-engineered
- [ ] No obvious scalability, performance or interdependency concerns
- [ ] Tests appropriately cover the main behaviour/edge cases
- [ ] Naming and structure are broadly understandable and consistent
- [ ] Docstrings are sufficient for future maintenance
- [ ] Docstrings cover non-obvious behaviour
