### PR TITLE
1700 Clean ascwds workplace - Convert format_date_fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ All notable changes to this project will be documented in this file.
 
 - Added placeholder polars tasks for clean ascwds workplace and validate clean ascwds workplace jobs.
 
+- Converted format_date_fields to polars as cast_date_strings_to_dates.
+
 ### Changed
 - Refactored job group filter to use magic numbers for outlier bounds.
 

--- a/polars_utils/cleaning_utils.py
+++ b/polars_utils/cleaning_utils.py
@@ -165,7 +165,7 @@ def create_banded_bed_count_column(
 def cast_date_strings_to_dates(
     lf: pl.LazyFrame,
     date_column_identifier: str = "date",
-    raw_date_format: str = None,
+    raw_date_format: str = "%d/%m/%Y",
 ) -> pl.LazyFrame:
     """
     Converts columns to date type.
@@ -177,7 +177,7 @@ def cast_date_strings_to_dates(
     Args:
         lf (pl.LazyFrame): A LazyFrame with string columns containing dates.
         date_column_identifier (str): A string to identify columns to convert. Defaults to 'date'.
-        raw_date_format (str): The format of string dates.
+        raw_date_format (str): The format of string dates. Defaults to '%d/%m/%Y'.
 
     Returns:
         pl.LazyFrame: The input LazyFrame with columns cast to dates.

--- a/polars_utils/cleaning_utils.py
+++ b/polars_utils/cleaning_utils.py
@@ -160,3 +160,37 @@ def create_banded_bed_count_column(
     return input_lf.with_columns(
         pl.when(is_not_care_home()).then(zero).otherwise(expr).alias(new_col)
     )
+
+
+def cast_date_strings_to_dates(
+    lf: pl.LazyFrame,
+    date_column_identifier: str = "date",
+    raw_date_format: str = None,
+) -> pl.LazyFrame:
+    """
+    Converts columns to date type.
+
+    All columns in LazyFrame with date_column_identifier in their name and
+    values formatted as raw_date_format will be type cast.
+    The raw_date_format must match data exactly, otherwise value will be nulled.
+
+    Args:
+        lf (pl.LazyFrame): A LazyFrame with string columns containing dates.
+        date_column_identifier (str): A string to identify columns to convert. Defaults to 'date'.
+        raw_date_format (str): The format of string dates.
+
+    Returns:
+        pl.LazyFrame: The input LazyFrame with columns cast to dates.
+    """
+    date_columns = [
+        col
+        for col in lf.collect_schema().names()
+        if date_column_identifier in col and "import_date" not in col
+    ]
+
+    return lf.with_columns(
+        [
+            pl.col(col).str.strptime(pl.Date, raw_date_format, strict=False).alias(col)
+            for col in date_columns
+        ]
+    )

--- a/polars_utils/cleaning_utils.py
+++ b/polars_utils/cleaning_utils.py
@@ -170,8 +170,8 @@ def cast_date_strings_to_dates(
     """
     Converts columns to date type.
 
-    All columns in LazyFrame with date_column_identifier in their name and
-    values formatted as raw_date_format will be type cast.
+    Columns in LazyFrame with date_column_identifier in their name excluding
+    'import_date' and values formatted as raw_date_format will be type cast.
     The raw_date_format must match data exactly, otherwise value will be nulled.
 
     Args:
@@ -190,7 +190,7 @@ def cast_date_strings_to_dates(
 
     return lf.with_columns(
         [
-            pl.col(col).str.strptime(pl.Date, raw_date_format, strict=False).alias(col)
+            pl.col(col).str.strptime(pl.Date, raw_date_format, strict=False)
             for col in date_columns
         ]
     )

--- a/projects/_01_ingest/ascwds/fargate/clean_ascwds_workplace.py
+++ b/projects/_01_ingest/ascwds/fargate/clean_ascwds_workplace.py
@@ -32,24 +32,13 @@ def main(
     # trello 1724
     # ascwds_workplace_df = remove_white_space_from_nmdsid(ascwds_workplace_df)
 
-    # trello 1724
-    # ascwds_workplace_df = ascwds_workplace_df.withColumnRenamed(
-    #     AWPClean.last_logged_in, AWPClean.last_logged_in_date
-    # )
+    lf = lf.rename({AWPClean.last_logged_in: AWPClean.last_logged_in_date})
 
-    # trello 1700
-    # ascwds_workplace_df = utils.format_date_fields(
-    #     ascwds_workplace_df,
-    #     date_column_identifier=DATE_COLUMN_IDENTIFIER,
-    #     raw_date_format="dd/MM/yyyy",
-    # )
+    lf = cUtils.cast_date_strings_to_dates(lf, raw_date_format="dd/MM/yyyy")
 
-    # trello 1700
-    # ascwds_workplace_df = cUtils.column_to_date(
-    #     ascwds_workplace_df,
-    #     AWPClean.import_date,
-    #     AWPClean.ascwds_workplace_import_date,
-    # )
+    lf = cUtils.column_to_date(
+        lf, AWPClean.import_date, AWPClean.ascwds_workplace_import_date
+    )
 
     # trello 1705
     # ascwds_workplace_df = cUtils.apply_categorical_labels(

--- a/projects/_01_ingest/ascwds/fargate/clean_ascwds_workplace.py
+++ b/projects/_01_ingest/ascwds/fargate/clean_ascwds_workplace.py
@@ -1,5 +1,6 @@
 import polars as pl
 
+from polars_utils import cleaning_utils as cUtils
 from polars_utils import utils
 from projects._01_ingest.ascwds.fargate.utils import clean_workplace_utils as wUtils
 from utils.column_names.cleaned_data_files.ascwds_workplace_cleaned import (

--- a/projects/_01_ingest/ascwds/fargate/clean_ascwds_workplace.py
+++ b/projects/_01_ingest/ascwds/fargate/clean_ascwds_workplace.py
@@ -36,9 +36,12 @@ def main(
 
     lf = cUtils.cast_date_strings_to_dates(lf, raw_date_format="%d/%m/%Y")
 
-    # lf = cUtils.column_to_date(
-    #     lf, AWPClean.import_date, AWPClean.ascwds_workplace_import_date
-    # )
+    lf = cUtils.column_to_date(
+        lf, AWPClean.import_date, AWPClean.ascwds_workplace_import_date
+    )
+
+    # Temporarily casting import_date to string to prevent it being bigint.
+    lf = lf.with_columns(pl.col(AWPClean.import_date).cast(pl.String))
 
     # trello 1705
     # ascwds_workplace_df = cUtils.apply_categorical_labels(

--- a/projects/_01_ingest/ascwds/fargate/clean_ascwds_workplace.py
+++ b/projects/_01_ingest/ascwds/fargate/clean_ascwds_workplace.py
@@ -36,9 +36,9 @@ def main(
 
     lf = cUtils.cast_date_strings_to_dates(lf, raw_date_format="%d/%m/%Y")
 
-    lf = cUtils.column_to_date(
-        lf, AWPClean.import_date, AWPClean.ascwds_workplace_import_date
-    )
+    # lf = cUtils.column_to_date(
+    #     lf, AWPClean.import_date, AWPClean.ascwds_workplace_import_date
+    # )
 
     # trello 1705
     # ascwds_workplace_df = cUtils.apply_categorical_labels(

--- a/projects/_01_ingest/ascwds/fargate/clean_ascwds_workplace.py
+++ b/projects/_01_ingest/ascwds/fargate/clean_ascwds_workplace.py
@@ -62,7 +62,7 @@ def main(
 
     lf = lf.rename({AWPClean.last_logged_in: AWPClean.last_logged_in_date})
 
-    lf = cUtils.cast_date_strings_to_dates(lf, raw_date_format="%d/%m/%Y")
+    lf = cUtils.cast_date_strings_to_dates(lf)
 
     lf = cUtils.column_to_date(
         lf, AWPClean.import_date, AWPClean.ascwds_workplace_import_date

--- a/projects/_01_ingest/ascwds/fargate/clean_ascwds_workplace.py
+++ b/projects/_01_ingest/ascwds/fargate/clean_ascwds_workplace.py
@@ -34,7 +34,7 @@ def main(
 
     lf = lf.rename({AWPClean.last_logged_in: AWPClean.last_logged_in_date})
 
-    lf = cUtils.cast_date_strings_to_dates(lf, raw_date_format="dd/MM/yyyy")
+    lf = cUtils.cast_date_strings_to_dates(lf, raw_date_format="%d/%m/%Y")
 
     lf = cUtils.column_to_date(
         lf, AWPClean.import_date, AWPClean.ascwds_workplace_import_date

--- a/projects/_01_ingest/ascwds/fargate/clean_ascwds_workplace.py
+++ b/projects/_01_ingest/ascwds/fargate/clean_ascwds_workplace.py
@@ -66,10 +66,7 @@ def main(
 
     lf = cUtils.column_to_date(
         lf, AWPClean.import_date, AWPClean.ascwds_workplace_import_date
-    )
-
-    # Temporarily casting import_date to string to prevent it being bigint.
-    lf = lf.with_columns(pl.col(AWPClean.import_date).cast(pl.String))
+    ).drop(AWPClean.import_date)
 
     # trello 1705
     # ascwds_workplace_df = cUtils.apply_categorical_labels(

--- a/projects/_01_ingest/ascwds/tests/fargate/test_clean_ascwds_workplace.py
+++ b/projects/_01_ingest/ascwds/tests/fargate/test_clean_ascwds_workplace.py
@@ -33,7 +33,7 @@ class MainTests(unittest.TestCase):
         scan_parquet_mock.assert_called_once_with(self.WORKPLACE_SOURCE)
 
         cast_date_strings_to_dates_mock.assert_called_once_with(
-            ANY, raw_date_format="dd/MM/yyyy"
+            ANY, raw_date_format="%d/%m/%Y"
         )
         column_to_date_mock.assert_called_once()
 

--- a/projects/_01_ingest/ascwds/tests/fargate/test_clean_ascwds_workplace.py
+++ b/projects/_01_ingest/ascwds/tests/fargate/test_clean_ascwds_workplace.py
@@ -37,9 +37,7 @@ class MainTests(unittest.TestCase):
         )
         valid_filter_mock.assert_called_once()
 
-        cast_date_strings_to_dates_mock.assert_called_once_with(
-            ANY, raw_date_format="%d/%m/%Y"
-        )
+        cast_date_strings_to_dates_mock.assert_called_once()
         column_to_date_mock.assert_called_once()
 
         self.assertEqual(sink_to_parquet_mock.call_count, 2)

--- a/projects/_01_ingest/ascwds/tests/fargate/test_clean_ascwds_workplace.py
+++ b/projects/_01_ingest/ascwds/tests/fargate/test_clean_ascwds_workplace.py
@@ -14,10 +14,14 @@ class MainTests(unittest.TestCase):
     WORKPLACE_FOR_RECONCILIATION_DESTINATION = "some/other/destination"
 
     @patch(f"{PATCH_PATH}.utils.sink_to_parquet")
+    @patch(f"{PATCH_PATH}.cUtils.column_to_date")
+    @patch(f"{PATCH_PATH}.cUtils.cast_date_strings_to_dates")
     @patch(f"{PATCH_PATH}.utils.scan_parquet")
     def test_main_runs(
         self,
         scan_parquet_mock: Mock,
+        cast_date_strings_to_dates_mock: Mock,
+        column_to_date_mock: Mock,
         sink_to_parquet_mock: Mock,
     ):
         job.main(
@@ -27,6 +31,11 @@ class MainTests(unittest.TestCase):
         )
 
         scan_parquet_mock.assert_called_once_with(self.WORKPLACE_SOURCE)
+
+        cast_date_strings_to_dates_mock.assert_called_once_with(
+            ANY, raw_date_format="dd/MM/yyyy"
+        )
+        column_to_date_mock.assert_called_once()
 
         assert sink_to_parquet_mock.call_count == 2
 

--- a/projects/_01_ingest/utils/fargate/utils.py
+++ b/projects/_01_ingest/utils/fargate/utils.py
@@ -1,1 +1,0 @@
-# format_date_fields

--- a/projects/_01_ingest/utils/fargate/utils.py
+++ b/projects/_01_ingest/utils/fargate/utils.py
@@ -1,0 +1,1 @@
+# format_date_fields

--- a/tests/test_polars_utils/test_cleaning_utils.py
+++ b/tests/test_polars_utils/test_cleaning_utils.py
@@ -241,9 +241,7 @@ class CastDateStringsToDatesTests(unittest.TestCase):
             },
             orient="row",
         )
-        returned_lf = job.cast_date_strings_to_dates(
-            test_lf, raw_date_format="%d/%m/%Y"
-        )
+        returned_lf = job.cast_date_strings_to_dates(test_lf)
         expected_lf = pl.LazyFrame(
             data=[("01/01/2026", date(2026, 1, 2), "words", None)],
             schema={
@@ -266,9 +264,7 @@ class CastDateStringsToDatesTests(unittest.TestCase):
             },
             orient="row",
         )
-        returned_lf = job.cast_date_strings_to_dates(
-            test_lf, raw_date_format="%d/%m/%Y"
-        )
+        returned_lf = job.cast_date_strings_to_dates(test_lf)
         expected_lf = pl.LazyFrame(
             data=[(None, None)],
             schema={

--- a/tests/test_polars_utils/test_cleaning_utils.py
+++ b/tests/test_polars_utils/test_cleaning_utils.py
@@ -232,55 +232,50 @@ class CreateBandedBedCountColumnTests(unittest.TestCase):
 class CastDateStringsToDatesTests(unittest.TestCase):
     def test_casts_cols_that_match_arg_format_except_import_date(self):
         test_lf = pl.LazyFrame(
-            data=[("01/01/2026", "02/01/2026", "words", None)],
+            data=[("01/01/2026", "02/01/2026", "02/01/2026")],
             schema={
                 "import_date": pl.String,
                 "any_other_date_col": pl.String,
-                "another_column": pl.String,
-                "null_date": pl.String,
+                "another_date_column": pl.String,
             },
             orient="row",
         )
         returned_lf = job.cast_date_strings_to_dates(test_lf)
         expected_lf = pl.LazyFrame(
-            data=[("01/01/2026", date(2026, 1, 2), "words", None)],
+            data=[("01/01/2026", date(2026, 1, 2), date(2026, 1, 2))],
             schema={
                 "import_date": pl.String,
                 "any_other_date_col": pl.Date,
-                "another_column": pl.String,
-                "null_date": pl.Date,
+                "another_date_column": pl.Date,
             },
             orient="row",
         )
 
         pl_testing.assert_frame_equal(returned_lf, expected_lf)
 
-    def test_returns_null_on_format_mismatch(self):
-        test_lf = pl.LazyFrame(
-            data=[("03/01/2026 00:00:00", "2026/01/03")],
-            schema={
-                "time_element_date": pl.String,
-                "malformed_date": pl.String,
-            },
-            orient="row",
-        )
-        returned_lf = job.cast_date_strings_to_dates(test_lf)
+    def test_invalid_date_strings_are_converted_to_null(self):
+        input_lf = pl.LazyFrame(
+            {
+                "time_element_date": [
+                    "01/01/2026",        # valid
+                    "03/01/2026 00:00",  # invalid format
+                    "2026/01/03",        # wrong format
+                    "",                  # empty
+                    None,                # already null
+                ]
+            }
+        ) # fmt: skip
+        result_lf = job.cast_date_strings_to_dates(input_lf, raw_date_format="%d/%m/%Y")
         expected_lf = pl.LazyFrame(
-            data=[(None, None)],
-            schema={
-                "time_element_date": pl.Date,
-                "malformed_date": pl.Date,
-            },
-            orient="row",
+            {
+                "time_element_date": [
+                    date(2026, 1, 1),
+                    None,
+                    None,
+                    None,
+                    None,
+                ]
+            }
         )
 
-        pl_testing.assert_frame_equal(returned_lf, expected_lf)
-
-    def test_when_raw_date_format_has_time_element(self):
-        test_lf = pl.LazyFrame({"time_element_date": ["2026/01/01 00:00:00"]})
-        returned_lf = job.cast_date_strings_to_dates(
-            test_lf, raw_date_format="%Y/%m/%d %T"
-        )
-        expected_lf = pl.LazyFrame({"time_element_date": date(2026, 1, 1)})
-
-        pl_testing.assert_frame_equal(returned_lf, expected_lf)
+        pl_testing.assert_frame_equal(result_lf, expected_lf)

--- a/tests/test_polars_utils/test_cleaning_utils.py
+++ b/tests/test_polars_utils/test_cleaning_utils.py
@@ -1,4 +1,5 @@
 import unittest
+from datetime import date
 
 import polars as pl
 import polars.testing as pl_testing
@@ -226,3 +227,60 @@ class CreateBandedBedCountColumnTests(unittest.TestCase):
         )
 
         pl_testing.assert_frame_equal(returned_lf, expected_lf)
+
+
+class CastDateStringsToDatesTests(unittest.TestCase):
+    def test_when_raw_date_format_is_ddmmyyyy(self):
+        test_lf_ddmmyyyy = pl.LazyFrame(
+            data=[
+                (
+                    "01/01/2026",
+                    "02/01/2026",
+                    "03/01/2026 00:00:00",
+                    "2026/01/03",
+                    "words",
+                )
+            ],
+            schema={
+                "import_date": pl.String,
+                "any_other_date_col": pl.String,
+                "date_time_element": pl.String,
+                "malformed_date": pl.String,
+                "another_column": pl.String,
+            },
+            orient="row",
+        )
+        returned_lf_ddmmyyyy = job.cast_date_strings_to_dates(
+            test_lf_ddmmyyyy, raw_date_format="%d/%m/%Y"
+        )
+        expected_lf_ddmmyyyy = pl.LazyFrame(
+            data=[("01/01/2026", date(2026, 1, 2), None, None, "words")],
+            schema={
+                "import_date": pl.String,
+                "any_other_date_col": pl.Date,
+                "date_time_element": pl.Date,
+                "malformed_date": pl.Date,
+                "another_column": pl.String,
+            },
+            orient="row",
+        )
+
+        pl_testing.assert_frame_equal(returned_lf_ddmmyyyy, expected_lf_ddmmyyyy)
+
+    def test_when_raw_date_format_is_yyyymmdd(self):
+        test_lf_ddmmyyyy = pl.LazyFrame({"any_other_date_col": ["2026/01/01"]})
+        returned_lf_ddmmyyyy = job.cast_date_strings_to_dates(
+            test_lf_ddmmyyyy, raw_date_format="%Y/%m/%d"
+        )
+        expected_lf_ddmmyyyy = pl.LazyFrame({"any_other_date_col": date(2026, 1, 1)})
+
+        pl_testing.assert_frame_equal(returned_lf_ddmmyyyy, expected_lf_ddmmyyyy)
+
+    def test_when_raw_date_format_has_time_element(self):
+        test_lf_ddmmyyyy = pl.LazyFrame({"any_other_date_col": ["2026/01/01 00:00:00"]})
+        returned_lf_ddmmyyyy = job.cast_date_strings_to_dates(
+            test_lf_ddmmyyyy, raw_date_format="%Y/%m/%d %T"
+        )
+        expected_lf_ddmmyyyy = pl.LazyFrame({"any_other_date_col": date(2026, 1, 1)})
+
+        pl_testing.assert_frame_equal(returned_lf_ddmmyyyy, expected_lf_ddmmyyyy)

--- a/tests/test_polars_utils/test_cleaning_utils.py
+++ b/tests/test_polars_utils/test_cleaning_utils.py
@@ -230,23 +230,14 @@ class CreateBandedBedCountColumnTests(unittest.TestCase):
 
 
 class CastDateStringsToDatesTests(unittest.TestCase):
-    def test_when_raw_date_format_is_ddmmyyyy(self):
+    def test_casts_cols_that_match_arg_format_except_import_date(self):
         test_lf_ddmmyyyy = pl.LazyFrame(
-            data=[
-                (
-                    "01/01/2026",
-                    "02/01/2026",
-                    "03/01/2026 00:00:00",
-                    "2026/01/03",
-                    "words",
-                )
-            ],
+            data=[("01/01/2026", "02/01/2026", "words", None)],
             schema={
                 "import_date": pl.String,
                 "any_other_date_col": pl.String,
-                "date_time_element": pl.String,
-                "malformed_date": pl.String,
                 "another_column": pl.String,
+                "null_date": pl.String,
             },
             orient="row",
         )
@@ -254,33 +245,46 @@ class CastDateStringsToDatesTests(unittest.TestCase):
             test_lf_ddmmyyyy, raw_date_format="%d/%m/%Y"
         )
         expected_lf_ddmmyyyy = pl.LazyFrame(
-            data=[("01/01/2026", date(2026, 1, 2), None, None, "words")],
+            data=[("01/01/2026", date(2026, 1, 2), "words", None)],
             schema={
                 "import_date": pl.String,
                 "any_other_date_col": pl.Date,
-                "date_time_element": pl.Date,
-                "malformed_date": pl.Date,
                 "another_column": pl.String,
+                "null_date": pl.Date,
             },
             orient="row",
         )
 
         pl_testing.assert_frame_equal(returned_lf_ddmmyyyy, expected_lf_ddmmyyyy)
 
-    def test_when_raw_date_format_is_yyyymmdd(self):
-        test_lf_ddmmyyyy = pl.LazyFrame({"any_other_date_col": ["2026/01/01"]})
-        returned_lf_ddmmyyyy = job.cast_date_strings_to_dates(
-            test_lf_ddmmyyyy, raw_date_format="%Y/%m/%d"
+    def test_returns_null_on_format_mismatch(self):
+        test_lf_ddmmyyyy = pl.LazyFrame(
+            data=[("03/01/2026 00:00:00", "2026/01/03")],
+            schema={
+                "time_element_date": pl.String,
+                "malformed_date": pl.String,
+            },
+            orient="row",
         )
-        expected_lf_ddmmyyyy = pl.LazyFrame({"any_other_date_col": date(2026, 1, 1)})
+        returned_lf_ddmmyyyy = job.cast_date_strings_to_dates(
+            test_lf_ddmmyyyy, raw_date_format="%d/%m/%Y"
+        )
+        expected_lf_ddmmyyyy = pl.LazyFrame(
+            data=[(None, None)],
+            schema={
+                "time_element_date": pl.Date,
+                "malformed_date": pl.Date,
+            },
+            orient="row",
+        )
 
         pl_testing.assert_frame_equal(returned_lf_ddmmyyyy, expected_lf_ddmmyyyy)
 
     def test_when_raw_date_format_has_time_element(self):
-        test_lf_ddmmyyyy = pl.LazyFrame({"any_other_date_col": ["2026/01/01 00:00:00"]})
+        test_lf_ddmmyyyy = pl.LazyFrame({"time_element_date": ["2026/01/01 00:00:00"]})
         returned_lf_ddmmyyyy = job.cast_date_strings_to_dates(
             test_lf_ddmmyyyy, raw_date_format="%Y/%m/%d %T"
         )
-        expected_lf_ddmmyyyy = pl.LazyFrame({"any_other_date_col": date(2026, 1, 1)})
+        expected_lf_ddmmyyyy = pl.LazyFrame({"time_element_date": date(2026, 1, 1)})
 
         pl_testing.assert_frame_equal(returned_lf_ddmmyyyy, expected_lf_ddmmyyyy)

--- a/tests/test_polars_utils/test_cleaning_utils.py
+++ b/tests/test_polars_utils/test_cleaning_utils.py
@@ -231,7 +231,7 @@ class CreateBandedBedCountColumnTests(unittest.TestCase):
 
 class CastDateStringsToDatesTests(unittest.TestCase):
     def test_casts_cols_that_match_arg_format_except_import_date(self):
-        test_lf_ddmmyyyy = pl.LazyFrame(
+        test_lf = pl.LazyFrame(
             data=[("01/01/2026", "02/01/2026", "words", None)],
             schema={
                 "import_date": pl.String,
@@ -241,10 +241,10 @@ class CastDateStringsToDatesTests(unittest.TestCase):
             },
             orient="row",
         )
-        returned_lf_ddmmyyyy = job.cast_date_strings_to_dates(
-            test_lf_ddmmyyyy, raw_date_format="%d/%m/%Y"
+        returned_lf = job.cast_date_strings_to_dates(
+            test_lf, raw_date_format="%d/%m/%Y"
         )
-        expected_lf_ddmmyyyy = pl.LazyFrame(
+        expected_lf = pl.LazyFrame(
             data=[("01/01/2026", date(2026, 1, 2), "words", None)],
             schema={
                 "import_date": pl.String,
@@ -255,10 +255,10 @@ class CastDateStringsToDatesTests(unittest.TestCase):
             orient="row",
         )
 
-        pl_testing.assert_frame_equal(returned_lf_ddmmyyyy, expected_lf_ddmmyyyy)
+        pl_testing.assert_frame_equal(returned_lf, expected_lf)
 
     def test_returns_null_on_format_mismatch(self):
-        test_lf_ddmmyyyy = pl.LazyFrame(
+        test_lf = pl.LazyFrame(
             data=[("03/01/2026 00:00:00", "2026/01/03")],
             schema={
                 "time_element_date": pl.String,
@@ -266,10 +266,10 @@ class CastDateStringsToDatesTests(unittest.TestCase):
             },
             orient="row",
         )
-        returned_lf_ddmmyyyy = job.cast_date_strings_to_dates(
-            test_lf_ddmmyyyy, raw_date_format="%d/%m/%Y"
+        returned_lf = job.cast_date_strings_to_dates(
+            test_lf, raw_date_format="%d/%m/%Y"
         )
-        expected_lf_ddmmyyyy = pl.LazyFrame(
+        expected_lf = pl.LazyFrame(
             data=[(None, None)],
             schema={
                 "time_element_date": pl.Date,
@@ -278,13 +278,13 @@ class CastDateStringsToDatesTests(unittest.TestCase):
             orient="row",
         )
 
-        pl_testing.assert_frame_equal(returned_lf_ddmmyyyy, expected_lf_ddmmyyyy)
+        pl_testing.assert_frame_equal(returned_lf, expected_lf)
 
     def test_when_raw_date_format_has_time_element(self):
-        test_lf_ddmmyyyy = pl.LazyFrame({"time_element_date": ["2026/01/01 00:00:00"]})
-        returned_lf_ddmmyyyy = job.cast_date_strings_to_dates(
-            test_lf_ddmmyyyy, raw_date_format="%Y/%m/%d %T"
+        test_lf = pl.LazyFrame({"time_element_date": ["2026/01/01 00:00:00"]})
+        returned_lf = job.cast_date_strings_to_dates(
+            test_lf, raw_date_format="%Y/%m/%d %T"
         )
-        expected_lf_ddmmyyyy = pl.LazyFrame({"time_element_date": date(2026, 1, 1)})
+        expected_lf = pl.LazyFrame({"time_element_date": date(2026, 1, 1)})
 
-        pl_testing.assert_frame_equal(returned_lf_ddmmyyyy, expected_lf_ddmmyyyy)
+        pl_testing.assert_frame_equal(returned_lf, expected_lf)

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -143,6 +143,7 @@ def read_csv_with_defined_schema(source, schema):
     return df
 
 
+# converted to polars as cast_date_strings_to_dates -> polars_utils\cleaning_utils.py
 def format_date_fields(df, date_column_identifier="date", raw_date_format=None):
     date_columns = [column for column in df.columns if date_column_identifier in column]
 


### PR DESCRIPTION
## Description
Trello ticket [1700](https://trello.com/c/cm1nQBdV)

Converted format_date_fields to polars as cast_date_strings_to_dates.

New function lives in polars_utils > cleaning_utils because it is used in cleaning ascwds workplace, ingest ons and spss_csv_to_parquet.

## Testing
- [x] Unit tests passing
- [x] Successful [Step Function run](https://eu-west-2.console.aws.amazon.com/states/home?region=eu-west-2#/statemachines/view/arn%3Aaws%3Astates%3Aeu-west-2%3A856699698263%3AstateMachine%3A1700-cln-wkp-5-Transform-ASCWDS-Data?type=standard)
- [ ] Outputs checked in Athena
- [ ] Outputs compared using [SageMaker script](https://eu-west-2.console.aws.amazon.com/sagemaker/home?region=eu-west-2#/notebook-instances/data-engineering-notebook)
      - Notebook name: compare_outputs.ipynb
- [ ] Output Screenshots added to Trello ticket

Outputs do not match pyspark version because other functions that filter workplace dataset are yet to be converted.

All the columns with "date" in name except import_date are date type.

## Migration to polars checklist
- [x] Check that similar utils functions don't already exist, or if one can be created
- [x] Check that utils are being saved in the appropriate place
- [x] Used LazyFrame option for test data
- [x] Unit tests added
- [x] Docstrings added
- [x] Added comment to pyspark functions which have been migrated with the link to the new location
      `# converted to polars -> filepath.py`
- [ ] Use new file structure when saving to S3
      `{dataset}_{sub_dataset_if_relevant}_{order_of_process_if_relevant}_{very_brief_description}`
- [x] Updated CHANGELOG
- [x] Code reviewed by AI
- [x] Moved Trello ticket to PR column

## Reviewer checklist
- [ ] PR solves the Trello ticket requirements
- [ ] Outputs appear reasonable and understandable
- [ ] The overall approach is appropriate and not over-engineered
- [ ] No obvious scalability, performance or interdependency concerns
- [ ] Tests appropriately cover the main behaviour/edge cases
- [ ] Naming and structure are broadly understandable and consistent
- [ ] Docstrings are sufficient for future maintenance
- [ ] Docstrings cover non-obvious behaviour
