### PR TITLE
1708 - Workplace Clean - convert set_column_bounds() and cast_to_int() to Polars

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ parameters:
     default: ""
   terraform_version:
     type: string
-    default: 1.13.5
+    default: 1.15.7
 
 orbs:
   aws-cli: circleci/aws-cli@5.4.1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ parameters:
     default: ""
   terraform_version:
     type: string
-    default: 1.15.7
+    default: 1.13.5
 
 orbs:
   aws-cli: circleci/aws-cli@5.4.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ All notable changes to this project will be documented in this file.
 
 - Added placeholder polars tasks for clean ascwds workplace and validate clean ascwds workplace jobs.
 
+- Added bounded columns for total staff and worker records in Clean ASCWDS Workplace Polars job.
+
 ### Changed
 - Refactored job group filter to use magic numbers for outlier bounds.
 

--- a/projects/_01_ingest/ascwds/fargate/clean_ascwds_workplace.py
+++ b/projects/_01_ingest/ascwds/fargate/clean_ascwds_workplace.py
@@ -97,7 +97,7 @@ def main(
     #     ascwds_workplace_df
     # )
 
-    lf = lf.with_columns(pl.col(INT_COLUMNS).cast(pl.Int32))
+    lf = lf.with_columns(pl.col(INT_COLUMNS).cast(pl.Int32, strict=False))
 
     lf = lf.with_columns(
         pl.when(pl.col(AWPClean.total_staff) >= MIN_VALID_WORKFORCE_COUNT)

--- a/projects/_01_ingest/ascwds/fargate/clean_ascwds_workplace.py
+++ b/projects/_01_ingest/ascwds/fargate/clean_ascwds_workplace.py
@@ -1,11 +1,13 @@
 import polars as pl
 
-from polars_utils import cleaning_utils as cUtils
 from polars_utils import utils
 from projects._01_ingest.ascwds.fargate.utils import clean_workplace_utils as wUtils
 from utils.column_names.cleaned_data_files.ascwds_workplace_cleaned import (
     AscwdsWorkplaceCleanedColumns as AWPClean,
 )
+
+INT_COLUMNS: list[str] = [AWPClean.total_staff, AWPClean.worker_records]
+MIN_VALID_WORKFORCE_COUNT: int = 1
 
 
 def main(
@@ -70,24 +72,18 @@ def main(
     #     ascwds_workplace_df
     # )
 
-    # trello 1709
-    # ascwds_workplace_df = cUtils.cast_to_int(ascwds_workplace_df, COLUMNS_TO_BOUND)
+    lf = lf.with_columns(pl.col(INT_COLUMNS).cast(pl.Int32))
 
-    # trello 1708
-    # ascwds_workplace_df = cUtils.set_column_bounds(
-    #     ascwds_workplace_df,
-    #     AWPClean.total_staff,
-    #     AWPClean.total_staff_bounded,
-    #     AscwdsScaleVariableLimits.total_staff_lower_limit,
-    # )
-
-    # trello 1708
-    # ascwds_workplace_df = cUtils.set_column_bounds(
-    #     ascwds_workplace_df,
-    #     AWPClean.worker_records,
-    #     AWPClean.worker_records_bounded,
-    #     AscwdsScaleVariableLimits.worker_records_lower_limit,
-    # )
+    lf = lf.with_columns(
+        pl.when(pl.col(AWPClean.total_staff) >= MIN_VALID_WORKFORCE_COUNT)
+        .then(pl.col(AWPClean.total_staff))
+        .otherwise(None)
+        .alias(AWPClean.total_staff_bounded),
+        pl.when(pl.col(AWPClean.worker_records) >= MIN_VALID_WORKFORCE_COUNT)
+        .then(pl.col(AWPClean.worker_records))
+        .otherwise(None)
+        .alias(AWPClean.worker_records_bounded),
+    )
 
     # trello 1710
     # reconciliation_df = reconciliation_df.select(cols_required_for_reconciliation_df)

--- a/projects/_01_ingest/ascwds/fargate/clean_ascwds_workplace.py
+++ b/projects/_01_ingest/ascwds/fargate/clean_ascwds_workplace.py
@@ -7,7 +7,8 @@ from utils.column_names.cleaned_data_files.ascwds_workplace_cleaned import (
 )
 
 INT_COLUMNS: list[str] = [AWPClean.total_staff, AWPClean.worker_records]
-MIN_VALID_WORKFORCE_COUNT: int = 1
+BOUNDED_STAFF_COLUMNS: list[str] = [AWPClean.total_staff, AWPClean.worker_records]
+MIN_VALID_STAFF_COUNT: int = 1
 
 COLUMNS_TO_IMPORT = [
     AWPClean.organisation_id,
@@ -100,14 +101,10 @@ def main(
     lf = lf.with_columns(pl.col(INT_COLUMNS).cast(pl.Int32, strict=False))
 
     lf = lf.with_columns(
-        pl.when(pl.col(AWPClean.total_staff) >= MIN_VALID_WORKFORCE_COUNT)
-        .then(pl.col(AWPClean.total_staff))
+        pl.when(pl.col(BOUNDED_STAFF_COLUMNS) >= MIN_VALID_STAFF_COUNT)
+        .then(pl.col(BOUNDED_STAFF_COLUMNS))
         .otherwise(None)
-        .alias(AWPClean.total_staff_bounded),
-        pl.when(pl.col(AWPClean.worker_records) >= MIN_VALID_WORKFORCE_COUNT)
-        .then(pl.col(AWPClean.worker_records))
-        .otherwise(None)
-        .alias(AWPClean.worker_records_bounded),
+        .name.suffix("_bounded")
     )
 
     # trello 1710

--- a/projects/_01_ingest/ascwds/tests/fargate/test_clean_ascwds_workplace.py
+++ b/projects/_01_ingest/ascwds/tests/fargate/test_clean_ascwds_workplace.py
@@ -29,7 +29,7 @@ class MainTests(unittest.TestCase):
         )
 
         scan_parquet_mock.assert_called_once_with(
-            self.WORKPLACE_SOURCE, selected_columns=job.columns_to_import
+            self.WORKPLACE_SOURCE, selected_columns=job.COLUMNS_TO_IMPORT
         )
         valid_filter_mock.assert_called_once()
 

--- a/utils/cleaning_utils.py
+++ b/utils/cleaning_utils.py
@@ -97,6 +97,7 @@ def apply_categorical_labels(
     return df
 
 
+# Not converting to polars, use inline -> pl.when().then().otherwise().alias()
 def set_column_bounds(
     df: DataFrame,
     col_name: str,


### PR DESCRIPTION
## Description
Trello ticket [#1708](https://trello.com/c/t0NzxVrT/1708-clean-workplace10-write-polars-code-for-setcolumnbounds-and-call-in-job)

This PR is to convert the PySpark cast_to_int() and set_column_bounds() functions to Polars.

**cast_to_int()**
Previously this was a function but is now inline and takes a list of integers. `strict=False` is set to return null values for invalid strings, such as empty " "

**set_column_bounds()**
This was a fairly complex function in PySpark with the option to have upper and/or lower bound. It's only used in the ASCWDS workplace job and only uses a minimum of 1 so I've just written this inline as it's a simple when, then, otherwise clause

## Testing
- [X] Unit tests passing
- [X] Successful [Step Function run](https://eu-west-2.console.aws.amazon.com/states/home?region=eu-west-2#/v2/executions/details/arn:aws:states:eu-west-2:856699698263:execution:1708-set-col-bounds-Transform-ASCWDS-Data:c0f87c92-f600-45fb-a189-1b01a246b62e)
- [X] Outputs checked in Athena
- [X] Output Screenshots added to Trello ticket

## Migration to polars checklist
- [X] Check that similar utils functions don't already exist, or if one can be created
- [X] Check that utils are being saved in the appropriate place
- [X] Used LazyFrame option for test data
- [X] Unit tests added
- [X] Docstrings added
- [X] Added comment to pyspark functions which have been migrated with the link to the new location
      `# converted to polars -> filepath.py`
- [X] Updated CHANGELOG
- [X] Code reviewed by AI
- [X] Moved Trello ticket to PR column

## Reviewer checklist
- [ ] PR solves the Trello ticket requirements
- [ ] Outputs appear reasonable and understandable
- [ ] The overall approach is appropriate and not over-engineered
- [ ] No obvious scalability, performance or interdependency concerns
- [ ] Tests appropriately cover the main behaviour/edge cases
- [ ] Naming and structure are broadly understandable and consistent
- [ ] Docstrings are sufficient for future maintenance
- [ ] Docstrings cover non-obvious behaviour
