### PR TITLE
1726- Updated clean workplace data (Polars) validation script to use new import date column

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,8 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 - Replace the all roles and all job groups functions with the appropriate categorical values attribute.
 
+- Updated `validate_clean_ascwds_workplace.py` to use `acswds_workplace_import_date` instead of `import_date`, since the `import_date` column is now dropped after being converted to a new date type column.
+
 
 ## [v2026.05.0] - 12/06/2026
 

--- a/projects/_01_ingest/ascwds/fargate/validate_clean_ascwds_workplace.py
+++ b/projects/_01_ingest/ascwds/fargate/validate_clean_ascwds_workplace.py
@@ -9,7 +9,7 @@ from utils.column_names.cleaned_data_files.ascwds_workplace_cleaned import (
     AscwdsWorkplaceCleanedColumns as ASCWPClean,
 )
 
-COLS_TO_IMPORT = [ASCWPClean.establishment_id, ASCWPClean.import_date]
+COLS_TO_IMPORT = [ASCWPClean.establishment_id, ASCWPClean.ascwds_workplace_import_date]
 
 
 def main(bucket_name: str, source_path: str, reports_path: str) -> None:
@@ -38,7 +38,7 @@ def main(bucket_name: str, source_path: str, reports_path: str) -> None:
         )
         # index columns
         .rows_distinct(
-            [ASCWPClean.establishment_id, ASCWPClean.import_date]
+            [ASCWPClean.establishment_id, ASCWPClean.ascwds_workplace_import_date]
         ).interrogate()
     )
     vl.write_reports(validation, bucket_name, reports_path)

--- a/projects/_01_ingest/ascwds/tests/fargate/test_validate_clean_ascwds_workplace.py
+++ b/projects/_01_ingest/ascwds/tests/fargate/test_validate_clean_ascwds_workplace.py
@@ -17,14 +17,14 @@ class ValidateCleanASCWDSWorkplaceTests(unittest.TestCase):
     def setUp(self) -> None:
         self.source_df = pl.DataFrame(
             [
-                ("123", "20240101"),
-                ("456", "20240101"),
-                ("123", "20240201"),
+                ("123", date(2014, 1, 1)),
+                ("456", date(2024, 1, 1)),
+                ("123", date(2024, 2, 1)),
             ],
             schema=pl.Schema(
                 [
                     (ASCWPClean.establishment_id, pl.String),
-                    (ASCWPClean.import_date, pl.String),
+                    (ASCWPClean.ascwds_workplace_import_date, pl.Date),
                 ]
             ),
             orient="row",


### PR DESCRIPTION
## Description
Trello ticket [#1726](https://trello.com/c/ZjE8wnD4/1726-update-the-clean-workplace-polars-data-validation-to-use-the-new-import-date)

Updated `validate_clean_ascwds_workplace.py` to use `acswds_workplace_import_date` instead of `import_date`, since the `import_date` column is now dropped after being converted to a new date type column.

## Testing
- [x] Unit tests passing
- [x] Successful [Step Function run](https://eu-west-2.console.aws.amazon.com/states/home?region=eu-west-2#/v2/executions/details/arn:aws:states:eu-west-2:856699698263:execution:1726-cln-wrkplc-val-Transform-ASCWDS-Data:16a472d9-5cf5-4592-b462-b1c01f065e23)

## Checklist (delete if not relevant)
- [x] Updated CHANGELOG
- [x] Moved Trello ticket to PR column

## Reviewer checklist
- [ ] PR solves the Trello ticket requirements
- [ ] Outputs appear reasonable and understandable
- [ ] The overall approach is appropriate and not over-engineered
- [ ] No obvious scalability, performance or interdependency concerns
- [ ] Tests appropriately cover the main behaviour/edge cases
- [ ] Naming and structure are broadly understandable and consistent
- [ ] Docstrings are sufficient for future maintenance
- [ ] Docstrings cover non-obvious behaviour
