### PR TITLE
1710 - Select columns for reconciliation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,8 @@ All notable changes to this project will be documented in this file.
 
 - Converted `create_purged_dfs_for_reconciliation_and_data` function within Clean Workplace Data job to Polars and updated tests for the same.
 
+- Updated output columns for reconciliation dataset.
+
 ### Fixed
 - Replace the all roles and all job groups functions with the appropriate categorical values attribute.
 

--- a/projects/_01_ingest/ascwds/fargate/clean_ascwds_workplace.py
+++ b/projects/_01_ingest/ascwds/fargate/clean_ascwds_workplace.py
@@ -44,6 +44,29 @@ COLUMNS_TO_IMPORT = [
     AWPClean.import_date,
 ]
 
+RECONCILIATION_COLUMNS = [
+    AWPClean.ascwds_workplace_import_date,
+    AWPClean.establishment_id,
+    AWPClean.nmds_id,
+    AWPClean.master_update_date,
+    AWPClean.master_update_date_org,
+    AWPClean.establishment_created_date,
+    AWPClean.is_parent,
+    AWPClean.parent_id,
+    AWPClean.organisation_id,
+    AWPClean.parent_permission,
+    AWPClean.establishment_type,
+    AWPClean.registration_type,
+    AWPClean.location_id,
+    AWPClean.main_service_id,
+    AWPClean.establishment_name,
+    AWPClean.region_id,
+    AWPClean.total_staff,
+    AWPClean.worker_records,
+    AWPClean.last_logged_in_date,
+    AWPClean.la_permission,
+]
+
 
 def main(
     workplace_source: str,
@@ -80,7 +103,6 @@ def main(
     #     add_as_new_column=False,
     # )
 
-    # trello 1706
     (
         lf,
         reconciliation_lf,
@@ -97,18 +119,21 @@ def main(
         .name.suffix("_bounded")
     )
 
-    # trello 1710
-    # reconciliation_df = reconciliation_df.select(cols_required_for_reconciliation_df)
+    reconciliation_lf = reconciliation_lf.select(RECONCILIATION_COLUMNS)
 
+    print(
+        f"Exporting clean ascwds workplace data as parquet to {cleaned_workplace_destination}"
+    )
     utils.sink_to_parquet(
-        # trello 1710
         lazy_df=lf,
         output_path=cleaned_workplace_destination,
     )
 
+    print(
+        f"Exporting ascwds workplace reconciliation data as parquet to {workplace_for_reconciliation_destination}"
+    )
     utils.sink_to_parquet(
-        # trello 1710
-        lazy_df=lf,
+        lazy_df=reconciliation_lf,
         output_path=workplace_for_reconciliation_destination,
     )
 


### PR DESCRIPTION
## Description
Trello ticket [#1710](https://trello.com/c/g6OFyjCp/1710-clean-workplace11-write-polars-code-to-select-columns-for-reconciliation-dataset-save-two-datasets-and-call-in-job)

Select columns for reconciliation dataset and save parquets out

## Testing
- [x] Unit tests passing
- [x] Successful [Job / Step Function run](https://eu-west-2.console.aws.amazon.com/states/home?region=eu-west-2#/v2/executions/details/arn:aws:states:eu-west-2:856699698263:execution:1710-cln-wkp-11-Transform-ASCWDS-Data:dc28ec36-ee11-4b65-b1c4-557e4676a123)

## Migration to polars checklist
- [x] Updated CHANGELOG
- [x] Moved Trello ticket to PR column

## Reviewer checklist
- [ ] PR solves the Trello ticket requirements
- [ ] Outputs appear reasonable and understandable
- [ ] The overall approach is appropriate and not over-engineered
- [ ] No obvious scalability, performance or interdependency concerns
- [ ] Tests appropriately cover the main behaviour/edge cases
- [ ] Naming and structure are broadly understandable and consistent
- [ ] Docstrings are sufficient for future maintenance
- [ ] Docstrings cover non-obvious behaviour
