### PR TITLE
1748 - Add careHome and numberofBeds columns to grouped provider output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@ All notable changes to this project will be documented in this file.
 
 - Added point blank validation of ASCWDS cleaned dataset.
 
+- Added `careHome` and `numberOfBeds` columns to Grouped Provider Output file and updated tests for the same.
+
 ### Changed
 - Refactored job group filter to use magic numbers for outlier bounds.
 

--- a/projects/_03_independent_cqc/_02_clean/fargate/clean_ind_cqc_filled_posts.py
+++ b/projects/_03_independent_cqc/_02_clean/fargate/clean_ind_cqc_filled_posts.py
@@ -44,6 +44,8 @@ GROUPED_PROVIDER_SCHEMA = pl.Schema(
         (NGPcol.grouped_provider_status, pl.String()),
         (NGPcol.grp_prov_identified_date, pl.Date()),
         (NGPcol.grp_prov_fixed_date, pl.Date()),
+        (IndCQC.care_home, pl.String()),
+        (IndCQC.number_of_beds, pl.Int32()),
     ]
 )
 

--- a/projects/_03_independent_cqc/_02_clean/fargate/clean_ind_cqc_filled_posts.py
+++ b/projects/_03_independent_cqc/_02_clean/fargate/clean_ind_cqc_filled_posts.py
@@ -45,7 +45,7 @@ GROUPED_PROVIDER_SCHEMA = pl.Schema(
         (NGPcol.grp_prov_identified_date, pl.Date()),
         (NGPcol.grp_prov_fixed_date, pl.Date()),
         (IndCQC.care_home, pl.String()),
-        (IndCQC.number_of_beds, pl.Int32()),
+        (IndCQC.number_of_beds, pl.Int64()),
     ]
 )
 

--- a/projects/_03_independent_cqc/_02_clean/fargate/utils/clean_ascwds_filled_post_outliers/null_grouped_providers.py
+++ b/projects/_03_independent_cqc/_02_clean/fargate/utils/clean_ascwds_filled_post_outliers/null_grouped_providers.py
@@ -328,6 +328,8 @@ def select_grouped_providers(lf: pl.LazyFrame) -> pl.LazyFrame:
         AWPClean.nmds_id,
         NGPcol.potential_grouped_provider,
         IndCQC.ascwds_filled_posts_dedup_clean,
+        IndCQC.care_home,
+        IndCQC.number_of_beds,
     ]
 
     date_col = pl.col(IndCQC.cqc_location_import_date)

--- a/projects/_03_independent_cqc/unittest_data/polars_ind_cqc_test_file_data.py
+++ b/projects/_03_independent_cqc/unittest_data/polars_ind_cqc_test_file_data.py
@@ -1185,41 +1185,41 @@ class NullGroupedProvidersData:
     ] # fmt: skip
 
     select_grouped_providers_rows = [
-        ("1-001", "prov-1", date(2026, 1, 1), "nmdsid_1", True, 1.0), # Grouped provider but undesired import date.
-        ("1-002", "prov-1", date(2026, 1, 1), "nmdsid_2", False, 1.0), # Not grouped provider and undesired import date.
-        ("1-003", "prov-1", date(2026, 2, 1), "nmdsid_3", False, 1.0), # Desired date but not grouped provider.
-        ("1-004", "prov-1", date(2026, 2, 1), "nmdsid_4", True, 1.0), # Keep
-        ("1-005", "prov-2", date(2026, 2, 1), "nmdsid_5", True, 1.0), # Keep (different provider)
-        ("1-006", "prov-1", date(2025, 1, 1), "nmdsid_6", True, 1.0), # Incorrect date with lower year and month than desired.
-        ("1-008", "prov-1", date(2025, 3, 1), "nmdsid_7", True, 1.0), # Incorrect date with lower year and higher month than desired.
+        ("1-001", "prov-1", date(2026, 1, 1), "nmdsid_1", True, 1.0, "N", 0), # Grouped provider but undesired import date.
+        ("1-002", "prov-1", date(2026, 1, 1), "nmdsid_2", False, 1.0, "N", 0), # Not grouped provider and undesired import date.
+        ("1-003", "prov-1", date(2026, 2, 1), "nmdsid_3", False, 1.0, "N", 0), # Desired date but not grouped provider.
+        ("1-004", "prov-1", date(2026, 2, 1), "nmdsid_4", True, 1.0, "N", 0), # Keep
+        ("1-005", "prov-2", date(2026, 2, 1), "nmdsid_5", True, 1.0, "N", 0), # Keep (different provider)
+        ("1-006", "prov-1", date(2025, 1, 1), "nmdsid_6", True, 1.0, "N", 0), # Incorrect date with lower year and month than desired.
+        ("1-008", "prov-1", date(2025, 3, 1), "nmdsid_7", True, 1.0, "N", 0), # Incorrect date with lower year and higher month than desired.
     ] # fmt: skip
 
     expected_select_grouped_providers_rows = [
-        ("1-004", "prov-1", date(2026, 2, 1), "nmdsid_4", True, 1.0, "problem", date(2026, 2, 1), None),
-        ("1-005", "prov-2", date(2026, 2, 1), "nmdsid_5", True, 1.0, "problem", date(2026, 2, 1), None),
+        ("1-004", "prov-1", date(2026, 2, 1), "nmdsid_4", True, 1.0, "N", 0, "problem", date(2026, 2, 1), None),
+        ("1-005", "prov-2", date(2026, 2, 1), "nmdsid_5", True, 1.0, "N", 0, "problem", date(2026, 2, 1), None),
     ] # fmt: skip
 
     # All rows have grouped_provider_status = "problem" and last_update_date = their import date.
     new_grouped_providers_rows = [
-        ("1-001", "prov-1", date(2026, 2, 1), "nmds_1", True, 10.0, "problem", date(2026, 2, 1), None),
-        ("1-003", "prov-2", date(2026, 2, 1), "nmds_3", True, 30.0, "problem", date(2026, 2, 1), None),
-        ("1-004", "prov-3", date(2026, 2, 1), "nmds_4", True, 40.0, "problem", date(2026, 2, 1), None),
+        ("1-001", "prov-1", date(2026, 2, 1), "nmds_1", True, 10.0, "N", 0, "problem", date(2026, 2, 1), None),
+        ("1-003", "prov-2", date(2026, 2, 1), "nmds_3", True, 30.0, "N", 0, "problem", date(2026, 2, 1), None),
+        ("1-004", "prov-3", date(2026, 2, 1), "nmds_4", True, 40.0, "N", 0, "problem", date(2026, 2, 1), None),
     ]  # fmt: skip
 
     # historical_grouped_providers_rows: what was previously saved to the grouped providers dataset.
     historical_grouped_providers_rows = [
-        ("1-001", "prov-1", date(2026, 1, 1), "nmds_1", True, 10.0, "problem", date(2026, 1, 1), None), # Still active problem — should be retained as-is (oldest kept, last_update_date stays same).
-        ("1-002", "prov-1", date(2026, 1, 1), "nmds_2", True, 20.0, "problem", date(2026, 1, 1), None), # Dropped off — not in new snapshot, should be flipped to "fixed".
-        ("1-003", "prov-2", date(2026, 1, 1), "nmds_3", True, 30.0, "fixed", date(2026, 1, 1), date(2026, 1, 1)), # Re-appearing — was fixed, now back as "problem" in new snapshot; new row appended.
+        ("1-001", "prov-1", date(2026, 1, 1), "nmds_1", True, 10.0, "N", 0, "problem", date(2026, 1, 1), None), # Still active problem — should be retained as-is (oldest kept, last_update_date stays same).
+        ("1-002", "prov-1", date(2026, 1, 1), "nmds_2", True, 20.0, "N", 0, "problem", date(2026, 1, 1), None), # Dropped off — not in new snapshot, should be flipped to "fixed".
+        ("1-003", "prov-2", date(2026, 1, 1), "nmds_3", True, 30.0, "N", 0, "fixed", date(2026, 1, 1), date(2026, 1, 1)), # Re-appearing — was fixed, now back as "problem" in new snapshot; new row appended.
     ]  # fmt: skip
 
     # expected_update_grouped_providers_history_rows: full history after update.
     expected_update_grouped_providers_history_rows = [
-        ("1-001", "prov-1", date(2026, 1, 1), "nmds_1", True, 10.0, "problem", date(2026, 1, 1), None), # Retained — oldest "problem" record kept, last_update_date unchanged.
-        ("1-002", "prov-1", date(2026, 1, 1), "nmds_2", True, 20.0, "fixed", date(2026, 1, 1), date(2026, 2, 1)), # Flipped — was "problem", now "fixed" with last_update_date = new snapshot date.
-        ("1-003", "prov-2", date(2026, 1, 1), "nmds_3", True, 30.0, "fixed", date(2026, 1, 1), date(2026, 1, 1)), # Preserved — old "fixed" row kept as part of full history.
-        ("1-003", "prov-2", date(2026, 2, 1), "nmds_3", True, 30.0, "problem", date(2026, 2, 1), None), # Re-appeared — new "problem" row appended alongside the old "fixed" row.
-        ("1-004", "prov-3", date(2026, 2, 1), "nmds_4", True, 40.0, "problem", date(2026, 2, 1), None), # New — first time seen, added with "problem" status.
+        ("1-001", "prov-1", date(2026, 1, 1), "nmds_1", True, 10.0, "N", 0, "problem", date(2026, 1, 1), None), # Retained — oldest "problem" record kept, last_update_date unchanged.
+        ("1-002", "prov-1", date(2026, 1, 1), "nmds_2", True, 20.0, "N", 0, "fixed", date(2026, 1, 1), date(2026, 2, 1)), # Flipped — was "problem", now "fixed" with last_update_date = new snapshot date.
+        ("1-003", "prov-2", date(2026, 1, 1), "nmds_3", True, 30.0, "N", 0, "fixed", date(2026, 1, 1), date(2026, 1, 1)), # Preserved — old "fixed" row kept as part of full history.
+        ("1-003", "prov-2", date(2026, 2, 1), "nmds_3", True, 30.0, "N", 0, "problem", date(2026, 2, 1), None), # Re-appeared — new "problem" row appended alongside the old "fixed" row.
+        ("1-004", "prov-3", date(2026, 2, 1), "nmds_4", True, 40.0, "N", 0, "problem", date(2026, 2, 1), None), # New — first time seen, added with "problem" status.
     ]  # fmt: skip
 
 

--- a/projects/_03_independent_cqc/unittest_data/polars_ind_cqc_test_file_schemas.py
+++ b/projects/_03_independent_cqc/unittest_data/polars_ind_cqc_test_file_schemas.py
@@ -1012,7 +1012,7 @@ class NullGroupedProvidersSchema:
             (NGPcol.potential_grouped_provider, pl.Boolean()),
             (IndCQC.ascwds_filled_posts_dedup_clean, pl.Float64()),
             (IndCQC.care_home, pl.String()),
-            (IndCQC.number_of_beds, pl.Int32()),
+            (IndCQC.number_of_beds, pl.Int64()),
         ]
     )
 

--- a/projects/_03_independent_cqc/unittest_data/polars_ind_cqc_test_file_schemas.py
+++ b/projects/_03_independent_cqc/unittest_data/polars_ind_cqc_test_file_schemas.py
@@ -1011,6 +1011,8 @@ class NullGroupedProvidersSchema:
             (AWPClean.nmds_id, pl.String()),
             (NGPcol.potential_grouped_provider, pl.Boolean()),
             (IndCQC.ascwds_filled_posts_dedup_clean, pl.Float64()),
+            (IndCQC.care_home, pl.String()),
+            (IndCQC.number_of_beds, pl.Int32()),
         ]
     )
 


### PR DESCRIPTION
## Description
Trello ticket [#1748](https://trello.com/c/oH1mZELA/1748-s-add-carehome-and-numberofbeds-into-grouped-provider-output-file)

Added `careHome` and `numberOfBeds` columns to Grouped Provider Output file and updated tests for the same. 

## Testing
- [x] Unit tests passing
- [x] Successful [Step Function run](https://eu-west-2.console.aws.amazon.com/states/home?region=eu-west-2#/v2/executions/details/arn:aws:states:eu-west-2:856699698263:execution:1748-grp-prov-outpt-Ind-CQC-Filled-Post-Estimates:3c58e1e0-b862-4cdb-b12e-d4ac2161c0b8)
- [x] Outputs checked in Athena

## Checklist (delete if not relevant)
- [x] Unit tests added/amended
- [ ] Docstrings added/updated
- [x] Updated CHANGELOG
- [x] Code reviewed by AI
- [x] Moved Trello ticket to PR column

## Reviewer checklist
- [ ] PR solves the Trello ticket requirements
- [ ] Outputs appear reasonable and understandable
- [ ] The overall approach is appropriate and not over-engineered
- [ ] No obvious scalability, performance or interdependency concerns
- [ ] Tests appropriately cover the main behaviour/edge cases
- [ ] Naming and structure are broadly understandable and consistent
- [ ] Docstrings are sufficient for future maintenance
- [ ] Docstrings cover non-obvious behaviour
