### PR TITLE
1763 - Use Polars selectors for date column casting

### DIFF
--- a/polars_utils/cleaning_utils.py
+++ b/polars_utils/cleaning_utils.py
@@ -1,6 +1,7 @@
 from typing import Generator, List
 
 import polars as pl
+import polars.selectors as cs
 
 from polars_utils.expressions import is_care_home, is_not_care_home
 from utils.column_names.data_labels_columns import DataLabelsColumns as DLC
@@ -251,7 +252,7 @@ def cast_date_strings_to_dates(
     raw_date_format: str = "%d/%m/%Y",
 ) -> pl.LazyFrame:
     """
-    Converts columns to date type.
+    Parses string date columns into `Date` values.
 
     Columns in LazyFrame with date_column_identifier in their name excluding
     'import_date' and values formatted as raw_date_format will be type cast.
@@ -265,15 +266,12 @@ def cast_date_strings_to_dates(
     Returns:
         pl.LazyFrame: The input LazyFrame with columns cast to dates.
     """
-    date_columns = [
-        col
-        for col in lf.collect_schema().names()
-        if date_column_identifier in col and "import_date" not in col
-    ]
+    date_columns = (
+        cs.string()
+        & cs.contains(date_column_identifier)
+        & ~cs.by_name("import_date", require_all=False)
+    )
 
     return lf.with_columns(
-        [
-            pl.col(col).str.strptime(pl.Date, raw_date_format, strict=False)
-            for col in date_columns
-        ]
+        date_columns.as_expr().str.strptime(pl.Date, raw_date_format, strict=False)
     )

--- a/tests/test_polars_utils/test_cleaning_utils.py
+++ b/tests/test_polars_utils/test_cleaning_utils.py
@@ -324,7 +324,9 @@ class CreateBandedBedCountColumnTests(unittest.TestCase):
 
 
 class CastDateStringsToDatesTests(unittest.TestCase):
-    def test_casts_cols_that_match_arg_format_except_import_date(self):
+    def test_string_cols_containing_identifier_are_converted_to_date_apart_from_import_date(
+        self,
+    ):
         test_lf = pl.LazyFrame(
             data=[("01/01/2026", "02/01/2026", "02/01/2026")],
             schema={
@@ -347,7 +349,7 @@ class CastDateStringsToDatesTests(unittest.TestCase):
 
         pl_testing.assert_frame_equal(returned_lf, expected_lf)
 
-    def test_invalid_date_strings_are_converted_to_null(self):
+    def test_date_strings_which_differ_to_raw_date_format_are_converted_to_null(self):
         input_lf = pl.LazyFrame(
             {
                 "time_element_date": [
@@ -373,3 +375,17 @@ class CastDateStringsToDatesTests(unittest.TestCase):
         )
 
         pl_testing.assert_frame_equal(result_lf, expected_lf)
+
+    def test_column_is_not_converted_if_already_date_type(self):
+        input_lf = pl.LazyFrame(
+            {
+                "time_element_date": [
+                    date(2026, 1, 1),
+                    date(2026, 1, 2),
+                    None,
+                ]
+            }
+        )
+        result_lf = job.cast_date_strings_to_dates(input_lf)
+
+        pl_testing.assert_frame_equal(result_lf, input_lf)


### PR DESCRIPTION
## Description
Trello ticket [#1763](https://trello.com/c/iKsM4yN6/1763-s-use-polars-selectors-for-castdatestringstodates)

Replace manual schema inspection and column list creation with Polars selectors when identifying date columns to cast.

- Use selectors to identify string columns containing the date identifier.
- Exclude import_date using selector logic.
- Apply the date parsing expression directly to the selected columns.

## Testing
- [X] Unit tests passing
- [X] Successful [Step Function run](https://eu-west-2.console.aws.amazon.com/states/home?region=eu-west-2#/v2/executions/details/arn:aws:states:eu-west-2:856699698263:execution:1763-polars-selectors-Transform-ASCWDS-Data:802731f1-3432-40cd-b9c1-6e7ccf1d10f5)
- [X] Outputs checked in Athena

<img width="411" height="247" alt="image" src="https://github.com/user-attachments/assets/fd291e93-b184-491b-9691-def6b18afa21" />

## Checklist (delete if not relevant)
- [X] Docstrings added/updated
- [X] Updated CHANGELOG
- [X] Code reviewed by AI
- [X] Moved Trello ticket to PR column

## Reviewer checklist
- [ ] PR solves the Trello ticket requirements
- [ ] Outputs appear reasonable and understandable
- [ ] The overall approach is appropriate and not over-engineered
- [ ] No obvious scalability, performance or interdependency concerns
- [ ] Tests appropriately cover the main behaviour/edge cases
- [ ] Naming and structure are broadly understandable and consistent
- [ ] Docstrings are sufficient for future maintenance
- [ ] Docstrings cover non-obvious behaviour
