### PR TITLE
1762 Reduce Circle CI long term storage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,8 +90,6 @@ jobs:
       - run:
             name: Output Coverage Report
             command: coverage report
-      - store_artifacts:
-          path: htmlcov.index.html
 
   lint-python:
     docker:
@@ -150,15 +148,6 @@ jobs:
             terraform init -input=false -backend-config=../${AWS_ENV}.s3.tfbackend
             terraform workspace select ${SANITISED_CIRCLE_BRANCH} || terraform workspace new ${SANITISED_CIRCLE_BRANCH}
             terraform plan -out tfplan
-      - run:
-          name: Check workspace size
-          command: |
-            du -sh utils
-            du -sh schemas
-            du -sh projects
-            du -sh polars_utils
-            du -sh terraform/pipeline/tfplan
-            du -sh terraform/pipeline/* || true
       - store_artifacts:
           path: terraform/pipeline/tfplan
       - persist_to_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -153,10 +153,11 @@ jobs:
       - persist_to_workspace:
           root: .
           paths:
+            # The workspace is intentionally limited to the Terraform plan file plus dependency folders to reduce CircleCI storage costs
             # Needed for terraform deployment
             - terraform/pipeline/tfplan
             - terraform/pipeline/.*
-            # Needed for dependancies folder in s3
+            # Needed for dependencies folder in s3
             - utils
             - schemas
             - projects

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -153,7 +153,11 @@ jobs:
       - run:
           name: Check workspace size
           command: |
-            du -sh .
+            du -sh utils
+            du -sh schemas
+            du -sh projects
+            du -sh environment
+            du -sh polars_utils
             du -sh terraform/pipeline/tfplan
             du -sh terraform/pipeline/* || true
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,7 +91,7 @@ jobs:
             name: Output Coverage Report
             command: coverage report
       - store_artifacts:
-          path: htmlcov
+          path: htmlcov.index.html
 
   lint-python:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -156,7 +156,6 @@ jobs:
             du -sh utils
             du -sh schemas
             du -sh projects
-            du -sh environment
             du -sh polars_utils
             du -sh terraform/pipeline/tfplan
             du -sh terraform/pipeline/* || true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -153,8 +153,10 @@ jobs:
       - persist_to_workspace:
           root: .
           paths:
+            # Needed for terraform deployment
             - terraform/pipeline/tfplan
             - terraform/pipeline/.*
+            # Needed for dependancies folder in s3
             - utils
             - schemas
             - projects

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -155,14 +155,14 @@ jobs:
           command: |
             du -sh .
             du -sh terraform/pipeline/tfplan
-            du -sh terraform/pipeline/tfplan/* || true
+            du -sh terraform/pipeline/* || true
       - store_artifacts:
           path: terraform/pipeline/tfplan
       - persist_to_workspace:
           root: .
           paths:
-            - terraform/pipeline/tfplan
-            #- terraform/pipeline/.*
+            #- terraform/pipeline/tfplan
+            - terraform/pipeline/.*
             #- .
 
   terraform-apply:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -161,7 +161,7 @@ jobs:
       - persist_to_workspace:
           root: .
           paths:
-            #- terraform/pipeline/tfplan
+            - terraform/pipeline/tfplan
             - terraform/pipeline/.*
             #- .
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -150,6 +150,12 @@ jobs:
             terraform init -input=false -backend-config=../${AWS_ENV}.s3.tfbackend
             terraform workspace select ${SANITISED_CIRCLE_BRANCH} || terraform workspace new ${SANITISED_CIRCLE_BRANCH}
             terraform plan -out tfapply
+      - run:
+          name: Check workspace size
+          command: |
+            du -sh .
+            du -sh terraform/pipeline/tfapply
+            du -sh terraform/pipeline/tfapply/* || true
       - store_artifacts:
           path: terraform/pipeline/tfapply
       - persist_to_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -163,7 +163,11 @@ jobs:
           paths:
             - terraform/pipeline/tfplan
             - terraform/pipeline/.*
-            #- .
+            - utils
+            - schemas
+            - projects
+            - environment
+            - polars_utils
 
   terraform-apply:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -149,21 +149,21 @@ jobs:
             cd terraform/pipeline
             terraform init -input=false -backend-config=../${AWS_ENV}.s3.tfbackend
             terraform workspace select ${SANITISED_CIRCLE_BRANCH} || terraform workspace new ${SANITISED_CIRCLE_BRANCH}
-            terraform plan -out tfapply
+            terraform plan -out tfplan
       - run:
           name: Check workspace size
           command: |
             du -sh .
-            du -sh terraform/pipeline/tfapply
-            du -sh terraform/pipeline/tfapply/* || true
+            du -sh terraform/pipeline/tfplan
+            du -sh terraform/pipeline/tfplan/* || true
       - store_artifacts:
-          path: terraform/pipeline/tfapply
+          path: terraform/pipeline/tfplan
       - persist_to_workspace:
           root: .
           paths:
-            - terraform/pipeline/tfapply
-            - terraform/pipeline/.*
-            - .
+            - terraform/pipeline/tfplan
+            #- terraform/pipeline/.*
+            #- .
 
   terraform-apply:
     docker:
@@ -182,7 +182,7 @@ jobs:
             unset AWS_ACCESS_KEY_ID
             unset AWS_SECRET_ACCESS_KEY
             cd terraform/pipeline
-            terraform apply -auto-approve tfapply
+            terraform apply -auto-approve tfplan
       - run:
           name: save pipeline resources bucket name
           command: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,8 @@ All notable changes to this project will be documented in this file.
 
 - Corrected datasets in SLV pipeline that need switching between main and dev in terraform.
 
+- Reduced persistant storage in CircleCI.
+
 
 ## [v2026.05.0] - 12/06/2026
 


### PR DESCRIPTION
## Description
Trello ticket [#1762](https://trello.com/c/Kh6AZlkS/1762-check-circle-ci-usage)

Reduce the amount of data saved to Circle CI as storage overheads are snowballing

## Testing
- [x] Successful deployment in [CircleCI](https://app.circleci.com/pipelines/github/NMDSdevopsServiceAdm/DataEngineering?branch=1762-fix-pl)

We are now saving approx 7MB instead of 800MB in workspace.
We are now saving approx 0.5MB instead of 40MB in artifacts.
No changes to cache.

## Checklist (delete if not relevant)
- [x] Updated CHANGELOG
- [x] Code reviewed by AI
- [x] Moved Trello ticket to PR column

## Reviewer checklist
- [ ] PR solves the Trello ticket requirements
- [ ] Outputs appear reasonable and understandable
- [ ] The overall approach is appropriate and not over-engineered
- [ ] No obvious scalability, performance or interdependency concerns
- [ ] Tests appropriately cover the main behaviour/edge cases
- [ ] Naming and structure are broadly understandable and consistent
- [ ] Docstrings are sufficient for future maintenance
- [ ] Docstrings cover non-obvious behaviour
