### PR TITLE
1763 - Remove .as_expr() following polars upgrade

### DIFF
--- a/polars_utils/cleaning_utils.py
+++ b/polars_utils/cleaning_utils.py
@@ -273,5 +273,5 @@ def cast_date_strings_to_dates(
     )
 
     return lf.with_columns(
-        date_columns.as_expr().str.strptime(pl.Date, raw_date_format, strict=False)
+        date_columns.str.strptime(pl.Date, raw_date_format, strict=False)
     )


### PR DESCRIPTION
## Description
Trello ticket [#1763](https://trello.com/c/iKsM4yN6/1763-s-use-polars-selectors-for-castdatestringstodates)

My version of polars was older than the repo version but I didn't realise this at the time so added .as_expr() to make this function work. The version we actually use doesn't require .as_expr() so I've removed it