### PR TITLE
1770 - Add lambdas folder to workspace

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -163,6 +163,7 @@ jobs:
             - projects
             - environment
             - polars_utils
+            - lambdas
 
   terraform-apply:
     docker:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,8 @@ All notable changes to this project will be documented in this file.
 
 - Reduced persistant storage in CircleCI.
 
+- Added missing lambda folder to deployment.
+
 
 ## [v2026.05.0] - 12/06/2026
 


### PR DESCRIPTION
## Description
Trello ticket [#1770](https://trello.com/c/vkjWlxBw/1770-terraform-apply-failing)

Fixes terraform apply failure caused by missing lambda folder

## Testing
- [x] Successful [CircleCI run](https://app.circleci.com/pipelines/github/NMDSdevopsServiceAdm/DataEngineering?branch=1770-test-1)


## Checklist (delete if not relevant)
- [x] Updated CHANGELOG
- [x] Moved Trello ticket to PR column

## Reviewer checklist
- [ ] PR solves the Trello ticket requirements
- [ ] Outputs appear reasonable and understandable
- [ ] The overall approach is appropriate and not over-engineered
- [ ] No obvious scalability, performance or interdependency concerns
- [ ] Tests appropriately cover the main behaviour/edge cases
- [ ] Naming and structure are broadly understandable and consistent
- [ ] Docstrings are sufficient for future maintenance
- [ ] Docstrings cover non-obvious behaviour
