### PR TITLE
1767 - Add generic function to deal with Workplace data issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,8 @@ All notable changes to this project will be documented in this file.
 
 - Added `careHome` and `numberOfBeds` columns to Grouped Provider Output file and updated tests for the same.
 
+- Added `apply_data_corrections` function to null out empty/whitespace string values and legacy `parent_permission` value `3` in ASC-WDS workplace data. Added tests for the same.
+
 ### Changed
 - Refactored job group filter to use magic numbers for outlier bounds.
 

--- a/projects/_01_ingest/ascwds/fargate/clean_ascwds_workplace.py
+++ b/projects/_01_ingest/ascwds/fargate/clean_ascwds_workplace.py
@@ -98,6 +98,8 @@ def main(
     """
     lf = utils.scan_parquet(workplace_source, selected_columns=COLUMNS_TO_IMPORT)
 
+    lf = wUtils.apply_data_corrections(lf)
+
     lf = lf.filter(wUtils.valid_workplace_filter())
 
     lf = lf.with_columns(pl.col(AWPClean.nmds_id).str.strip_chars())

--- a/projects/_01_ingest/ascwds/fargate/clean_ascwds_workplace.py
+++ b/projects/_01_ingest/ascwds/fargate/clean_ascwds_workplace.py
@@ -102,8 +102,6 @@ def main(
 
     lf = lf.filter(wUtils.valid_workplace_filter())
 
-    lf = lf.with_columns(pl.col(AWPClean.nmds_id).str.strip_chars())
-
     lf = lf.rename({AWPClean.last_logged_in: AWPClean.last_logged_in_date})
 
     lf = cUtils.cast_date_strings_to_dates(lf)

--- a/projects/_01_ingest/ascwds/fargate/utils/clean_workplace_utils.py
+++ b/projects/_01_ingest/ascwds/fargate/utils/clean_workplace_utils.py
@@ -201,3 +201,41 @@ def create_purged_lfs_for_reconciliation_and_data(
     )
 
     return ascwds_workplace_lf, reconciliation_lf
+
+
+def apply_data_corrections(lf: pl.LazyFrame) -> pl.LazyFrame:
+    """
+    Apply legacy data corrections to an ASC-WDS workplace LazyFrame.
+
+    The following corrections are applied:
+        - Convert empty and whitespace-only string values to NULL across all
+          string columns.
+        - Set `parent_permission` to NULL where its value is `3`, as this is a
+          legacy value present in older data.
+
+    Args:
+        lf (pl.LazyFrame): Input LazyFrame containing ASC-WDS workplace data.
+
+    Returns:
+        pl.LazyFrame: A LazyFrame with the data corrections applied.
+    """
+    schema = lf.collect_schema()
+
+    string_columns = [name for name, dtype in schema.items() if dtype == pl.String]
+
+    lf = lf.with_columns(
+        pl.when(pl.col(col).str.strip_chars() == "")
+        .then(None)
+        .otherwise(pl.col(col))
+        .alias(col)
+        for col in string_columns
+    )
+
+    lf = lf.with_columns(
+        pl.when(pl.col(AWPClean.parent_permission) == "3")
+        .then(None)
+        .otherwise(pl.col(AWPClean.parent_permission))
+        .alias(AWPClean.parent_permission)
+    )
+
+    return lf

--- a/projects/_01_ingest/ascwds/fargate/utils/clean_workplace_utils.py
+++ b/projects/_01_ingest/ascwds/fargate/utils/clean_workplace_utils.py
@@ -1,4 +1,5 @@
 import polars as pl
+import polars.selectors as cs
 
 from utils.column_names.cleaned_data_files.ascwds_workplace_cleaned import (
     AscwdsWorkplaceCleanedColumns as AWPClean,
@@ -219,23 +220,10 @@ def apply_data_corrections(lf: pl.LazyFrame) -> pl.LazyFrame:
     Returns:
         pl.LazyFrame: A LazyFrame with the data corrections applied.
     """
-    schema = lf.collect_schema()
+    # Treat blank strings as missing values.
+    lf = lf.with_columns(cs.string().str.strip_chars().replace("", None))
 
-    string_columns = [name for name, dtype in schema.items() if dtype == pl.String]
-
-    lf = lf.with_columns(
-        pl.when(pl.col(col).str.strip_chars() == "")
-        .then(None)
-        .otherwise(pl.col(col))
-        .alias(col)
-        for col in string_columns
-    )
-
-    lf = lf.with_columns(
-        pl.when(pl.col(AWPClean.parent_permission) == "3")
-        .then(None)
-        .otherwise(pl.col(AWPClean.parent_permission))
-        .alias(AWPClean.parent_permission)
-    )
+    # legacy parent permission temporarily contained invalid "3" codes
+    lf = lf.with_columns(pl.col(AWPClean.parent_permission).replace(3, None))
 
     return lf

--- a/projects/_01_ingest/ascwds/tests/fargate/test_clean_ascwds_workplace.py
+++ b/projects/_01_ingest/ascwds/tests/fargate/test_clean_ascwds_workplace.py
@@ -68,8 +68,6 @@ class MainTests(unittest.TestCase):
 
         create_purged_lfs_for_reconciliation_and_data_mock.assert_called_once()
 
-        create_purged_lfs_for_reconciliation_and_data_mock.assert_called_once()
-
         scan_csv_mock.assert_called_once_with(
             self.DATA_LABELS_SOURCE, schema=job.data_labels_schema
         )

--- a/projects/_01_ingest/ascwds/tests/fargate/test_clean_ascwds_workplace.py
+++ b/projects/_01_ingest/ascwds/tests/fargate/test_clean_ascwds_workplace.py
@@ -28,10 +28,12 @@ class MainTests(unittest.TestCase):
     @patch(f"{PATCH_PATH}.cUtils.column_to_date")
     @patch(f"{PATCH_PATH}.cUtils.cast_date_strings_to_dates")
     @patch(f"{PATCH_PATH}.wUtils.valid_workplace_filter")
+    @patch(f"{PATCH_PATH}.wUtils.apply_data_corrections")
     @patch(f"{PATCH_PATH}.utils.scan_parquet")
     def test_main_runs(
         self,
         scan_parquet_mock: Mock,
+        apply_data_corrections_mock: Mock,
         valid_filter_mock: Mock,
         cast_date_strings_to_dates_mock: Mock,
         column_to_date_mock: Mock,
@@ -55,6 +57,9 @@ class MainTests(unittest.TestCase):
         scan_parquet_mock.assert_called_once_with(
             self.WORKPLACE_SOURCE, selected_columns=job.COLUMNS_TO_IMPORT
         )
+
+        apply_data_corrections_mock.assert_called_once()
+
         valid_filter_mock.assert_called_once()
 
         cast_date_strings_to_dates_mock.assert_called_once()

--- a/projects/_01_ingest/ascwds/tests/fargate/utils/test_clean_workplace_utils.py
+++ b/projects/_01_ingest/ascwds/tests/fargate/utils/test_clean_workplace_utils.py
@@ -6,7 +6,13 @@ import pytest
 
 import projects._01_ingest.ascwds.fargate.utils.clean_workplace_utils as job
 from projects._01_ingest.unittest_data.polars_ingest_test_file_data import (
+    TestApplyDataCorrections as CorrectionsData,
+)
+from projects._01_ingest.unittest_data.polars_ingest_test_file_data import (
     TestCreatePurgedLfsForReconciliationAndData as Data,
+)
+from projects._01_ingest.unittest_data.polars_ingest_test_file_schema import (
+    TestApplyDataCorrectionsSchemas as CorrectionsSchemas,
 )
 from projects._01_ingest.unittest_data.polars_ingest_test_file_schema import (
     TestCreatePurgedLfsForReconciliationAndDataSchemas as Schemas,
@@ -202,3 +208,27 @@ class TestCreatePurgedLfsForReconciliationAndData:
 
         assert isinstance(workplace_lf, pl.LazyFrame)
         assert isinstance(recon_lf, pl.LazyFrame)
+
+
+class TestApplyDataCorrections:
+    @pytest.mark.parametrize(
+        "case",
+        [
+            pytest.param(case, id=case.id)
+            for case in CorrectionsData.apply_data_corrections_test_cases
+        ],
+    )
+    def test_function_returns_expected_values(self, case):
+        test_lf = pl.LazyFrame(
+            case.test_data, CorrectionsSchemas.ApplyDataCorrectionsSchema, orient="row"
+        )
+
+        expected_workplace_lf = pl.LazyFrame(
+            case.expected_data,
+            CorrectionsSchemas.ApplyDataCorrectionsSchema,
+            orient="row",
+        )
+
+        returned_lf = job.apply_data_corrections(test_lf)
+
+        pl_testing.assert_frame_equal(returned_lf, expected_workplace_lf)

--- a/projects/_01_ingest/ascwds/tests/fargate/utils/test_clean_workplace_utils.py
+++ b/projects/_01_ingest/ascwds/tests/fargate/utils/test_clean_workplace_utils.py
@@ -6,16 +6,10 @@ import pytest
 
 import projects._01_ingest.ascwds.fargate.utils.clean_workplace_utils as job
 from projects._01_ingest.unittest_data.polars_ingest_test_file_data import (
-    TestApplyDataCorrections as CorrectionsData,
-)
-from projects._01_ingest.unittest_data.polars_ingest_test_file_data import (
-    TestCreatePurgedLfsForReconciliationAndData as Data,
+    TestCleanAscwdsWorkplaceUtilsData as Data,
 )
 from projects._01_ingest.unittest_data.polars_ingest_test_file_schema import (
-    TestApplyDataCorrectionsSchemas as CorrectionsSchemas,
-)
-from projects._01_ingest.unittest_data.polars_ingest_test_file_schema import (
-    TestCreatePurgedLfsForReconciliationAndDataSchemas as Schemas,
+    TestCleanAscwdsWorkplaceUtilsSchemas as Schemas,
 )
 from utils.column_names.cleaned_data_files.ascwds_workplace_cleaned import (
     AscwdsWorkplaceCleanedColumns as AWPClean,
@@ -215,17 +209,17 @@ class TestApplyDataCorrections:
         "case",
         [
             pytest.param(case, id=case.id)
-            for case in CorrectionsData.apply_data_corrections_test_cases
+            for case in Data.apply_data_corrections_test_cases
         ],
     )
     def test_function_returns_expected_values(self, case):
         test_lf = pl.LazyFrame(
-            case.test_data, CorrectionsSchemas.ApplyDataCorrectionsSchema, orient="row"
+            case.test_data, Schemas.apply_data_corrections_schema, orient="row"
         )
 
         expected_workplace_lf = pl.LazyFrame(
             case.expected_data,
-            CorrectionsSchemas.ApplyDataCorrectionsSchema,
+            Schemas.apply_data_corrections_schema,
             orient="row",
         )
 

--- a/projects/_01_ingest/unittest_data/polars_ingest_test_file_data.py
+++ b/projects/_01_ingest/unittest_data/polars_ingest_test_file_data.py
@@ -2,6 +2,9 @@ from dataclasses import dataclass
 from datetime import date
 from typing import Any, Optional
 
+from utils.column_names.cleaned_data_files.ascwds_workplace_cleaned import (
+    AscwdsWorkplaceCleanedColumns as AWPClean,
+)
 from utils.column_names.raw_data_files.cqc_location_api_columns import (
     NewCqcLocationApiColumns as CQCL,
 )
@@ -1670,5 +1673,177 @@ class TestCreatePurgedLfsForReconciliationAndData:
             ],
             expected_workplace_data=None,
             expected_recon_data=None,
+        ),
+    ]
+
+
+BASE_ROW = {
+    AWPClean.organisation_id: "org-001",
+    AWPClean.period: "2023-04",
+    AWPClean.establishment_id: "1",
+    AWPClean.establishment_id_from_nmds: "E001",
+    AWPClean.parent_id: "100",
+    AWPClean.nmds_id: "N001",
+    AWPClean.establishment_created_date: date(2020, 1, 1),
+    AWPClean.establishment_updated_date: date(2023, 1, 1),
+    AWPClean.master_update_date: date(2023, 4, 1),
+    AWPClean.last_logged_in: date(2023, 4, 1),
+    AWPClean.la_permission: "1",
+    AWPClean.is_bulk_uploader: "0",
+    AWPClean.is_parent: "0",
+    AWPClean.parent_permission: "1",
+    AWPClean.registration_type: "1",
+    AWPClean.provider_id: "PR-001",
+    AWPClean.location_id: "LOC-001",
+    AWPClean.establishment_type: "1",
+    AWPClean.establishment_name: "Sunnyside Care Home",
+    AWPClean.address: "1 Example Street",
+    AWPClean.postcode: "M1 1AA",
+    AWPClean.region_id: "5",
+    AWPClean.total_staff: "20",
+    AWPClean.worker_records: "18",
+    AWPClean.total_starters: "2",
+    AWPClean.total_leavers: "1",
+    AWPClean.total_vacancies: "3",
+    AWPClean.main_service_id: "10",
+    AWPClean.version: "1.0",
+    AWPClean.import_date: date(2023, 4, 15),
+}
+
+
+def make_row(**overrides: Any) -> tuple:
+    """Build a full row tuple (in COLUMNS_TO_IMPORT order) from the baseline,
+    with specific columns overridden for a given test case."""
+    row = {**BASE_ROW, **overrides}
+    return tuple(row[col] for col in BASE_ROW.keys())
+
+
+@dataclass
+class ApplyDataCorrectionsTestCase:
+    id: str
+    test_data: list[Any]
+    expected_data: Optional[list[Any]]
+
+
+@dataclass
+class TestApplyDataCorrections:
+    apply_data_corrections_test_cases = [
+        ApplyDataCorrectionsTestCase(
+            id="empty_string_converted_to_null",
+            test_data=[
+                make_row(**{AWPClean.location_id: ""}),
+            ],
+            expected_data=[
+                make_row(**{AWPClean.location_id: None}),
+            ], # fmt: skip
+        ),
+        ApplyDataCorrectionsTestCase(
+            id="whitespace_only_string_converted_to_null",
+            test_data=[
+                make_row(**{AWPClean.location_id: " "}),
+            ],
+            expected_data=[
+                make_row(**{AWPClean.location_id: None}),
+            ], # fmt: skip
+        ),
+        ApplyDataCorrectionsTestCase(
+            id="non_empty_string_unchanged",
+            test_data=[
+                make_row(),
+            ],
+            expected_data=[
+                make_row(),
+            ], # fmt: skip
+        ),
+        ApplyDataCorrectionsTestCase(
+            id="null_string_remains_null",
+            test_data=[
+                make_row(**{AWPClean.postcode: None}),
+            ],
+            expected_data=[
+                make_row(**{AWPClean.postcode: None}),
+            ], # fmt: skip
+        ),
+        ApplyDataCorrectionsTestCase(
+            id="parent_permission_converted_to_null_when_value_is_3",
+            test_data=[
+                make_row(**{AWPClean.parent_permission: "3"}),
+            ],
+            expected_data=[
+                make_row(**{AWPClean.parent_permission: None}),
+            ], # fmt: skip
+        ),
+        ApplyDataCorrectionsTestCase(
+            id="parent_permission_non_legacy_value_unchanged",
+            test_data=[
+                make_row(**{AWPClean.parent_permission: "2"}),
+            ],
+            expected_data=[
+                make_row(**{AWPClean.parent_permission: "2"}),
+            ], # fmt: skip
+        ),
+        ApplyDataCorrectionsTestCase(
+            id="parent_permission_empty_string_converted_to_null",
+            test_data=[
+                make_row(**{AWPClean.parent_permission: ""}),
+            ],
+            expected_data=[
+                make_row(**{AWPClean.parent_permission: None}),
+            ], # fmt: skip
+        ),
+        ApplyDataCorrectionsTestCase(
+            id="parent_permission_whitespace_only_converted_to_null",
+            test_data=[
+                make_row(**{AWPClean.parent_permission: "   "}),
+            ],
+            expected_data=[
+                make_row(**{AWPClean.parent_permission: None}),
+            ], # fmt: skip
+        ),
+        ApplyDataCorrectionsTestCase(
+            id="parent_permission_already_null_remains_null",
+            test_data=[
+                make_row(**{AWPClean.parent_permission: None}),
+            ],
+            expected_data=[
+                make_row(**{AWPClean.parent_permission: None}),
+            ], # fmt: skip
+        ),
+        ApplyDataCorrectionsTestCase(
+            id="multiple_rows_mixed_corrections",
+            test_data=[
+                make_row(**{AWPClean.establishment_name: "", AWPClean.parent_permission: "3"}),
+                make_row(**{AWPClean.address: "  ", AWPClean.parent_permission: "2"}),
+                make_row(**{AWPClean.postcode: "", AWPClean.parent_permission: None}),
+                make_row(**{AWPClean.la_permission: "1", AWPClean.parent_permission: "1"}),
+            ],
+            expected_data=[
+                make_row(**{AWPClean.establishment_name: None, AWPClean.parent_permission: None}),
+                make_row(**{AWPClean.address: None, AWPClean.parent_permission: "2"}),
+                make_row(**{AWPClean.postcode: None, AWPClean.parent_permission: None}),
+                make_row(**{AWPClean.la_permission: "1", AWPClean.parent_permission: "1"}),
+            ], # fmt: skip
+        ),
+        ApplyDataCorrectionsTestCase(
+            id="multiple_string_columns_cleaned_in_same_row",
+            test_data=[
+                make_row(**{
+                    AWPClean.establishment_name: "",
+                    AWPClean.address: "   ",
+                    AWPClean.postcode: "M1 1AA",
+                }),
+            ],
+            expected_data=[
+                make_row(**{
+                    AWPClean.establishment_name: None,
+                    AWPClean.address: None,
+                    AWPClean.postcode: "M1 1AA",
+                }),
+            ], # fmt: skip
+        ),
+        ApplyDataCorrectionsTestCase(
+            id="empty_dataframe_are_unchanged",
+            test_data=[],
+            expected_data=[], # fmt: skip
         ),
     ]

--- a/projects/_01_ingest/unittest_data/polars_ingest_test_file_data.py
+++ b/projects/_01_ingest/unittest_data/polars_ingest_test_file_data.py
@@ -1554,8 +1554,56 @@ class PurgedLfsTestCase:
     expected_recon_data: Optional[list[Any]]
 
 
+BASE_ROW = {
+    AWPClean.organisation_id: "org-001",
+    AWPClean.period: "2023-04",
+    AWPClean.establishment_id: "1",
+    AWPClean.establishment_id_from_nmds: "E001",
+    AWPClean.parent_id: "100",
+    AWPClean.nmds_id: "N001",
+    AWPClean.establishment_created_date: date(2020, 1, 1),
+    AWPClean.establishment_updated_date: date(2023, 1, 1),
+    AWPClean.master_update_date: date(2023, 4, 1),
+    AWPClean.last_logged_in: date(2023, 4, 1),
+    AWPClean.la_permission: "1",
+    AWPClean.is_bulk_uploader: "0",
+    AWPClean.is_parent: "0",
+    AWPClean.parent_permission: "1",
+    AWPClean.registration_type: "1",
+    AWPClean.provider_id: "PR-001",
+    AWPClean.location_id: "LOC-001",
+    AWPClean.establishment_type: "1",
+    AWPClean.establishment_name: "Sunnyside Care Home",
+    AWPClean.address: "1 Example Street",
+    AWPClean.postcode: "M1 1AA",
+    AWPClean.region_id: "5",
+    AWPClean.total_staff: "20",
+    AWPClean.worker_records: "18",
+    AWPClean.total_starters: "2",
+    AWPClean.total_leavers: "1",
+    AWPClean.total_vacancies: "3",
+    AWPClean.main_service_id: "10",
+    AWPClean.version: "1.0",
+    AWPClean.import_date: date(2023, 4, 15),
+}
+
+
+def make_apply_data_corrections_test_row(**overrides: Any) -> tuple:
+    """Build a full row tuple (in COLUMNS_TO_IMPORT order) from the baseline,
+    with specific columns overridden for a given test case."""
+    row = {**BASE_ROW, **overrides}
+    return tuple(row[col] for col in BASE_ROW.keys())
+
+
 @dataclass
-class TestCreatePurgedLfsForReconciliationAndData:
+class ApplyDataCorrectionsTestCase:
+    id: str
+    test_data: list[Any]
+    expected_data: Optional[list[Any]]
+
+
+@dataclass
+class TestCleanAscwdsWorkplaceUtilsData:
     purge_date_test_cases = [
         CleanWorkplaceUtilsTestCase(
             id="subtracts_correct_months",
@@ -1676,165 +1724,114 @@ class TestCreatePurgedLfsForReconciliationAndData:
         ),
     ]
 
-
-BASE_ROW = {
-    AWPClean.organisation_id: "org-001",
-    AWPClean.period: "2023-04",
-    AWPClean.establishment_id: "1",
-    AWPClean.establishment_id_from_nmds: "E001",
-    AWPClean.parent_id: "100",
-    AWPClean.nmds_id: "N001",
-    AWPClean.establishment_created_date: date(2020, 1, 1),
-    AWPClean.establishment_updated_date: date(2023, 1, 1),
-    AWPClean.master_update_date: date(2023, 4, 1),
-    AWPClean.last_logged_in: date(2023, 4, 1),
-    AWPClean.la_permission: "1",
-    AWPClean.is_bulk_uploader: "0",
-    AWPClean.is_parent: "0",
-    AWPClean.parent_permission: "1",
-    AWPClean.registration_type: "1",
-    AWPClean.provider_id: "PR-001",
-    AWPClean.location_id: "LOC-001",
-    AWPClean.establishment_type: "1",
-    AWPClean.establishment_name: "Sunnyside Care Home",
-    AWPClean.address: "1 Example Street",
-    AWPClean.postcode: "M1 1AA",
-    AWPClean.region_id: "5",
-    AWPClean.total_staff: "20",
-    AWPClean.worker_records: "18",
-    AWPClean.total_starters: "2",
-    AWPClean.total_leavers: "1",
-    AWPClean.total_vacancies: "3",
-    AWPClean.main_service_id: "10",
-    AWPClean.version: "1.0",
-    AWPClean.import_date: date(2023, 4, 15),
-}
-
-
-def make_row(**overrides: Any) -> tuple:
-    """Build a full row tuple (in COLUMNS_TO_IMPORT order) from the baseline,
-    with specific columns overridden for a given test case."""
-    row = {**BASE_ROW, **overrides}
-    return tuple(row[col] for col in BASE_ROW.keys())
-
-
-@dataclass
-class ApplyDataCorrectionsTestCase:
-    id: str
-    test_data: list[Any]
-    expected_data: Optional[list[Any]]
-
-
-@dataclass
-class TestApplyDataCorrections:
     apply_data_corrections_test_cases = [
         ApplyDataCorrectionsTestCase(
             id="empty_string_converted_to_null",
             test_data=[
-                make_row(**{AWPClean.location_id: ""}),
+                make_apply_data_corrections_test_row(**{AWPClean.location_id: ""}),
             ],
             expected_data=[
-                make_row(**{AWPClean.location_id: None}),
+                make_apply_data_corrections_test_row(**{AWPClean.location_id: None}),
             ], # fmt: skip
         ),
         ApplyDataCorrectionsTestCase(
             id="whitespace_only_string_converted_to_null",
             test_data=[
-                make_row(**{AWPClean.location_id: " "}),
+                make_apply_data_corrections_test_row(**{AWPClean.location_id: " "}),
             ],
             expected_data=[
-                make_row(**{AWPClean.location_id: None}),
+                make_apply_data_corrections_test_row(**{AWPClean.location_id: None}),
             ], # fmt: skip
         ),
         ApplyDataCorrectionsTestCase(
             id="non_empty_string_unchanged",
             test_data=[
-                make_row(),
+                make_apply_data_corrections_test_row(),
             ],
             expected_data=[
-                make_row(),
+                make_apply_data_corrections_test_row(),
             ], # fmt: skip
         ),
         ApplyDataCorrectionsTestCase(
             id="null_string_remains_null",
             test_data=[
-                make_row(**{AWPClean.postcode: None}),
+                make_apply_data_corrections_test_row(**{AWPClean.postcode: None}),
             ],
             expected_data=[
-                make_row(**{AWPClean.postcode: None}),
+                make_apply_data_corrections_test_row(**{AWPClean.postcode: None}),
             ], # fmt: skip
         ),
         ApplyDataCorrectionsTestCase(
             id="parent_permission_converted_to_null_when_value_is_3",
             test_data=[
-                make_row(**{AWPClean.parent_permission: "3"}),
+                make_apply_data_corrections_test_row(**{AWPClean.parent_permission: "3"}),
             ],
             expected_data=[
-                make_row(**{AWPClean.parent_permission: None}),
+                make_apply_data_corrections_test_row(**{AWPClean.parent_permission: None}),
             ], # fmt: skip
         ),
         ApplyDataCorrectionsTestCase(
             id="parent_permission_non_legacy_value_unchanged",
             test_data=[
-                make_row(**{AWPClean.parent_permission: "2"}),
+                make_apply_data_corrections_test_row(**{AWPClean.parent_permission: "2"}),
             ],
             expected_data=[
-                make_row(**{AWPClean.parent_permission: "2"}),
+                make_apply_data_corrections_test_row(**{AWPClean.parent_permission: "2"}),
             ], # fmt: skip
         ),
         ApplyDataCorrectionsTestCase(
             id="parent_permission_empty_string_converted_to_null",
             test_data=[
-                make_row(**{AWPClean.parent_permission: ""}),
+                make_apply_data_corrections_test_row(**{AWPClean.parent_permission: ""}),
             ],
             expected_data=[
-                make_row(**{AWPClean.parent_permission: None}),
+                make_apply_data_corrections_test_row(**{AWPClean.parent_permission: None}),
             ], # fmt: skip
         ),
         ApplyDataCorrectionsTestCase(
             id="parent_permission_whitespace_only_converted_to_null",
             test_data=[
-                make_row(**{AWPClean.parent_permission: "   "}),
+                make_apply_data_corrections_test_row(**{AWPClean.parent_permission: "   "}),
             ],
             expected_data=[
-                make_row(**{AWPClean.parent_permission: None}),
+                make_apply_data_corrections_test_row(**{AWPClean.parent_permission: None}),
             ], # fmt: skip
         ),
         ApplyDataCorrectionsTestCase(
             id="parent_permission_already_null_remains_null",
             test_data=[
-                make_row(**{AWPClean.parent_permission: None}),
+                make_apply_data_corrections_test_row(**{AWPClean.parent_permission: None}),
             ],
             expected_data=[
-                make_row(**{AWPClean.parent_permission: None}),
+                make_apply_data_corrections_test_row(**{AWPClean.parent_permission: None}),
             ], # fmt: skip
         ),
         ApplyDataCorrectionsTestCase(
             id="multiple_rows_mixed_corrections",
             test_data=[
-                make_row(**{AWPClean.establishment_name: "", AWPClean.parent_permission: "3"}),
-                make_row(**{AWPClean.address: "  ", AWPClean.parent_permission: "2"}),
-                make_row(**{AWPClean.postcode: "", AWPClean.parent_permission: None}),
-                make_row(**{AWPClean.la_permission: "1", AWPClean.parent_permission: "1"}),
+                make_apply_data_corrections_test_row(**{AWPClean.establishment_name: "", AWPClean.parent_permission: "3"}),
+                make_apply_data_corrections_test_row(**{AWPClean.address: "  ", AWPClean.parent_permission: "2"}),
+                make_apply_data_corrections_test_row(**{AWPClean.postcode: "", AWPClean.parent_permission: None}),
+                make_apply_data_corrections_test_row(**{AWPClean.la_permission: "1", AWPClean.parent_permission: "1"}),
             ],
             expected_data=[
-                make_row(**{AWPClean.establishment_name: None, AWPClean.parent_permission: None}),
-                make_row(**{AWPClean.address: None, AWPClean.parent_permission: "2"}),
-                make_row(**{AWPClean.postcode: None, AWPClean.parent_permission: None}),
-                make_row(**{AWPClean.la_permission: "1", AWPClean.parent_permission: "1"}),
+                make_apply_data_corrections_test_row(**{AWPClean.establishment_name: None, AWPClean.parent_permission: None}),
+                make_apply_data_corrections_test_row(**{AWPClean.address: None, AWPClean.parent_permission: "2"}),
+                make_apply_data_corrections_test_row(**{AWPClean.postcode: None, AWPClean.parent_permission: None}),
+                make_apply_data_corrections_test_row(**{AWPClean.la_permission: "1", AWPClean.parent_permission: "1"}),
             ], # fmt: skip
         ),
         ApplyDataCorrectionsTestCase(
             id="multiple_string_columns_cleaned_in_same_row",
             test_data=[
-                make_row(**{
+                make_apply_data_corrections_test_row(**{
                     AWPClean.establishment_name: "",
                     AWPClean.address: "   ",
                     AWPClean.postcode: "M1 1AA",
                 }),
             ],
             expected_data=[
-                make_row(**{
+                make_apply_data_corrections_test_row(**{
                     AWPClean.establishment_name: None,
                     AWPClean.address: None,
                     AWPClean.postcode: "M1 1AA",

--- a/projects/_01_ingest/unittest_data/polars_ingest_test_file_schema.py
+++ b/projects/_01_ingest/unittest_data/polars_ingest_test_file_schema.py
@@ -488,3 +488,39 @@ class TestCreatePurgedLfsForReconciliationAndDataSchemas:
         **last_amended_date_exprs_schema,
         AWPClean.workplace_last_active_date: pl.Date,
     }
+
+
+@dataclass
+class TestApplyDataCorrectionsSchemas:
+    ApplyDataCorrectionsSchema = {
+        AWPClean.organisation_id: pl.String,
+        AWPClean.period: pl.String,
+        AWPClean.establishment_id: pl.String,
+        AWPClean.establishment_id_from_nmds: pl.String,
+        AWPClean.parent_id: pl.String,
+        AWPClean.nmds_id: pl.String,
+        AWPClean.establishment_created_date: pl.Date,
+        AWPClean.establishment_updated_date: pl.Date,
+        AWPClean.master_update_date: pl.Date,
+        AWPClean.last_logged_in: pl.Date,
+        AWPClean.la_permission: pl.String,
+        AWPClean.is_bulk_uploader: pl.String,
+        AWPClean.is_parent: pl.String,
+        AWPClean.parent_permission: pl.String,
+        AWPClean.registration_type: pl.String,
+        AWPClean.provider_id: pl.String,
+        AWPClean.location_id: pl.String,
+        AWPClean.establishment_type: pl.String,
+        AWPClean.establishment_name: pl.String,
+        AWPClean.address: pl.String,
+        AWPClean.postcode: pl.String,
+        AWPClean.region_id: pl.String,
+        AWPClean.total_staff: pl.String,
+        AWPClean.worker_records: pl.String,
+        AWPClean.total_starters: pl.String,
+        AWPClean.total_leavers: pl.String,
+        AWPClean.total_vacancies: pl.String,
+        AWPClean.main_service_id: pl.String,
+        AWPClean.version: pl.String,
+        AWPClean.import_date: pl.Date,
+    }

--- a/projects/_01_ingest/unittest_data/polars_ingest_test_file_schema.py
+++ b/projects/_01_ingest/unittest_data/polars_ingest_test_file_schema.py
@@ -464,7 +464,7 @@ class ValidateCqcLocations4FullLatestSnapshotTest:
 
 
 @dataclass
-class TestCreatePurgedLfsForReconciliationAndDataSchemas:
+class TestCleanAscwdsWorkplaceUtilsSchemas:
     test_schema = {
         AWPClean.organisation_id: pl.String,
         AWPClean.ascwds_workplace_import_date: pl.Date,
@@ -489,10 +489,7 @@ class TestCreatePurgedLfsForReconciliationAndDataSchemas:
         AWPClean.workplace_last_active_date: pl.Date,
     }
 
-
-@dataclass
-class TestApplyDataCorrectionsSchemas:
-    ApplyDataCorrectionsSchema = {
+    apply_data_corrections_schema = {
         AWPClean.organisation_id: pl.String,
         AWPClean.period: pl.String,
         AWPClean.establishment_id: pl.String,


### PR DESCRIPTION
## Description
Trello ticket [#1767](https://trello.com/c/k61vcYJq)

Implemented a generic function:
1. to set parent_permission to NULL when its value is 3 (legacy values from Oct–Dec 2020 in the workplace raw dataset).
2. to replace empty or whitespace-only strings with NULL across all columns imported in the clean job. 

## Testing
- [x] Unit tests passing
- [x] Successful [Step Function run](https://eu-west-2.console.aws.amazon.com/states/home?region=eu-west-2#/v2/executions/details/arn:aws:states:eu-west-2:856699698263:execution:1767-gen-wrkplc-fixs-Transform-ASCWDS-Data:1e0b4fad-9f13-423e-96b7-4d278b20bc10)
- [x] Outputs checked in Athena

[Add any additional testing information here - add screenshot if relevant]

## Checklist (delete if not relevant)
- [x] Unit tests added/amended
- [x] Docstrings added/updated
- [x] Updated CHANGELOG
- [x] Code reviewed by AI
- [x] Moved Trello ticket to PR column

## Reviewer checklist
- [ ] PR solves the Trello ticket requirements
- [ ] Outputs appear reasonable and understandable
- [ ] The overall approach is appropriate and not over-engineered
- [ ] No obvious scalability, performance or interdependency concerns
- [ ] Tests appropriately cover the main behaviour/edge cases
- [ ] Naming and structure are broadly understandable and consistent
- [ ] Docstrings are sufficient for future maintenance
- [ ] Docstrings cover non-obvious behaviour
