### PR TITLE
1772 Remove unneccesary storage usage during deployment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -152,9 +152,9 @@ jobs:
             # This transformation should match the workspace_prefix set in terraform/pipeline/main.tf locals block
             export SANITISED_CIRCLE_BRANCH=$(echo ${CIRCLE_BRANCH:0:30} | tr -c '[:alnum:]\n' '-' | tr '[:upper:]' '[:lower:]')
             cd terraform/pipeline
+            terraform providers
             terraform init -input=false -backend-config=../${AWS_ENV}.s3.tfbackend -plugin-dir=custom-terraform-plugins
             terraform workspace select ${SANITISED_CIRCLE_BRANCH} || terraform workspace new ${SANITISED_CIRCLE_BRANCH}
-            terraform providers
             terraform plan -out tfplan
       - store_artifacts:
           path: terraform/pipeline/tfplan

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -156,21 +156,21 @@ jobs:
             # The workspace is intentionally limited to the Terraform plan file plus dependency folders to reduce CircleCI storage costs
             # Needed for terraform deployment
             - terraform/pipeline/tfplan
-            - terraform/pipeline/policy_documents/.*
-            - terraform/pipeline/step_functions/.*
-            - terraform/pipeline/ecr.tf
-            - terraform/pipeline/eventbridge.tf
-            - terraform/pipeline/fargate.tf
-            - terraform/pipeline/glue.tf
-            - terraform/pipeline/iam.tf
-            - terraform/pipeline/lambda.tf
-            - terraform/pipeline/main.tf
-            - terraform/pipeline/outputs.tf
-            - terraform/pipeline/parameter-store.tf
-            - terraform/pipeline/s3.tf
-            - terraform/pipeline/sns.tf
-            - terraform/pipeline/step-function.tf
-            - terraform/pipeline/variables.tf
+            #- terraform/pipeline/policy_documents/.*
+            #- terraform/pipeline/step_functions/.*
+            #- terraform/pipeline/ecr.tf
+            #- terraform/pipeline/eventbridge.tf
+            #- terraform/pipeline/fargate.tf
+            #- terraform/pipeline/glue.tf
+            #- terraform/pipeline/iam.tf
+            #- terraform/pipeline/lambda.tf
+            #- terraform/pipeline/main.tf
+            #- terraform/pipeline/outputs.tf
+            #- terraform/pipeline/parameter-store.tf
+            #- terraform/pipeline/s3.tf
+            #- terraform/pipeline/sns.tf
+            #- terraform/pipeline/step-function.tf
+            #- terraform/pipeline/variables.tf
             # Needed for dependencies folder in s3
             - utils
             - schemas

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,15 +28,16 @@ commands:
   initialise_terraform:
     description: "Set up the terraform backend for terraform jobs"
     steps:
-      - checkout
       # UNSET old keys to force AWS CLI to use OIDC
-      - run: unset AWS_ACCESS_KEY_ID
-      - run: unset AWS_SECRET_ACCESS_KEY
-      # This transformation should match the workspace_prefix set in terraform/pipeline/main.tf locals block
-      - run: export SANITISED_CIRCLE_BRANCH=$(echo ${CIRCLE_BRANCH:0:30} | tr -c '[:alnum:]\n' '-' | tr '[:upper:]' '[:lower:]')
-      - run: cd terraform/pipeline
-      - run: terraform init -input=false -backend-config=../${AWS_ENV}.s3.tfbackend
-      - run: terraform workspace select ${SANITISED_CIRCLE_BRANCH} || terraform workspace new ${SANITISED_CIRCLE_BRANCH}
+      - run: |
+          unset AWS_ACCESS_KEY_ID
+          unset AWS_SECRET_ACCESS_KEY
+          # This transformation should match the workspace_prefix set in terraform/pipeline/main.tf locals block
+          export CIRCLE_BRANCH="<< pipeline.parameters.GHA_Meta >>"
+          export SANITISED_CIRCLE_BRANCH=$(echo ${CIRCLE_BRANCH:0:30} | tr -c '[:alnum:]\n' '-' | tr '[:upper:]' '[:lower:]')
+          cd terraform/pipeline
+          terraform init -input=false -backend-config=../${AWS_ENV}.s3.tfbackend
+          terraform workspace select ${SANITISED_CIRCLE_BRANCH} || terraform workspace new ${SANITISED_CIRCLE_BRANCH}
 
 
 jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -156,21 +156,6 @@ jobs:
             # The workspace is intentionally limited to the Terraform plan file plus dependency folders to reduce CircleCI storage costs
             # Needed for terraform deployment
             - terraform/pipeline/tfplan
-            #- terraform/pipeline/policy_documents/.*
-            #- terraform/pipeline/step_functions/.*
-            #- terraform/pipeline/ecr.tf
-            #- terraform/pipeline/eventbridge.tf
-            #- terraform/pipeline/fargate.tf
-            #- terraform/pipeline/glue.tf
-            #- terraform/pipeline/iam.tf
-            #- terraform/pipeline/lambda.tf
-            #- terraform/pipeline/main.tf
-            #- terraform/pipeline/outputs.tf
-            #- terraform/pipeline/parameter-store.tf
-            #- terraform/pipeline/s3.tf
-            #- terraform/pipeline/sns.tf
-            #- terraform/pipeline/step-function.tf
-            #- terraform/pipeline/variables.tf
             # Needed for dependencies folder in s3
             - utils
             - schemas

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,29 +25,27 @@ orbs:
   aws-cli: circleci/aws-cli@5.4.1
 
 commands:
-  unset-keys:
-    description: "UNSET old keys to force AWS CLI to use OIDC"
+  sanitise-branch:
+    description: "Create workspace prefix from CIRCLE BRANCH"
     steps:
       - run:
-          name: Unset keys
+          name: Sanitise branch
           command: |
-            # UNSET old keys to force AWS CLI to use OIDC
-            unset AWS_ACCESS_KEY_ID
-            unset AWS_SECRET_ACCESS_KEY
+            # This transformation should match the workspace_prefix set in terraform/pipeline/main.tf locals block
+            export SANITISED_CIRCLE_BRANCH=$(echo ${CIRCLE_BRANCH:0:30} | tr -c "[:alnum:]\n" "-" | tr "[:upper:]" "[:lower:]")
   initialise_terraform:
     description: "Set up the terraform backend for terraform jobs"
     steps:
-      - unset-keys
+      - sanitise-branch
       - run:
           name: Initialise terraform
           command: |
             # UNSET old keys to force AWS CLI to use OIDC
-            # unset AWS_ACCESS_KEY_ID
-            # unset AWS_SECRET_ACCESS_KEY
+            unset AWS_ACCESS_KEY_ID
+            unset AWS_SECRET_ACCESS_KEY
             # This transformation should match the workspace_prefix set in terraform/pipeline/main.tf locals block
-            export SANITISED_CIRCLE_BRANCH=$(echo ${CIRCLE_BRANCH:0:30} | tr -c "[:alnum:]\n" "-" | tr "[:upper:]" "[:lower:]")
+            # export SANITISED_CIRCLE_BRANCH=$(echo ${CIRCLE_BRANCH:0:30} | tr -c "[:alnum:]\n" "-" | tr "[:upper:]" "[:lower:]")
             cd terraform/pipeline
-            echo ${AWS_ENV}
             terraform init -input=false -backend-config=../${AWS_ENV}.s3.tfbackend
             terraform workspace select ${SANITISED_CIRCLE_BRANCH} || terraform workspace new ${SANITISED_CIRCLE_BRANCH}
 
@@ -63,6 +61,7 @@ jobs:
       - aws-cli/setup:
           role_arn: $AWS_ROLE_ARN
           region: $AWS_REGION
+      - sanitise-branch
       - run:
           name: Build Docker Images
           command: |
@@ -73,7 +72,7 @@ jobs:
             aws ecr get-login-password --region eu-west-2 | docker login -u AWS --password-stdin ${AWS_ACCOUNT_ID}.dkr.ecr.eu-west-2.amazonaws.com
             echo "Rebuilding lambdas and pushing to ECR."
             # Needed for docker-bake. This transformation should match the workspace_prefix set in terraform/pipeline/main.tf locals block
-            export SANITISED_CIRCLE_BRANCH=$(echo ${CIRCLE_BRANCH:0:30} | tr -c "[:alnum:]\n" "-" | tr "[:upper:]" "[:lower:]")
+            #export SANITISED_CIRCLE_BRANCH=$(echo ${CIRCLE_BRANCH:0:30} | tr -c "[:alnum:]\n" "-" | tr "[:upper:]" "[:lower:]")
             docker buildx bake all --push
 
   test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,15 +29,17 @@ commands:
     description: "Set up the terraform backend for terraform jobs"
     steps:
       # UNSET old keys to force AWS CLI to use OIDC
-      - run: |
-          unset AWS_ACCESS_KEY_ID
-          unset AWS_SECRET_ACCESS_KEY
-          # This transformation should match the workspace_prefix set in terraform/pipeline/main.tf locals block
-          export CIRCLE_BRANCH="<< pipeline.parameters.GHA_Meta >>"
-          export SANITISED_CIRCLE_BRANCH=$(echo ${CIRCLE_BRANCH:0:30} | tr -c '[:alnum:]\n' '-' | tr '[:upper:]' '[:lower:]')
-          cd terraform/pipeline
-          terraform init -input=false -backend-config=../${AWS_ENV}.s3.tfbackend
-          terraform workspace select ${SANITISED_CIRCLE_BRANCH} || terraform workspace new ${SANITISED_CIRCLE_BRANCH}
+      - run:
+          name: Initialise terraform
+          command: |
+            unset AWS_ACCESS_KEY_ID
+            unset AWS_SECRET_ACCESS_KEY
+            # This transformation should match the workspace_prefix set in terraform/pipeline/main.tf locals block
+            export CIRCLE_BRANCH="<< pipeline.parameters.GHA_Meta >>"
+            export SANITISED_CIRCLE_BRANCH=$(echo ${CIRCLE_BRANCH:0:30} | tr -c '[:alnum:]\n' '-' | tr '[:upper:]' '[:lower:]')
+            cd terraform/pipeline
+            terraform init -input=false -backend-config=../${AWS_ENV}.s3.tfbackend
+            terraform workspace select ${SANITISED_CIRCLE_BRANCH} || terraform workspace new ${SANITISED_CIRCLE_BRANCH}
 
 
 jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,6 +25,15 @@ orbs:
   aws-cli: circleci/aws-cli@5.4.1
 
 commands:
+  sanitise-branch:
+    description: "Create workspace prefix from CIRCLE BRANCH"
+    steps:
+      - run:
+          name: Sanitise branch
+          command: |
+            # This transformation should match the workspace_prefix set in terraform/pipeline/main.tf locals block
+            echo 'export SANITISED_CIRCLE_BRANCH=$(echo ${CIRCLE_BRANCH:0:30} | tr -c "[:alnum:]\n" "-" | tr "[:upper:]" "[:lower:]")' >> "$BASH_ENV"
+            source "$BASH_ENV"
   initialise_terraform:
     description: "Set up the terraform backend for terraform jobs"
     steps:
@@ -53,6 +62,7 @@ jobs:
       - aws-cli/setup:
           role_arn: $AWS_ROLE_ARN
           region: $AWS_REGION
+      - sanitise-branch
       - run:
           name: Build Docker Images
           command: |
@@ -63,7 +73,7 @@ jobs:
             aws ecr get-login-password --region eu-west-2 | docker login -u AWS --password-stdin ${AWS_ACCOUNT_ID}.dkr.ecr.eu-west-2.amazonaws.com
             echo "Rebuilding lambdas and pushing to ECR."
             # Needed for docker-bake. This transformation should match the workspace_prefix set in terraform/pipeline/main.tf locals block
-            export SANITISED_CIRCLE_BRANCH=$(echo ${CIRCLE_BRANCH:0:30} | tr -c "[:alnum:]\n" "-" | tr "[:upper:]" "[:lower:]")
+            # export SANITISED_CIRCLE_BRANCH=$(echo ${CIRCLE_BRANCH:0:30} | tr -c "[:alnum:]\n" "-" | tr "[:upper:]" "[:lower:]")
             docker buildx bake all --push
 
   test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,9 +37,10 @@ commands:
             # This transformation should match the workspace_prefix set in terraform/pipeline/main.tf locals block
             export SANITISED_CIRCLE_BRANCH=$(echo ${CIRCLE_BRANCH:0:30} | tr -c "[:alnum:]\n" "-" | tr "[:upper:]" "[:lower:]")
             cd terraform/pipeline
+            ls .
             terraform init -input=false -backend-config=../${AWS_ENV}.s3.tfbackend
-            echo SANITISED_CIRCLE_BRANCH
             terraform workspace select ${SANITISED_CIRCLE_BRANCH} || terraform workspace new ${SANITISED_CIRCLE_BRANCH}
+            ls .
 
 
 jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -138,6 +138,13 @@ jobs:
           role_arn: $AWS_ROLE_ARN
           region: $AWS_REGION
       - run:
+          name: copy terraform provider binaries
+          command: |
+            unset AWS_ACCESS_KEY_ID
+            unset AWS_SECRET_ACCESS_KEY
+            mkdir custom-terraform-plugins
+            aws s3 cp s3://${AWS_BINARY_BUCKET}/terraform-provider-aws_v6.15.0_x5.exe custom-terraform-plugins/terraform-provider-aws_v6.15.0_x5.exe
+      - run:
           name: terraform plan
           command: |
             unset AWS_ACCESS_KEY_ID
@@ -145,7 +152,7 @@ jobs:
             # This transformation should match the workspace_prefix set in terraform/pipeline/main.tf locals block
             export SANITISED_CIRCLE_BRANCH=$(echo ${CIRCLE_BRANCH:0:30} | tr -c '[:alnum:]\n' '-' | tr '[:upper:]' '[:lower:]')
             cd terraform/pipeline
-            terraform init -input=false -backend-config=../${AWS_ENV}.s3.tfbackend
+            terraform init -input=false -backend-config=../${AWS_ENV}.s3.tfbackend -plugin-dir=custom-terraform-plugins
             terraform workspace select ${SANITISED_CIRCLE_BRANCH} || terraform workspace new ${SANITISED_CIRCLE_BRANCH}
             terraform plan -out tfplan
       - store_artifacts:
@@ -195,7 +202,10 @@ jobs:
           command: |
             unset AWS_ACCESS_KEY_ID
             unset AWS_SECRET_ACCESS_KEY
+            export SANITISED_CIRCLE_BRANCH=$(echo ${CIRCLE_BRANCH:0:30} | tr -c '[:alnum:]\n' '-' | tr '[:upper:]' '[:lower:]')
             cd terraform/pipeline
+            terraform init -input=false -backend-config=../${AWS_ENV}.s3.tfbackend -plugin-dir=custom-terraform-plugins
+            terraform workspace select ${SANITISED_CIRCLE_BRANCH} || terraform workspace new ${SANITISED_CIRCLE_BRANCH}
             terraform apply -auto-approve tfplan
       - run:
           name: save pipeline resources bucket name

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -154,6 +154,7 @@ jobs:
             cd terraform/pipeline
             terraform init -input=false -backend-config=../${AWS_ENV}.s3.tfbackend -plugin-dir=custom-terraform-plugins
             terraform workspace select ${SANITISED_CIRCLE_BRANCH} || terraform workspace new ${SANITISED_CIRCLE_BRANCH}
+            terraform providers
             terraform plan -out tfplan
       - store_artifacts:
           path: terraform/pipeline/tfplan

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,9 +57,6 @@ jobs:
       SPARK_VERSION: "3.5"       # Required for pydeequ to initialize
     steps:
       - checkout
-      # - restore_cache:
-      #     keys:
-      #       - v1.2-uv-cache-{{ checksum "Pipfile.lock" }}
       - run:
           name: Install system packages
           command: |
@@ -68,17 +65,10 @@ jobs:
       - run:
           name: install dependencies
           command: uv pip install --system -r <(uvx pipenv requirements --dev)
-      # Pre-cache the pyqeequ dependency so xdist works better.
-      # - run:
-      #       name: Pre-cache Spark JARs
-      #       command: python scripts/fetch_spark_dependencies.py
-      # - save_cache:
-      #     key: v1.2-uv-cache-{{ checksum "Pipfile.lock" }}
-      #     paths:
-      #       - ~/.m2/repository
-      #       - ~/.ivy2/jars
-      #       - ~/.ivy2/cache
-      #       - ~/.cache/uv
+      # Download the pyqeequ dependency and configure.
+      - run:
+            name: Fetch Spark JARs
+            command: python scripts/fetch_spark_dependencies.py
       - run:
           name: Run unit tests and generate coverage
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,10 +37,9 @@ commands:
             # This transformation should match the workspace_prefix set in terraform/pipeline/main.tf locals block
             export SANITISED_CIRCLE_BRANCH=$(echo ${CIRCLE_BRANCH:0:30} | tr -c "[:alnum:]\n" "-" | tr "[:upper:]" "[:lower:]")
             cd terraform/pipeline
-            ls .
+            echo ${AWS_ENV}
             terraform init -input=false -backend-config=../${AWS_ENV}.s3.tfbackend
             terraform workspace select ${SANITISED_CIRCLE_BRANCH} || terraform workspace new ${SANITISED_CIRCLE_BRANCH}
-            ls .
 
 
 jobs:
@@ -149,7 +148,10 @@ jobs:
       - run:
           name: terraform plan
           command: |
+            unset AWS_ACCESS_KEY_ID
+            unset AWS_SECRET_ACCESS_KEY
             cd terraform/pipeline
+            echo ${AWS_ENV}
             terraform plan -out tfplan
       - store_artifacts:
           path: terraform/pipeline/tfplan
@@ -183,6 +185,8 @@ jobs:
       - run:
           name: terraform apply
           command: |
+            unset AWS_ACCESS_KEY_ID
+            unset AWS_SECRET_ACCESS_KEY
             cd terraform/pipeline
             terraform apply -auto-approve tfplan
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -198,6 +198,13 @@ jobs:
           role_arn: $AWS_ROLE_ARN
           region: $AWS_REGION
       - run:
+          name: copy terraform provider binaries
+          command: |
+            unset AWS_ACCESS_KEY_ID
+            unset AWS_SECRET_ACCESS_KEY
+            mkdir -p custom-terraform-plugins
+            aws s3 cp s3://${AWS_BINARY_BUCKET}/terraform-provider-aws_6.15.0_linux_amd64.zip custom-terraform-plugins/terraform-provider-aws_6.15.0_linux_amd64.zip
+      - run:
           name: terraform apply
           command: |
             unset AWS_ACCESS_KEY_ID

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,30 +27,18 @@ orbs:
 commands:
   initialise_terraform:
     description: "Set up the terraform backend for terraform jobs"
-    parameters:
-      access-key:
-        type: env_var_name
-        default: AWS_ACCESS_KEY
-      secret-key:
-        type: env_var_name
-        default: AWS_SECRET_KEY
-      circle-branch:
-        type: env_var_name
-        default: CIRCLE_BRANCH
-      aws-env:
-        type: env_var_name
-        default: AWS_ENV
     steps:
       # UNSET old keys to force AWS CLI to use OIDC
       - run:
           name: Initialise terraform
           command: |
-            unset parameters.access_key
-            unset parameters.secret_key
+            unset AWS_ACCESS_KEY_ID
+            unset AWS_SECRET_ACCESS_KEY
             # This transformation should match the workspace_prefix set in terraform/pipeline/main.tf locals block
-            export SANITISED_CIRCLE_BRANCH=$(echo ${parameters.circle-branch:0:30} | tr -c '[:alnum:]\n' '-' | tr '[:upper:]' '[:lower:]')
+            export CIRCLE_BRANCH="<< pipeline.parameters.GHA_Meta >>"
+            export SANITISED_CIRCLE_BRANCH=$(echo ${CIRCLE_BRANCH:0:30} | tr -c '[:alnum:]\n' '-' | tr '[:upper:]' '[:lower:]')
             cd terraform/pipeline
-            terraform init -input=false -backend-config=../${parameters.aws-env}.s3.tfbackend
+            terraform init -input=false -backend-config=../${AWS_ENV}.s3.tfbackend
             terraform workspace select ${SANITISED_CIRCLE_BRANCH} || terraform workspace new ${SANITISED_CIRCLE_BRANCH}
 
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,9 +57,9 @@ jobs:
       SPARK_VERSION: "3.5"       # Required for pydeequ to initialize
     steps:
       - checkout
-      - restore_cache:
-          keys:
-            - v1.2-uv-cache-{{ checksum "Pipfile.lock" }}
+      # - restore_cache:
+      #     keys:
+      #       - v1.2-uv-cache-{{ checksum "Pipfile.lock" }}
       - run:
           name: Install system packages
           command: |
@@ -72,13 +72,13 @@ jobs:
       - run:
             name: Pre-cache Spark JARs
             command: python scripts/fetch_spark_dependencies.py
-      - save_cache:
-          key: v1.2-uv-cache-{{ checksum "Pipfile.lock" }}
-          paths:
-            - ~/.m2/repository
-            - ~/.ivy2/jars
-            - ~/.ivy2/cache
-            - ~/.cache/uv
+      # - save_cache:
+      #     key: v1.2-uv-cache-{{ checksum "Pipfile.lock" }}
+      #     paths:
+      #       - ~/.m2/repository
+      #       - ~/.ivy2/jars
+      #       - ~/.ivy2/cache
+      #       - ~/.cache/uv
       - run:
           name: Run unit tests and generate coverage
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,14 +25,6 @@ orbs:
   aws-cli: circleci/aws-cli@5.4.1
 
 commands:
-  sanitise-branch:
-    description: "Create workspace prefix from CIRCLE BRANCH"
-    steps:
-      - run:
-          name: Sanitise branch
-          command: |
-            # This transformation should match the workspace_prefix set in terraform/pipeline/main.tf locals block
-            export SANITISED_CIRCLE_BRANCH=$(echo ${CIRCLE_BRANCH:0:30} | tr -c "[:alnum:]\n" "-" | tr "[:upper:]" "[:lower:]")
   initialise_terraform:
     description: "Set up the terraform backend for terraform jobs"
     steps:
@@ -44,7 +36,7 @@ commands:
             unset AWS_ACCESS_KEY_ID
             unset AWS_SECRET_ACCESS_KEY
             # This transformation should match the workspace_prefix set in terraform/pipeline/main.tf locals block
-            # export SANITISED_CIRCLE_BRANCH=$(echo ${CIRCLE_BRANCH:0:30} | tr -c "[:alnum:]\n" "-" | tr "[:upper:]" "[:lower:]")
+            export SANITISED_CIRCLE_BRANCH=$(echo ${CIRCLE_BRANCH:0:30} | tr -c "[:alnum:]\n" "-" | tr "[:upper:]" "[:lower:]")
             cd terraform/pipeline
             terraform init -input=false -backend-config=../${AWS_ENV}.s3.tfbackend
             terraform workspace select ${SANITISED_CIRCLE_BRANCH} || terraform workspace new ${SANITISED_CIRCLE_BRANCH}
@@ -61,7 +53,6 @@ jobs:
       - aws-cli/setup:
           role_arn: $AWS_ROLE_ARN
           region: $AWS_REGION
-      - sanitise-branch
       - run:
           name: Build Docker Images
           command: |
@@ -72,7 +63,7 @@ jobs:
             aws ecr get-login-password --region eu-west-2 | docker login -u AWS --password-stdin ${AWS_ACCOUNT_ID}.dkr.ecr.eu-west-2.amazonaws.com
             echo "Rebuilding lambdas and pushing to ECR."
             # Needed for docker-bake. This transformation should match the workspace_prefix set in terraform/pipeline/main.tf locals block
-            #export SANITISED_CIRCLE_BRANCH=$(echo ${CIRCLE_BRANCH:0:30} | tr -c "[:alnum:]\n" "-" | tr "[:upper:]" "[:lower:]")
+            export SANITISED_CIRCLE_BRANCH=$(echo ${CIRCLE_BRANCH:0:30} | tr -c "[:alnum:]\n" "-" | tr "[:upper:]" "[:lower:]")
             docker buildx bake all --push
 
   test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -142,8 +142,8 @@ jobs:
           command: |
             unset AWS_ACCESS_KEY_ID
             unset AWS_SECRET_ACCESS_KEY
-            mkdir -p hashicorp/aws/custom-terraform-plugins
-            aws s3 cp s3://${AWS_BINARY_BUCKET}/terraform-provider-aws_v6.15.0_x5.exe hashicorp/aws/custom-terraform-plugins/terraform-provider-aws_v6.15.0_x5.exe
+            mkdir -p custom-terraform-plugins
+            aws s3 cp s3://${AWS_BINARY_BUCKET}/terraform-provider-aws_6.15.0_linux_amd64.zip custom-terraform-plugins/terraform-provider-aws_6.15.0_linux_amd64.zip
       - run:
           name: terraform plan
           command: |
@@ -152,7 +152,7 @@ jobs:
             # This transformation should match the workspace_prefix set in terraform/pipeline/main.tf locals block
             export SANITISED_CIRCLE_BRANCH=$(echo ${CIRCLE_BRANCH:0:30} | tr -c '[:alnum:]\n' '-' | tr '[:upper:]' '[:lower:]')
             cd terraform/pipeline
-            terraform init -input=false -backend-config=../${AWS_ENV}.s3.tfbackend -plugin-dir=hashicorp/aws/custom-terraform-plugins
+            terraform init -input=false -backend-config=../${AWS_ENV}.s3.tfbackend -plugin-dir=custom-terraform-plugins
             terraform workspace select ${SANITISED_CIRCLE_BRANCH} || terraform workspace new ${SANITISED_CIRCLE_BRANCH}
             terraform plan -out tfplan
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,15 +25,25 @@ orbs:
   aws-cli: circleci/aws-cli@5.4.1
 
 commands:
-  initialise_terraform:
-    description: "Set up the terraform backend for terraform jobs"
+  unset-keys:
+    description: "UNSET old keys to force AWS CLI to use OIDC"
     steps:
       - run:
-          name: Initialise terraform
+          name: Unset keys
           command: |
             # UNSET old keys to force AWS CLI to use OIDC
             unset AWS_ACCESS_KEY_ID
             unset AWS_SECRET_ACCESS_KEY
+  initialise_terraform:
+    description: "Set up the terraform backend for terraform jobs"
+    steps:
+      - unset-keys
+      - run:
+          name: Initialise terraform
+          command: |
+            # UNSET old keys to force AWS CLI to use OIDC
+            # unset AWS_ACCESS_KEY_ID
+            # unset AWS_SECRET_ACCESS_KEY
             # This transformation should match the workspace_prefix set in terraform/pipeline/main.tf locals block
             export SANITISED_CIRCLE_BRANCH=$(echo ${CIRCLE_BRANCH:0:30} | tr -c "[:alnum:]\n" "-" | tr "[:upper:]" "[:lower:]")
             cd terraform/pipeline

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -149,7 +149,9 @@ jobs:
       - initialise_terraform
       - run:
           name: terraform plan
-          command: terraform plan -out tfplan
+          command: |
+            cd terraform/pipeline
+            terraform plan -out tfplan
       - store_artifacts:
           path: terraform/pipeline/tfplan
       - persist_to_workspace:
@@ -181,7 +183,9 @@ jobs:
       - initialise_terraform # Reinitialising terraform to reduce cost of persisting .terraform folder in workspace
       - run:
           name: terraform apply
-          command: terraform apply -auto-approve tfplan
+          command: |
+            cd terraform/pipeline
+            terraform apply -auto-approve tfplan
       - run:
           name: save pipeline resources bucket name
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,9 +69,9 @@ jobs:
           name: install dependencies
           command: uv pip install --system -r <(uvx pipenv requirements --dev)
       # Pre-cache the pyqeequ dependency so xdist works better.
-      - run:
-            name: Pre-cache Spark JARs
-            command: python scripts/fetch_spark_dependencies.py
+      # - run:
+      #       name: Pre-cache Spark JARs
+      #       command: python scripts/fetch_spark_dependencies.py
       # - save_cache:
       #     key: v1.2-uv-cache-{{ checksum "Pipfile.lock" }}
       #     paths:
@@ -154,15 +154,16 @@ jobs:
           root: .
           paths:
             # The workspace is intentionally limited to the Terraform plan file plus dependency folders to reduce CircleCI storage costs
-            # Needed for terraform deployment
+            # Needed for terraform apply step
             - terraform/pipeline/tfplan
-            # Needed for dependencies folder in s3
+            - lambdas
+            # Needed for deploy-dependencies step
             - utils
             - schemas
             - projects
             - environment
             - polars_utils
-            - lambdas
+
 
   terraform-apply:
     docker:
@@ -182,6 +183,7 @@ jobs:
             unset AWS_SECRET_ACCESS_KEY
             export SANITISED_CIRCLE_BRANCH=$(echo ${CIRCLE_BRANCH:0:30} | tr -c '[:alnum:]\n' '-' | tr '[:upper:]' '[:lower:]')
             cd terraform/pipeline
+            # Reinitialising terraform to reduce cost of persisting .terraform folder in workspace
             terraform init -input=false -backend-config=../${AWS_ENV}.s3.tfbackend
             terraform workspace select ${SANITISED_CIRCLE_BRANCH} || terraform workspace new ${SANITISED_CIRCLE_BRANCH}
             terraform apply -auto-approve tfplan

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -156,7 +156,21 @@ jobs:
             # The workspace is intentionally limited to the Terraform plan file plus dependency folders to reduce CircleCI storage costs
             # Needed for terraform deployment
             - terraform/pipeline/tfplan
-            - terraform/pipeline/.*
+            - terraform/pipeline/policy_documents/.*
+            - terraform/pipeline/step_functions/.*
+            - terraform/pipeline/ecr.tf
+            - terraform/pipeline/eventbridge.tf
+            - terraform/pipeline/fargate.tf
+            - terraform/pipeline/glue.tf
+            - terraform/pipeline/iam.tf
+            - terraform/pipeline/lambda.tf
+            - terraform/pipeline/main.tf
+            - terraform/pipeline/outputs.tf
+            - terraform/pipeline/parameter-store.tf
+            - terraform/pipeline/s3.tf
+            - terraform/pipeline/sns.tf
+            - terraform/pipeline/step-function.tf
+            - terraform/pipeline/variables.tf
             # Needed for dependencies folder in s3
             - utils
             - schemas

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,18 +27,30 @@ orbs:
 commands:
   initialise_terraform:
     description: "Set up the terraform backend for terraform jobs"
+    parameters:
+      access-key:
+        type: env_var_name
+        default: AWS_ACCESS_KEY
+      secret-key:
+        type: env_var_name
+        default: AWS_SECRET_KEY
+      circle-branch:
+        type: env_var_name
+        default: CIRCLE_BRANCH
+      aws-env:
+        type: env_var_name
+        default: AWS_ENV
     steps:
       # UNSET old keys to force AWS CLI to use OIDC
       - run:
           name: Initialise terraform
           command: |
-            unset AWS_ACCESS_KEY_ID
-            unset AWS_SECRET_ACCESS_KEY
+            unset parameters.access_key
+            unset parameters.secret_key
             # This transformation should match the workspace_prefix set in terraform/pipeline/main.tf locals block
-            export CIRCLE_BRANCH="<< pipeline.parameters.GHA_Meta >>"
-            export SANITISED_CIRCLE_BRANCH=$(echo ${CIRCLE_BRANCH:0:30} | tr -c '[:alnum:]\n' '-' | tr '[:upper:]' '[:lower:]')
+            export SANITISED_CIRCLE_BRANCH=$(echo ${parameters.circle-branch:0:30} | tr -c '[:alnum:]\n' '-' | tr '[:upper:]' '[:lower:]')
             cd terraform/pipeline
-            terraform init -input=false -backend-config=../${AWS_ENV}.s3.tfbackend
+            terraform init -input=false -backend-config=../${parameters.aws-env}.s3.tfbackend
             terraform workspace select ${SANITISED_CIRCLE_BRANCH} || terraform workspace new ${SANITISED_CIRCLE_BRANCH}
 
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -142,8 +142,8 @@ jobs:
           command: |
             unset AWS_ACCESS_KEY_ID
             unset AWS_SECRET_ACCESS_KEY
-            mkdir custom-terraform-plugins
-            aws s3 cp s3://${AWS_BINARY_BUCKET}/terraform-provider-aws_v6.15.0_x5.exe custom-terraform-plugins/terraform-provider-aws_v6.15.0_x5.exe
+            mkdir hashicorp/aws/custom-terraform-plugins
+            aws s3 cp s3://${AWS_BINARY_BUCKET}/terraform-provider-aws_v6.15.0_x5.exe hashicorp/aws/custom-terraform-plugins/terraform-provider-aws_v6.15.0_x5.exe
       - run:
           name: terraform plan
           command: |
@@ -152,8 +152,7 @@ jobs:
             # This transformation should match the workspace_prefix set in terraform/pipeline/main.tf locals block
             export SANITISED_CIRCLE_BRANCH=$(echo ${CIRCLE_BRANCH:0:30} | tr -c '[:alnum:]\n' '-' | tr '[:upper:]' '[:lower:]')
             cd terraform/pipeline
-            terraform providers
-            terraform init -input=false -backend-config=../${AWS_ENV}.s3.tfbackend -plugin-dir=custom-terraform-plugins
+            terraform init -input=false -backend-config=../${AWS_ENV}.s3.tfbackend -plugin-dir=hashicorp/aws/custom-terraform-plugins
             terraform workspace select ${SANITISED_CIRCLE_BRANCH} || terraform workspace new ${SANITISED_CIRCLE_BRANCH}
             terraform plan -out tfplan
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,15 +28,14 @@ commands:
   initialise_terraform:
     description: "Set up the terraform backend for terraform jobs"
     steps:
-      # UNSET old keys to force AWS CLI to use OIDC
       - run:
           name: Initialise terraform
           command: |
+            # UNSET old keys to force AWS CLI to use OIDC
             unset AWS_ACCESS_KEY_ID
             unset AWS_SECRET_ACCESS_KEY
             # This transformation should match the workspace_prefix set in terraform/pipeline/main.tf locals block
-            export CIRCLE_BRANCH="<< pipeline.parameters.GHA_Meta >>"
-            export SANITISED_CIRCLE_BRANCH=$(echo ${CIRCLE_BRANCH:0:30} | tr -c '[:alnum:]\n' '-' | tr '[:upper:]' '[:lower:]')
+            export SANITISED_CIRCLE_BRANCH=$(echo ${CIRCLE_BRANCH:0:30} | tr -c "[:alnum:]\n" "-" | tr "[:upper:]" "[:lower:]")
             cd terraform/pipeline
             terraform init -input=false -backend-config=../${AWS_ENV}.s3.tfbackend
             terraform workspace select ${SANITISED_CIRCLE_BRANCH} || terraform workspace new ${SANITISED_CIRCLE_BRANCH}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,6 +38,7 @@ commands:
             export SANITISED_CIRCLE_BRANCH=$(echo ${CIRCLE_BRANCH:0:30} | tr -c "[:alnum:]\n" "-" | tr "[:upper:]" "[:lower:]")
             cd terraform/pipeline
             terraform init -input=false -backend-config=../${AWS_ENV}.s3.tfbackend
+            echo SANITISED_CIRCLE_BRANCH
             terraform workspace select ${SANITISED_CIRCLE_BRANCH} || terraform workspace new ${SANITISED_CIRCLE_BRANCH}
 
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -138,13 +138,6 @@ jobs:
           role_arn: $AWS_ROLE_ARN
           region: $AWS_REGION
       - run:
-          name: copy terraform provider binaries
-          command: |
-            unset AWS_ACCESS_KEY_ID
-            unset AWS_SECRET_ACCESS_KEY
-            mkdir -p custom-terraform-plugins
-            aws s3 cp s3://${AWS_BINARY_BUCKET}/terraform-provider-aws_6.15.0_linux_amd64.zip custom-terraform-plugins/terraform-provider-aws_6.15.0_linux_amd64.zip
-      - run:
           name: terraform plan
           command: |
             unset AWS_ACCESS_KEY_ID
@@ -152,7 +145,7 @@ jobs:
             # This transformation should match the workspace_prefix set in terraform/pipeline/main.tf locals block
             export SANITISED_CIRCLE_BRANCH=$(echo ${CIRCLE_BRANCH:0:30} | tr -c '[:alnum:]\n' '-' | tr '[:upper:]' '[:lower:]')
             cd terraform/pipeline
-            terraform init -input=false -backend-config=../${AWS_ENV}.s3.tfbackend -plugin-dir=custom-terraform-plugins
+            terraform init -input=false -backend-config=../${AWS_ENV}.s3.tfbackend
             terraform workspace select ${SANITISED_CIRCLE_BRANCH} || terraform workspace new ${SANITISED_CIRCLE_BRANCH}
             terraform plan -out tfplan
       - store_artifacts:
@@ -198,20 +191,13 @@ jobs:
           role_arn: $AWS_ROLE_ARN
           region: $AWS_REGION
       - run:
-          name: copy terraform provider binaries
-          command: |
-            unset AWS_ACCESS_KEY_ID
-            unset AWS_SECRET_ACCESS_KEY
-            mkdir -p custom-terraform-plugins
-            aws s3 cp s3://${AWS_BINARY_BUCKET}/terraform-provider-aws_6.15.0_linux_amd64.zip custom-terraform-plugins/terraform-provider-aws_6.15.0_linux_amd64.zip
-      - run:
           name: terraform apply
           command: |
             unset AWS_ACCESS_KEY_ID
             unset AWS_SECRET_ACCESS_KEY
             export SANITISED_CIRCLE_BRANCH=$(echo ${CIRCLE_BRANCH:0:30} | tr -c '[:alnum:]\n' '-' | tr '[:upper:]' '[:lower:]')
             cd terraform/pipeline
-            terraform init -input=false -backend-config=../${AWS_ENV}.s3.tfbackend -plugin-dir=custom-terraform-plugins
+            terraform init -input=false -backend-config=../${AWS_ENV}.s3.tfbackend
             terraform workspace select ${SANITISED_CIRCLE_BRANCH} || terraform workspace new ${SANITISED_CIRCLE_BRANCH}
             terraform apply -auto-approve tfplan
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,7 +64,7 @@ jobs:
             aws ecr get-login-password --region eu-west-2 | docker login -u AWS --password-stdin ${AWS_ACCOUNT_ID}.dkr.ecr.eu-west-2.amazonaws.com
             echo "Rebuilding lambdas and pushing to ECR."
             # This transformation should match the workspace_prefix set in terraform/pipeline/main.tf locals block
-            export SANITISED_CIRCLE_BRANCH=$(echo ${CIRCLE_BRANCH:0:30} | tr -c '[:alnum:]\n' '-' | tr '[:upper:]' '[:lower:]')
+            # export SANITISED_CIRCLE_BRANCH=$(echo ${CIRCLE_BRANCH:0:30} | tr -c "[:alnum:]\n" "-" | tr "[:upper:]" "[:lower:]")
 
             docker buildx bake all --push
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -142,7 +142,7 @@ jobs:
           command: |
             unset AWS_ACCESS_KEY_ID
             unset AWS_SECRET_ACCESS_KEY
-            mkdir hashicorp/aws/custom-terraform-plugins
+            mkdir -p hashicorp/aws/custom-terraform-plugins
             aws s3 cp s3://${AWS_BINARY_BUCKET}/terraform-provider-aws_v6.15.0_x5.exe hashicorp/aws/custom-terraform-plugins/terraform-provider-aws_v6.15.0_x5.exe
       - run:
           name: terraform plan

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,9 +63,8 @@ jobs:
             # Authenticate Docker to ECR
             aws ecr get-login-password --region eu-west-2 | docker login -u AWS --password-stdin ${AWS_ACCOUNT_ID}.dkr.ecr.eu-west-2.amazonaws.com
             echo "Rebuilding lambdas and pushing to ECR."
-            # This transformation should match the workspace_prefix set in terraform/pipeline/main.tf locals block
-            # export SANITISED_CIRCLE_BRANCH=$(echo ${CIRCLE_BRANCH:0:30} | tr -c "[:alnum:]\n" "-" | tr "[:upper:]" "[:lower:]")
-
+            # Needed for docker-bake. This transformation should match the workspace_prefix set in terraform/pipeline/main.tf locals block
+            export SANITISED_CIRCLE_BRANCH=$(echo ${CIRCLE_BRANCH:0:30} | tr -c "[:alnum:]\n" "-" | tr "[:upper:]" "[:lower:]")
             docker buildx bake all --push
 
   test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,6 +24,21 @@ parameters:
 orbs:
   aws-cli: circleci/aws-cli@5.4.1
 
+commands:
+  initialise_terraform:
+    description: "Set up the terraform backend for terraform jobs"
+    steps:
+      - checkout
+      # UNSET old keys to force AWS CLI to use OIDC
+      - run: unset AWS_ACCESS_KEY_ID
+      - run: unset AWS_SECRET_ACCESS_KEY
+      # This transformation should match the workspace_prefix set in terraform/pipeline/main.tf locals block
+      - run: export SANITISED_CIRCLE_BRANCH=$(echo ${CIRCLE_BRANCH:0:30} | tr -c '[:alnum:]\n' '-' | tr '[:upper:]' '[:lower:]')
+      - run: cd terraform/pipeline
+      - run: terraform init -input=false -backend-config=../${AWS_ENV}.s3.tfbackend
+      - run: terraform workspace select ${SANITISED_CIRCLE_BRANCH} || terraform workspace new ${SANITISED_CIRCLE_BRANCH}
+
+
 jobs:
   task-containerisation:
     docker:
@@ -65,7 +80,7 @@ jobs:
       - run:
           name: install dependencies
           command: uv pip install --system -r <(uvx pipenv requirements --dev)
-      # Download the pyqeequ dependency and configure.
+      # Download the pydeequ dependency and configure.
       - run:
             name: Fetch Spark JARs
             command: python scripts/fetch_spark_dependencies.py
@@ -127,17 +142,10 @@ jobs:
       - aws-cli/setup:
           role_arn: $AWS_ROLE_ARN
           region: $AWS_REGION
+      - initialise_terraform
       - run:
           name: terraform plan
-          command: |
-            unset AWS_ACCESS_KEY_ID
-            unset AWS_SECRET_ACCESS_KEY
-            # This transformation should match the workspace_prefix set in terraform/pipeline/main.tf locals block
-            export SANITISED_CIRCLE_BRANCH=$(echo ${CIRCLE_BRANCH:0:30} | tr -c '[:alnum:]\n' '-' | tr '[:upper:]' '[:lower:]')
-            cd terraform/pipeline
-            terraform init -input=false -backend-config=../${AWS_ENV}.s3.tfbackend
-            terraform workspace select ${SANITISED_CIRCLE_BRANCH} || terraform workspace new ${SANITISED_CIRCLE_BRANCH}
-            terraform plan -out tfplan
+          command: terraform plan -out tfplan
       - store_artifacts:
           path: terraform/pipeline/tfplan
       - persist_to_workspace:
@@ -166,17 +174,10 @@ jobs:
       - aws-cli/setup:
           role_arn: $AWS_ROLE_ARN
           region: $AWS_REGION
+      - initialise_terraform # Reinitialising terraform to reduce cost of persisting .terraform folder in workspace
       - run:
           name: terraform apply
-          command: |
-            unset AWS_ACCESS_KEY_ID
-            unset AWS_SECRET_ACCESS_KEY
-            export SANITISED_CIRCLE_BRANCH=$(echo ${CIRCLE_BRANCH:0:30} | tr -c '[:alnum:]\n' '-' | tr '[:upper:]' '[:lower:]')
-            cd terraform/pipeline
-            # Reinitialising terraform to reduce cost of persisting .terraform folder in workspace
-            terraform init -input=false -backend-config=../${AWS_ENV}.s3.tfbackend
-            terraform workspace select ${SANITISED_CIRCLE_BRANCH} || terraform workspace new ${SANITISED_CIRCLE_BRANCH}
-            terraform apply -auto-approve tfplan
+          command: terraform apply -auto-approve tfplan
       - run:
           name: save pipeline resources bucket name
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,19 +25,9 @@ orbs:
   aws-cli: circleci/aws-cli@5.4.1
 
 commands:
-  sanitise-branch:
-    description: "Create workspace prefix from CIRCLE BRANCH"
-    steps:
-      - run:
-          name: Sanitise branch
-          command: |
-            # This transformation should match the workspace_prefix set in terraform/pipeline/main.tf locals block
-            echo 'export SANITISED_CIRCLE_BRANCH=$(echo ${CIRCLE_BRANCH:0:30} | tr -c "[:alnum:]\n" "-" | tr "[:upper:]" "[:lower:]")' >> "$BASH_ENV"
-            source "$BASH_ENV"
   initialise_terraform:
     description: "Set up the terraform backend for terraform jobs"
     steps:
-      - sanitise-branch
       - run:
           name: Initialise terraform
           command: |
@@ -62,7 +52,6 @@ jobs:
       - aws-cli/setup:
           role_arn: $AWS_ROLE_ARN
           region: $AWS_REGION
-      - sanitise-branch
       - run:
           name: Build Docker Images
           command: |
@@ -73,7 +62,7 @@ jobs:
             aws ecr get-login-password --region eu-west-2 | docker login -u AWS --password-stdin ${AWS_ACCOUNT_ID}.dkr.ecr.eu-west-2.amazonaws.com
             echo "Rebuilding lambdas and pushing to ECR."
             # Needed for docker-bake. This transformation should match the workspace_prefix set in terraform/pipeline/main.tf locals block
-            # export SANITISED_CIRCLE_BRANCH=$(echo ${CIRCLE_BRANCH:0:30} | tr -c "[:alnum:]\n" "-" | tr "[:upper:]" "[:lower:]")
+            export SANITISED_CIRCLE_BRANCH=$(echo ${CIRCLE_BRANCH:0:30} | tr -c "[:alnum:]\n" "-" | tr "[:upper:]" "[:lower:]")
             docker buildx bake all --push
 
   test:
@@ -161,7 +150,6 @@ jobs:
             unset AWS_ACCESS_KEY_ID
             unset AWS_SECRET_ACCESS_KEY
             cd terraform/pipeline
-            echo ${AWS_ENV}
             terraform plan -out tfplan
       - store_artifacts:
           path: terraform/pipeline/tfplan

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,7 +75,7 @@ All notable changes to this project will be documented in this file.
 
 - Corrected datasets in SLV pipeline that need switching between main and dev in terraform.
 
-- Optimised persistant storage in CircleCI.
+- Optimised persistent storage in CircleCI.
 
 - Added missing lambda folder to deployment.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,7 +75,7 @@ All notable changes to this project will be documented in this file.
 
 - Corrected datasets in SLV pipeline that need switching between main and dev in terraform.
 
-- Reduced persistant storage in CircleCI.
+- Optimised persistant storage in CircleCI.
 
 - Added missing lambda folder to deployment.
 


### PR DESCRIPTION
## Description
Trello ticket [#1772](https://trello.com/c/oNDKGIvH/1772-circleci-stuff)

- Removed caching of spark jars. This did not affect performance of the test job.
- Remove persisting to workspace of .terraform folder and .tf files. Instead, reinitialise terraform in apply step.
- Abstract terraform initialisation steps into single command.
- TFplan still persisted to make consistant changes.

New storage usage per deployment:
- cache - negligable
- artifacts ~500KB
- workspace ~1MB

## Testing
- [x] Unit tests passing
- [x] Successful [CircleCI run](https://app.circleci.com/pipelines/github/NMDSdevopsServiceAdm/DataEngineering?branch=1772-rm-bin)

## Checklist (delete if not relevant)
- [x] Updated CHANGELOG
- [x] Code reviewed by AI
- [x] Moved Trello ticket to PR column

## Reviewer checklist
- [ ] PR solves the Trello ticket requirements
- [ ] Outputs appear reasonable and understandable
- [ ] The overall approach is appropriate and not over-engineered
- [ ] No obvious scalability, performance or interdependency concerns
- [ ] Tests appropriately cover the main behaviour/edge cases
- [ ] Naming and structure are broadly understandable and consistent
- [ ] Docstrings are sufficient for future maintenance
- [ ] Docstrings cover non-obvious behaviour
