### PR TITLE
1732 - Pull metadata cols into merge job

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,8 @@ All notable changes to this project will be documented in this file.
 
 - National care work thresholds removed from job role estimates validation.
 
+- Pull metadata columns into merge job within SLV pipeline.
+
 ### Fixed
 - Replace the all roles and all job groups functions with the appropriate categorical values attribute.
 

--- a/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/_01_merge.py
+++ b/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/_01_merge.py
@@ -25,13 +25,6 @@ metadata_columns_schema = {
     IndCQC.ascwds_filled_posts_dedup_clean: pl.Float32,
     IndCQC.ascwds_pir_merged: pl.Float32,
     IndCQC.ascwds_filtering_rule: pl.Categorical,
-    IndCQC.current_ons_import_date: pl.Date,
-    IndCQC.current_cssr: pl.Categorical,
-    IndCQC.current_region: pl.Categorical,
-    IndCQC.current_icb: pl.Categorical,
-    IndCQC.current_rural_urban_indicator_2011: pl.Categorical,
-    IndCQC.current_lsoa21: pl.Categorical,
-    IndCQC.current_msoa21: pl.Categorical,
     IndCQC.estimate_filled_posts_source: CatColType.EstimatesFilledPostSourceEnumType,
 }
 

--- a/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/_01_merge.py
+++ b/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/_01_merge.py
@@ -2,30 +2,27 @@ import polars as pl
 
 import projects._07_workforce_characteristics._01_starters_leavers_vacancies.fargate.utils.merge_utils as mUtils
 from polars_utils import utils
-from projects._03_independent_cqc._07_estimate_filled_posts_by_job_role.fargate.utils.utils import (
-    CategoricalColumnTypes as CatColType,
-)
 from utils.column_names.ind_cqc_pipeline_columns import IndCqcColumns as IndCQC
 
-metadata_columns_schema = {
-    IndCQC.id_per_locationid_import_date: pl.Int64,
-    IndCQC.name: str,
-    IndCQC.provider_id: CatColType.ProviderCatType,
-    IndCQC.brand_id: CatColType.BrandCatType,
-    IndCQC.services_offered: pl.List(str),
-    IndCQC.primary_service_type_second_level: pl.Categorical,
-    IndCQC.care_home: pl.Categorical,
-    IndCQC.dormancy: pl.Categorical,
-    IndCQC.number_of_beds: pl.Int16,
-    IndCQC.imputed_registration_date: pl.Date,
-    IndCQC.ascwds_workplace_import_date: pl.Date,
-    IndCQC.establishment_id: CatColType.EstablishmentCatType,
-    IndCQC.organisation_id: str,
-    IndCQC.worker_records_bounded: pl.Int16,
-    IndCQC.ascwds_filled_posts_dedup_clean: pl.Float32,
-    IndCQC.ascwds_pir_merged: pl.Float32,
-    IndCQC.ascwds_filtering_rule: pl.Categorical,
-    IndCQC.estimate_filled_posts_source: CatColType.EstimatesFilledPostSourceEnumType,
+metadata_columns = {
+    IndCQC.id_per_locationid_import_date,
+    IndCQC.name,
+    IndCQC.provider_id,
+    IndCQC.brand_id,
+    IndCQC.services_offered,
+    IndCQC.primary_service_type_second_level,
+    IndCQC.care_home,
+    IndCQC.dormancy,
+    IndCQC.number_of_beds,
+    IndCQC.imputed_registration_date,
+    IndCQC.ascwds_workplace_import_date,
+    IndCQC.establishment_id,
+    IndCQC.organisation_id,
+    IndCQC.worker_records_bounded,
+    IndCQC.ascwds_filled_posts_dedup_clean,
+    IndCQC.ascwds_pir_merged,
+    IndCQC.ascwds_filtering_rule,
+    IndCQC.estimate_filled_posts_source,
 }
 
 
@@ -48,7 +45,7 @@ def main(
     # mUtils.create_list_of_cols_for_ascwds()
 
     metadata_lf = utils.scan_parquet(
-        source=metadata_source, schema=metadata_columns_schema
+        source=metadata_source, selected_columns=metadata_columns
     )
     job_role_estimates_lf = utils.scan_parquet(job_role_estimates_source)
     cleaned_ascwds_workplace_lf = utils.scan_parquet(cleaned_ascwds_workplace_source)

--- a/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/_01_merge.py
+++ b/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/_01_merge.py
@@ -1,5 +1,39 @@
+import polars as pl
+
 import projects._07_workforce_characteristics._01_starters_leavers_vacancies.fargate.utils.merge_utils as mUtils
 from polars_utils import utils
+from projects._03_independent_cqc._07_estimate_filled_posts_by_job_role.fargate.utils.utils import (
+    CategoricalColumnTypes as CatColType,
+)
+from utils.column_names.ind_cqc_pipeline_columns import IndCqcColumns as IndCQC
+
+metadata_columns_schema = {
+    IndCQC.id_per_locationid_import_date: pl.Int64,
+    IndCQC.name: str,
+    IndCQC.provider_id: CatColType.ProviderCatType,
+    IndCQC.brand_id: CatColType.BrandCatType,
+    IndCQC.services_offered: pl.List(str),
+    IndCQC.primary_service_type_second_level: pl.Categorical,
+    IndCQC.care_home: pl.Categorical,
+    IndCQC.dormancy: pl.Categorical,
+    IndCQC.number_of_beds: pl.Int16,
+    IndCQC.imputed_registration_date: pl.Date,
+    IndCQC.ascwds_workplace_import_date: pl.Date,
+    IndCQC.establishment_id: CatColType.EstablishmentCatType,
+    IndCQC.organisation_id: str,
+    IndCQC.worker_records_bounded: pl.Int16,
+    IndCQC.ascwds_filled_posts_dedup_clean: pl.Float32,
+    IndCQC.ascwds_pir_merged: pl.Float32,
+    IndCQC.ascwds_filtering_rule: pl.Categorical,
+    IndCQC.current_ons_import_date: pl.Date,
+    IndCQC.current_cssr: pl.Categorical,
+    IndCQC.current_region: pl.Categorical,
+    IndCQC.current_icb: pl.Categorical,
+    IndCQC.current_rural_urban_indicator_2011: pl.Categorical,
+    IndCQC.current_lsoa21: pl.Categorical,
+    IndCQC.current_msoa21: pl.Categorical,
+    IndCQC.estimate_filled_posts_source: CatColType.EstimatesFilledPostSourceEnumType,
+}
 
 
 def main(
@@ -20,7 +54,9 @@ def main(
     # TODO: Placeholder only
     # mUtils.create_list_of_cols_for_ascwds()
 
-    metadata_lf = utils.scan_parquet(metadata_source)
+    metadata_lf = utils.scan_parquet(
+        source=metadata_source, schema=metadata_columns_schema
+    )
     job_role_estimates_lf = utils.scan_parquet(job_role_estimates_source)
     cleaned_ascwds_workplace_lf = utils.scan_parquet(cleaned_ascwds_workplace_source)
 

--- a/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/tests/fargate/test_01_merge.py
+++ b/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/tests/fargate/test_01_merge.py
@@ -37,7 +37,7 @@ class MainTests(unittest.TestCase):
         assert len(scan_parquet_mock.call_args_list) == 3
 
         scan_calls = [
-            call(self.METADATA_SOURCE),
+            call(source=self.METADATA_SOURCE, schema=job.metadata_columns_schema),
             call(self.JOB_ROLE_ESTIMATES_SOURCE),
             call(self.CLEANED_ASCWDS_WORKPLACE_SOURCE),
         ]

--- a/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/tests/fargate/test_01_merge.py
+++ b/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/tests/fargate/test_01_merge.py
@@ -37,7 +37,7 @@ class MainTests(unittest.TestCase):
         assert len(scan_parquet_mock.call_args_list) == 3
 
         scan_calls = [
-            call(source=self.METADATA_SOURCE, schema=job.metadata_columns_schema),
+            call(source=self.METADATA_SOURCE, selected_columns=job.metadata_columns),
             call(self.JOB_ROLE_ESTIMATES_SOURCE),
             call(self.CLEANED_ASCWDS_WORKPLACE_SOURCE),
         ]


### PR DESCRIPTION
## Description
Trello ticket [#1732](https://trello.com/c/j36FM7BK)

Pull metadata cols into merge job. I did not bring the geography columns in as io thought we wont need them in SLV job. If we need them we can bring/join at the end from metadata parquet files.

## Testing
- [x] Unit tests passing
- [x] Successful [Step Function run](https://eu-west-2.console.aws.amazon.com/states/home?region=eu-west-2#/v2/executions/details/arn:aws:states:eu-west-2:856699698263:execution:1732-slv-mrg-mtdta-Ind-CQC-SLV:1e4a3e6d-990d-4746-8e5f-cdc1044b3a65)

## Checklist (delete if not relevant)
- [x] Unit tests added/amended
- [x] Docstrings added/updated
- [x] Updated CHANGELOG
- [x] Code reviewed by AI
- [x] Moved Trello ticket to PR column

## Reviewer checklist
- [ ] PR solves the Trello ticket requirements
- [ ] Outputs appear reasonable and understandable
- [ ] The overall approach is appropriate and not over-engineered
- [ ] No obvious scalability, performance or interdependency concerns
- [ ] Tests appropriately cover the main behaviour/edge cases
- [ ] Naming and structure are broadly understandable and consistent
- [ ] Docstrings are sufficient for future maintenance
- [ ] Docstrings cover non-obvious behaviour
