### PR TITLE
1762 - Replace .over() window functions with streaming-friendly join and group-by

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,9 @@ All notable changes to this project will be documented in this file.
 
 
 ### Changed
-
 - Pull clean workplace columns into merge job within SLV pipeline.
+
+- Replaced Polars .over() usages (not supported by Polars' streaming engine) with join-based equivalents.
 
 ### Fixed
 

--- a/projects/_03_independent_cqc/_03_impute/fargate/impute_ind_cqc_ascwds_and_pir.py
+++ b/projects/_03_independent_cqc/_03_impute/fargate/impute_ind_cqc_ascwds_and_pir.py
@@ -156,31 +156,53 @@ def main(cleaned_ind_cqc_source: str, destination: str) -> None:
 
 
 def calculate_rolling_average(
+    lf: pl.LazyFrame,
     column_to_average: str,
     period: str,
     columns_to_partition_by: list,
-) -> pl.Expr:
+    new_column_name: str,
+) -> pl.LazyFrame:
     """
     Calculate the rolling mean of the "column_to_average" over a given period
-    and partition.
+    and partition, and join the result back onto the input LazyFrame.
 
     This function calculates the rolling mean of a column based on a given
-    number of days and a column to partition by. For example, a 3-day rolling
+    number of days and columns to partition by. For example, a 3-day rolling
     average includes the current day plus the two preceding days.
 
+    A frame-level rolling group-by (rather than `pl.mean().rolling().over()`)
+    is used because `.over()` is not supported by the Polars streaming
+    engine. Rolling group-by returns one row per contributing source row, so
+    `.unique()` is used to deduplicate to one row per partition and import
+    date before joining back onto the input LazyFrame.
+
     Args:
+        lf (pl.LazyFrame): The input LazyFrame containing column_to_average.
         column_to_average (str): The name of the column with the values to average.
-        period (str): period (str): String language timedelta. See:
+        period (str): String language timedelta. See:
           https://docs.pola.rs/api/python/stable/reference/dataframe/api/polars.DataFrame.rolling.html
-        columns_to_partition_by (list): The name of the column to partition the window by.
+        columns_to_partition_by (list): The names of the columns to partition the window by.
+        new_column_name (str): The name of the new column to store the rolling mean in.
 
     Returns:
-        pl.Expr: Expression for rolling mean of column_to_average.
+        pl.LazyFrame: The input LazyFrame with new_column_name added, containing
+            the rolling mean of column_to_average.
     """
-    return (
-        pl.mean(column_to_average)
-        .rolling(index_column=IndCQC.cqc_location_import_date, period=period)
-        .over(columns_to_partition_by)
+    rolling_average_lf = (
+        lf.sort(columns_to_partition_by + [IndCQC.cqc_location_import_date])
+        .rolling(
+            index_column=IndCQC.cqc_location_import_date,
+            period=period,
+            group_by=columns_to_partition_by,
+        )
+        .agg(pl.mean(column_to_average).alias(new_column_name))
+        .unique(columns_to_partition_by + [IndCQC.cqc_location_import_date])
+    )
+
+    return lf.join(
+        rolling_average_lf,
+        on=columns_to_partition_by + [IndCQC.cqc_location_import_date],
+        how="left",
     )
 
 

--- a/projects/_03_independent_cqc/_03_impute/fargate/utils/primary_service_rate_of_change.py
+++ b/projects/_03_independent_cqc/_03_impute/fargate/utils/primary_service_rate_of_change.py
@@ -114,14 +114,26 @@ def model_primary_service_rate_of_change_trendline(
         .alias(TempCol.current_period_interpolated)
     )
 
-    roc_lf = roc_lf.with_columns(
-        pl.col(TempCol.current_period_interpolated)
-        .sort_by(IndCqc.cqc_location_import_date)
-        .shift(1)
-        .over(IndCqc.location_id)
-        .cast(pl.Float32)
-        .alias(TempCol.previous_period_interpolated)
+    roc_lf = roc_lf.sort(IndCqc.cqc_location_import_date)
+
+    previous_period_lf = roc_lf.select(
+        IndCqc.location_id,
+        IndCqc.cqc_location_import_date,
+        pl.col(TempCol.current_period_interpolated).alias(
+            TempCol.previous_period_interpolated
+        ),
     )
+
+    # A backward as-of join (excluding exact date matches) is used instead of
+    # `.over()`, because `.over()` is not supported by the Polars streaming
+    # engine.
+    roc_lf = roc_lf.join_asof(
+        previous_period_lf,
+        on=IndCqc.cqc_location_import_date,
+        by=IndCqc.location_id,
+        strategy="backward",
+        allow_exact_matches=False,
+    ).with_columns(pl.col(TempCol.previous_period_interpolated).cast(pl.Float32))
 
     roc_lf = clean_non_residential_rate_of_change(roc_lf)
 
@@ -329,9 +341,12 @@ def calculate_trendline(
     calculated by taking the exponential of the sum of the logarithms of the
     values.
 
-    The input rows are sorted by the grouping columns and import date before the
-    cumulative sum is computed. This ensures stable and deterministic trendline
-    values even when input rows arrive out of order.
+    The input rows are sorted by the grouping columns and import date, then
+    aggregated into one list per group so the cumulative sum can be computed
+    per group via `list.eval` and exploded back out. This is used instead of
+    `cum_sum().over()` because `.over()` is not supported by the Polars
+    streaming engine. This ensures stable and deterministic trendline values
+    even when input rows arrive out of order.
 
     Args:
         lf (pl.LazyFrame): The input LazyFrame.
@@ -343,10 +358,13 @@ def calculate_trendline(
     """
     rate_col = IndCqc.single_period_rate_of_change
 
-    rolling_product = pl.col(rate_col).log().cum_sum().over(group_cols).exp()
-
     return (
         lf.sort(group_cols + [IndCqc.cqc_location_import_date])
-        .with_columns(rolling_product.alias(out_col))
-        .drop(rate_col)
+        .group_by(group_cols, maintain_order=True)
+        .agg(
+            pl.col(IndCqc.cqc_location_import_date),
+            pl.col(rate_col).log().alias(out_col),
+        )
+        .with_columns(pl.col(out_col).list.eval(pl.element().cum_sum().exp()))
+        .explode(IndCqc.cqc_location_import_date, out_col)
     )

--- a/projects/_03_independent_cqc/_03_impute/tests/fargate/test_impute_ind_cqc_ascwds_and_pir.py
+++ b/projects/_03_independent_cqc/_03_impute/tests/fargate/test_impute_ind_cqc_ascwds_and_pir.py
@@ -70,12 +70,12 @@ class CalculateRollingAverageTests(unittest.TestCase):
             orient="row",
         )
         test_lf = expected_lf.drop(IndCQC.posts_rolling_average_model)
-        returned_lf = test_lf.with_columns(
-            job.calculate_rolling_average(
-                column_to_average=IndCQC.ascwds_filled_posts_dedup_clean,
-                period=Data.test_rolling_average_period,
-                columns_to_partition_by=[IndCQC.location_id],
-            ).alias(IndCQC.posts_rolling_average_model)
+        returned_lf = job.calculate_rolling_average(
+            test_lf,
+            column_to_average=IndCQC.ascwds_filled_posts_dedup_clean,
+            period=Data.test_rolling_average_period,
+            columns_to_partition_by=[IndCQC.location_id],
+            new_column_name=IndCQC.posts_rolling_average_model,
         )
 
-        pl_testing.assert_frame_equal(returned_lf, expected_lf)
+        pl_testing.assert_frame_equal(returned_lf, expected_lf, check_row_order=False)

--- a/projects/_03_independent_cqc/utils/imputation/extrapolation.py
+++ b/projects/_03_independent_cqc/utils/imputation/extrapolation.py
@@ -70,12 +70,8 @@ def model_extrapolation(
     )
 
     # Get last observed values
-    lf = lf.with_columns(
-        [
-            get_previous_value(column_with_null_values).alias(TEMP.previous_value),
-            get_previous_value(TEMP.model_with_nulls).alias(TEMP.previous_model),
-        ]
-    )
+    lf = get_previous_value(lf, column_with_null_values, TEMP.previous_value)
+    lf = get_previous_value(lf, TEMP.model_with_nulls, TEMP.previous_model)
 
     expr = ExtrapolationCalculationExpressions(model_to_extrapolate_from)
 
@@ -147,29 +143,45 @@ def build_extrapolation_aggregates(
     )
 
 
-def get_previous_value(col: str) -> pl.Expr:
+def get_previous_value(
+    lf: pl.LazyFrame, col: str, new_column_name: str
+) -> pl.LazyFrame:
     """
-    Generate an expression for the previous observed non-null value within a group.
+    Joins on the previous observed non-null value of `col` within each
+    `location_id` group.
 
-    This expression forward-fills null values within each `location_id` group,
-    then shifts the result by one row to obtain the most recent prior observed value.
+    This uses a backward as-of join against the non-null rows of `col`
+    (excluding exact date matches) to find the most recent prior observed
+    value within each `location_id` group. An as-of join is used instead of
+    `.over()` because `.over()` is not supported by the Polars streaming
+    engine.
 
     It is used to support forward extrapolation, where the last known value
     prior to a gap is required.
 
     Args:
+        lf (pl.LazyFrame): Input LazyFrame containing time series data.
         col (str): Name of the column to compute previous values for.
+        new_column_name (str): Name of the column to store the previous
+            value in.
 
     Returns:
-        pl.Expr: Polars expression representing the previous observed value
-        within each `location_id` group.
+        pl.LazyFrame: The input LazyFrame with `new_column_name` added,
+            containing the previous observed value of `col` within each
+            `location_id` group.
     """
-    return (
-        pl.col(col)
-        .sort_by(IMPORT_DATE)
-        .fill_null(strategy="forward")
-        .shift(1)
-        .over(IndCqc.location_id, order_by=IMPORT_DATE)
+    previous_values = (
+        lf.filter(pl.col(col).is_not_null())
+        .select(IndCqc.location_id, IMPORT_DATE, pl.col(col).alias(new_column_name))
+        .sort(IMPORT_DATE)
+    )
+
+    return lf.sort(IMPORT_DATE).join_asof(
+        previous_values,
+        on=IMPORT_DATE,
+        by=IndCqc.location_id,
+        strategy="backward",
+        allow_exact_matches=False,
     )
 
 

--- a/projects/_03_independent_cqc/utils/imputation/interpolation.py
+++ b/projects/_03_independent_cqc/utils/imputation/interpolation.py
@@ -98,8 +98,12 @@ def calculate_residuals(
     second_column).
 
     This function computes the residual between two non-null values in the
-    specified columns, then backward fills the residual into rows where
-    either of the specified columns are null.
+    specified columns, then joins that residual onto rows where either of the
+    specified columns are null, using the next available residual within the
+    same `location_id` group.
+
+    A forward as-of join is used instead of `.over()` because `.over()` is
+    not supported by the Polars streaming engine.
 
     Args:
         lf (pl.LazyFrame): The input LazyFrame containing the data.
@@ -110,16 +114,26 @@ def calculate_residuals(
         pl.LazyFrame: The LazyFrame with the calculated residuals in a new
             column.
     """
-    lf = lf.sort([IndCqc.location_id, IndCqc.cqc_location_import_date])
+    lf = lf.sort(IndCqc.cqc_location_import_date)
 
-    residual_expr = pl.when(
-        pl.col(first_column).is_not_null() & pl.col(second_column).is_not_null()
-    ).then(pl.col(first_column) - pl.col(second_column))
-
-    lf = lf.with_columns(
-        residual_expr.backward_fill().over(IndCqc.location_id).alias(IndCqc.residual)
+    residuals = (
+        lf.filter(
+            pl.col(first_column).is_not_null() & pl.col(second_column).is_not_null()
+        )
+        .select(
+            IndCqc.location_id,
+            IndCqc.cqc_location_import_date,
+            (pl.col(first_column) - pl.col(second_column)).alias(IndCqc.residual),
+        )
+        .sort(IndCqc.cqc_location_import_date)
     )
-    return lf
+
+    return lf.join_asof(
+        residuals,
+        on=IndCqc.cqc_location_import_date,
+        by=IndCqc.location_id,
+        strategy="forward",
+    )
 
 
 def calculate_proportion_of_days_between_submissions(
@@ -128,6 +142,12 @@ def calculate_proportion_of_days_between_submissions(
     """
     Calculates the proportion of days between consecutive non-null values
     based on cqc_location_import_date.
+
+    The previous and next submission dates for each row are found using
+    backward and forward as-of joins (within each `location_id` group)
+    against the rows where `column_with_null_values` is not null, instead of
+    `.over()`, because `.over()` is not supported by the Polars streaming
+    engine.
 
     Args:
         lf (pl.LazyFrame): The input LazyFrame containing the data.
@@ -139,18 +159,41 @@ def calculate_proportion_of_days_between_submissions(
             (days_between_submissions and proportion_of_days_between_submissions)
             added.
     """
-    lf = lf.sort([IndCqc.location_id, IndCqc.cqc_location_import_date])
-    val_not_null_date = pl.when(pl.col(column_with_null_values).is_not_null()).then(
-        pl.col(IndCqc.cqc_location_import_date)
+    previous_submission_date = "previous_submission_date"
+    next_submission_date = "next_submission_date"
+
+    lf = lf.sort(IndCqc.cqc_location_import_date)
+
+    submission_dates = (
+        lf.filter(pl.col(column_with_null_values).is_not_null())
+        .select(IndCqc.location_id, IndCqc.cqc_location_import_date)
+        .sort(IndCqc.cqc_location_import_date)
     )
-    previous_submission_date = val_not_null_date.forward_fill().over(IndCqc.location_id)
-    next_submission_date = val_not_null_date.backward_fill().over(IndCqc.location_id)
+
+    lf = lf.join_asof(
+        submission_dates.rename(
+            {IndCqc.cqc_location_import_date: previous_submission_date}
+        ),
+        left_on=IndCqc.cqc_location_import_date,
+        right_on=previous_submission_date,
+        by=IndCqc.location_id,
+        strategy="backward",
+    )
+    lf = lf.join_asof(
+        submission_dates.rename(
+            {IndCqc.cqc_location_import_date: next_submission_date}
+        ),
+        left_on=IndCqc.cqc_location_import_date,
+        right_on=next_submission_date,
+        by=IndCqc.location_id,
+        strategy="forward",
+    )
 
     condition = pl.col(IndCqc.cqc_location_import_date).is_between(
-        previous_submission_date, next_submission_date, "none"
+        pl.col(previous_submission_date), pl.col(next_submission_date), "none"
     )
     days_between_values = (
-        next_submission_date - previous_submission_date
+        pl.col(next_submission_date) - pl.col(previous_submission_date)
     ).dt.total_days()
 
     lf = lf.with_columns(
@@ -160,13 +203,14 @@ def calculate_proportion_of_days_between_submissions(
         pl.when(condition)
         .then(
             (
-                pl.col(IndCqc.cqc_location_import_date) - previous_submission_date
+                pl.col(IndCqc.cqc_location_import_date)
+                - pl.col(previous_submission_date)
             ).dt.total_days()
             / days_between_values
         )
         .alias(IndCqc.proportion_of_days_between_submissions),
     )
-    return lf
+    return lf.drop(previous_submission_date, next_submission_date)
 
 
 def calculate_interpolated_values(

--- a/projects/_03_independent_cqc/utils/imputation/interpolation.py
+++ b/projects/_03_independent_cqc/utils/imputation/interpolation.py
@@ -2,6 +2,9 @@ from typing import Optional
 
 import polars as pl
 
+from projects._03_independent_cqc.utils.imputation.extrapolation import (
+    get_previous_value,
+)
 from utils.column_names.ind_cqc_pipeline_columns import IndCqcColumns as IndCqc
 
 
@@ -53,16 +56,8 @@ def model_interpolation(
         )
 
     elif method == "straight":
-        lf.sort([IndCqc.location_id, IndCqc.cqc_location_import_date])
-        lf = lf.with_columns(
-            (
-                pl.when(pl.col(column_with_null_values).is_not_null())
-                .then(pl.col(column_with_null_values))
-                .otherwise(None)
-                .shift(1)
-                .forward_fill()
-                .over(IndCqc.location_id)
-            ).alias(IndCqc.previous_non_null_value)
+        lf = get_previous_value(
+            lf, column_with_null_values, IndCqc.previous_non_null_value
         )
 
         lf = calculate_residuals(

--- a/projects/_03_independent_cqc/utils/tests/imputation/test_extrapolation.py
+++ b/projects/_03_independent_cqc/utils/tests/imputation/test_extrapolation.py
@@ -129,10 +129,8 @@ class TestGetPreviousValue:
             orient="row",
         )
         input_lf = expected_lf.drop(ExtrapCol.previous_value)
-        returned_lf = input_lf.with_columns(
-            job.get_previous_value(IndCQC.ascwds_pir_merged).alias(
-                ExtrapCol.previous_value
-            )
+        returned_lf = job.get_previous_value(
+            input_lf, IndCQC.ascwds_pir_merged, ExtrapCol.previous_value
         )
 
         pl_testing.assert_frame_equal(returned_lf, expected_lf, check_row_order=False)


### PR DESCRIPTION
## Description
Trello ticket [#1782](https://trello.com/c/MxnwcUS0/1782-replace-over-with-more-streaming-friendly-methods-in-impute-job)

Part of the OOM investigation on the impute job, .over() isn't supported by Polars' streaming engine, so any query plan containing it falls back to full in-memory execution for that whole subgraph (confirmed via POLARS_VERBOSE=1).

Replaces the remaining order-dependent .over() usages (shift/forward-fill/cumulative) with join-based equivalents.

- `get_previous_value` - now a backward as-of join instead of sort_by().fill_null().shift().over(). Signature changed from returning a pl.Expr to taking/returning a pl.LazyFrame.

- `calculate_proportion_of_days_between_submissions and calculate_residuals` - as-of joins instead of forward_fill()/backward_fill().over().

- `previous_period_interpolated` - self as-of join instead of shift().over().

- `calculate_trendline` - group_by().agg() + list.eval(cum_sum()) + explode() instead of cum_sum().over().

- `calculate_rolling_average` - now uses the same rolling-group-by pattern already used by calculate_rolling_sums, rather than adding an .over() pattern that would need redoing later. Signature changed from expression-returning to lf-in/lf-out with a join-back.

- `model_interpolation` - had an in-line .over() call which has been replaced with the pre-written (and amended) `get_previous_value`

## Testing
- [X] Unit tests passing
- [X] Successful [Step Function run](https://eu-west-2.console.aws.amazon.com/states/home?region=eu-west-2#/v2/executions/details/arn:aws:states:eu-west-2:856699698263:execution:fix-over-calls-Ind-CQC-Filled-Post-Estimates:06adc407-a357-46ce-a6be-75d8fbd967f1)
- [X] Outputs checked in Athena

## Checklist (delete if not relevant)
- [X] Unit tests added/amended
- [X] Docstrings added/updated
- [X] Updated CHANGELOG
- [X] Code reviewed by AI
- [X] Moved Trello ticket to PR column

## Reviewer checklist
- [ ] PR solves the Trello ticket requirements
- [ ] Outputs appear reasonable and understandable
- [ ] The overall approach is appropriate and not over-engineered
- [ ] No obvious scalability, performance or interdependency concerns
- [ ] Tests appropriately cover the main behaviour/edge cases
- [ ] Naming and structure are broadly understandable and consistent
- [ ] Docstrings are sufficient for future maintenance
- [ ] Docstrings cover non-obvious behaviour
