### PR TITLE
1780 - Get SLV columns using combined schema within clean workplace job

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ All notable changes to this project will be documented in this file.
 
 - Removed PySpark version of `clean_ascwds_workplace_data.py` and replaced with the Polars version in the pipeline
 
+- Get Workplace data schema from `discover_combined_schema` within Clean Workplace Job. Updated tests for the same.
+
 ### Fixed
 
 

--- a/projects/_01_ingest/ascwds/fargate/clean_ascwds_workplace.py
+++ b/projects/_01_ingest/ascwds/fargate/clean_ascwds_workplace.py
@@ -13,38 +13,38 @@ INT_COLUMNS: list[str] = [AWPClean.total_staff, AWPClean.worker_records]
 BOUNDED_STAFF_COLUMNS: list[str] = [AWPClean.total_staff, AWPClean.worker_records]
 MIN_VALID_STAFF_COUNT: int = 1
 
-COLUMNS_TO_IMPORT = [
-    AWPClean.organisation_id,
-    AWPClean.period,
-    AWPClean.establishment_id,
-    AWPClean.establishment_id_from_nmds,
-    AWPClean.parent_id,
-    AWPClean.nmds_id,
-    AWPClean.establishment_created_date,
-    AWPClean.establishment_updated_date,
-    AWPClean.master_update_date,
-    AWPClean.last_logged_in,
-    AWPClean.la_permission,
-    AWPClean.is_bulk_uploader,
-    AWPClean.is_parent,
-    AWPClean.parent_permission,
-    AWPClean.registration_type,
-    AWPClean.provider_id,
-    AWPClean.location_id,
-    AWPClean.establishment_type,
-    AWPClean.establishment_name,
-    AWPClean.address,
-    AWPClean.postcode,
-    AWPClean.region_id,
-    AWPClean.total_staff,
-    AWPClean.worker_records,
-    AWPClean.total_starters,
-    AWPClean.total_leavers,
-    AWPClean.total_vacancies,
-    AWPClean.main_service_id,
-    AWPClean.version,
-    AWPClean.import_date,
-]
+WORKPLACE_SCHEMA = {
+    AWPClean.organisation_id: pl.String,
+    AWPClean.period: pl.String,
+    AWPClean.establishment_id: pl.String,
+    AWPClean.establishment_id_from_nmds: pl.String,
+    AWPClean.parent_id: pl.String,
+    AWPClean.nmds_id: pl.String,
+    AWPClean.establishment_created_date: pl.String,
+    AWPClean.establishment_updated_date: pl.String,
+    AWPClean.master_update_date: pl.String,
+    AWPClean.last_logged_in: pl.String,
+    AWPClean.la_permission: pl.String,
+    AWPClean.is_bulk_uploader: pl.String,
+    AWPClean.is_parent: pl.String,
+    AWPClean.parent_permission: pl.String,
+    AWPClean.registration_type: pl.String,
+    AWPClean.provider_id: pl.String,
+    AWPClean.location_id: pl.String,
+    AWPClean.establishment_type: pl.String,
+    AWPClean.establishment_name: pl.String,
+    AWPClean.address: pl.String,
+    AWPClean.postcode: pl.String,
+    AWPClean.region_id: pl.String,
+    AWPClean.total_staff: pl.String,
+    AWPClean.worker_records: pl.String,
+    AWPClean.total_starters: pl.String,
+    AWPClean.total_leavers: pl.String,
+    AWPClean.total_vacancies: pl.String,
+    AWPClean.main_service_id: pl.String,
+    AWPClean.version: pl.String,
+    AWPClean.import_date: pl.String,
+}
 
 SFC_INTERNAL_COLUMNS = [
     AWPClean.ascwds_workplace_import_date,
@@ -99,7 +99,9 @@ def main(
         ascwds_for_sfc_internal_destination (str): destination for ASC-WDS data
             for SFC internal pipeline use
     """
-    lf = utils.scan_parquet(workplace_source, selected_columns=COLUMNS_TO_IMPORT)
+    lf = utils.scan_parquet(workplace_source, schema=WORKPLACE_SCHEMA).select(
+        WORKPLACE_SCHEMA.keys()
+    )
 
     lf = wUtils.apply_data_corrections(lf)
 
@@ -143,10 +145,12 @@ def main(
 
     workplace_lf = wUtils.remove_rows_with_duplicate_location_ids(workplace_lf)
 
-    slv_lf = utils.scan_parquet(workplace_source).select(
+    combined_schema = utils.discover_combined_schema(workplace_source)
+    slv_lf = utils.scan_parquet(workplace_source, schema=combined_schema).select(
         *[AWPClean.establishment_id, AWPClean.import_date],
         expr.is_slv_job_role_column(),
     )
+    slv_lf = slv_lf.with_columns(pl.col(AWPClean.import_date).cast(pl.String))
 
     workplace_lf = workplace_lf.join(
         slv_lf, on=[AWPClean.establishment_id, AWPClean.import_date], how="left"

--- a/projects/_01_ingest/ascwds/fargate/validate_clean_ascwds_workplace.py
+++ b/projects/_01_ingest/ascwds/fargate/validate_clean_ascwds_workplace.py
@@ -49,8 +49,6 @@ columns = {
     ASCWPClean.purge_date: "Date",
     ASCWPClean.data_last_amended_date: "Date",
     ASCWPClean.workplace_last_active_date: "Date",
-    ASCWPClean.total_staff_bounded: "Int32",
-    ASCWPClean.worker_records_bounded: "Int32",
 }
 
 

--- a/projects/_01_ingest/ascwds/fargate/validate_clean_ascwds_workplace.py
+++ b/projects/_01_ingest/ascwds/fargate/validate_clean_ascwds_workplace.py
@@ -69,9 +69,20 @@ def main(bucket_name: str, source_path: str, reports_path: str) -> None:
         source=f"s3://{bucket_name}/{source_path}",
     )
 
-    jr_cols = source_df.select(expr.is_slv_job_role_column()).collect_schema().names()
-    columns.update({k: pl.Int32 for k in jr_cols})
-    EXPECTED_SCHEMA = pb.Schema(columns=columns)
+    # Job role columns vary between imports as ASCWDS adds/drops codes over
+    # time, so the expected set is read off the data being validated itself
+    # rather than a fixed list.
+    slv_columns = {
+        col: "Int32" for col in source_df.select(expr.is_slv_job_role_column()).columns
+    }
+    columns.update(slv_columns.items())  # Add job role columns.
+    columns.update(
+        {
+            ASCWPClean.total_staff_bounded: "Int32",
+            ASCWPClean.worker_records_bounded: "Int32",
+        }
+    )  # Add columns created after job role cols are joined.
+    EXPECTED_SCHEMA = pb.Schema(columns)
 
     validation = (
         pb.Validate(
@@ -82,10 +93,10 @@ def main(bucket_name: str, source_path: str, reports_path: str) -> None:
             actions=GLOBAL_ACTIONS,
         )
         # dataset schema
-        # .col_schema_match(
-        #     schema=EXPECTED_SCHEMA,
-        #     brief="Dataset should match the expected schema",
-        # )
+        .col_schema_match(
+            schema=EXPECTED_SCHEMA,
+            brief="Dataset should match the expected schema",
+        )
         # index columns
         .rows_distinct(
             [ASCWPClean.establishment_id, ASCWPClean.ascwds_workplace_import_date]

--- a/projects/_01_ingest/ascwds/tests/fargate/test_clean_ascwds_workplace.py
+++ b/projects/_01_ingest/ascwds/tests/fargate/test_clean_ascwds_workplace.py
@@ -1,7 +1,12 @@
 import unittest
 from unittest.mock import ANY, Mock, call, patch
 
+import polars as pl
+
 import projects._01_ingest.ascwds.fargate.clean_ascwds_workplace as job
+from utils.column_names.cleaned_data_files.ascwds_workplace_cleaned import (
+    AscwdsWorkplaceCleanedColumns as AWPClean,
+)
 
 PATCH_PATH = "projects._01_ingest.ascwds.fargate.clean_ascwds_workplace"
 
@@ -14,6 +19,7 @@ class MainTests(unittest.TestCase):
 
     @patch(f"{PATCH_PATH}.wUtils.remove_rows_with_duplicate_location_ids")
     @patch(f"{PATCH_PATH}.utils.sink_to_parquet")
+    @patch(f"{PATCH_PATH}.utils.discover_combined_schema")
     @patch(f"{PATCH_PATH}.wUtils.create_purge_date_columns")
     @patch(f"{PATCH_PATH}.cUtils.apply_categorical_labels")
     @patch(f"{PATCH_PATH}.pl.scan_csv")
@@ -32,9 +38,15 @@ class MainTests(unittest.TestCase):
         scan_csv_mock: Mock,
         apply_categorical_labels_mock: Mock,
         create_purge_date_columns_mock: Mock,
+        discover_combined_schema_mock: Mock,
         sink_to_parquet_mock: Mock,
         remove_rows_with_duplicate_location_ids_mock: Mock,
     ):
+        discover_combined_schema_mock.return_value = {
+            "jr09emp": pl.String,
+            AWPClean.establishment_id: pl.String,
+        }
+
         job.main(
             self.WORKPLACE_SOURCE,
             self.DATA_LABELS_SOURCE,
@@ -43,11 +55,14 @@ class MainTests(unittest.TestCase):
         )
 
         assert scan_parquet_mock.call_count == 2
-        scan_parquet_mock.assert_has_calls(
-            [
-                call(self.WORKPLACE_SOURCE, selected_columns=job.COLUMNS_TO_IMPORT),
-                call(self.WORKPLACE_SOURCE),
-            ]
+        assert scan_parquet_mock.call_args_list[0] == call(
+            self.WORKPLACE_SOURCE, schema=job.WORKPLACE_SCHEMA
+        )
+        assert scan_parquet_mock.call_args_list[1] == call(
+            self.WORKPLACE_SOURCE,
+            schema=pl.Schema(
+                {"jr09emp": pl.String, AWPClean.establishment_id: pl.String}
+            ),
         )
 
         apply_data_corrections_mock.assert_called_once()
@@ -60,6 +75,7 @@ class MainTests(unittest.TestCase):
         apply_categorical_labels_mock.assert_called_once()
         create_purge_date_columns_mock.assert_called_once()
         remove_rows_with_duplicate_location_ids_mock.assert_called_once()
+        discover_combined_schema_mock.assert_called_once_with(self.WORKPLACE_SOURCE)
 
         assert sink_to_parquet_mock.call_count == 2
         sink_to_parquet_mock.assert_has_calls(

--- a/projects/_01_ingest/ascwds/tests/fargate/test_validate_clean_ascwds_workplace.py
+++ b/projects/_01_ingest/ascwds/tests/fargate/test_validate_clean_ascwds_workplace.py
@@ -93,6 +93,7 @@ class ValidateCleanASCWDSWorkplaceTests(unittest.TestCase):
                 ASCWPClean.worker_records_bounded: pl.Int32,
             },
         )
+        self.test_schema = {ASCWPClean.job_role_01_employees: pl.Int32}
 
     @patch(f"{PATCH_PATH}.vl.write_reports")
     @patch(f"{PATCH_PATH}.utils.read_parquet")
@@ -124,7 +125,7 @@ class ValidateCleanASCWDSWorkplaceTests(unittest.TestCase):
         assertion_types_present = {item["assertion_type"] for item in report_json}
 
         expected_assertions = {
-            # "col_schema_match",
+            "col_schema_match",
             "col_vals_not_null",
             "rows_distinct",
             "col_vals_between",

--- a/projects/_01_ingest/ascwds/tests/fargate/utils/test_clean_workplace_utils.py
+++ b/projects/_01_ingest/ascwds/tests/fargate/utils/test_clean_workplace_utils.py
@@ -1,4 +1,3 @@
-import unittest
 from datetime import date
 
 import polars as pl


### PR DESCRIPTION
## Description
Trello ticket [#1780](https://trello.com/c/AWyrSBtU/1780-spike-05-days-ascwds-workplace-clean-bring-job-roles-higher-than-41-into-the-cleaning-dataset)

this PR is to use `discover_combined_schema` function to generate/get SLV columns within clean workplace job.

## Testing
- [x] Unit tests passing
- [x] Successful [Step Function run](https://eu-west-2.console.aws.amazon.com/states/home?region=eu-west-2#/v2/executions/details/arn:aws:states:eu-west-2:856699698263:execution:1780-get-high-jr-v2-Transform-ASCWDS-Data:693b0e77-322f-4329-8f89-04e3f440b34f)
- [x] Outputs checked in Athena

<img width="1933" height="1071" alt="image" src="https://github.com/user-attachments/assets/54c56e03-f50e-4830-9d85-5e3d53a85233" />

All columns list from this query is exported and attached to the ticket.

<img width="1901" height="822" alt="image" src="https://github.com/user-attachments/assets/b4aee621-07c2-429f-89db-9d40f003cb5d" />


## Checklist (delete if not relevant)
- [x] Unit tests added/amended
- [x] Docstrings added/updated
- [x] Updated CHANGELOG
- [x] Code reviewed by AI
- [x] Moved Trello ticket to PR column

## Reviewer checklist
- [ ] PR solves the Trello ticket requirements
- [ ] Outputs appear reasonable and understandable
- [ ] The overall approach is appropriate and not over-engineered
- [ ] No obvious scalability, performance or interdependency concerns
- [ ] Tests appropriately cover the main behaviour/edge cases
- [ ] Naming and structure are broadly understandable and consistent
- [ ] Docstrings are sufficient for future maintenance
- [ ] Docstrings cover non-obvious behaviour
