### PR TITLE
1799 Add prepare workplace step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Added
+- Added a skeleton `_00_prepare` task (with validation) ahead of the merge step in the SLV pipeline, and rewired the merge step to read its output.
+
 - Added `discover_combined_schema` function in Polars Utils to generate combined schema from a partitioned dataset.
 
 - Added workplace and worker datasets to syncing to branch.

--- a/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/_00_prepare.py
+++ b/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/_00_prepare.py
@@ -1,0 +1,36 @@
+from polars_utils import utils
+
+
+def main(
+    cleaned_ascwds_workplace_source: str,
+    prepared_data_destination: str,
+) -> None:
+    """Load the cleaned ASCWDS workplace dataset and save it unchanged.
+
+    Args:
+        cleaned_ascwds_workplace_source (str): path to the cleaned ascwds workplace data
+        prepared_data_destination (str): destination for output
+    """
+    lf = utils.scan_parquet(cleaned_ascwds_workplace_source)
+
+    utils.sink_to_parquet(
+        lazy_df=lf,
+        output_path=prepared_data_destination,
+    )
+
+
+if __name__ == "__main__":
+    args = utils.get_args(
+        (
+            "--cleaned_ascwds_workplace_source",
+            "Source s3 directory for cleaned ascwds workplace data",
+        ),
+        (
+            "--prepared_data_destination",
+            "Destination s3 directory for prepared data",
+        ),
+    )
+    main(
+        cleaned_ascwds_workplace_source=args.cleaned_ascwds_workplace_source,
+        prepared_data_destination=args.prepared_data_destination,
+    )

--- a/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/_00_prepare.py
+++ b/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/_00_prepare.py
@@ -11,10 +11,10 @@ def main(
         cleaned_ascwds_workplace_source (str): path to the cleaned ascwds workplace data
         prepared_data_destination (str): destination for output
     """
-    lf = utils.scan_parquet(cleaned_ascwds_workplace_source)
+    workplace_lf = utils.scan_parquet(cleaned_ascwds_workplace_source)
 
     utils.sink_to_parquet(
-        lazy_df=lf,
+        lazy_df=workplace_lf,
         output_path=prepared_data_destination,
     )
 

--- a/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/_01_merge.py
+++ b/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/_01_merge.py
@@ -49,7 +49,7 @@ job_role_estimates_columns = [
 def main(
     metadata_source: str,
     job_role_estimates_source: str,
-    cleaned_ascwds_workplace_source: str,
+    prepared_slv_dataset_source: str,
     merged_data_destination: str,
 ) -> None:
     """
@@ -58,7 +58,7 @@ def main(
     Args:
         metadata_source (str): path to the estimates ind cqc filled posts data
         job_role_estimates_source (str): path to the job role estimates data
-        cleaned_ascwds_workplace_source (str): path to the cleaned ascwds workplace data
+        prepared_slv_dataset_source (str): path to the cleaned ascwds workplace data
         merged_data_destination (str): destination for merged output
     """
 
@@ -69,7 +69,7 @@ def main(
         source=job_role_estimates_source, selected_columns=job_role_estimates_columns
     )
     cleaned_ascwds_workplace_lf = utils.scan_parquet(
-        cleaned_ascwds_workplace_source
+        prepared_slv_dataset_source
     ).select(
         *[AWPClean.establishment_id, AWPClean.ascwds_workplace_import_date],
         expr.is_slv_job_role_column()
@@ -101,7 +101,7 @@ if __name__ == "__main__":
             "Source s3 directory for job role estimates data",
         ),
         (
-            "--cleaned_ascwds_workplace_source",
+            "--prepared_slv_dataset_source",
             "Source s3 directory for cleaned ascwds workplace data",
         ),
         (
@@ -112,6 +112,6 @@ if __name__ == "__main__":
     main(
         metadata_source=args.metadata_source,
         job_role_estimates_source=args.job_role_estimates_source,
-        cleaned_ascwds_workplace_source=args.cleaned_ascwds_workplace_source,
+        prepared_slv_dataset_source=args.prepared_slv_dataset_source,
         merged_data_destination=args.merged_data_destination,
     )

--- a/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/validate_00_prepare.py
+++ b/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/validate_00_prepare.py
@@ -1,0 +1,67 @@
+import sys
+
+import pointblank as pb
+
+from polars_utils import utils
+from polars_utils.validation import actions as vl
+from polars_utils.validation.constants import GLOBAL_ACTIONS, GLOBAL_THRESHOLDS
+from utils.column_names.cleaned_data_files.ascwds_workplace_cleaned import (
+    AscwdsWorkplaceCleanedColumns as AWPClean,
+)
+
+COMPARE_COLS_TO_IMPORT = [
+    AWPClean.establishment_id,
+]
+
+
+def main(
+    bucket_name: str, source_path: str, compare_path: str, reports_path: str
+) -> None:
+    """Validates a dataset according to a set of provided rules and produces a
+        summary report as well as failure outputs.
+
+    Args:
+        bucket_name (str): the bucket (name only) in which to source the dataset
+            and output the report to (should correspond to workspace / feature
+            branch name)
+        source_path (str): the source dataset path to be validated
+        compare_path (str): the path to the dataset to compare against
+        reports_path (str): the output path to write reports to
+    """
+    source_df = utils.read_parquet(source=f"s3://{bucket_name}/{source_path}")
+    compare_df = utils.read_parquet(
+        source=f"s3://{bucket_name}/{compare_path}",
+        selected_columns=COMPARE_COLS_TO_IMPORT,
+    )
+    expected_row_count = compare_df.height
+
+    validation = (
+        pb.Validate(
+            data=source_df,
+            label=f"Validation of {source_path}",
+            thresholds=GLOBAL_THRESHOLDS,
+            brief=True,
+            actions=GLOBAL_ACTIONS,
+        )
+        # dataset size
+        .row_count_match(
+            expected_row_count,
+            brief=f"Expects {expected_row_count} rows",
+        ).interrogate()
+    )
+    vl.write_reports(validation, bucket_name, reports_path)
+
+
+if __name__ == "__main__":
+    print(f"Validation script called with parameters: {sys.argv}")
+
+    args = utils.get_args(
+        ("--bucket_name", "S3 bucket for source dataset and validation report"),
+        ("--source_path", "The filepath of the dataset to validate"),
+        ("--compare_path", "The filepath of the dataset to compare against"),
+        ("--reports_path", "The filepath to output reports"),
+    )
+    print(f"Starting validation for {args.source_path}")
+
+    main(args.bucket_name, args.source_path, args.compare_path, args.reports_path)
+    print(f"Validation of {args.source_path} complete")

--- a/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/tests/fargate/test_00_prepare.py
+++ b/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/tests/fargate/test_00_prepare.py
@@ -1,0 +1,30 @@
+import unittest
+from unittest.mock import ANY, Mock, patch
+
+import projects._07_workforce_characteristics._01_starters_leavers_vacancies.fargate._00_prepare as job
+
+PATCH_PATH = "projects._07_workforce_characteristics._01_starters_leavers_vacancies.fargate._00_prepare"
+
+
+class MainTests(unittest.TestCase):
+    CLEANED_ASCWDS_WORKPLACE_SOURCE = "some/source"
+    PREPARED_DATA_DESTINATION = "some/destination"
+
+    @patch(f"{PATCH_PATH}.utils.sink_to_parquet")
+    @patch(f"{PATCH_PATH}.utils.scan_parquet")
+    def test_main_runs(
+        self,
+        scan_parquet_mock: Mock,
+        sink_to_parquet_mock: Mock,
+    ):
+        job.main(
+            self.CLEANED_ASCWDS_WORKPLACE_SOURCE,
+            self.PREPARED_DATA_DESTINATION,
+        )
+
+        scan_parquet_mock.assert_called_once_with(self.CLEANED_ASCWDS_WORKPLACE_SOURCE)
+
+        sink_to_parquet_mock.assert_called_once_with(
+            lazy_df=ANY,
+            output_path=self.PREPARED_DATA_DESTINATION,
+        )

--- a/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/tests/fargate/test_01_merge.py
+++ b/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/tests/fargate/test_01_merge.py
@@ -9,7 +9,7 @@ PATCH_PATH = "projects._07_workforce_characteristics._01_starters_leavers_vacanc
 class MainTests(unittest.TestCase):
     METADATA_SOURCE = "some/source"
     JOB_ROLE_ESTIMATES_SOURCE = "another/source"
-    CLEANED_ASCWDS_WORKPLACE_SOURCE = "other/source"
+    PREPARED_SLV_DATASET_SOURCE = "other/source"
     MERGED_DATA_DESTINATION = "some/destination"
 
     @patch(f"{PATCH_PATH}.utils.sink_to_parquet")
@@ -30,7 +30,7 @@ class MainTests(unittest.TestCase):
         job.main(
             self.METADATA_SOURCE,
             self.JOB_ROLE_ESTIMATES_SOURCE,
-            self.CLEANED_ASCWDS_WORKPLACE_SOURCE,
+            self.PREPARED_SLV_DATASET_SOURCE,
             self.MERGED_DATA_DESTINATION,
         )
 
@@ -42,7 +42,7 @@ class MainTests(unittest.TestCase):
                 source=self.JOB_ROLE_ESTIMATES_SOURCE,
                 selected_columns=job.job_role_estimates_columns,
             ),
-            call(self.CLEANED_ASCWDS_WORKPLACE_SOURCE),
+            call(self.PREPARED_SLV_DATASET_SOURCE),
         ]
         scan_parquet_mock.assert_has_calls(scan_calls)
 

--- a/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/tests/fargate/test_validate_00_prepare.py
+++ b/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/tests/fargate/test_validate_00_prepare.py
@@ -1,0 +1,77 @@
+import json
+import unittest
+from unittest.mock import Mock, call, patch
+
+import polars as pl
+
+import projects._07_workforce_characteristics._01_starters_leavers_vacancies.fargate.validate_00_prepare as job
+from utils.column_names.cleaned_data_files.ascwds_workplace_cleaned import (
+    AscwdsWorkplaceCleanedColumns as AWPClean,
+)
+
+PATCH_PATH = "projects._07_workforce_characteristics._01_starters_leavers_vacancies.fargate.validate_00_prepare"
+
+
+class ValidatePreparedSLVDataTests(unittest.TestCase):
+    def setUp(self) -> None:
+        source_schema = {
+            AWPClean.establishment_id: pl.String,
+        }
+        source_rows = [
+            ("1-001"),
+        ]  # fmt: skip
+        self.source_df = pl.DataFrame(source_rows, source_schema, orient="row")
+        self.compare_df = self.source_df.select([AWPClean.establishment_id])
+
+    @patch(f"{PATCH_PATH}.vl.write_reports")
+    @patch(f"{PATCH_PATH}.utils.read_parquet")
+    def test_validation_runs(
+        self,
+        mock_read_parquet: Mock,
+        mock_write_reports: Mock,
+    ):
+        mock_read_parquet.side_effect = [self.source_df, self.compare_df]
+        job.main("bucket", "my/source/", "my/compare/", "my/reports/")
+
+        self.assertEqual(mock_read_parquet.call_count, 2)
+        mock_read_parquet.assert_has_calls(
+            [
+                call(source="s3://bucket/my/source/"),
+                call(
+                    source="s3://bucket/my/compare/",
+                    selected_columns=job.COMPARE_COLS_TO_IMPORT,
+                ),
+            ]
+        )
+        mock_write_reports.assert_called_once()
+
+    @patch(f"{PATCH_PATH}.vl.write_reports")
+    @patch(f"{PATCH_PATH}.utils.read_parquet")
+    def test_validation_report_includes_expected_validations(
+        self,
+        mock_read_parquet: Mock,
+        mock_write_reports: Mock,
+    ):
+        mock_read_parquet.side_effect = [self.source_df, self.compare_df]
+
+        job.main("bucket", "my/source/", "my/compare/", "my/reports/")
+
+        validation_arg = mock_write_reports.call_args[0][0]
+        report_json = json.loads(validation_arg.get_json_report())
+
+        assertion_types_present = {item["assertion_type"] for item in report_json}
+
+        expected_assertions = {
+            "row_count_match",
+        }
+
+        for assertion in expected_assertions:
+            self.assertIn(
+                assertion,
+                assertion_types_present,
+                f"{assertion} not found in validation report",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main(warnings="ignore")

--- a/projects/_07_workforce_characteristics/dockerfile_and_requirements/Dockerfile
+++ b/projects/_07_workforce_characteristics/dockerfile_and_requirements/Dockerfile
@@ -9,6 +9,7 @@ ENV PYTHONPATH=/app
 # Dependencies
 COPY polars_utils /app/polars_utils
 COPY utils/column_names /app/utils/column_names/
+COPY utils/column_values /app/utils/column_values/
 COPY projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/utils /app/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/utils
 
 # Copy python jobs to WORKDIR

--- a/projects/_07_workforce_characteristics/dockerfile_and_requirements/Dockerfile
+++ b/projects/_07_workforce_characteristics/dockerfile_and_requirements/Dockerfile
@@ -12,15 +12,8 @@ COPY utils/column_names /app/utils/column_names/
 COPY projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/utils /app/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/utils
 
 # Copy python jobs to WORKDIR
-COPY projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/_00_prepare.py /app/_01_starters_leavers_vacancies/fargate/_00_prepare.py
-COPY projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/_01_merge.py /app/_01_starters_leavers_vacancies/fargate/_01_merge.py
-COPY projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/_02_clean.py /app/_01_starters_leavers_vacancies/fargate/_02_clean.py
-COPY projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/_03_impute.py /app/_01_starters_leavers_vacancies/fargate/_03_impute.py
-COPY projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/_04_estimate.py /app/_01_starters_leavers_vacancies/fargate/_04_estimate.py
-COPY projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/validate_01_merge.py /app/_01_starters_leavers_vacancies/fargate/validate_01_merge.py
-COPY projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/validate_02_clean.py /app/_01_starters_leavers_vacancies/fargate/validate_02_clean.py
-COPY projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/validate_03_impute.py /app/_01_starters_leavers_vacancies/fargate/validate_03_impute.py
-COPY projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/validate_04_estimate.py /app/_01_starters_leavers_vacancies/fargate/validate_04_estimate.py
+COPY projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/*.py /app/_01_starters_leavers_vacancies/fargate/*.py
+
 COPY projects/_07_workforce_characteristics/dockerfile_and_requirements/requirements.txt /app/requirements.txt
 
 RUN pip install --no-cache-dir -r requirements.txt

--- a/projects/_07_workforce_characteristics/dockerfile_and_requirements/Dockerfile
+++ b/projects/_07_workforce_characteristics/dockerfile_and_requirements/Dockerfile
@@ -12,8 +12,16 @@ COPY utils/column_names /app/utils/column_names/
 COPY projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/utils /app/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/utils
 
 # Copy python jobs to WORKDIR
-COPY projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/*.py /app/_01_starters_leavers_vacancies/fargate/*.py
-
+COPY projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/_00_prepare.py /app/_01_starters_leavers_vacancies/fargate/_00_prepare.py
+COPY projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/_01_merge.py /app/_01_starters_leavers_vacancies/fargate/_01_merge.py
+COPY projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/_02_clean.py /app/_01_starters_leavers_vacancies/fargate/_02_clean.py
+COPY projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/_03_impute.py /app/_01_starters_leavers_vacancies/fargate/_03_impute.py
+COPY projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/_04_estimate.py /app/_01_starters_leavers_vacancies/fargate/_04_estimate.py
+COPY projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/validate_00_prepare.py /app/_01_starters_leavers_vacancies/fargate/validate_00_prepare.py
+COPY projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/validate_01_merge.py /app/_01_starters_leavers_vacancies/fargate/validate_01_merge.py
+COPY projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/validate_02_clean.py /app/_01_starters_leavers_vacancies/fargate/validate_02_clean.py
+COPY projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/validate_03_impute.py /app/_01_starters_leavers_vacancies/fargate/validate_03_impute.py
+COPY projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/validate_04_estimate.py /app/_01_starters_leavers_vacancies/fargate/validate_04_estimate.py
 COPY projects/_07_workforce_characteristics/dockerfile_and_requirements/requirements.txt /app/requirements.txt
 
 RUN pip install --no-cache-dir -r requirements.txt

--- a/projects/_07_workforce_characteristics/dockerfile_and_requirements/Dockerfile
+++ b/projects/_07_workforce_characteristics/dockerfile_and_requirements/Dockerfile
@@ -12,6 +12,7 @@ COPY utils/column_names /app/utils/column_names/
 COPY projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/utils /app/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/utils
 
 # Copy python jobs to WORKDIR
+COPY projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/_00_prepare.py /app/_01_starters_leavers_vacancies/fargate/_00_prepare.py
 COPY projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/_01_merge.py /app/_01_starters_leavers_vacancies/fargate/_01_merge.py
 COPY projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/_02_clean.py /app/_01_starters_leavers_vacancies/fargate/_02_clean.py
 COPY projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/_03_impute.py /app/_01_starters_leavers_vacancies/fargate/_03_impute.py

--- a/terraform/pipeline/step-functions/dynamic/Ind-CQC-SLV.json
+++ b/terraform/pipeline/step-functions/dynamic/Ind-CQC-SLV.json
@@ -66,7 +66,7 @@
                                 "_01_starters_leavers_vacancies/fargate/_01_merge.py",
                                 "--metadata_source", "${dataset_bucket_uri}/domain=ind_cqc_filled_posts/dataset=${ind_cqc_job_role_metadata}/",
                                 "--job_role_estimates_source", "${dataset_bucket_uri}/domain=ind_cqc_filled_posts/dataset=${ind_cqc_job_role_estimates}/",
-                                "--cleaned_ascwds_workplace_source", "${dataset_bucket_uri}/domain=workforce_characteristics/dataset=ind_cqc_00_prepare_slv/",
+                                "--prepared_slv_dataset_source", "${dataset_bucket_uri}/domain=workforce_characteristics/dataset=ind_cqc_00_prepare_slv/",
                                 "--merged_data_destination","${dataset_bucket_uri}/domain=workforce_characteristics/dataset=ind_cqc_01_merge_slv/"
                               ]
                             }

--- a/terraform/pipeline/step-functions/dynamic/Ind-CQC-SLV.json
+++ b/terraform/pipeline/step-functions/dynamic/Ind-CQC-SLV.json
@@ -6,9 +6,9 @@
       "Type": "Parallel",
       "Branches": [
         {
-          "StartAt": "Merge data",
+          "StartAt": "Prepare data",
           "States": {
-            "Merge data": {
+            "Prepare data": {
               "Type": "Task",
               "Resource": "arn:aws:states:::ecs:runTask.sync",
               "Parameters": {
@@ -27,17 +27,93 @@
                     {
                       "Name": "_07_workforce_characteristics-container",
                       "Command": [
-                        "_01_starters_leavers_vacancies/fargate/_01_merge.py",
-                        "--metadata_source", "${dataset_bucket_uri}/domain=ind_cqc_filled_posts/dataset=${ind_cqc_job_role_metadata}/",
-                        "--job_role_estimates_source", "${dataset_bucket_uri}/domain=ind_cqc_filled_posts/dataset=${ind_cqc_job_role_estimates}/",
+                        "_01_starters_leavers_vacancies/fargate/_00_prepare.py",
                         "--cleaned_ascwds_workplace_source", "${dataset_bucket_uri}/domain=ASCWDS/dataset=workplace_cleaned/",
-                        "--merged_data_destination","${dataset_bucket_uri}/domain=workforce_characteristics/dataset=ind_cqc_01_merge_slv/"
+                        "--prepared_data_destination", "${dataset_bucket_uri}/domain=workforce_characteristics/dataset=ind_cqc_00_prepare_slv/"
                       ]
                     }
                   ]
                 }
               },
-              "Next": "Clean and Validate Merged Data"
+              "Next": "Merge and Validate Prepared Data"
+            },
+            "Merge and Validate Prepared Data": {
+              "Type": "Parallel",
+              "Next": "Clean and Validate Merged Data",
+              "Branches": [
+                {
+                  "StartAt": "Merge data",
+                  "States": {
+                    "Merge data": {
+                      "Type": "Task",
+                      "Resource": "arn:aws:states:::ecs:runTask.sync",
+                      "Parameters": {
+                        "Cluster": "${polars_cluster_arn}",
+                        "TaskDefinition": "${workforce_characteristics_task_arn}",
+                        "LaunchType": "FARGATE",
+                        "NetworkConfiguration": {
+                          "AwsvpcConfiguration": {
+                            "Subnets": ${public_subnet_ids},
+                            "SecurityGroups": ["${workforce_characteristics_security_group_id}"],
+                            "AssignPublicIp": "ENABLED"
+                          }
+                        },
+                        "Overrides": {
+                          "ContainerOverrides": [
+                            {
+                              "Name": "_07_workforce_characteristics-container",
+                              "Command": [
+                                "_01_starters_leavers_vacancies/fargate/_01_merge.py",
+                                "--metadata_source", "${dataset_bucket_uri}/domain=ind_cqc_filled_posts/dataset=${ind_cqc_job_role_metadata}/",
+                                "--job_role_estimates_source", "${dataset_bucket_uri}/domain=ind_cqc_filled_posts/dataset=${ind_cqc_job_role_estimates}/",
+                                "--cleaned_ascwds_workplace_source", "${dataset_bucket_uri}/domain=workforce_characteristics/dataset=ind_cqc_00_prepare_slv/",
+                                "--merged_data_destination","${dataset_bucket_uri}/domain=workforce_characteristics/dataset=ind_cqc_01_merge_slv/"
+                              ]
+                            }
+                          ]
+                        }
+                      },
+                      "End": true
+                    }
+                  }
+                },
+                {
+                  "StartAt": "Validate Prepared Data",
+                  "States": {
+                    "Validate Prepared Data": {
+                      "Type": "Task",
+                      "Resource": "arn:aws:states:::ecs:runTask.sync",
+                      "Parameters": {
+                        "Cluster": "${polars_cluster_arn}",
+                        "TaskDefinition": "${workforce_characteristics_task_arn}",
+                        "LaunchType": "FARGATE",
+                        "NetworkConfiguration": {
+                          "AwsvpcConfiguration": {
+                            "Subnets": ${public_subnet_ids},
+                            "SecurityGroups": ["${workforce_characteristics_security_group_id}"],
+                            "AssignPublicIp": "ENABLED"
+                          }
+                        },
+                        "Overrides": {
+                          "ContainerOverrides": [
+                            {
+                              "Name": "_07_workforce_characteristics-container",
+                              "Command": [
+                                "_01_starters_leavers_vacancies/fargate/validate_00_prepare.py",
+                                "--bucket_name", "${dataset_bucket_name}",
+                                "--source_path", "domain=workforce_characteristics/dataset=ind_cqc_00_prepare_slv/",
+                                "--compare_path", "domain=ASCWDS/dataset=workplace_cleaned/",
+                                "--reports_path", "domain=data_validation_reports/dataset=validation_ind_cqc_00_prepare_slv/"
+                              ]
+                            }
+                          ]
+                        }
+                      },
+                      "End": true
+                    }
+                  }
+                }
+              ]
             },
             "Clean and Validate Merged Data": {
               "Type": "Parallel",


### PR DESCRIPTION
## Description
Trello ticket [#1799](https://trello.com/c/ehwv0ll5/1799-s-pivot0add-pivot-job)

Add a prepare ECS task ahead of the merge task in the SLV pipeline

## Testing
- [x] Unit tests passing
- [x] Successful [Step Function run](https://eu-west-2.console.aws.amazon.com/states/home?region=eu-west-2#/statemachines/view/arn:aws:states:eu-west-2:856699698263:stateMachine:1799-add-prep-Ind-CQC-SLV)
- [x] Outputs checked in Athena

<img width="390" height="311" alt="image" src="https://github.com/user-attachments/assets/34e91227-2398-47d0-8053-2babed5eb3ec" />

## Checklist (delete if not relevant)
- [x] Unit tests added/amended
- [x] Docstrings added/updated
- [x] Updated CHANGELOG
- [x] Code reviewed by AI
- [x] Moved Trello ticket to PR column

## Reviewer checklist
- [ ] PR solves the Trello ticket requirements
- [ ] Outputs appear reasonable and understandable
- [ ] The overall approach is appropriate and not over-engineered
- [ ] No obvious scalability, performance or interdependency concerns
- [ ] Tests appropriately cover the main behaviour/edge cases
- [ ] Naming and structure are broadly understandable and consistent
- [ ] Docstrings are sufficient for future maintenance
- [ ] Docstrings cover non-obvious behaviour
