### PR TITLE
1808 Hot fix to increase wait time on orchestrator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ All notable changes to this project will be documented in this file.
 - Get Workplace data schema from `discover_combined_schema` within Clean Workplace Job. Updated tests for the same.
 
 ### Fixed
-
+- Increased wait time on CQC and ASCWDS Orchestrator to avoid timeout of loop.
 
 
 ## [v2026.06.0] - 15/07/2026

--- a/terraform/pipeline/step-functions/CQC-And-ASCWDS-Orchestrator.json
+++ b/terraform/pipeline/step-functions/CQC-And-ASCWDS-Orchestrator.json
@@ -64,7 +64,7 @@
                     },
                     "Wait For Worker": {
                       "Type": "Wait",
-                      "Seconds": 10,
+                      "Seconds": 60,
                       "Next": "Check Worker"
                    },
                     "Mark Worker Ready": {
@@ -104,7 +104,7 @@
                     },
                     "Wait For Workplace": {
                       "Type": "Wait",
-                      "Seconds": 10,
+                      "Seconds": 60,
                       "Next": "Check Workplace"
                     },
                     "Mark Workplace Ready": {


### PR DESCRIPTION
## Description
Trello ticket [#1808](https://trello.com/c/fNSQtOdI/1808-increase-wait-time-on-orchestrator-step-function)

Hot fix to reduce risk of silent failure of CQC & ASCWDS orchestrator.
Currently working on a full patch (1809)- this will give us a longer timeout for the next run in case more substantial changes aren't ready by then

## Testing
- [x] Unit tests passing
Run in branch here https://eu-west-2.console.aws.amazon.com/states/home?region=eu-west-2#/v2/executions/details/arn:aws:states:eu-west-2:856699698263:execution:1808-inc-wait-CQC-And-ASCWDS-Orchestrator:4bd01f3a-e5a5-448c-aa76-1784c203fc91
Demonstrates that the 1 min wait time is working. As no new files are added today, it is difficult to test that it would trigger. However, no changes have been made to this part of the code. It should now run for 5-6 times as long before maxing out the number of states.

## Checklist (delete if not relevant)
- [x] Updated CHANGELOG
- [x] Moved Trello ticket to PR column

## Reviewer checklist
- [ ] PR solves the Trello ticket requirements
- [ ] Outputs appear reasonable and understandable
- [ ] The overall approach is appropriate and not over-engineered
- [ ] No obvious scalability, performance or interdependency concerns
- [ ] Tests appropriately cover the main behaviour/edge cases
- [ ] Naming and structure are broadly understandable and consistent
- [ ] Docstrings are sufficient for future maintenance
- [ ] Docstrings cover non-obvious behaviour
