### PR TITLE
1811 - Fix Ind CQC Pipeline Group Providers function giving error)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -272,7 +272,6 @@ jobs:
             aws s3 sync "s3://sfc-main-datasets/domain=ind_cqc_filled_posts/dataset=ind_cqc_06_estimated_filled_posts/" "s3://$BRANCH_DATASET_BUCKET/domain=ind_cqc_filled_posts/dataset=main_ind_cqc_06_estimated_filled_posts/" --delete
             aws s3 sync "s3://sfc-main-datasets/domain=ind_cqc_filled_posts/dataset=ind_cqc_07_04_estimate_job_roles/" "s3://$BRANCH_DATASET_BUCKET/domain=ind_cqc_filled_posts/dataset=main_ind_cqc_07_04_estimate_job_roles/" --delete
             aws s3 sync "s3://sfc-main-datasets/domain=ind_cqc_filled_posts/dataset=ind_cqc_07_01_merge_metadata_job_roles/" "s3://$BRANCH_DATASET_BUCKET/domain=ind_cqc_filled_posts/dataset=main_ind_cqc_07_01_merge_metadata_job_roles/" --delete
-            aws s3 sync "s3://sfc-main-datasets/domain=SfC/dataset=sfc_grouped_providers/" "s3://$BRANCH_DATASET_BUCKET/domain=SfC/dataset=sfc_grouped_providers/" --delete
       - run:
           name: Copy models to non-prod dataset
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -272,6 +272,7 @@ jobs:
             aws s3 sync "s3://sfc-main-datasets/domain=ind_cqc_filled_posts/dataset=ind_cqc_06_estimated_filled_posts/" "s3://$BRANCH_DATASET_BUCKET/domain=ind_cqc_filled_posts/dataset=main_ind_cqc_06_estimated_filled_posts/" --delete
             aws s3 sync "s3://sfc-main-datasets/domain=ind_cqc_filled_posts/dataset=ind_cqc_07_04_estimate_job_roles/" "s3://$BRANCH_DATASET_BUCKET/domain=ind_cqc_filled_posts/dataset=main_ind_cqc_07_04_estimate_job_roles/" --delete
             aws s3 sync "s3://sfc-main-datasets/domain=ind_cqc_filled_posts/dataset=ind_cqc_07_01_merge_metadata_job_roles/" "s3://$BRANCH_DATASET_BUCKET/domain=ind_cqc_filled_posts/dataset=main_ind_cqc_07_01_merge_metadata_job_roles/" --delete
+            aws s3 sync "s3://sfc-main-datasets/domain=SfC/dataset=sfc_grouped_providers/" "s3://$BRANCH_DATASET_BUCKET/domain=SfC/dataset=sfc_grouped_providers/" --delete
       - run:
           name: Copy models to non-prod dataset
           command: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 - Fixed the Transform ASCWDS Data pipeline, which was failing due to an incorrect dataset name in Terraform and the clean workplace job dropping the `import_date` column that the clean worker job depends on. Corrected the Terraform dataset name and removed the drop statement for `import_date`. 
 
+- Fixed Schema mismatch error while generating grouped providers output.
+
 
 
 ## [v2026.06.0] - 15/07/2026

--- a/projects/_03_independent_cqc/_02_clean/fargate/clean_ind_cqc_filled_posts.py
+++ b/projects/_03_independent_cqc/_02_clean/fargate/clean_ind_cqc_filled_posts.py
@@ -41,11 +41,11 @@ GROUPED_PROVIDER_SCHEMA = pl.Schema(
         (AWPClean.nmds_id, pl.String()),
         (NGPcol.potential_grouped_provider, pl.Boolean()),
         (IndCQC.ascwds_filled_posts_dedup_clean, pl.Float64()),
+        (IndCQC.care_home, pl.String()),
+        (IndCQC.number_of_beds, pl.Int64()),
         (NGPcol.grouped_provider_status, pl.String()),
         (NGPcol.grp_prov_identified_date, pl.Date()),
         (NGPcol.grp_prov_fixed_date, pl.Date()),
-        (IndCQC.care_home, pl.String()),
-        (IndCQC.number_of_beds, pl.Int64()),
     ]
 )
 


### PR DESCRIPTION
## Description
Trello ticket [#1811](https://trello.com/c/eMBnPJOS/1811-fix-grouped-provider-concat-issue-clean-ind-cqc-job-failing-in-main)

When creating final output for Grouped Providers, we concat 3 different LazyFrames (Active, Fixed and New grouped providers). When this ran the first time, it was successful as Active LazyFrame was same as the other 2. But once we already have a parquet file with existing grouped providers, it is scanned in clean job with specific schema which does not match the other 2 and sop the error. I have updated the schema which should solve the issue.

## Testing
- [x] Unit tests passing
- [x] Successful [Step Function run](https://eu-west-2.console.aws.amazon.com/states/home?region=eu-west-2&hashArgs=%23%2Fv2%2Fexecutions%2Fdetails%2Farn%3Aaws%3Astates%3Aeu-west-2%3A856699698263%3Aexecution%3A1785-slv-invstgtn-Transform-ASCWDS-Data%3A98ec9ef5-b744-4b03-82a0-9f41ab6ac017&oauthStart=1784706726828#/v2/executions/details/arn:aws:states:eu-west-2:856699698263:execution:1811-fix-grp-prov-Ind-CQC-Filled-Post-Estimates:0cb30c74-50e5-4097-9efd-8eceb9b66162)
- [x] Outputs checked in Athena

[Add any additional testing information here - add screenshot if relevant]

## Checklist (delete if not relevant)
- [ ] Unit tests added/amended
- [ ] Docstrings added/updated
- [ ] Updated CHANGELOG
- [ ] Code reviewed by AI
- [ ] Moved Trello ticket to PR column

## Reviewer checklist
- [ ] PR solves the Trello ticket requirements
- [ ] Outputs appear reasonable and understandable
- [ ] The overall approach is appropriate and not over-engineered
- [ ] No obvious scalability, performance or interdependency concerns
- [ ] Tests appropriately cover the main behaviour/edge cases
- [ ] Naming and structure are broadly understandable and consistent
- [ ] Docstrings are sufficient for future maintenance
- [ ] Docstrings cover non-obvious behaviour
