### PR TITLE
1804 - Renamed SLV datasets so appear separately in Athena tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,10 +25,13 @@ All notable changes to this project will be documented in this file.
 
 - Get Workplace data schema from `discover_combined_schema` within Clean Workplace Job. Updated tests for the same.
 
+- Renamed 'slv' datasets in AWS so they are grouped together in alphabetical order.
+
 ### Fixed
 - Fixed the Transform ASCWDS Data pipeline, which was failing due to an incorrect dataset name in Terraform and the clean workplace job dropping the `import_date` column that the clean worker job depends on. Corrected the Terraform dataset name and removed the drop statement for `import_date`.
 
 - Fixed Schema mismatch error while generating grouped providers output.
+
 - Added missing error notifications for the CQC/ASC-WDS orchestrator and crawler-refresh steps in three ingestion pipelines, and a bounded timeout for the ASC-WDS worker/workplace file-arrival polling loops.
 
 ## [v2026.06.0] - 15/07/2026

--- a/terraform/pipeline/step-functions/dynamic/Ind-CQC-SLV.json
+++ b/terraform/pipeline/step-functions/dynamic/Ind-CQC-SLV.json
@@ -29,7 +29,7 @@
                       "Command": [
                         "_01_starters_leavers_vacancies/fargate/_00_prepare.py",
                         "--cleaned_ascwds_workplace_source", "${dataset_bucket_uri}/domain=ASCWDS/dataset=workplace_cleaned/",
-                        "--prepared_data_destination", "${dataset_bucket_uri}/domain=workforce_characteristics/dataset=ind_cqc_00_prepare_slv/"
+                        "--prepared_data_destination", "${dataset_bucket_uri}/domain=workforce_characteristics/dataset=ind_cqc_slv_00_prepare/"
                       ]
                     }
                   ]
@@ -66,8 +66,8 @@
                                 "_01_starters_leavers_vacancies/fargate/_01_merge.py",
                                 "--metadata_source", "${dataset_bucket_uri}/domain=ind_cqc_filled_posts/dataset=${ind_cqc_job_role_metadata}/",
                                 "--job_role_estimates_source", "${dataset_bucket_uri}/domain=ind_cqc_filled_posts/dataset=${ind_cqc_job_role_estimates}/",
-                                "--prepared_slv_dataset_source", "${dataset_bucket_uri}/domain=workforce_characteristics/dataset=ind_cqc_00_prepare_slv/",
-                                "--merged_data_destination","${dataset_bucket_uri}/domain=workforce_characteristics/dataset=ind_cqc_01_merge_slv/"
+                                "--prepared_slv_dataset_source", "${dataset_bucket_uri}/domain=workforce_characteristics/dataset=ind_cqc_slv_00_prepare/",
+                                "--merged_data_destination","${dataset_bucket_uri}/domain=workforce_characteristics/dataset=ind_cqc_slv_01_merge/"
                               ]
                             }
                           ]
@@ -101,9 +101,9 @@
                               "Command": [
                                 "_01_starters_leavers_vacancies/fargate/validate_00_prepare.py",
                                 "--bucket_name", "${dataset_bucket_name}",
-                                "--source_path", "domain=workforce_characteristics/dataset=ind_cqc_00_prepare_slv/",
+                                "--source_path", "domain=workforce_characteristics/dataset=ind_cqc_slv_00_prepare/",
                                 "--compare_path", "domain=ASCWDS/dataset=workplace_cleaned/",
-                                "--reports_path", "domain=data_validation_reports/dataset=validation_ind_cqc_00_prepare_slv/"
+                                "--reports_path", "domain=data_validation_reports/dataset=validation_ind_cqc_slv_00_prepare/"
                               ]
                             }
                           ]
@@ -142,8 +142,8 @@
                               "Name": "_07_workforce_characteristics-container",
                               "Command": [
                                 "_01_starters_leavers_vacancies/fargate/_02_clean.py",
-                                "--merged_data_source", "${dataset_bucket_uri}/domain=workforce_characteristics/dataset=ind_cqc_01_merge_slv/",
-                                "--cleaned_data_destination", "${dataset_bucket_uri}/domain=workforce_characteristics/dataset=ind_cqc_02_clean_slv/"
+                                "--merged_data_source", "${dataset_bucket_uri}/domain=workforce_characteristics/dataset=ind_cqc_slv_01_merge/",
+                                "--cleaned_data_destination", "${dataset_bucket_uri}/domain=workforce_characteristics/dataset=ind_cqc_slv_02_clean/"
                               ]
                             }
                           ]
@@ -177,9 +177,9 @@
                               "Command": [
                                 "_01_starters_leavers_vacancies/fargate/validate_01_merge.py",
                                 "--bucket_name", "${dataset_bucket_name}",
-                                "--source_path", "domain=workforce_characteristics/dataset=ind_cqc_01_merge_slv/",
+                                "--source_path", "domain=workforce_characteristics/dataset=ind_cqc_slv_01_merge/",
                                 "--compare_path", "domain=ind_cqc_filled_posts/dataset=${ind_cqc_job_role_estimates}/",
-                                "--reports_path", "domain=data_validation_reports/dataset=validation_ind_cqc_01_merge_slv/"
+                                "--reports_path", "domain=data_validation_reports/dataset=validation_ind_cqc_slv_01_merge/"
                               ]
                             }
                           ]
@@ -218,8 +218,8 @@
                               "Name": "_07_workforce_characteristics-container",
                               "Command": [
                                 "_01_starters_leavers_vacancies/fargate/_03_impute.py",
-                                "--cleaned_data_source", "${dataset_bucket_uri}/domain=workforce_characteristics/dataset=ind_cqc_02_clean_slv/",
-                                "--imputed_data_destination", "${dataset_bucket_uri}/domain=workforce_characteristics/dataset=ind_cqc_03_impute_slv/"
+                                "--cleaned_data_source", "${dataset_bucket_uri}/domain=workforce_characteristics/dataset=ind_cqc_slv_02_clean/",
+                                "--imputed_data_destination", "${dataset_bucket_uri}/domain=workforce_characteristics/dataset=ind_cqc_slv_03_impute/"
                               ]
                             }
                           ]
@@ -253,9 +253,9 @@
                               "Command": [
                                 "_01_starters_leavers_vacancies/fargate/validate_02_clean.py",
                                 "--bucket_name", "${dataset_bucket_name}",
-                                "--source_path", "domain=workforce_characteristics/dataset=ind_cqc_02_clean_slv/",
-                                "--compare_path", "domain=workforce_characteristics/dataset=ind_cqc_01_merge_slv/",
-                                "--reports_path", "domain=data_validation_reports/dataset=validation_ind_cqc_02_clean_slv/"
+                                "--source_path", "domain=workforce_characteristics/dataset=ind_cqc_slv_02_clean/",
+                                "--compare_path", "domain=workforce_characteristics/dataset=ind_cqc_slv_01_merge/",
+                                "--reports_path", "domain=data_validation_reports/dataset=validation_ind_cqc_slv_02_clean/"
                               ]
                             }
                           ]
@@ -294,8 +294,8 @@
                               "Name": "_07_workforce_characteristics-container",
                               "Command": [
                                 "_01_starters_leavers_vacancies/fargate/_04_estimate.py",
-                                "--imputed_data_source", "${dataset_bucket_uri}/domain=workforce_characteristics/dataset=ind_cqc_03_impute_slv/",
-                                "--estimated_data_destination", "${dataset_bucket_uri}/domain=workforce_characteristics/dataset=ind_cqc_04_estimate_slv/"
+                                "--imputed_data_source", "${dataset_bucket_uri}/domain=workforce_characteristics/dataset=ind_cqc_slv_03_impute/",
+                                "--estimated_data_destination", "${dataset_bucket_uri}/domain=workforce_characteristics/dataset=ind_cqc_slv_04_estimate/"
                               ]
                             }
                           ]
@@ -329,9 +329,9 @@
                               "Command": [
                                 "_01_starters_leavers_vacancies/fargate/validate_03_impute.py",
                                 "--bucket_name", "${dataset_bucket_name}",
-                                "--source_path", "domain=workforce_characteristics/dataset=ind_cqc_03_impute_slv/",
-                                "--compare_path", "domain=workforce_characteristics/dataset=ind_cqc_02_clean_slv/",
-                                "--reports_path", "domain=data_validation_reports/dataset=validation_ind_cqc_03_impute_slv/"
+                                "--source_path", "domain=workforce_characteristics/dataset=ind_cqc_slv_03_impute/",
+                                "--compare_path", "domain=workforce_characteristics/dataset=ind_cqc_slv_02_clean/",
+                                "--reports_path", "domain=data_validation_reports/dataset=validation_ind_cqc_slv_03_impute/"
                               ]
                             }
                           ]
@@ -364,9 +364,9 @@
                               "Command": [
                                 "_01_starters_leavers_vacancies/fargate/validate_04_estimate.py",
                                 "--bucket_name", "${dataset_bucket_name}",
-                                "--source_path", "domain=workforce_characteristics/dataset=ind_cqc_04_estimate_slv/",
-                                "--compare_path", "domain=workforce_characteristics/dataset=ind_cqc_03_impute_slv/",
-                                "--reports_path", "domain=data_validation_reports/dataset=validation_ind_cqc_04_estimate_slv/"
+                                "--source_path", "domain=workforce_characteristics/dataset=ind_cqc_slv_04_estimate/",
+                                "--compare_path", "domain=workforce_characteristics/dataset=ind_cqc_slv_03_impute/",
+                                "--reports_path", "domain=data_validation_reports/dataset=validation_ind_cqc_slv_04_estimate/"
                               ]
                             }
                           ]


### PR DESCRIPTION
## Description
Trello ticket [#1804](https://trello.com/c/lmhxnUfO/1804-s-rename-s3-slv-datasets)

Renamed the SLV datasets so that they sit next to each other once ordered alphabetically (easier to find in Athena tables etc)

Previously
<img width="335" height="257" alt="image" src="https://github.com/user-attachments/assets/11c974d0-5833-400c-9405-27e44dd4b849" />

Now
<img width="394" height="277" alt="image" src="https://github.com/user-attachments/assets/9f0634cd-912d-475b-8c4d-24bed366e4cf" />


## Testing
- [X] Unit tests passing
- [X] Successful [Step Function run](https://eu-west-2.console.aws.amazon.com/states/home?region=eu-west-2#/v2/executions/details/arn:aws:states:eu-west-2:856699698263:execution:1804-rename-slv-Workforce-Intelligence-Pipeline:62584960-fc4c-4c40-9666-ad278bf5f0ec)
- [X] Outputs checked in Athena

## Checklist (delete if not relevant)
- [X] Updated CHANGELOG
- [X] Moved Trello ticket to PR column

## Reviewer checklist
- [ ] PR solves the Trello ticket requirements
- [ ] Outputs appear reasonable and understandable
- [ ] The overall approach is appropriate and not over-engineered
- [ ] No obvious scalability, performance or interdependency concerns
- [ ] Tests appropriately cover the main behaviour/edge cases
- [ ] Naming and structure are broadly understandable and consistent
- [ ] Docstrings are sufficient for future maintenance
- [ ] Docstrings cover non-obvious behaviour
