### PR TITLE
1813 - Increase ASCWDS retry time period

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,6 @@ All notable changes to this project will be documented in this file.
 - Added placeholders to slv prepare job, a utils script for prep with placeholders and tests placeholders.
 
 ### Changed
-- Widened the ASC-WDS file-arrival polling in the orchestrator step function to check every 15 minutes for up to 15 hours, to accommodate ASC-WDS data now arriving much later than before.
-
 - Pull clean workplace columns into merge job within SLV pipeline.
 
 - Updated references from workplace data for 'reconciliation' process to 'SfC internal' as the dataset is used in multiple jobs
@@ -26,6 +24,8 @@ All notable changes to this project will be documented in this file.
 - Refactored bounding of total staff and worker record columns in `clean_ascwds_workplace.py` and added logic for bounding SLV columns.
 
 - Get Workplace data schema from `discover_combined_schema` within Clean Workplace Job. Updated tests for the same.
+
+- Widened the ASC-WDS file-arrival polling in the orchestrator step function to check every 15 minutes for up to 15 hours, to accommodate ASC-WDS data now arriving much later than before.
 
 ### Fixed
 - Fixed the Transform ASCWDS Data pipeline, which was failing due to an incorrect dataset name in Terraform and the clean workplace job dropping the `import_date` column that the clean worker job depends on. Corrected the Terraform dataset name and removed the drop statement for `import_date`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ All notable changes to this project will be documented in this file.
 
 - Renamed 'slv' datasets in AWS so they are grouped together in alphabetical order.
 
-- Widened the ASC-WDS file-arrival polling in the orchestrator step function to check every 15 minutes for up to 15 hours, to accommodate ASC-WDS data now arriving much later than before.
+- Widened the ASC-WDS file-arrival polling in the orchestrator step function to check every 15 minutes for up to 15 hours on the main workspace, to accommodate ASC-WDS data now arriving much later than before, and made the polling interval and attempt count workspace-configurable so non-main workspaces poll every 10 seconds for up to 100 seconds instead.
 
 ### Fixed
 - Fixed the Transform ASCWDS Data pipeline, which was failing due to an incorrect dataset name in Terraform and the clean workplace job dropping the `import_date` column that the clean worker job depends on. Corrected the Terraform dataset name and removed the drop statement for `import_date`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ All notable changes to this project will be documented in this file.
 - Added placeholders to slv prepare job, a utils script for prep with placeholders and tests placeholders.
 
 ### Changed
+- Widened the ASC-WDS file-arrival polling in the orchestrator step function to check every 15 minutes for up to 15 hours, to accommodate ASC-WDS data now arriving much later than before.
+
 - Pull clean workplace columns into merge job within SLV pipeline.
 
 - Updated references from workplace data for 'reconciliation' process to 'SfC internal' as the dataset is used in multiple jobs

--- a/terraform/pipeline/step-function.tf
+++ b/terraform/pipeline/step-function.tf
@@ -13,7 +13,7 @@ locals {
   # worker/workplace file-arrival check gives up and notifies.
   # NOTE: coupled to that Wait interval - if it changes, this number no longer
   # represents the same wall-clock timeout and should be revisited.
-  ascwds_polling_max_attempts = terraform.workspace == "main" ? 120 : 5
+  ascwds_polling_max_attempts = terraform.workspace == "main" ? 60 : 5
 }
 
 # Created explicitly as required by dynamic step functions

--- a/terraform/pipeline/step-function.tf
+++ b/terraform/pipeline/step-function.tf
@@ -8,12 +8,13 @@ locals {
   ind_cqc_job_role_estimates_dataset_name = terraform.workspace == "main" ? "ind_cqc_07_04_estimate_job_roles" : "main_ind_cqc_07_04_estimate_job_roles"
   ind_cqc_job_role_metadata_dataset_name  = terraform.workspace == "main" ? "ind_cqc_07_01_merge_metadata_job_roles" : "main_ind_cqc_07_01_merge_metadata_job_roles"
 
-  # Max polling attempts (at the Wait interval configured in "Wait For Worker"/
-  # "Wait For Workplace" in CQC-And-ASCWDS-Orchestrator.json) before the ASC-WDS
-  # worker/workplace file-arrival check gives up and notifies.
-  # NOTE: coupled to that Wait interval - if it changes, this number no longer
-  # represents the same wall-clock timeout and should be revisited.
+  # Max polling attempts and per-attempt wait (seconds) for the "Wait For Worker"/
+  # "Wait For Workplace" states in CQC-And-ASCWDS-Orchestrator.json, before the
+  # ASC-WDS worker/workplace file-arrival check gives up and notifies.
+  # Non-main workspaces poll faster and fewer times so a failure surfaces in
+  # seconds rather than tying up a dev run for over an hour.
   ascwds_polling_max_attempts = terraform.workspace == "main" ? 60 : 5
+  ascwds_polling_wait_seconds = terraform.workspace == "main" ? 900 : 10
 }
 
 # Created explicitly as required by dynamic step functions
@@ -64,6 +65,7 @@ resource "aws_sfn_state_machine" "cqc_and_ascwds_orchestrator_state_machine" {
     workforce_intelligence_state_machine_arn = aws_sfn_state_machine.workforce_intelligence_state_machine.arn
     pipeline_failure_lambda_function_arn     = aws_lambda_function.error_notification_lambda.arn
     ascwds_polling_max_attempts              = local.ascwds_polling_max_attempts
+    ascwds_polling_wait_seconds              = local.ascwds_polling_wait_seconds
   })
 
   depends_on = [

--- a/terraform/pipeline/step-functions/CQC-And-ASCWDS-Orchestrator.json
+++ b/terraform/pipeline/step-functions/CQC-And-ASCWDS-Orchestrator.json
@@ -94,7 +94,7 @@
                     },
                     "Wait For Worker": {
                       "Type": "Wait",
-                      "Seconds": 900,
+                      "Seconds": ${ascwds_polling_wait_seconds},
                       "Next": "Check Worker"
                    },
                     "Worker Timeout": {
@@ -160,7 +160,7 @@
                     },
                     "Wait For Workplace": {
                       "Type": "Wait",
-                      "Seconds": 900,
+                      "Seconds": ${ascwds_polling_wait_seconds},
                       "Next": "Check Workplace"
                     },
                     "Workplace Timeout": {

--- a/terraform/pipeline/step-functions/CQC-And-ASCWDS-Orchestrator.json
+++ b/terraform/pipeline/step-functions/CQC-And-ASCWDS-Orchestrator.json
@@ -94,7 +94,7 @@
                     },
                     "Wait For Worker": {
                       "Type": "Wait",
-                      "Seconds": 60,
+                      "Seconds": 900,
                       "Next": "Check Worker"
                    },
                     "Worker Timeout": {
@@ -160,7 +160,7 @@
                     },
                     "Wait For Workplace": {
                       "Type": "Wait",
-                      "Seconds": 60,
+                      "Seconds": 900,
                       "Next": "Check Workplace"
                     },
                     "Workplace Timeout": {


### PR DESCRIPTION
## Description
Trello ticket [#1813](https://trello.com/c/my0pfXss/1813-extend-ascwds-file-retrying-process)

Widened the ASC-WDS file-arrival polling in the orchestrator step function to check every 15 minutes for up to 15 hours, to accommodate ASC-WDS data now arriving much later than before.

## Checklist 
- [X] Updated CHANGELOG
- [X] Moved Trello ticket to PR column

## Reviewer checklist
- [ ] PR solves the Trello ticket requirements
- [ ] Outputs appear reasonable and understandable
- [ ] The overall approach is appropriate and not over-engineered
- [ ] No obvious scalability, performance or interdependency concerns
- [ ] Tests appropriately cover the main behaviour/edge cases
- [ ] Naming and structure are broadly understandable and consistent
- [ ] Docstrings are sufficient for future maintenance
- [ ] Docstrings cover non-obvious behaviour
