### PR TITLE
1796 Reduce cleaned workplace lazyframe to published roles in slv prep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ All notable changes to this project will be documented in this file.
 
 - Renamed 'slv' datasets in AWS so they are grouped together in alphabetical order.
 
+- Called merge_job_role_columns in slv prepare job.
+
 ### Fixed
 - Fixed the Transform ASCWDS Data pipeline, which was failing due to an incorrect dataset name in Terraform and the clean workplace job dropping the `import_date` column that the clean worker job depends on. Corrected the Terraform dataset name and removed the drop statement for `import_date`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,8 @@ All notable changes to this project will be documented in this file.
 
 - Renamed 'slv' datasets in AWS so they are grouped together in alphabetical order.
 
-- Called merge_job_role_columns in slv prepare job.
+- Called merge_job_role_columns in slv prepare job to reduce job role columns to only published roles plus
+  'other direct care/manager/etc'
 
 ### Fixed
 - Fixed the Transform ASCWDS Data pipeline, which was failing due to an incorrect dataset name in Terraform and the clean workplace job dropping the `import_date` column that the clean worker job depends on. Corrected the Terraform dataset name and removed the drop statement for `import_date`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,10 +37,6 @@ All notable changes to this project will be documented in this file.
 
 - Reduced the SLV prepare step further to one file per calendar month, matching the granularity the downstream job role estimates dataset already uses. Generalised the existing earliest-file-per-month reduction into a shared `earliest_file_per_month_filter_expr` in Polars Utils (alongside `reduced_data_filter_expr`) so both pipelines use the same definition, and updated its existing callers in the independent CQC clean job accordingly.
 
-- Widened the ASC-WDS file-arrival polling in the orchestrator step function to check every 15 minutes for up to 15 hours on the main workspace, to accommodate ASC-WDS data now arriving much later than before, and made the polling interval and attempt count workspace-configurable so non-main workspaces poll every 10 seconds for up to 100 seconds instead.
-
-- Reduced the rows carried through the SLV prepare step to the same retention window the downstream job role estimates already use, and moved `reduced_data_filter_expr` into Polars Utils so both pipelines share one definition of that window.
-
 - Called merge_job_role_columns in slv prepare job to reduce job role columns to only published roles plus
   'other direct care/manager/etc'
 

--- a/polars_utils/cleaning_utils.py
+++ b/polars_utils/cleaning_utils.py
@@ -302,9 +302,15 @@ def merge_job_role_columns(
         {re.sub(r"^jr\d+", "", col) for col in job_role_cols if col.startswith("jr")}
     )
 
+    print("column names before merging:")
+    print(lf.collect_schema().names())
+
     lf = lf.with_columns(
         merge_job_roles_expressions(job_role_mapping, job_role_suffixes),
     )
+
+    print("column names after merging:")
+    print(lf.collect_schema().names())
 
     old_roles = [old for olds in job_role_mapping.values() for old in olds]
     lf = lf.drop(cs.starts_with(*[f"jr{role}" for role in old_roles]))
@@ -336,6 +342,9 @@ def merge_job_roles_expressions(
         for suffix in slv_suffixes:
             prefixes = [f"jr{role_to_keep}"] + [f"jr{old}" for old in roles_to_merge]
             cols = cs.starts_with(*prefixes) & cs.ends_with(suffix)
+
+            print(f"jr{role_to_keep}{suffix}")
+
             yield (
                 pl.when(pl.all_horizontal(cols.is_null()))
                 .then(pl.lit(None))

--- a/polars_utils/cleaning_utils.py
+++ b/polars_utils/cleaning_utils.py
@@ -302,18 +302,15 @@ def merge_job_role_columns(
         {re.sub(r"^jr\d+", "", col) for col in job_role_cols if col.startswith("jr")}
     )
 
-    print("column names before merging:")
-    print(lf.collect_schema().names())
-
     lf = lf.with_columns(
         merge_job_roles_expressions(job_role_mapping, job_role_suffixes),
     )
 
-    print("column names after merging:")
-    print(lf.collect_schema().names())
-
     old_roles = [old for olds in job_role_mapping.values() for old in olds]
-    lf = lf.drop(cs.starts_with(*[f"jr{role}" for role in old_roles]))
+    roles_to_drop = [
+        f"jr{role}{suffix}" for role in old_roles for suffix in job_role_suffixes
+    ]
+    lf = lf.drop(cs.by_name(*roles_to_drop, require_all=False))
 
     return lf
 
@@ -342,9 +339,6 @@ def merge_job_roles_expressions(
         for suffix in slv_suffixes:
             prefixes = [f"jr{role_to_keep}"] + [f"jr{old}" for old in roles_to_merge]
             cols = cs.starts_with(*prefixes) & cs.ends_with(suffix)
-
-            print(f"jr{role_to_keep}{suffix}")
-
             yield (
                 pl.when(pl.all_horizontal(cols.is_null()))
                 .then(pl.lit(None))

--- a/polars_utils/cleaning_utils.py
+++ b/polars_utils/cleaning_utils.py
@@ -306,6 +306,8 @@ def merge_job_role_columns(
         merge_job_roles_expressions(job_role_mapping, job_role_suffixes),
     )
 
+    # Flatten job role lists from job_role_mapping into single list, format them
+    # to match column names, then drop those columns.
     old_roles = [old for olds in job_role_mapping.values() for old in olds]
     roles_to_drop = [
         f"jr{role}{suffix}" for role in old_roles for suffix in job_role_suffixes

--- a/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/_00_prepare.py
+++ b/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/_00_prepare.py
@@ -1,3 +1,5 @@
+import polars.selectors as cs
+
 import polars_utils.cleaning_utils as cUtils
 import projects._07_workforce_characteristics._01_starters_leavers_vacancies.fargate.utils.prepare_utils as pUtils
 from polars_utils import utils
@@ -5,8 +7,8 @@ from polars_utils import utils
 unpublished_roles_mapping = {
     "101": ["02", "03", "05", "24", "45", "47", "49", "50"], # other managers
     "102": ["35", "37"], # other regulated professions
-    "103": ["10", "11", "22", "23", "38"], # other direct care
-    "104": ["25", "26", "27", "34", "36", "39", "40", "41", "42", "44", "46", "48", "51"], # other
+    "103": ["10", "11", "23", "38"], # other direct care
+    "104": ["25", "26", "27", "34", "36", "39", "40", "42", "44", "46", "48", "51"], # other
 } # fmt: skip
 
 
@@ -25,6 +27,12 @@ def main(
 
     workplace_lf = cUtils.merge_job_role_columns(
         workplace_lf, unpublished_roles_mapping
+    )
+
+    # These columns refer to overall and job groups.
+    # They are not required because we only want job roles at this stage.
+    workplace_lf = workplace_lf.drop(
+        cs.matches(r"^jr(28|29|30|31|32)(emp|strt|stop|vacy)$")
     )
 
     # TODO: Backlog ticket/no number - Placeholder only.

--- a/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/_00_prepare.py
+++ b/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/_00_prepare.py
@@ -3,7 +3,7 @@ import projects._07_workforce_characteristics._01_starters_leavers_vacancies.far
 from polars_utils import utils
 
 unpublished_roles_mapping = {
-    "101": ["2", "3", "4", "24", "45", "47", "49", "50"], # other managers
+    "101": ["2", "3", "5", "24", "45", "47", "49", "50"], # other managers
     "102": ["35", "37"], # other regulated professions
     "103": ["10", "11", "22", "23", "38"], # other direct care
     "104": ["25", "26", "27", "34", "36", "39", "40", "41", "42", "44", "46", "48", "51"], # other

--- a/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/_00_prepare.py
+++ b/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/_00_prepare.py
@@ -1,6 +1,13 @@
+import polars_utils.cleaning_utils as cUtils
 import projects._07_workforce_characteristics._01_starters_leavers_vacancies.fargate.utils.prepare_utils as pUtils
 from polars_utils import utils
-from polars_utils.cleaning_utils import apply_categorical_labels
+
+unpublished_roles_mapping = {
+    "101": ["2", "3", "4", "24", "45", "47", "49", "50"], # other managers
+    "102": ["35", "37"], # other regulated professions
+    "103": ["10", "11", "22", "23", "38"], # other direct care
+    "104": ["25", "26", "27", "34", "36", "39", "40", "41", "42", "44", "46", "48", "51"], # other
+} # fmt: skip
 
 
 def main(
@@ -15,8 +22,9 @@ def main(
     """
     workplace_lf = utils.scan_parquet(cleaned_ascwds_workplace_source)
 
-    # TODO: 1796 - Placeholder only.
-    # pUtils.reduce_to_published_roles()
+    workplace_lf = cUtils.merge_job_role_columns(
+        workplace_lf, unpublished_roles_mapping
+    )
 
     # TODO: Backlog ticket/no number - Placeholder only.
     # pUtils.pivot_job_role_cols_to_rows()

--- a/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/_00_prepare.py
+++ b/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/_00_prepare.py
@@ -3,7 +3,7 @@ import projects._07_workforce_characteristics._01_starters_leavers_vacancies.far
 from polars_utils import utils
 
 unpublished_roles_mapping = {
-    "101": ["2", "3", "5", "24", "45", "47", "49", "50"], # other managers
+    "101": ["02", "03", "05", "24", "45", "47", "49", "50"], # other managers
     "102": ["35", "37"], # other regulated professions
     "103": ["10", "11", "22", "23", "38"], # other direct care
     "104": ["25", "26", "27", "34", "36", "39", "40", "41", "42", "44", "46", "48", "51"], # other
@@ -14,7 +14,8 @@ def main(
     cleaned_ascwds_workplace_source: str,
     prepared_data_destination: str,
 ) -> None:
-    """Load the cleaned ASCWDS workplace dataset and save it unchanged.
+    """Load the cleaned ASCWDS workplace dataset and then:
+        - Merge unpublished roles into 'other' groups
 
     Args:
         cleaned_ascwds_workplace_source (str): path to the cleaned ascwds workplace data

--- a/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/_00_prepare.py
+++ b/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/_00_prepare.py
@@ -5,10 +5,10 @@ import projects._07_workforce_characteristics._01_starters_leavers_vacancies.far
 from polars_utils import utils
 
 unpublished_roles_mapping = {
-    "101": ["02", "03", "05", "24", "45", "47", "49", "50"], # other managers
-    "102": ["35", "37"], # other regulated professions
-    "103": ["10", "11", "23", "38"], # other direct care
-    "104": ["25", "26", "27", "34", "36", "39", "40", "42", "44", "46", "48", "51"], # other
+    "1001": ["02", "03", "05", "24", "45", "47", "49", "50"], # other managers
+    "1002": ["35", "37"], # other regulated professions
+    "1003": ["10", "11", "23", "38"], # other direct care
+    "1004": ["25", "26", "27", "34", "36", "39", "40", "42", "44", "46", "48", "51"], # other
 } # fmt: skip
 
 
@@ -29,7 +29,7 @@ def main(
         workplace_lf, unpublished_roles_mapping
     )
 
-    # These columns refer to overall and job groups.
+    # These columns refer to the toal for all job roles (28) and the total for job groups (29-32).
     # They are not required because we only want job roles at this stage.
     workplace_lf = workplace_lf.drop(
         cs.matches(r"^jr(28|29|30|31|32)(emp|strt|stop|vacy)$")

--- a/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/_00_prepare.py
+++ b/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/_00_prepare.py
@@ -25,7 +25,8 @@ def main(
     prepared_data_destination: str,
 ) -> None:
     """Load the cleaned ASCWDS workplace dataset and then:
-        - reduce data to quarterly import dates before two previous financial years
+        - reduce rows to quarterly import dates before two previous financial years
+          and then earliest import day per month.
         - merge unpublished roles into 'other' groups
 
     Args:

--- a/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/tests/fargate/test_00_prepare.py
+++ b/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/tests/fargate/test_00_prepare.py
@@ -11,18 +11,18 @@ class MainTests(unittest.TestCase):
     PREPARED_DATA_DESTINATION = "some/destination"
 
     @patch(f"{PATCH_PATH}.utils.sink_to_parquet")
-    @patch(f"{PATCH_PATH}.apply_categorical_labels")
+    @patch(f"{PATCH_PATH}.cUtils.apply_categorical_labels")
     @patch(f"{PATCH_PATH}.pUtils.convert_job_role_strings_to_number_only")
     @patch(f"{PATCH_PATH}.pUtils.pivot_job_role_cols_to_rows")
-    @patch(f"{PATCH_PATH}.pUtils.reduce_to_published_roles")
+    @patch(f"{PATCH_PATH}.cUtils.merge_job_role_columns")
     @patch(f"{PATCH_PATH}.utils.scan_parquet")
     def test_main_runs(
         self,
         scan_parquet_mock: Mock,
-        reduce_to_published_roles: Mock,
-        pivot_job_role_cols_to_rows: Mock,
-        convert_job_role_strings_to_number_only: Mock,
-        apply_categorical_labels: Mock,
+        merge_job_role_columns_mock: Mock,
+        pivot_job_role_cols_to_rows_mock: Mock,
+        convert_job_role_strings_to_number_only_mock: Mock,
+        apply_categorical_labels_mock: Mock,
         sink_to_parquet_mock: Mock,
     ):
         job.main(
@@ -33,10 +33,10 @@ class MainTests(unittest.TestCase):
         scan_parquet_mock.assert_called_once_with(self.CLEANED_ASCWDS_WORKPLACE_SOURCE)
 
         # TODO: Uncomment these assertions when the placeholder functions are implemented
-        # reduce_to_published_roles.assert_called_once()
-        # pivot_job_role_cols_to_rows.assert_called_once()
-        # convert_job_role_strings_to_number_only.assert_called_once()
-        # apply_categorical_labels.assert_called_once()
+        merge_job_role_columns_mock.assert_called_once()
+        # pivot_job_role_cols_to_rows_mock.assert_called_once()
+        # convert_job_role_strings_to_number_only_mock.assert_called_once()
+        # apply_categorical_labels_mock.assert_called_once()
 
         sink_to_parquet_mock.assert_called_once_with(
             lazy_df=ANY,

--- a/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/tests/fargate/test_00_prepare.py
+++ b/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/tests/fargate/test_00_prepare.py
@@ -1,4 +1,4 @@
-from unittest.mock import Mock, patch
+from unittest.mock import ANY, Mock, patch
 
 import projects._07_workforce_characteristics._01_starters_leavers_vacancies.fargate._00_prepare as job
 from utils.column_names.cleaned_data_files.ascwds_workplace_cleaned import (
@@ -50,6 +50,6 @@ class TestPrepare:
         # apply_categorical_labels_mock.assert_called_once()
 
         sink_to_parquet_mock.assert_called_once_with(
-            lazy_df=scan_lf.filter.return_value,
+            lazy_df=ANY,
             output_path=self.PREPARED_DATA_DESTINATION,
         )

--- a/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/tests/fargate/test_00_prepare.py
+++ b/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/tests/fargate/test_00_prepare.py
@@ -60,11 +60,14 @@ class TestPrepare:
 
         # TODO: Uncomment these assertions when the placeholder functions are implemented
         merge_job_role_columns_mock.assert_called_once()
+        merged_jr_cols_lf = merge_job_role_columns_mock.return_value
+        merged_jr_cols_lf.drop.assert_called_once()
+        dropped_cols_lf = merged_jr_cols_lf.drop.return_value
         # pivot_job_role_cols_to_rows_mock.assert_called_once()
         # convert_job_role_strings_to_number_only_mock.assert_called_once()
         # apply_categorical_labels_mock.assert_called_once()
 
         sink_to_parquet_mock.assert_called_once_with(
-            lazy_df=ANY,
+            lazy_df=dropped_cols_lf,
             output_path=self.PREPARED_DATA_DESTINATION,
         )

--- a/tests/test_polars_utils/test_cleaning_utils.py
+++ b/tests/test_polars_utils/test_cleaning_utils.py
@@ -496,6 +496,38 @@ class TestMergeJobRoleColumns:
                 "not_a_job_role_column": "A",
             },
         ),
+        MergeJobRoleColumnsTestCase(
+            id="handles_three_digit_job_role",
+            mapping={"101": ["02"]},
+            input_data={
+                AWPClean.job_role_01_employees: 1,
+                AWPClean.job_role_02_employees: 2,
+            },
+            expected_data={
+                AWPClean.job_role_01_employees: 1,
+                "jr101emp": 2,
+            },
+        ),
+        MergeJobRoleColumnsTestCase(
+            id="handles_multiple_roles_to_keep",
+            mapping={"101": ["02"], "102": ["02", "03"]},
+            input_data={
+                AWPClean.job_role_01_employees: 1,
+                AWPClean.job_role_02_employees: 2,
+                AWPClean.job_role_03_employees: 3,
+                AWPClean.job_role_01_starters: 10,
+                AWPClean.job_role_02_starters: 20,
+                AWPClean.job_role_03_starters: 30,
+            },
+            expected_data={
+                AWPClean.job_role_01_employees: 1,
+                AWPClean.job_role_01_starters: 10,
+                "jr101emp": 2,
+                "jr102emp": 5,
+                "jr101strt": 20,
+                "jr102strt": 60,
+            },
+        ),
     ]
 
     @pytest.mark.parametrize(
@@ -507,4 +539,6 @@ class TestMergeJobRoleColumns:
         expected_lf = pl.LazyFrame(case.expected_data)
         returned_lf = job.merge_job_role_columns(test_lf, case.mapping)
 
-        pl_testing.assert_frame_equal(returned_lf, expected_lf)
+        pl_testing.assert_frame_equal(
+            returned_lf, expected_lf, check_column_order=False
+        )

--- a/tests/test_polars_utils/test_cleaning_utils.py
+++ b/tests/test_polars_utils/test_cleaning_utils.py
@@ -497,35 +497,13 @@ class TestMergeJobRoleColumns:
             },
         ),
         MergeJobRoleColumnsTestCase(
-            id="handles_three_digit_job_role",
-            mapping={"101": ["02"]},
+            id="handles_job_roles_with_same_characters",
+            mapping={"101": ["10"]},
             input_data={
-                AWPClean.job_role_01_employees: 1,
-                AWPClean.job_role_02_employees: 2,
+                AWPClean.job_role_10_employees: 10,
             },
             expected_data={
-                AWPClean.job_role_01_employees: 1,
-                "jr101emp": 2,
-            },
-        ),
-        MergeJobRoleColumnsTestCase(
-            id="handles_multiple_roles_to_keep",
-            mapping={"101": ["02"], "102": ["02", "03"]},
-            input_data={
-                AWPClean.job_role_01_employees: 1,
-                AWPClean.job_role_02_employees: 2,
-                AWPClean.job_role_03_employees: 3,
-                AWPClean.job_role_01_starters: 10,
-                AWPClean.job_role_02_starters: 20,
-                AWPClean.job_role_03_starters: 30,
-            },
-            expected_data={
-                AWPClean.job_role_01_employees: 1,
-                AWPClean.job_role_01_starters: 10,
-                "jr101emp": 2,
-                "jr102emp": 5,
-                "jr101strt": 20,
-                "jr102strt": 60,
+                "jr101emp": 10,
             },
         ),
     ]

--- a/tests/test_polars_utils/test_cleaning_utils.py
+++ b/tests/test_polars_utils/test_cleaning_utils.py
@@ -517,6 +517,4 @@ class TestMergeJobRoleColumns:
         expected_lf = pl.LazyFrame(case.expected_data)
         returned_lf = job.merge_job_role_columns(test_lf, case.mapping)
 
-        pl_testing.assert_frame_equal(
-            returned_lf, expected_lf, check_column_order=False
-        )
+        pl_testing.assert_frame_equal(returned_lf, expected_lf)


### PR DESCRIPTION
## Description
Trello ticket [1796](https://trello.com/c/MLY0CvhG)

Called cleaning util merge_job_role_columns in slv prep job script.
Updated job test script to reflect function call.

I had to change the merge function to prevent dropping job role columns with similar chars in name. 
Targeting jr10emp would also drop jr101emp.
I added a test for this.

## Testing
- [x] Unit tests passing
- [x] Successful [Step Function run](https://eu-west-2.console.aws.amazon.com/states/home?region=eu-west-2#/v2/executions/details/arn:aws:states:eu-west-2:856699698263:execution:1796-less-roles-Ind-CQC-SLV:90f630f4-f57b-4b8c-97d2-331103ebb6f7)
- [x] Outputs checked in Athena

See Excel attached to Trello ticket.
First tab shows how job roles are mapped.
Second tab compares manually summing job roles in workplace_cleaned to slv_prep output. There's zero difference.

## Checklist (delete if not relevant)
- [x] Docstrings added/updated
- [x] Updated CHANGELOG
- [x] Moved Trello ticket to PR column

## Reviewer checklist
- [ ] PR solves the Trello ticket requirements
- [ ] Outputs appear reasonable and understandable
- [ ] The overall approach is appropriate and not over-engineered
- [ ] No obvious scalability, performance or interdependency concerns
- [ ] Tests appropriately cover the main behaviour/edge cases
- [ ] Naming and structure are broadly understandable and consistent
- [ ] Docstrings are sufficient for future maintenance
- [ ] Docstrings cover non-obvious behaviour
