### PR TITLE
1814 - Implement production SLV job-role reshape in _00_prepare

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Added
+- Added the production reshape of SLV job-role columns from wide to long format in the `_00_prepare` job, with matching validation checks and the `_01_merge` column-selection update needed to read the new shape.
+
 - Added a skeleton `_00_prepare` task (with validation) ahead of the merge step in the SLV pipeline, and rewired the merge step to read its output.
 
 - Added `discover_combined_schema` function in Polars Utils to generate combined schema from a partitioned dataset.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ All notable changes to this project will be documented in this file.
 - Renamed 'slv' datasets in AWS so they are grouped together in alphabetical order.
 
 ### Fixed
+- Fixed an OOM in the SLV `_00_prepare` validation job caused by pointblank's `rows_distinct()` grain-uniqueness check at production scale (~370M rows); replaced it with a custom, lower-memory duplicate-grain check.
+
 - Fixed the Transform ASCWDS Data pipeline, which was failing due to an incorrect dataset name in Terraform and the clean workplace job dropping the `import_date` column that the clean worker job depends on. Corrected the Terraform dataset name and removed the drop statement for `import_date`.
 
 - Fixed Schema mismatch error while generating grouped providers output.

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,0 +1,157 @@
+# SPEC: Production implementation of the SLV job-role reshape (1814)
+
+## Context
+
+Ticket 1797 designed how to reshape `_00_prepare.py`'s 148 wide `jrNN{emp,strt,stop,vacy}`
+SLV job-role columns into a long-format table: one row per `establishment_id` ×
+`ascwds_workplace_import_date` × `job_role_code`, with `employees`/`starters`/
+`leavers`/`vacancies` metric columns. Job-role codes are discovered dynamically
+from the schema at runtime, not hardcoded, so this stays robust to ASC-WDS
+adding/retiring codes.
+
+Two prototype branches were built and deployed at real production scale
+(`sfc-*-datasets/domain=ASCWDS/dataset=workplace_cleaned`, ~6.6M rows × 210 cols):
+Candidate A (`1797-a-unpivot`, four `.unpivot()` calls joined back together) OOM'd
+on the 60 GiB Fargate task; Candidate B (`1797-b-struct`, `pl.struct()` per
+job-role code → `concat_list` → `explode` → `unnest`) succeeded at ~14 GB peak
+RSS. That decision is closed — Candidate B is the technique used here.
+
+A production-readiness design was interviewed and agreed afterwards, but never
+implemented — `main` only had the bare placeholder stub added by ticket 1798.
+**This ticket (1814) is that implementation**, built on branch `1814-slv-reshp`
+in a separate git worktree (`../DataEngineering-1814-slv-reshp`), not a
+continuation of `1797-b-struct` (which stays untouched as the historical
+prototype record).
+
+One thing the earlier interview didn't anticipate: candidate B's `_00_prepare.py`
+was written *before* ticket 1798 added commented-out placeholders for three
+unrelated future tickets (`reduce_to_published_roles` [1796],
+`convert_job_role_strings_to_number_only` [1795], `apply_categorical_labels`
+[1794]) — candidate B has no trace of them. This spec reconciles that (see
+Decisions).
+
+## Decisions
+
+| Topic | Decision |
+|---|---|
+| Branch / worktree | `1814-slv-reshp` (14 chars, under the repo's 16-char limit), in a sibling worktree directory, matching the convention used for the earlier `-candidate-b` worktree |
+| 1796 / 1794 placeholders | Left untouched in `_00_prepare.py` — `reduce_to_published_roles()` and `apply_categorical_labels()` stay commented, belong to their own tickets |
+| 1795 placeholder | **Removed.** `discover_job_role_codes()` already strips leading zeros and emits bare-number `job_role_code` values (`"1"`, `"45"`), which already accomplishes what `convert_job_role_strings_to_number_only()` was for. The placeholder function and its call/comment were deleted — ticket 1795 is likely closeable as a no-op; whoever reviews it should confirm against this reshape's output. |
+| Prototype branch cleanup | `1797-a-unpivot` and `1797-b-struct` are now superseded and safe to delete, but that wasn't done as part of this ticket — a separate, explicit decision. |
+| Test fixture scope | `polars_slv_test_data.py` / `polars_slv_test_schemas.py` were populated scoped tightly to what `_00_prepare`'s own tests need (wide SLV input rows + long-format expected output) — not designed for hypothetical reuse by `_01_merge`/`_02_clean`/`_03_impute`/`_04_estimate`. |
+| Int16 downcast location | Inside `convert_job_role_columns_to_rows()`, cast on the `pl.struct()` fields themselves (before `concat_list`/`explode`) — shrinks the intermediate list-of-structs column too, not just the final sink. Safe because upstream bounding (`BoundingExpressions.slv_lower_bound`/`slv_upper_bound` in `clean_workplace_utils.py`) already constrains these metrics to `[1, 998]`. |
+| Job-role label (1794) vs reshape (1814) boundary | **Resolved — no change needed in 1814.** See "Job-role labelling: benchmark result" below. |
+
+## Job-role labelling: benchmark result
+
+`apply_categorical_labels()` (ticket 1794, staying a placeholder) is a generic
+`replace_strict()`-based label-join, already used elsewhere for the
+*worker-level* `main_job_role_clean` column via `MainJobRoleID`/
+`MainJobRoleLabels` (`utils/column_values/categorical_column_values.py`). The
+SLV `jrNN` codes use the same ASC-WDS numeric ID scheme, so that mapping is
+directly reusable once 1794 is picked up — just not yet wired to `job_role_code`.
+
+Initial concern: running `apply_categorical_labels()` post-explode touches ~370M
+long-format rows instead of ~6.6M wide rows. A theoretically "free" alternative
+was floated — inject the label as a second literal field in
+`convert_job_role_columns_to_rows()`'s per-code `pl.struct()` (~50 distinct
+codes), before `concat_list`/`explode`.
+
+**Local benchmark (synthetic frame, 1M wide rows × 50 job-role codes → 50M
+long-format rows, single process per candidate, `psutil` peak_wset):**
+
+| | Post-explode `replace_strict` | Struct-literal injection |
+|---|---|---|
+| Collect time | 33.1s | 39.6s |
+| Peak RSS | 7,371 MB | 7,680 MB |
+
+The struct-literal approach was **not** free — it was slightly slower and used
+slightly more memory. A `pl.lit()` placed inside a per-code struct still gets
+broadcast to every row once exploded, so it costs the same per-row
+materialisation as a post-explode `replace_strict()`, plus it widens the
+intermediate struct/list column before the explode itself. `replace_strict()` is
+an in-place expression (not a join), so per this repo's own established memory
+model, running it over more rows post-explode is a compute-time cost, not an OOM
+risk — and the benchmark shows it isn't even the slower option.
+
+**Conclusion: leave `apply_categorical_labels()` exactly as the untouched 1794
+placeholder.** No labelling code was added to 1814's reshape.
+
+**Caveat — not yet confirmed at production scale.** This benchmark used a local
+synthetic frame; the environment this was built in has no AWS credentials, so
+the production-scale deployment comparison planned as the deciding check
+(deploying both candidate implementations to the real Fargate task and
+comparing peak RSS/run time, the same way Candidate A vs B was originally
+settled) has **not been run**. Prototype benchmark scripts with logging
+(`bench_post_explode_label.py` / `bench_struct_literal_label.py`) were used
+locally but are not part of this repo — whoever has deployment access should
+re-run an equivalent comparison at production scale before treating this as
+fully closed.
+
+## Files changed
+
+- **`projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/utils/prepare_utils.py`**
+  Added `discover_job_role_codes()` and `convert_job_role_columns_to_rows()`
+  (ported from `1797-b-struct`, stripped of `peak_rss_kb()` and all prototype
+  instrumentation). Added a new guard in `discover_job_role_codes()`: raises
+  `ValueError` when zero SLV columns are found (previously silently returned an
+  empty list). Applied the `Int16` downcast per the decision above. Removed
+  `convert_job_role_strings_to_number_only()`.
+
+- **`projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/_00_prepare.py`**
+  Kept the existing structure (commented `reduce_to_published_roles()` /
+  `apply_categorical_labels()` calls untouched); replaced the
+  `pivot_job_role_cols_to_rows()` placeholder with the real
+  `discover_job_role_codes()` + narrowed re-scan + `convert_job_role_columns_to_rows()`
+  flow, stripped of all instrumentation/logging.
+
+- **`utils/column_names/cleaned_data_files/ascwds_workplace_job_roles.py`** (new)
+  `AscwdsWorkplaceJobRolesColumns` dataclass, ported from `1797-b-struct`.
+
+- **`projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/validate_00_prepare.py`**
+  Added `rows_distinct` on the grain columns, `col_vals_not_null` on grain
+  columns, `col_vals_between(1, 998, na_pass=True)` on the 4 metric columns.
+  Changed `expected_row_count` to be derived independently — a cheap lazy
+  `utils.scan_parquet(compare_path).collect_schema()` call (schema/metadata
+  only, no data materialised) feeds `discover_job_role_codes()`, rather than
+  counting distinct `job_role_code` values from the `source_df` being validated
+  (self-referential in the candidate-B version).
+
+- **`projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/_01_merge.py`**
+  Carried over only the column-selection fix from `1797-b-struct`: scans with
+  `selected_columns=workplace_columns` (the new `AWPJobRoles` columns) directly,
+  instead of the old post-scan `.select(index_cols, expr.is_slv_job_role_column())`.
+  The three stub `mUtils` placeholder calls are untouched.
+
+- **Tests**: ported and adjusted `test_prepare_utils.py` (added a zero-columns
+  guard test and an Int16-downcast test to candidate B's cases) and
+  `test_00_prepare.py` (kept as a single `test_main_runs`-shaped test, updated to
+  assert the real calls, not candidate B's 3-way split). Migrated
+  `test_01_merge.py` from `unittest.TestCase` to pytest style. Populated
+  `polars_slv_test_data.py`/`polars_slv_test_schemas.py` with `Data`/`Schemas`
+  classes, replacing inline-built LazyFrames. Updated `test_validate_00_prepare.py`
+  to mock the new `utils.scan_parquet` schema-discovery call and assert all 4
+  validation checks are present in the report.
+
+- **`CHANGELOG.md`**: one `### Added` bullet under `[Unreleased]`.
+
+## Testing / Verification
+
+- `pipenv run pytest projects/_07_workforce_characteristics` — 30 passed.
+- `discover_job_role_codes()`'s zero-columns guard is covered by
+  `test_raises_when_no_slv_columns_are_found`.
+- Local synthetic-frame benchmark for the labelling question — see above; not
+  yet confirmed at production scale (no AWS credentials in this environment).
+- **Not yet done**: a real production-scale deployment run (the same style of
+  check used for Candidate A vs B — peak RSS, run time) to confirm this
+  production version performs at least as well as Candidate B's ~14 GB
+  measurement now that instrumentation is stripped and the `Int16` downcast is
+  applied. Needs to be run by whoever has access to the actual Fargate task and
+  S3 data.
+
+## Changelog note on this file
+
+Per this repo's existing convention for working specs (see ticket 1809's
+`SPEC.md`, added in `3d272a889` and removed in `e7a7e40f9` once merged), this
+file may be removed as a cleanup commit once 1814 merges — that's a call for
+whoever merges it, not done as part of this ticket.

--- a/SPEC.md
+++ b/SPEC.md
@@ -155,3 +155,227 @@ Per this repo's existing convention for working specs (see ticket 1809's
 `SPEC.md`, added in `3d272a889` and removed in `e7a7e40f9` once merged), this
 file may be removed as a cleanup commit once 1814 merges — that's a call for
 whoever merges it, not done as part of this ticket.
+
+---
+
+# Addendum: `validate_00_prepare.py` OOM at production scale, and its fix
+
+## Context
+
+The manual production deploy of 1814 (see main spec above) hit an **immediate OOM** in
+`validate_00_prepare.py` on the same 60 GiB Fargate task the reshape+sink step handles comfortably.
+A control deploy with `validate_00_prepare` removed had every other job succeed, isolating the
+problem specifically to this script.
+
+## Diagnostic process
+
+A temporary, throwaway Step Functions state machine (`Ind-CQC-SLV-1814-oom-diag`, auto-discovered via
+`terraform/pipeline/step-functions/dynamic/`) chained four standalone diagnostic scripts
+(`diag_01_read_parquet_only.py` → `diag_04_full_instrumented.py`, under the project's `fargate/`
+folder, each writing `psutil`/`resource`-based peak-RSS checkpoints straight to S3 via
+`fargate/utils/diag_helpers.py`, to survive an OOM-kill that would otherwise lose all stdout). Each
+stage has its own `Catch`, redirecting to a distinct terminal `Succeed` state on failure rather than
+erroring out, so the whole battery self-stops cleanly at the first experiment that reproduces the
+OOM.
+
+**Confirmed results:**
+- `diag_01` (bare `utils.read_parquet()`, no pointblank at all): **succeeded**, peak RSS **15.36 GB**
+  (`diag_01_after_read` checkpoint) — ~45 GB of real headroom under the 60 GiB ceiling. The eager
+  full-table materialization was never the bottleneck.
+- `diag_02` (same read + only `.rows_distinct(GRAIN_COLUMNS)`): **OOM'd**, never reaching its
+  `after_interrogate` checkpoint. Adding just this one check exhausts the remaining headroom.
+- Execution correctly stopped at `"Stopped After Diag 2 - Rows Distinct Only"`; `diag_03`/`diag_04`
+  never needed to run.
+
+## Root cause, confirmed at the code level
+
+`pointblank`'s `Interrogator.rows_distinct()` (`pointblank/_interrogation.py:783-804`):
+```python
+count_tbl = tbl.group_by(columns_subset).agg(nw.len().alias("pb_count_"))
+tbl = tbl.join(count_tbl, on=columns_subset, how="left")   # <-- broadcast join
+tbl = tbl.with_columns(pb_is_good_=nw.col("pb_count_") == 1).drop("pb_count_")
+```
+This **joins the per-group count back onto every one of the ~370M original rows** — the "join that
+broadcasts a computed value back onto every row" anti-pattern this repo's own CLAUDE.md already
+documents from a prior production incident, producing a full second, wider copy of the whole table.
+
+Then in `RowsDistinct.test()` (`pointblank/_interrogation.py:1391-1400`):
+```python
+results_list = nw.from_native(self.test_unit_res)["pb_is_good_"].to_list()
+return _threshold_check(failing_test_units=results_list.count(False), ...)
+```
+The per-row `pb_is_good_` boolean column (~370M values) is converted to a **Python list** just to
+count `False` values in pure Python — a large, unnecessary allocation purely to compute a single
+number. Combined with the base ~370M-row frame already confirmed in memory (~15.4 GB), these two
+extra allocations account for the OOM.
+
+## Decisions
+
+| Topic | Decision |
+|---|---|
+| Chosen fix | Replace `.rows_distinct(GRAIN_COLUMNS)` with a custom `.specially()` validator, `has_no_duplicate_grain_rows()`, built on `pl.DataFrame.is_duplicated()` — no join at all, unlike pointblank's built-in check or a `group_by()`+semi-join alternative (both considered, documented below as retained alternatives, not chosen). |
+| `is_duplicated()` vs. `group_by()`+semi-join | `is_duplicated()` has **zero precedent** in this codebase, vs. 11 files using `.group_by(...)` and one existing `how="semi"` join. Went with `is_duplicated()` anyway per explicit user steer, accepting the lack of in-repo track record for its leaner, single-pass approach. |
+| Side-effect placement | The S3 write (and stale-file cleanup) happens **inside** the validator itself, not split out into `main()`. Simpler, one pass — but makes this the first side-effecting custom validator in `polars_utils/validation/actions.py` (the existing ones, `is_unique_count_equal()` / `make_col_has_fewer_nulls_validator()`, are pure functions of the DataFrame). Tests mock `boto3`/`write_to_parquet` accordingly, following the existing pattern in `TestReportOnFail`. |
+| Fix scope | Scoped to `validate_00_prepare.py` only. The identical `.rows_distinct()` pattern exists in **23 other `validate_XX.py` scripts** across the repo (grep-confirmed) — currently safe at their row-count scale, but the same latent risk. Explicitly **not** touched by this ticket; flagged here as a follow-up concern for a separate ticket. |
+| Extract cap | Capped at **1,000 duplicate rows** written to S3 (`max_rows_to_extract` parameter, default `1000`), bounding the worst case if the reshape ever has a systemic bug duplicating a large fraction of the ~370M rows — the extract itself should never become a second OOM/slow-write risk. |
+| Extract semantics | Includes **all instances** of a duplicated grain-tuple (native `is_duplicated()` behavior) — e.g. a grain appearing 3 times yields all 3 rows in the extract, not just the 2 "extra" ones beyond the first occurrence. |
+| Null handling | Rows with null grain columns are included in the duplicate check using Polars' default equality semantics (two nulls in the same grain column count as a match). Deliberate overlap with the separate `col_vals_not_null` check (which still independently flags nulls) — not treated as a gap. |
+| Stale reports | On a passing run, the check **deletes** any previously-written `duplicate_grain_rows.parquet` from a prior failing run (`s3_client.delete_object`, safe/idempotent even if no such object exists), so the reports folder never retains a misleading stale artifact. |
+| Production-scale confirmation | `diag_02_rows_distinct_only.py` gets updated to use the new `has_no_duplicate_grain_rows()` logic, so one more production-scale deploy of the temporary diagnostic pipeline can confirm peak RSS is safe **before** the fix is applied to the real `validate_00_prepare.py`. |
+
+## Implementation
+
+New helper in `polars_utils/validation/actions.py`, alongside the existing `is_unique_count_equal()`
+/ `make_col_has_fewer_nulls_validator()` (`boto3` and `Callable` are already imported in this
+module):
+
+```python
+DEFAULT_MAX_DUPLICATE_ROWS_TO_EXTRACT = 1000
+
+
+def has_no_duplicate_grain_rows(
+    columns: list[str],
+    bucket_name: str,
+    reports_path: str,
+    max_rows_to_extract: int = DEFAULT_MAX_DUPLICATE_ROWS_TO_EXTRACT,
+) -> Callable[[pl.DataFrame], bool]:
+    """Creates a validation function which checks that no row is duplicated across `columns`.
+
+    Writes up to `max_rows_to_extract` duplicated rows directly to S3 on
+    failure - since pointblank's get_data_extracts() does not support custom
+    (specially) validations - bounding the worst case if a systemic bug
+    duplicates a large fraction of rows. Deletes any stale extract left by a
+    prior failing run once the check passes again.
+
+    Uses is_duplicated() rather than pointblank's own rows_distinct(): that
+    built-in check joins its per-group count back onto every original row and
+    converts a full per-row boolean column to a Python list, which is what
+    OOM'd at ~370M rows (see ticket 1814's isolation experiments, above).
+
+    Args:
+        columns (list[str]): the columns whose combination must be unique per row.
+        bucket_name (str): the bucket to write the duplicate-row extract to (or
+            clean up from, on a passing run).
+        reports_path (str): the folder (relative to the bucket) to write the
+            extract under.
+        max_rows_to_extract (int): the maximum number of duplicate rows to
+            write out on failure. Defaults to 1000.
+
+    Returns:
+        Callable[[pl.DataFrame], bool]: the inner function pointblank's
+        `.specially()` invokes with the validated DataFrame.
+    """
+    extract_key = f"{reports_path.strip('/')}/duplicate_grain_rows.parquet"
+
+    def inner_callable(df: pl.DataFrame) -> bool:
+        is_dup = df.select(columns).is_duplicated()
+        has_duplicates = is_dup.any()
+
+        s3_client = boto3.client("s3")
+        if has_duplicates:
+            dup_rows = df.filter(is_dup).head(max_rows_to_extract)
+            utils.write_to_parquet(
+                dup_rows, f"s3://{bucket_name}/{extract_key}", append=False
+            )
+        else:
+            s3_client.delete_object(Bucket=bucket_name, Key=extract_key)
+
+        return not has_duplicates
+
+    return inner_callable
+```
+
+In `validate_00_prepare.py`, replace:
+```python
+.rows_distinct(
+    GRAIN_COLUMNS,
+    brief="Grain should be unique per establishment, import date and job role",
+)
+```
+with:
+```python
+.specially(
+    vl.has_no_duplicate_grain_rows(GRAIN_COLUMNS, bucket_name, reports_path),
+    brief="Grain should be unique per establishment, import date and job role",
+)
+```
+`row_count_match`, `col_vals_not_null`, and `col_vals_between` are left unchanged — they were never
+implicated (the eager frame they run against is already confirmed to have headroom), and
+`col_vals_not_null`/`col_vals_between` are simple elementwise boolean ops, not group-by/join
+operations. `.specially()` returning a single boolean counts as exactly one test unit
+(`pointblank/validate.py:9244+`), so `GLOBAL_THRESHOLDS = pb.Thresholds(error=1)` still triggers
+`assert_below_threshold` on a genuine duplicate, consistent with how the existing custom validators
+already behave in production.
+
+## Test plan
+
+`has_no_duplicate_grain_rows()` (new tests in `tests/test_polars_utils/test_validation_actions.py`,
+mocking `boto3.client` / `polars_utils.utils.write_to_parquet` per the existing `TestReportOnFail`
+pattern):
+- No duplicates → returns `True`; `write_to_parquet` not called; `delete_object` **is** called
+  (stale-file cleanup).
+- Duplicates present → returns `False`; `write_to_parquet` called with all instances of the
+  duplicated rows.
+- Duplicates exceeding `max_rows_to_extract` → extract truncated to the cap (test by passing a small
+  override, e.g. `max_rows_to_extract=2`, against a small fixture — avoids needing a 1000+-row
+  fixture).
+- Two rows sharing a null in a grain column → treated as duplicates (default Polars equality
+  semantics) — explicit test case.
+- A row with a null grain value that appears only once → not flagged as a duplicate.
+
+`validate_00_prepare.py` (update `tests/fargate/test_validate_00_prepare.py`): assert the assembled
+validation now includes a `.specially()` step wired to `has_no_duplicate_grain_rows()` in place of
+`.rows_distinct()`.
+
+## Verification
+
+1. Update `diag_02_rows_distinct_only.py` to use `has_no_duplicate_grain_rows()` in place of
+   `.rows_distinct()`, matching the real fix exactly.
+2. Redeploy the temporary `Ind-CQC-SLV-1814-oom-diag` state machine (same branch/workspace) and
+   confirm `diag_02` now completes, with peak RSS comfortably under 60 GiB (expected: close to
+   `diag_01`'s ~15.4 GB, plus a modest increment — nowhere near the ~370M-row-sized allocations the
+   old `rows_distinct()` required).
+3. Apply the same change to `validate_00_prepare.py`, run the updated unit tests, then redeploy the
+   real pipeline end-to-end and confirm `validate_00_prepare.py` completes successfully.
+4. Once confirmed, remove the temporary diagnostic scaffolding — `diag_0N_*.py` scripts,
+   `fargate/utils/diag_helpers.py`, their `Dockerfile` `COPY` lines, and
+   `terraform/pipeline/step-functions/dynamic/Ind-CQC-SLV-1814-oom-diag.json` — before merging 1814
+   to `main`. None of it is meant to reach `main`.
+
+## Alternatives considered but not chosen (retained for later)
+
+Two other candidate replacements for `.rows_distinct()` were designed and rejected only in favour of
+the one above — not because they're flawed, kept here in case they're wanted later:
+
+**Option 1 alone (bypassing pointblank's `.specially()` entirely)** — the same `is_duplicated()` logic,
+but run as a standalone check in `validate_00_prepare.py`'s `main()`, raising `AssertionError`
+directly instead of going through pointblank's report/threshold framework:
+```python
+is_dup = source_df.select(GRAIN_COLUMNS).is_duplicated()
+if is_dup.any():
+    dup_rows = source_df.filter(is_dup)
+    utils.write_to_parquet(
+        dup_rows, f"s3://{bucket_name}/{reports_path}duplicate_grain_rows.parquet", append=False
+    )
+    raise AssertionError(f"Found {dup_rows.height} rows with duplicate grain in {source_path}")
+```
+
+**Option 2 (`group_by()` + semi-join, either standalone or wrapped in `.specially()`)** — mirrors the
+`group_by`-and-count approach pointblank's own `rows_distinct()` uses internally, but stops there
+instead of joining the count back onto every original row, using a `semi` join (row-filtering, no new
+columns attached) for the extract instead of pointblank's `how="left"` (attaches a column to every
+row):
+```python
+dup_groups = source_df.group_by(GRAIN_COLUMNS).len().filter(pl.col("len") > 1)
+if dup_groups.height > 0:
+    dup_rows = source_df.join(dup_groups.select(GRAIN_COLUMNS), on=GRAIN_COLUMNS, how="semi")
+    utils.write_to_parquet(
+        dup_rows, f"s3://{bucket_name}/{reports_path}duplicate_grain_rows.parquet", append=False
+    )
+    raise AssertionError(f"Found {dup_groups.height} duplicate grain groups in {source_path}")
+```
+This option is built entirely from primitives with existing precedent in this codebase
+(`.group_by(...)` in 11 files; `how="semi"` in
+`projects/_03_independent_cqc/_02_clean/fargate/utils/clean_ascwds_filled_post_outliers/null_grouped_providers.py:396-398`),
+making it the lower-risk pick if `is_duplicated()` ever turns out to misbehave at scale and this needs
+revisiting.

--- a/polars_utils/categorical_types.py
+++ b/polars_utils/categorical_types.py
@@ -1,0 +1,5 @@
+import polars as pl
+
+EstablishmentCatType = pl.Categorical(
+    pl.Categories("establishment", namespace="filled_posts")
+)

--- a/polars_utils/validation/actions.py
+++ b/polars_utils/validation/actions.py
@@ -172,6 +172,61 @@ def make_col_has_fewer_nulls_validator(
     return validate_col_has_fewer_nulls
 
 
+DEFAULT_MAX_DUPLICATE_ROWS_TO_EXTRACT = 1000
+
+
+def has_no_duplicate_grain_rows(
+    columns: list[str],
+    bucket_name: str,
+    reports_path: str,
+    max_rows_to_extract: int = DEFAULT_MAX_DUPLICATE_ROWS_TO_EXTRACT,
+) -> Callable[[pl.DataFrame], bool]:
+    """Creates a validation function which checks that no row is duplicated across `columns`.
+
+    Writes up to `max_rows_to_extract` duplicated rows directly to S3 on
+    failure - since pointblank's get_data_extracts() does not support custom
+    (specially) validations - bounding the worst case if a systemic bug
+    duplicates a large fraction of rows. Deletes any stale extract left by a
+    prior failing run once the check passes again.
+
+    Uses is_duplicated() rather than pointblank's own rows_distinct(): that
+    built-in check joins its per-group count back onto every original row and
+    converts a full per-row boolean column to a Python list, which is what
+    OOM'd at ~370M rows (see ticket 1814's isolation experiments).
+
+    Args:
+        columns (list[str]): the columns whose combination must be unique per row.
+        bucket_name (str): the bucket to write the duplicate-row extract to (or
+            clean up from, on a passing run).
+        reports_path (str): the folder (relative to the bucket) to write the
+            extract under.
+        max_rows_to_extract (int): the maximum number of duplicate rows to
+            write out on failure. Defaults to 1000.
+
+    Returns:
+        Callable[[pl.DataFrame], bool]: the inner function pointblank's
+        `.specially()` invokes with the validated DataFrame.
+    """
+    extract_key = f"{reports_path.strip('/')}/duplicate_grain_rows.parquet"
+
+    def inner_callable(df: pl.DataFrame) -> bool:
+        is_dup = df.select(columns).is_duplicated()
+        has_duplicates = is_dup.any()
+
+        s3_client = boto3.client("s3")
+        if has_duplicates:
+            dup_rows = df.filter(is_dup).head(max_rows_to_extract)
+            utils.write_to_parquet(
+                dup_rows, f"s3://{bucket_name}/{extract_key}", append=False
+            )
+        else:
+            s3_client.delete_object(Bucket=bucket_name, Key=extract_key)
+
+        return not has_duplicates
+
+    return inner_callable
+
+
 def make_convert_col_to_integers_preprocessor(
     column: str,
 ) -> Callable[[pl.DataFrame], pl.DataFrame]:

--- a/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/_01_merge.py
+++ b/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/_01_merge.py
@@ -1,6 +1,7 @@
 import polars as pl
 
 from polars_utils import utils
+from polars_utils.categorical_types import EstablishmentCatType
 from projects._03_independent_cqc._07_estimate_filled_posts_by_job_role.fargate.utils.merge_utils import (
     join_estimates_to_ascwds,
     reduced_data_filter_expr,
@@ -25,7 +26,7 @@ metadata_columns = {
     IndCQC.number_of_beds: pl.Int16,
     IndCQC.imputed_registration_date: pl.Date,
     IndCQC.ascwds_workplace_import_date: pl.Date,
-    IndCQC.establishment_id: CatColType.EstablishmentCatType,
+    IndCQC.establishment_id: EstablishmentCatType,
     IndCQC.organisation_id: str,
     IndCQC.worker_records_bounded: pl.Int16,
     IndCQC.ascwds_filled_posts_dedup_clean: pl.Float32,
@@ -42,14 +43,14 @@ metadata_columns = {
 }
 ascwds_columns_to_import = {
     IndCQC.ascwds_worker_import_date: pl.Date,
-    IndCQC.establishment_id: CatColType.EstablishmentCatType,
+    IndCQC.establishment_id: EstablishmentCatType,
     IndCQC.main_job_role_clean_labelled: CatColType.JobRoleEnumType,
     IndCQC.ascwds_job_role_counts: pl.Int16,
 }
 transformation_columns = {
     IndCQC.location_id: CatColType.LocationCatType,
     IndCQC.cqc_location_import_date: pl.Date,
-    IndCQC.establishment_id: CatColType.EstablishmentCatType,
+    IndCQC.establishment_id: EstablishmentCatType,
     IndCQC.ascwds_workplace_import_date: pl.Date,
     IndCQC.estimate_filled_posts: pl.Float32,
     IndCQC.estimate_filled_posts_source: CatColType.EstimatesFilledPostSourceEnumType,

--- a/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/utils/utils.py
+++ b/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/utils/utils.py
@@ -135,9 +135,6 @@ class CategoricalColumnTypes:
     LocationCatType = pl.Categorical(
         pl.Categories("location", namespace="filled_posts")
     )
-    EstablishmentCatType = pl.Categorical(
-        pl.Categories("establishment", namespace="filled_posts")
-    )
     ProviderCatType = pl.Categorical(
         pl.Categories("provider", namespace="filled_posts")
     )

--- a/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/_00_prepare.py
+++ b/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/_00_prepare.py
@@ -1,34 +1,49 @@
 import projects._07_workforce_characteristics._01_starters_leavers_vacancies.fargate.utils.prepare_utils as pUtils
 from polars_utils import utils
 from polars_utils.cleaning_utils import apply_categorical_labels
+from utils.column_names.cleaned_data_files.ascwds_workplace_cleaned import (
+    AscwdsWorkplaceCleanedColumns as AWPClean,
+)
+
+INDEX_COLUMNS = [AWPClean.establishment_id, AWPClean.ascwds_workplace_import_date]
 
 
 def main(
     cleaned_ascwds_workplace_source: str,
     prepared_data_destination: str,
 ) -> None:
-    """Load the cleaned ASCWDS workplace dataset and save it unchanged.
+    """Reshape the cleaned ASCWDS workplace dataset's job-role columns from wide to long.
+
+    Discovers the ASC-WDS job-role codes present in the source schema at runtime,
+    then converts the 4-metrics-per-code wide SLV block into one row per
+    (establishment_id, ascwds_workplace_import_date, job_role_code).
 
     Args:
         cleaned_ascwds_workplace_source (str): path to the cleaned ascwds workplace data
         prepared_data_destination (str): destination for output
     """
-    workplace_lf = utils.scan_parquet(cleaned_ascwds_workplace_source)
+    raw_lf = utils.scan_parquet(cleaned_ascwds_workplace_source)
+    job_role_columns = pUtils.discover_job_role_codes(raw_lf.collect_schema())
 
     # TODO: 1796 - Placeholder only.
     # pUtils.reduce_to_published_roles()
 
-    # TODO: Backlog ticket/no number - Placeholder only.
-    # pUtils.pivot_job_role_cols_to_rows()
+    slv_source_columns = [
+        column
+        for cols in job_role_columns
+        for column in (cols.employees, cols.starters, cols.leavers, cols.vacancies)
+    ]
+    workplace_lf = raw_lf.select(*INDEX_COLUMNS, *slv_source_columns)
 
-    # TODO: 1795 - Placeholder only.
-    # pUtils.convert_job_role_strings_to_number_only()
+    job_roles_lf = pUtils.convert_job_role_columns_to_rows(
+        workplace_lf, INDEX_COLUMNS, job_role_columns
+    )
 
     # TODO: 1794 - Placeholder only.
-    # workplace_lf = apply_categorical_labels()
+    # job_roles_lf = apply_categorical_labels()
 
     utils.sink_to_parquet(
-        lazy_df=workplace_lf,
+        lazy_df=job_roles_lf,
         output_path=prepared_data_destination,
     )
 

--- a/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/_00_prepare.py
+++ b/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/_00_prepare.py
@@ -1,5 +1,8 @@
+import polars as pl
+
 import projects._07_workforce_characteristics._01_starters_leavers_vacancies.fargate.utils.prepare_utils as pUtils
 from polars_utils import utils
+from polars_utils.categorical_types import EstablishmentCatType
 from polars_utils.cleaning_utils import apply_categorical_labels
 from utils.column_names.cleaned_data_files.ascwds_workplace_cleaned import (
     AscwdsWorkplaceCleanedColumns as AWPClean,
@@ -18,6 +21,13 @@ def main(
     then converts the 4-metrics-per-code wide SLV block into one row per
     (establishment_id, ascwds_workplace_import_date, job_role_code).
 
+    establishment_id is cast to Categorical (EstablishmentCatType) here, on
+    the wide frame before the explode - job_role_code gets the equivalent
+    cast inside convert_job_role_columns_to_rows(). Hashing/comparing these
+    grain columns as raw Strings at the ~370M-row exploded scale is what
+    caused a production OOM in validate_00_prepare.py's grain-uniqueness
+    check (see ticket 1814's SPEC.md addendum).
+
     Args:
         cleaned_ascwds_workplace_source (str): path to the cleaned ascwds workplace data
         prepared_data_destination (str): destination for output
@@ -33,7 +43,9 @@ def main(
         for cols in job_role_columns
         for column in (cols.employees, cols.starters, cols.leavers, cols.vacancies)
     ]
-    workplace_lf = raw_lf.select(*INDEX_COLUMNS, *slv_source_columns)
+    workplace_lf = raw_lf.select(*INDEX_COLUMNS, *slv_source_columns).with_columns(
+        pl.col(AWPClean.establishment_id).cast(EstablishmentCatType)
+    )
 
     job_roles_lf = pUtils.convert_job_role_columns_to_rows(
         workplace_lf, INDEX_COLUMNS, job_role_columns

--- a/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/_01_merge.py
+++ b/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/_01_merge.py
@@ -1,16 +1,23 @@
 import polars as pl
 
 import projects._07_workforce_characteristics._01_starters_leavers_vacancies.fargate.utils.merge_utils as mUtils
-from polars_utils import expressions as expr
 from polars_utils import utils
 from utils.column_names.cleaned_data_files.ascwds_workplace_cleaned import (
     AscwdsWorkplaceCleanedColumns as AWPClean,
+)
+from utils.column_names.cleaned_data_files.ascwds_workplace_job_roles import (
+    AscwdsWorkplaceJobRolesColumns as AWPJobRoles,
 )
 from utils.column_names.ind_cqc_pipeline_columns import IndCqcColumns as IndCQC
 
 workplace_columns = [
     AWPClean.establishment_id,
     AWPClean.ascwds_workplace_import_date,
+    AWPJobRoles.job_role_code,
+    AWPJobRoles.employees,
+    AWPJobRoles.starters,
+    AWPJobRoles.leavers,
+    AWPJobRoles.vacancies,
 ]
 
 metadata_columns = [
@@ -69,10 +76,7 @@ def main(
         source=job_role_estimates_source, selected_columns=job_role_estimates_columns
     )
     cleaned_ascwds_workplace_lf = utils.scan_parquet(
-        prepared_slv_dataset_source
-    ).select(
-        *[AWPClean.establishment_id, AWPClean.ascwds_workplace_import_date],
-        expr.is_slv_job_role_column()
+        prepared_slv_dataset_source, selected_columns=workplace_columns
     )
 
     # TODO: Placeholder only

--- a/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/diag_01_read_parquet_only.py
+++ b/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/diag_01_read_parquet_only.py
@@ -1,0 +1,41 @@
+import sys
+
+import projects._07_workforce_characteristics._01_starters_leavers_vacancies.fargate.utils.diag_helpers as diag
+from polars_utils import utils
+
+
+def main(bucket_name: str, source_path: str, reports_path: str) -> None:
+    """Isolates the memory cost of utils.read_parquet()'s eager collect alone.
+
+    Throwaway diagnostic for the ticket 1814 validate_00_prepare OOM - see the
+    isolation plan, not part of the permanent pipeline.
+
+    Args:
+        bucket_name (str): the bucket containing the source dataset and to
+            write diagnostic checkpoints to.
+        source_path (str): the filepath of the dataset to read.
+        reports_path (str): the filepath to write diagnostic checkpoints to.
+    """
+    diag.write_checkpoint(bucket_name, reports_path, "diag_01_before_read")
+
+    source_df = utils.read_parquet(source=f"s3://{bucket_name}/{source_path}")
+
+    diag.write_checkpoint(
+        bucket_name,
+        reports_path,
+        "diag_01_after_read",
+        row_count=source_df.height,
+    )
+
+
+if __name__ == "__main__":
+    print(f"Diagnostic script called with parameters: {sys.argv}")
+
+    args = utils.get_args(
+        ("--bucket_name", "S3 bucket for source dataset and diagnostic checkpoints"),
+        ("--source_path", "The filepath of the dataset to read"),
+        ("--reports_path", "The filepath to write diagnostic checkpoints"),
+    )
+
+    main(args.bucket_name, args.source_path, args.reports_path)
+    print("Diagnostic diag_01_read_parquet_only complete")

--- a/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/diag_02_rows_distinct_only.py
+++ b/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/diag_02_rows_distinct_only.py
@@ -1,0 +1,69 @@
+import sys
+
+import pointblank as pb
+
+import projects._07_workforce_characteristics._01_starters_leavers_vacancies.fargate.utils.diag_helpers as diag
+from polars_utils import utils
+from utils.column_names.cleaned_data_files.ascwds_workplace_cleaned import (
+    AscwdsWorkplaceCleanedColumns as AWPClean,
+)
+from utils.column_names.cleaned_data_files.ascwds_workplace_job_roles import (
+    AscwdsWorkplaceJobRolesColumns as AWPJobRoles,
+)
+
+GRAIN_COLUMNS = [
+    AWPClean.establishment_id,
+    AWPClean.ascwds_workplace_import_date,
+    AWPJobRoles.job_role_code,
+]
+
+
+def main(bucket_name: str, source_path: str, reports_path: str) -> None:
+    """Isolates the incremental memory cost of pointblank's rows_distinct() check.
+
+    Runs the same eager read as diag_01_read_parquet_only.py, then only the
+    high-cardinality grain-uniqueness check - no row_count_match or the other
+    checks. Comparing its peak RSS against diag_01's isolates what
+    rows_distinct() adds on top of the base materialisation.
+
+    Throwaway diagnostic for the ticket 1814 validate_00_prepare OOM - see the
+    isolation plan, not part of the permanent pipeline.
+
+    Args:
+        bucket_name (str): the bucket containing the source dataset and to
+            write diagnostic checkpoints to.
+        source_path (str): the filepath of the dataset to read.
+        reports_path (str): the filepath to write diagnostic checkpoints to.
+    """
+    diag.write_checkpoint(bucket_name, reports_path, "diag_02_before_read")
+
+    source_df = utils.read_parquet(source=f"s3://{bucket_name}/{source_path}")
+
+    diag.write_checkpoint(
+        bucket_name,
+        reports_path,
+        "diag_02_after_read",
+        row_count=source_df.height,
+    )
+
+    validation = (
+        pb.Validate(data=source_df, label="diag_02_rows_distinct_only")
+        .rows_distinct(GRAIN_COLUMNS)
+        .interrogate()
+    )
+
+    diag.write_checkpoint(bucket_name, reports_path, "diag_02_after_interrogate")
+    print(validation.get_json_report(), flush=True)
+
+
+if __name__ == "__main__":
+    print(f"Diagnostic script called with parameters: {sys.argv}")
+
+    args = utils.get_args(
+        ("--bucket_name", "S3 bucket for source dataset and diagnostic checkpoints"),
+        ("--source_path", "The filepath of the dataset to read"),
+        ("--reports_path", "The filepath to write diagnostic checkpoints"),
+    )
+
+    main(args.bucket_name, args.source_path, args.reports_path)
+    print("Diagnostic diag_02_rows_distinct_only complete")

--- a/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/diag_02_rows_distinct_only.py
+++ b/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/diag_02_rows_distinct_only.py
@@ -1,9 +1,14 @@
 import sys
 
+import pointblank as pb
 import polars as pl
 
 import projects._07_workforce_characteristics._01_starters_leavers_vacancies.fargate.utils.diag_helpers as diag
 from polars_utils import utils
+from polars_utils.categorical_types import EstablishmentCatType
+from projects._07_workforce_characteristics._01_starters_leavers_vacancies.fargate.utils.categorical_types import (
+    JobRoleCatType,
+)
 from utils.column_names.cleaned_data_files.ascwds_workplace_cleaned import (
     AscwdsWorkplaceCleanedColumns as AWPClean,
 )
@@ -17,21 +22,22 @@ GRAIN_COLUMNS = [
     AWPJobRoles.job_role_code,
 ]
 
-MAX_ROWS_TO_EXTRACT = 1000
-
 
 def main(bucket_name: str, source_path: str, reports_path: str) -> None:
-    """Prototypes a group_by()+semi-join replacement for is_duplicated().
+    """Prototypes Categorical-encoded grain columns + pointblank's stock rows_distinct().
 
-    is_duplicated() was confirmed to be the OOM culprit, not the .filter()
-    extraction step originally suspected: diag_02_after_read now succeeds at
-    ~15.4GB peak RSS (matching diag_01), but diag_02_after_duplicate_count
-    (computed via source_df.select(GRAIN_COLUMNS).is_duplicated()) never
-    appears. This bypasses has_no_duplicate_grain_rows() entirely for this
-    diagnostic and instead prototypes SPEC.md's already-documented "Option 2"
-    fallback - group_by()+len() for detection, a how="semi" join (bounded to
-    MAX_ROWS_TO_EXTRACT duplicate-group keys) for the extract - to confirm it
-    avoids the OOM before changing the real validator.
+    Both is_duplicated() and a group_by()+semi-join replacement (this
+    script's two previous prototypes) were confirmed to OOM at production
+    scale regardless of algorithm - the group_by version OOM'd before even
+    reaching its own diag_02_after_group_by_check checkpoint, isolating the
+    real cost to hashing/grouping ~370M rows of String-typed grain columns,
+    not to any particular join/no-join design.
+
+    This prototype instead Categorical-encodes establishment_id/job_role_code
+    (matching the cast now applied upstream in _00_prepare.py/prepare_utils.py)
+    and reverts to pointblank's plain built-in .rows_distinct(), to confirm
+    that's what actually makes grain-uniqueness checking viable at this row
+    count, before applying the same change to the real validator.
 
     Throwaway diagnostic for the ticket 1814 validate_00_prepare OOM - see the
     isolation plan, not part of the permanent pipeline.
@@ -53,40 +59,25 @@ def main(bucket_name: str, source_path: str, reports_path: str) -> None:
         row_count=source_df.height,
     )
 
-    dup_groups = (
-        source_df.select(GRAIN_COLUMNS)
-        .group_by(GRAIN_COLUMNS)
-        .len()
-        .filter(pl.col("len") > 1)
+    source_df = source_df.with_columns(
+        pl.col(AWPClean.establishment_id).cast(EstablishmentCatType),
+        pl.col(AWPJobRoles.job_role_code).cast(JobRoleCatType),
     )
-    dup_group_count = dup_groups.height
-    has_duplicates = dup_group_count > 0
+    diag.write_checkpoint(bucket_name, reports_path, "diag_02_after_categorical_cast")
+
+    validation = (
+        pb.Validate(data=source_df, label="diag_02_rows_distinct_only")
+        .rows_distinct(GRAIN_COLUMNS)
+        .interrogate()
+    )
+
     diag.write_checkpoint(
         bucket_name,
         reports_path,
-        "diag_02_after_group_by_check",
-        dup_group_count=dup_group_count,
-        has_duplicates=has_duplicates,
+        "diag_02_after_interrogate",
+        all_passed=validation.all_passed(),
     )
-
-    if has_duplicates:
-        dup_rows = source_df.join(
-            dup_groups.select(GRAIN_COLUMNS).head(MAX_ROWS_TO_EXTRACT),
-            on=GRAIN_COLUMNS,
-            how="semi",
-        ).head(MAX_ROWS_TO_EXTRACT)
-        diag.write_checkpoint(
-            bucket_name,
-            reports_path,
-            "diag_02_after_semi_join_extract",
-            extracted_row_count=dup_rows.height,
-        )
-
-    diag.write_checkpoint(bucket_name, reports_path, "diag_02_complete")
-    print(
-        f"has_duplicates={has_duplicates}, dup_group_count={dup_group_count}",
-        flush=True,
-    )
+    print(f"all_passed={validation.all_passed()}", flush=True)
 
 
 if __name__ == "__main__":

--- a/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/diag_02_rows_distinct_only.py
+++ b/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/diag_02_rows_distinct_only.py
@@ -1,10 +1,9 @@
 import sys
 
-import pointblank as pb
+import polars as pl
 
 import projects._07_workforce_characteristics._01_starters_leavers_vacancies.fargate.utils.diag_helpers as diag
 from polars_utils import utils
-from polars_utils.validation import actions as vl
 from utils.column_names.cleaned_data_files.ascwds_workplace_cleaned import (
     AscwdsWorkplaceCleanedColumns as AWPClean,
 )
@@ -18,24 +17,21 @@ GRAIN_COLUMNS = [
     AWPJobRoles.job_role_code,
 ]
 
+MAX_ROWS_TO_EXTRACT = 1000
+
 
 def main(bucket_name: str, source_path: str, reports_path: str) -> None:
-    """Isolates the incremental memory cost of the grain-uniqueness check.
+    """Prototypes a group_by()+semi-join replacement for is_duplicated().
 
-    Runs the same eager read as diag_01_read_parquet_only.py, then only the
-    high-cardinality grain-uniqueness check - no row_count_match or the other
-    checks. Comparing its peak RSS against diag_01's isolates what the check
-    adds on top of the base materialisation.
-
-    Uses has_no_duplicate_grain_rows() rather than pointblank's own
-    rows_distinct(), matching the real fix in validate_00_prepare.py - see
-    ticket 1814's isolation experiments for why rows_distinct() OOM'd here.
-
-    Records the duplicate count/fraction as its own checkpoint before running
-    has_no_duplicate_grain_rows() - a boolean .sum() is a cheap O(n)
-    reduction, unlike the .filter() the validator itself does further on, so
-    this isolates whether a high duplicate rate (not is_duplicated() itself)
-    is what's driving a second OOM here.
+    is_duplicated() was confirmed to be the OOM culprit, not the .filter()
+    extraction step originally suspected: diag_02_after_read now succeeds at
+    ~15.4GB peak RSS (matching diag_01), but diag_02_after_duplicate_count
+    (computed via source_df.select(GRAIN_COLUMNS).is_duplicated()) never
+    appears. This bypasses has_no_duplicate_grain_rows() entirely for this
+    diagnostic and instead prototypes SPEC.md's already-documented "Option 2"
+    fallback - group_by()+len() for detection, a how="semi" join (bounded to
+    MAX_ROWS_TO_EXTRACT duplicate-group keys) for the extract - to confirm it
+    avoids the OOM before changing the real validator.
 
     Throwaway diagnostic for the ticket 1814 validate_00_prepare OOM - see the
     isolation plan, not part of the permanent pipeline.
@@ -57,26 +53,40 @@ def main(bucket_name: str, source_path: str, reports_path: str) -> None:
         row_count=source_df.height,
     )
 
-    is_dup = source_df.select(GRAIN_COLUMNS).is_duplicated()
-    dup_count = int(is_dup.sum())
+    dup_groups = (
+        source_df.select(GRAIN_COLUMNS)
+        .group_by(GRAIN_COLUMNS)
+        .len()
+        .filter(pl.col("len") > 1)
+    )
+    dup_group_count = dup_groups.height
+    has_duplicates = dup_group_count > 0
     diag.write_checkpoint(
         bucket_name,
         reports_path,
-        "diag_02_after_duplicate_count",
-        dup_count=dup_count,
-        dup_fraction=dup_count / source_df.height,
+        "diag_02_after_group_by_check",
+        dup_group_count=dup_group_count,
+        has_duplicates=has_duplicates,
     )
 
-    validation = (
-        pb.Validate(data=source_df, label="diag_02_rows_distinct_only")
-        .specially(
-            vl.has_no_duplicate_grain_rows(GRAIN_COLUMNS, bucket_name, reports_path)
+    if has_duplicates:
+        dup_rows = source_df.join(
+            dup_groups.select(GRAIN_COLUMNS).head(MAX_ROWS_TO_EXTRACT),
+            on=GRAIN_COLUMNS,
+            how="semi",
+        ).head(MAX_ROWS_TO_EXTRACT)
+        diag.write_checkpoint(
+            bucket_name,
+            reports_path,
+            "diag_02_after_semi_join_extract",
+            extracted_row_count=dup_rows.height,
         )
-        .interrogate()
-    )
 
-    diag.write_checkpoint(bucket_name, reports_path, "diag_02_after_interrogate")
-    print(validation.get_json_report(), flush=True)
+    diag.write_checkpoint(bucket_name, reports_path, "diag_02_complete")
+    print(
+        f"has_duplicates={has_duplicates}, dup_group_count={dup_group_count}",
+        flush=True,
+    )
 
 
 if __name__ == "__main__":

--- a/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/diag_02_rows_distinct_only.py
+++ b/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/diag_02_rows_distinct_only.py
@@ -31,6 +31,12 @@ def main(bucket_name: str, source_path: str, reports_path: str) -> None:
     rows_distinct(), matching the real fix in validate_00_prepare.py - see
     ticket 1814's isolation experiments for why rows_distinct() OOM'd here.
 
+    Records the duplicate count/fraction as its own checkpoint before running
+    has_no_duplicate_grain_rows() - a boolean .sum() is a cheap O(n)
+    reduction, unlike the .filter() the validator itself does further on, so
+    this isolates whether a high duplicate rate (not is_duplicated() itself)
+    is what's driving a second OOM here.
+
     Throwaway diagnostic for the ticket 1814 validate_00_prepare OOM - see the
     isolation plan, not part of the permanent pipeline.
 
@@ -49,6 +55,16 @@ def main(bucket_name: str, source_path: str, reports_path: str) -> None:
         reports_path,
         "diag_02_after_read",
         row_count=source_df.height,
+    )
+
+    is_dup = source_df.select(GRAIN_COLUMNS).is_duplicated()
+    dup_count = int(is_dup.sum())
+    diag.write_checkpoint(
+        bucket_name,
+        reports_path,
+        "diag_02_after_duplicate_count",
+        dup_count=dup_count,
+        dup_fraction=dup_count / source_df.height,
     )
 
     validation = (

--- a/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/diag_02_rows_distinct_only.py
+++ b/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/diag_02_rows_distinct_only.py
@@ -4,6 +4,7 @@ import pointblank as pb
 
 import projects._07_workforce_characteristics._01_starters_leavers_vacancies.fargate.utils.diag_helpers as diag
 from polars_utils import utils
+from polars_utils.validation import actions as vl
 from utils.column_names.cleaned_data_files.ascwds_workplace_cleaned import (
     AscwdsWorkplaceCleanedColumns as AWPClean,
 )
@@ -19,12 +20,16 @@ GRAIN_COLUMNS = [
 
 
 def main(bucket_name: str, source_path: str, reports_path: str) -> None:
-    """Isolates the incremental memory cost of pointblank's rows_distinct() check.
+    """Isolates the incremental memory cost of the grain-uniqueness check.
 
     Runs the same eager read as diag_01_read_parquet_only.py, then only the
     high-cardinality grain-uniqueness check - no row_count_match or the other
-    checks. Comparing its peak RSS against diag_01's isolates what
-    rows_distinct() adds on top of the base materialisation.
+    checks. Comparing its peak RSS against diag_01's isolates what the check
+    adds on top of the base materialisation.
+
+    Uses has_no_duplicate_grain_rows() rather than pointblank's own
+    rows_distinct(), matching the real fix in validate_00_prepare.py - see
+    ticket 1814's isolation experiments for why rows_distinct() OOM'd here.
 
     Throwaway diagnostic for the ticket 1814 validate_00_prepare OOM - see the
     isolation plan, not part of the permanent pipeline.
@@ -48,7 +53,9 @@ def main(bucket_name: str, source_path: str, reports_path: str) -> None:
 
     validation = (
         pb.Validate(data=source_df, label="diag_02_rows_distinct_only")
-        .rows_distinct(GRAIN_COLUMNS)
+        .specially(
+            vl.has_no_duplicate_grain_rows(GRAIN_COLUMNS, bucket_name, reports_path)
+        )
         .interrogate()
     )
 

--- a/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/diag_02_rows_distinct_only.py
+++ b/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/diag_02_rows_distinct_only.py
@@ -24,20 +24,31 @@ GRAIN_COLUMNS = [
 
 
 def main(bucket_name: str, source_path: str, reports_path: str) -> None:
-    """Prototypes Categorical-encoded grain columns + pointblank's stock rows_distinct().
+    """Prototypes a narrow, grain-only load + Categorical + pointblank's stock rows_distinct().
 
-    Both is_duplicated() and a group_by()+semi-join replacement (this
-    script's two previous prototypes) were confirmed to OOM at production
-    scale regardless of algorithm - the group_by version OOM'd before even
-    reaching its own diag_02_after_group_by_check checkpoint, isolating the
-    real cost to hashing/grouping ~370M rows of String-typed grain columns,
-    not to any particular join/no-join design.
+    The previous prototype (Categorical-encoded grain columns, but loading
+    all 7 columns of the validated table) still OOM'd, dying somewhere after
+    the diag_02_after_categorical_cast checkpoint (~18.1GB peak RSS) inside
+    .rows_distinct().interrogate(). Reading pointblank's installed source
+    (_interrogation.py:783-804) shows why Categorical-encoding the grain
+    columns alone was never going to be enough: RowsDistinct's column-subset
+    prep (_utils.py:499-510) does not narrow the table to just the grain
+    columns - Interrogator.rows_distinct() joins its group-by count back onto
+    `self.x`, the FULL validated table (all 7 columns), not a 3-column grain
+    subset. That join reconstructs a full second copy of the entire table
+    regardless of grain-column dtype, and RowsDistinct.test() (line 1396)
+    converts the resulting boolean column to a Python list - both costs scale
+    with row count and total column width, not with how compact the grain
+    columns are encoded.
 
-    This prototype instead Categorical-encodes establishment_id/job_role_code
-    (matching the cast now applied upstream in _00_prepare.py/prepare_utils.py)
-    and reverts to pointblank's plain built-in .rows_distinct(), to confirm
-    that's what actually makes grain-uniqueness checking viable at this row
-    count, before applying the same change to the real validator.
+    This prototype instead loads ONLY GRAIN_COLUMNS via
+    utils.read_parquet(selected_columns=...) - true column projection at scan
+    time, not a post-read .select() - so pointblank's join operates on a
+    3-column table instead of a 7-column one, on top of the Categorical
+    encoding already confirmed cheap to apply. Matches the narrow-load
+    architecture already used elsewhere in this repo (e.g.
+    _07_estimate_filled_posts_by_job_role's validate_03_impute.py splits its
+    index-uniqueness check into its own narrowly-loaded pb.Validate call).
 
     Throwaway diagnostic for the ticket 1814 validate_00_prepare OOM - see the
     isolation plan, not part of the permanent pipeline.
@@ -50,12 +61,15 @@ def main(bucket_name: str, source_path: str, reports_path: str) -> None:
     """
     diag.write_checkpoint(bucket_name, reports_path, "diag_02_before_read")
 
-    source_df = utils.read_parquet(source=f"s3://{bucket_name}/{source_path}")
+    source_df = utils.read_parquet(
+        source=f"s3://{bucket_name}/{source_path}",
+        selected_columns=GRAIN_COLUMNS,
+    )
 
     diag.write_checkpoint(
         bucket_name,
         reports_path,
-        "diag_02_after_read",
+        "diag_02_after_narrow_read",
         row_count=source_df.height,
     )
 

--- a/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/diag_03_cheap_checks_only.py
+++ b/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/diag_03_cheap_checks_only.py
@@ -1,0 +1,78 @@
+import sys
+
+import pointblank as pb
+
+import projects._07_workforce_characteristics._01_starters_leavers_vacancies.fargate.utils.diag_helpers as diag
+from polars_utils import utils
+from utils.column_names.cleaned_data_files.ascwds_workplace_cleaned import (
+    AscwdsWorkplaceCleanedColumns as AWPClean,
+)
+from utils.column_names.cleaned_data_files.ascwds_workplace_job_roles import (
+    AscwdsWorkplaceJobRolesColumns as AWPJobRoles,
+)
+
+GRAIN_COLUMNS = [
+    AWPClean.establishment_id,
+    AWPClean.ascwds_workplace_import_date,
+    AWPJobRoles.job_role_code,
+]
+
+METRIC_COLUMNS = [
+    AWPJobRoles.employees,
+    AWPJobRoles.starters,
+    AWPJobRoles.leavers,
+    AWPJobRoles.vacancies,
+]
+
+
+def main(bucket_name: str, source_path: str, reports_path: str) -> None:
+    """Isolates the incremental memory cost of the two elementwise checks.
+
+    Runs the same eager read as diag_01_read_parquet_only.py, then only
+    col_vals_not_null() and col_vals_between() - no row_count_match or
+    rows_distinct(). Both are expected to be cheap, elementwise boolean
+    operations rather than group-by/dedup, so this confirms that rather than
+    assuming it.
+
+    Throwaway diagnostic for the ticket 1814 validate_00_prepare OOM - see the
+    isolation plan, not part of the permanent pipeline.
+
+    Args:
+        bucket_name (str): the bucket containing the source dataset and to
+            write diagnostic checkpoints to.
+        source_path (str): the filepath of the dataset to read.
+        reports_path (str): the filepath to write diagnostic checkpoints to.
+    """
+    diag.write_checkpoint(bucket_name, reports_path, "diag_03_before_read")
+
+    source_df = utils.read_parquet(source=f"s3://{bucket_name}/{source_path}")
+
+    diag.write_checkpoint(
+        bucket_name,
+        reports_path,
+        "diag_03_after_read",
+        row_count=source_df.height,
+    )
+
+    validation = (
+        pb.Validate(data=source_df, label="diag_03_cheap_checks_only")
+        .col_vals_not_null(columns=GRAIN_COLUMNS)
+        .col_vals_between(columns=METRIC_COLUMNS, left=1, right=998, na_pass=True)
+        .interrogate()
+    )
+
+    diag.write_checkpoint(bucket_name, reports_path, "diag_03_after_interrogate")
+    print(validation.get_json_report(), flush=True)
+
+
+if __name__ == "__main__":
+    print(f"Diagnostic script called with parameters: {sys.argv}")
+
+    args = utils.get_args(
+        ("--bucket_name", "S3 bucket for source dataset and diagnostic checkpoints"),
+        ("--source_path", "The filepath of the dataset to read"),
+        ("--reports_path", "The filepath to write diagnostic checkpoints"),
+    )
+
+    main(args.bucket_name, args.source_path, args.reports_path)
+    print("Diagnostic diag_03_cheap_checks_only complete")

--- a/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/diag_04_full_instrumented.py
+++ b/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/diag_04_full_instrumented.py
@@ -1,0 +1,130 @@
+import sys
+
+import pointblank as pb
+
+import projects._07_workforce_characteristics._01_starters_leavers_vacancies.fargate.utils.diag_helpers as diag
+import projects._07_workforce_characteristics._01_starters_leavers_vacancies.fargate.utils.prepare_utils as pUtils
+from polars_utils import utils
+from polars_utils.validation import actions as vl
+from polars_utils.validation.constants import GLOBAL_ACTIONS, GLOBAL_THRESHOLDS
+from utils.column_names.cleaned_data_files.ascwds_workplace_cleaned import (
+    AscwdsWorkplaceCleanedColumns as AWPClean,
+)
+from utils.column_names.cleaned_data_files.ascwds_workplace_job_roles import (
+    AscwdsWorkplaceJobRolesColumns as AWPJobRoles,
+)
+
+COMPARE_COLS_TO_IMPORT = [
+    AWPClean.establishment_id,
+]
+
+GRAIN_COLUMNS = [
+    AWPClean.establishment_id,
+    AWPClean.ascwds_workplace_import_date,
+    AWPJobRoles.job_role_code,
+]
+
+METRIC_COLUMNS = [
+    AWPJobRoles.employees,
+    AWPJobRoles.starters,
+    AWPJobRoles.leavers,
+    AWPJobRoles.vacancies,
+]
+
+
+def main(
+    bucket_name: str, source_path: str, compare_path: str, reports_path: str
+) -> None:
+    """Runs validate_00_prepare.py's full logic with peak-RSS checkpoints at each stage.
+
+    Sanity-checks whether diag_01/02/03's isolated costs add up to the full
+    observed OOM, and is the only one of the diagnostics that can catch
+    anything the isolated experiments miss (e.g. pointblank accumulating
+    internal copies across chained checks, or a genuine validation failure
+    making write_reports()'s get_data_extracts() pull an unexpectedly large
+    failing-row set).
+
+    Throwaway diagnostic for the ticket 1814 validate_00_prepare OOM - see the
+    isolation plan, not part of the permanent pipeline.
+
+    Args:
+        bucket_name (str): the bucket containing the source/compare datasets
+            and to write diagnostic checkpoints and reports to.
+        source_path (str): the source dataset path to be validated.
+        compare_path (str): the path to the dataset to compare against.
+        reports_path (str): the output path to write diagnostic checkpoints
+            and reports to.
+    """
+    diag.write_checkpoint(bucket_name, reports_path, "diag_04_before_read")
+
+    source_df = utils.read_parquet(source=f"s3://{bucket_name}/{source_path}")
+
+    diag.write_checkpoint(
+        bucket_name,
+        reports_path,
+        "diag_04_after_read",
+        row_count=source_df.height,
+    )
+
+    compare_lf = utils.scan_parquet(source=f"s3://{bucket_name}/{compare_path}")
+    compare_schema = compare_lf.collect_schema()
+    job_role_code_count = len(pUtils.discover_job_role_codes(compare_schema))
+    compare_row_count = compare_lf.select(COMPARE_COLS_TO_IMPORT).collect().height
+    expected_row_count = compare_row_count * job_role_code_count
+
+    diag.write_checkpoint(
+        bucket_name,
+        reports_path,
+        "diag_04_after_expected_row_count",
+        expected_row_count=expected_row_count,
+    )
+
+    validation = (
+        pb.Validate(
+            data=source_df,
+            label=f"diag_04_full_instrumented {source_path}",
+            thresholds=GLOBAL_THRESHOLDS,
+            brief=True,
+            actions=GLOBAL_ACTIONS,
+        )
+        .row_count_match(
+            expected_row_count,
+            brief=f"Expects {expected_row_count} rows",
+        )
+        .rows_distinct(
+            GRAIN_COLUMNS,
+            brief="Grain should be unique per establishment, import date and job role",
+        )
+        .col_vals_not_null(
+            columns=GRAIN_COLUMNS,
+            brief="Grain columns should contain no null values",
+        )
+        .col_vals_between(
+            columns=METRIC_COLUMNS,
+            left=1,
+            right=998,
+            na_pass=True,
+            brief="Metrics should be between 1 and 998 where present.",
+        )
+        .interrogate()
+    )
+
+    diag.write_checkpoint(bucket_name, reports_path, "diag_04_after_interrogate")
+
+    vl.write_reports(validation, bucket_name, reports_path)
+
+    diag.write_checkpoint(bucket_name, reports_path, "diag_04_after_write_reports")
+
+
+if __name__ == "__main__":
+    print(f"Diagnostic script called with parameters: {sys.argv}")
+
+    args = utils.get_args(
+        ("--bucket_name", "S3 bucket for source dataset and diagnostic checkpoints"),
+        ("--source_path", "The filepath of the dataset to validate"),
+        ("--compare_path", "The filepath of the dataset to compare against"),
+        ("--reports_path", "The filepath to write diagnostic checkpoints and reports"),
+    )
+
+    main(args.bucket_name, args.source_path, args.compare_path, args.reports_path)
+    print("Diagnostic diag_04_full_instrumented complete")

--- a/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/utils/categorical_types.py
+++ b/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/utils/categorical_types.py
@@ -1,0 +1,3 @@
+import polars as pl
+
+JobRoleCatType = pl.Categorical(pl.Categories("job_role", namespace="filled_posts"))

--- a/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/utils/diag_helpers.py
+++ b/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/utils/diag_helpers.py
@@ -1,0 +1,50 @@
+"""Throwaway instrumentation for the ticket 1814 validate_00_prepare OOM isolation experiments.
+
+Not part of the permanent pipeline - delete this module, the diag_0N_*.py scripts
+that import it, their Dockerfile COPY lines, and the temporary
+Ind-CQC-SLV-1814-oom-diag.json state machine once the OOM root cause has been
+isolated.
+"""
+
+import json
+import resource
+
+import boto3
+
+
+def peak_rss_kb() -> int:
+    """Returns this process's peak RSS in KB.
+
+    Uses `resource.getrusage` rather than `psutil` because `ru_maxrss` is
+    already reported in KB on Linux (the Fargate runtime), giving a true
+    monotonic peak with no need to diff before/after readings.
+    """
+    return resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+
+
+def write_checkpoint(
+    bucket_name: str, reports_path: str, label: str, **extra: object
+) -> None:
+    """Writes a diagnostic checkpoint straight to S3 and flushes stdout.
+
+    The original OOM-killed run produced zero log output because the ECS log
+    driver's stdout buffer never flushed before the container was killed.
+    Writing each checkpoint directly to S3 as it happens means results survive
+    even if this process is OOM-killed immediately afterwards.
+
+    Args:
+        bucket_name (str): the bucket to write the checkpoint to.
+        reports_path (str): the folder (relative to the bucket) to write under.
+        label (str): a short identifier for this checkpoint, used as both the
+            S3 key and a log marker.
+        **extra (object): any additional JSON-serialisable fields to record
+            alongside the peak RSS reading (e.g. row_count).
+    """
+    payload = {"label": label, "peak_rss_kb": peak_rss_kb(), **extra}
+    print(f"CHECKPOINT: {payload}", flush=True)
+    s3_client = boto3.client("s3")
+    s3_client.put_object(
+        Body=json.dumps(payload).encode("utf-8"),
+        Bucket=bucket_name,
+        Key=f"{reports_path.strip('/')}/{label}.json",
+    )

--- a/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/utils/prepare_utils.py
+++ b/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/utils/prepare_utils.py
@@ -1,3 +1,24 @@
+import re
+from dataclasses import dataclass
+
+import polars as pl
+import polars.selectors as cs
+
+from polars_utils import expressions as expr
+from utils.column_names.cleaned_data_files.ascwds_workplace_job_roles import (
+    AscwdsWorkplaceJobRolesColumns as AWPJobRoles,
+)
+
+_JOB_ROLE_COLUMN_PATTERN = re.compile(r"^jr0*(\d+)(emp|strt|stop|vacy)$")
+
+_METRIC_ATTR_BY_SUFFIX = {
+    "emp": AWPJobRoles.employees,
+    "strt": AWPJobRoles.starters,
+    "stop": AWPJobRoles.leavers,
+    "vacy": AWPJobRoles.vacancies,
+}
+
+
 def reduce_to_published_roles():
     """
     Placeholder function to reduce columns to only published roles plus
@@ -6,15 +27,129 @@ def reduce_to_published_roles():
     pass
 
 
-def pivot_job_role_cols_to_rows():
-    """
-    Placeholder function to pivot job role columns into rows to create column
-    for job role number and columns for emps, starters, leavers and vacancies.
-    """
-    pass
+@dataclass(frozen=True)
+class JobRoleCodeColumns:
+    """Source column names for one ASC-WDS job-role code's four SLV metrics."""
+
+    job_role_code: str
+    employees: str
+    starters: str
+    leavers: str
+    vacancies: str
 
 
-def convert_job_role_strings_to_number_only():
+def discover_job_role_codes(
+    schema: pl.Schema | dict[str, pl.DataType],
+) -> list[JobRoleCodeColumns]:
+    """Discover the ASC-WDS SLV job-role codes present in a schema and their source columns.
+
+    Job-role codes are derived dynamically from the schema (rather than a hardcoded
+    list) so this stays robust to ASC-WDS adding or retiring codes over time.
+
+    Args:
+        schema (pl.Schema | dict[str, pl.DataType]): schema of the cleaned ASCWDS
+            workplace dataset, e.g. from `LazyFrame.collect_schema()`.
+
+    Returns:
+        list[JobRoleCodeColumns]: one entry per discovered job-role code, ordered
+            by code ascending.
+
+    Raises:
+        ValueError: if no columns match `is_slv_job_role_column()`, if a column
+            matches it but not the expected `jr<code><metric>` naming pattern, if
+            two columns normalise to the same code and metric (e.g. `jr01emp` and
+            `jr1emp`), or if a job-role code has some but not all 4 metric
+            columns present — these would indicate the SLV column-naming
+            convention has changed upstream.
     """
-    Placeholder function to 'jr01/02/03' etc into '1/2/3' etc ."""
-    pass
+    slv_columns = cs.expand_selector(schema, expr.is_slv_job_role_column())
+
+    if not slv_columns:
+        raise ValueError("No SLV job-role columns found in schema.")
+
+    columns_by_code: dict[str, dict[str, str]] = {}
+    for column in slv_columns:
+        match = _JOB_ROLE_COLUMN_PATTERN.match(column)
+        if match is None:
+            raise ValueError(
+                f"Column '{column}' matched is_slv_job_role_column() but not the "
+                "expected jr<code><metric> naming pattern."
+            )
+        code, suffix = match.group(1), match.group(2)
+        metric_attr = _METRIC_ATTR_BY_SUFFIX[suffix]
+        code_columns = columns_by_code.setdefault(code, {})
+        existing_column = code_columns.get(metric_attr)
+        if existing_column is not None:
+            raise ValueError(
+                f"Columns '{existing_column}' and '{column}' both normalise to "
+                f"job role code '{code}' for the same metric."
+            )
+        code_columns[metric_attr] = column
+
+    incomplete_codes = {
+        code: metrics
+        for code, metrics in columns_by_code.items()
+        if len(metrics) != len(_METRIC_ATTR_BY_SUFFIX)
+    }
+    if incomplete_codes:
+        raise ValueError(
+            "Job role code(s) missing one or more of the 4 SLV metric columns: "
+            f"{incomplete_codes}"
+        )
+
+    return [
+        JobRoleCodeColumns(job_role_code=code, **columns_by_code[code])
+        for code in sorted(columns_by_code, key=int)
+    ]
+
+
+def convert_job_role_columns_to_rows(
+    workplace_lf: pl.LazyFrame,
+    index_cols: list[str],
+    job_role_columns: list[JobRoleCodeColumns],
+) -> pl.LazyFrame:
+    """Reshape wide SLV job-role columns into one row per job-role code.
+
+    Builds one struct per job-role code (job_role_code plus its 4 metrics),
+    concatenates those structs into a single list column per row, then explodes
+    and unnests it into long format. Single pass, no joins.
+
+    Metric columns are downcast to Int16 on the struct fields (before
+    concat_list/explode), not after — this keeps the intermediate
+    list-of-structs column smaller too, not just the final sunk output. Safe
+    because upstream bounding already constrains these metrics to [1, 998]
+    (see `BoundingExpressions.slv_lower_bound`/`slv_upper_bound`).
+
+    Args:
+        workplace_lf (pl.LazyFrame): the (already column-pruned) cleaned ASCWDS
+            workplace LazyFrame, containing `index_cols` and the SLV job-role
+            columns referenced by `job_role_columns`.
+        index_cols (list[str]): grain columns preserved through the reshape,
+            e.g. establishment_id and ascwds_workplace_import_date.
+        job_role_columns (list[JobRoleCodeColumns]): source column names per
+            discovered job-role code, from `discover_job_role_codes`.
+
+    Returns:
+        pl.LazyFrame: long-format frame with one row per
+            (*index_cols, job_role_code), and `employees`/`starters`/`leavers`/
+            `vacancies` metric columns as Int16.
+    """
+    job_role_structs = [
+        pl.struct(
+            pl.lit(cols.job_role_code).alias(AWPJobRoles.job_role_code),
+            pl.col(cols.employees).cast(pl.Int16).alias(AWPJobRoles.employees),
+            pl.col(cols.starters).cast(pl.Int16).alias(AWPJobRoles.starters),
+            pl.col(cols.leavers).cast(pl.Int16).alias(AWPJobRoles.leavers),
+            pl.col(cols.vacancies).cast(pl.Int16).alias(AWPJobRoles.vacancies),
+        )
+        for cols in job_role_columns
+    ]
+
+    job_roles_lf = (
+        workplace_lf.select(
+            *index_cols, pl.concat_list(job_role_structs).alias("_job_roles")
+        )
+        .explode("_job_roles")
+        .unnest("_job_roles")
+    )
+    return job_roles_lf

--- a/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/utils/prepare_utils.py
+++ b/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/utils/prepare_utils.py
@@ -5,6 +5,9 @@ import polars as pl
 import polars.selectors as cs
 
 from polars_utils import expressions as expr
+from projects._07_workforce_characteristics._01_starters_leavers_vacancies.fargate.utils.categorical_types import (
+    JobRoleCatType,
+)
 from utils.column_names.cleaned_data_files.ascwds_workplace_job_roles import (
     AscwdsWorkplaceJobRolesColumns as AWPJobRoles,
 )
@@ -120,6 +123,13 @@ def convert_job_role_columns_to_rows(
     because upstream bounding already constrains these metrics to [1, 998]
     (see `BoundingExpressions.slv_lower_bound`/`slv_upper_bound`).
 
+    job_role_code is cast to Categorical (JobRoleCatType) at the same point,
+    for the same reason: encoding it once per discovered code here is far
+    cheaper than encoding it on the ~370M exploded rows afterwards. Hashing/
+    comparing this column as a raw String at that row count is what caused a
+    production OOM in validate_00_prepare.py's grain-uniqueness check (see
+    ticket 1814's SPEC.md addendum).
+
     Args:
         workplace_lf (pl.LazyFrame): the (already column-pruned) cleaned ASCWDS
             workplace LazyFrame, containing `index_cols` and the SLV job-role
@@ -136,7 +146,9 @@ def convert_job_role_columns_to_rows(
     """
     job_role_structs = [
         pl.struct(
-            pl.lit(cols.job_role_code).alias(AWPJobRoles.job_role_code),
+            pl.lit(cols.job_role_code)
+            .cast(JobRoleCatType)
+            .alias(AWPJobRoles.job_role_code),
             pl.col(cols.employees).cast(pl.Int16).alias(AWPJobRoles.employees),
             pl.col(cols.starters).cast(pl.Int16).alias(AWPJobRoles.starters),
             pl.col(cols.leavers).cast(pl.Int16).alias(AWPJobRoles.leavers),

--- a/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/validate_00_prepare.py
+++ b/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/validate_00_prepare.py
@@ -2,15 +2,32 @@ import sys
 
 import pointblank as pb
 
+import projects._07_workforce_characteristics._01_starters_leavers_vacancies.fargate.utils.prepare_utils as pUtils
 from polars_utils import utils
 from polars_utils.validation import actions as vl
 from polars_utils.validation.constants import GLOBAL_ACTIONS, GLOBAL_THRESHOLDS
 from utils.column_names.cleaned_data_files.ascwds_workplace_cleaned import (
     AscwdsWorkplaceCleanedColumns as AWPClean,
 )
+from utils.column_names.cleaned_data_files.ascwds_workplace_job_roles import (
+    AscwdsWorkplaceJobRolesColumns as AWPJobRoles,
+)
 
 COMPARE_COLS_TO_IMPORT = [
     AWPClean.establishment_id,
+]
+
+GRAIN_COLUMNS = [
+    AWPClean.establishment_id,
+    AWPClean.ascwds_workplace_import_date,
+    AWPJobRoles.job_role_code,
+]
+
+METRIC_COLUMNS = [
+    AWPJobRoles.employees,
+    AWPJobRoles.starters,
+    AWPJobRoles.leavers,
+    AWPJobRoles.vacancies,
 ]
 
 
@@ -29,11 +46,15 @@ def main(
         reports_path (str): the output path to write reports to
     """
     source_df = utils.read_parquet(source=f"s3://{bucket_name}/{source_path}")
-    compare_df = utils.read_parquet(
-        source=f"s3://{bucket_name}/{compare_path}",
-        selected_columns=COMPARE_COLS_TO_IMPORT,
-    )
-    expected_row_count = compare_df.height
+
+    # Single scan of compare_path, reused for both the schema-derived job-role
+    # count (independent of the output being validated, rather than counting
+    # distinct job_role_code values from source_df itself) and the row count.
+    compare_lf = utils.scan_parquet(source=f"s3://{bucket_name}/{compare_path}")
+    compare_schema = compare_lf.collect_schema()
+    job_role_code_count = len(pUtils.discover_job_role_codes(compare_schema))
+    compare_row_count = compare_lf.select(COMPARE_COLS_TO_IMPORT).collect().height
+    expected_row_count = compare_row_count * job_role_code_count
 
     validation = (
         pb.Validate(
@@ -47,6 +68,24 @@ def main(
         .row_count_match(
             expected_row_count,
             brief=f"Expects {expected_row_count} rows",
+        )
+        # index columns
+        .rows_distinct(
+            GRAIN_COLUMNS,
+            brief="Grain should be unique per establishment, import date and job role",
+        )
+        # complete columns
+        .col_vals_not_null(
+            columns=GRAIN_COLUMNS,
+            brief="Grain columns should contain no null values",
+        )
+        # numerical
+        .col_vals_between(
+            columns=METRIC_COLUMNS,
+            left=1,
+            right=998,
+            na_pass=True,
+            brief="Metrics should be between 1 and 998 where present.",
         ).interrogate()
     )
     vl.write_reports(validation, bucket_name, reports_path)

--- a/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/validate_00_prepare.py
+++ b/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/validate_00_prepare.py
@@ -70,8 +70,8 @@ def main(
             brief=f"Expects {expected_row_count} rows",
         )
         # index columns
-        .rows_distinct(
-            GRAIN_COLUMNS,
+        .specially(
+            vl.has_no_duplicate_grain_rows(GRAIN_COLUMNS, bucket_name, reports_path),
             brief="Grain should be unique per establishment, import date and job role",
         )
         # complete columns

--- a/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/tests/fargate/test_00_prepare.py
+++ b/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/tests/fargate/test_00_prepare.py
@@ -12,19 +12,29 @@ class MainTests(unittest.TestCase):
 
     @patch(f"{PATCH_PATH}.utils.sink_to_parquet")
     @patch(f"{PATCH_PATH}.apply_categorical_labels")
-    @patch(f"{PATCH_PATH}.pUtils.convert_job_role_strings_to_number_only")
-    @patch(f"{PATCH_PATH}.pUtils.pivot_job_role_cols_to_rows")
+    @patch(f"{PATCH_PATH}.pUtils.convert_job_role_columns_to_rows")
+    @patch(f"{PATCH_PATH}.pUtils.discover_job_role_codes")
     @patch(f"{PATCH_PATH}.pUtils.reduce_to_published_roles")
     @patch(f"{PATCH_PATH}.utils.scan_parquet")
     def test_main_runs(
         self,
         scan_parquet_mock: Mock,
         reduce_to_published_roles: Mock,
-        pivot_job_role_cols_to_rows: Mock,
-        convert_job_role_strings_to_number_only: Mock,
+        discover_job_role_codes_mock: Mock,
+        convert_job_role_columns_to_rows_mock: Mock,
         apply_categorical_labels: Mock,
         sink_to_parquet_mock: Mock,
     ):
+        discover_job_role_codes_mock.return_value = [
+            job.pUtils.JobRoleCodeColumns(
+                job_role_code="1",
+                employees="jr01emp",
+                starters="jr01strt",
+                leavers="jr01stop",
+                vacancies="jr01vacy",
+            ),
+        ]
+
         job.main(
             self.CLEANED_ASCWDS_WORKPLACE_SOURCE,
             self.PREPARED_DATA_DESTINATION,
@@ -32,10 +42,18 @@ class MainTests(unittest.TestCase):
 
         scan_parquet_mock.assert_called_once_with(self.CLEANED_ASCWDS_WORKPLACE_SOURCE)
 
+        scan_parquet_mock.return_value.select.assert_called_once_with(
+            *job.INDEX_COLUMNS, "jr01emp", "jr01strt", "jr01stop", "jr01vacy"
+        )
+
+        convert_job_role_columns_to_rows_mock.assert_called_once_with(
+            scan_parquet_mock.return_value.select.return_value,
+            job.INDEX_COLUMNS,
+            discover_job_role_codes_mock.return_value,
+        )
+
         # TODO: Uncomment these assertions when the placeholder functions are implemented
         # reduce_to_published_roles.assert_called_once()
-        # pivot_job_role_cols_to_rows.assert_called_once()
-        # convert_job_role_strings_to_number_only.assert_called_once()
         # apply_categorical_labels.assert_called_once()
 
         sink_to_parquet_mock.assert_called_once_with(

--- a/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/tests/fargate/test_01_merge.py
+++ b/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/tests/fargate/test_01_merge.py
@@ -1,55 +1,51 @@
-import unittest
 from unittest.mock import ANY, Mock, call, patch
 
 import projects._07_workforce_characteristics._01_starters_leavers_vacancies.fargate._01_merge as job
 
 PATCH_PATH = "projects._07_workforce_characteristics._01_starters_leavers_vacancies.fargate._01_merge"
 
+METADATA_SOURCE = "some/source"
+JOB_ROLE_ESTIMATES_SOURCE = "another/source"
+PREPARED_SLV_DATASET_SOURCE = "other/source"
+MERGED_DATA_DESTINATION = "some/destination"
 
-class MainTests(unittest.TestCase):
-    METADATA_SOURCE = "some/source"
-    JOB_ROLE_ESTIMATES_SOURCE = "another/source"
-    PREPARED_SLV_DATASET_SOURCE = "other/source"
-    MERGED_DATA_DESTINATION = "some/destination"
 
+class TestMain:
     @patch(f"{PATCH_PATH}.utils.sink_to_parquet")
     @patch(f"{PATCH_PATH}.mUtils.apply_employment_status_magic_numbers")
     @patch(f"{PATCH_PATH}.mUtils.join_datasets")
-    @patch(f"{PATCH_PATH}.expr.is_slv_job_role_column")
     @patch(f"{PATCH_PATH}.utils.scan_parquet")
     def test_main_runs(
         self,
         scan_parquet_mock: Mock,
-        is_slv_job_role_column_mock: Mock,
         join_datasets_mock: Mock,
         apply_employment_status_magic_numbers_mock: Mock,
         sink_to_parquet_mock: Mock,
     ):
         job.main(
-            self.METADATA_SOURCE,
-            self.JOB_ROLE_ESTIMATES_SOURCE,
-            self.PREPARED_SLV_DATASET_SOURCE,
-            self.MERGED_DATA_DESTINATION,
+            METADATA_SOURCE,
+            JOB_ROLE_ESTIMATES_SOURCE,
+            PREPARED_SLV_DATASET_SOURCE,
+            MERGED_DATA_DESTINATION,
         )
 
         assert len(scan_parquet_mock.call_args_list) == 3
 
         scan_calls = [
-            call(source=self.METADATA_SOURCE, selected_columns=job.metadata_columns),
+            call(source=METADATA_SOURCE, selected_columns=job.metadata_columns),
             call(
-                source=self.JOB_ROLE_ESTIMATES_SOURCE,
+                source=JOB_ROLE_ESTIMATES_SOURCE,
                 selected_columns=job.job_role_estimates_columns,
             ),
-            call(self.PREPARED_SLV_DATASET_SOURCE),
+            call(PREPARED_SLV_DATASET_SOURCE, selected_columns=job.workplace_columns),
         ]
         scan_parquet_mock.assert_has_calls(scan_calls)
 
         # TODO: Uncomment these assertions when the placeholder functions are implemented
-        is_slv_job_role_column_mock.assert_called_once()
         # join_datasets_mock.assert_called_once()
         # apply_employment_status_magic_numbers_mock.assert_called_once()
 
         sink_to_parquet_mock.assert_called_once_with(
             lazy_df=ANY,
-            output_path=self.MERGED_DATA_DESTINATION,
+            output_path=MERGED_DATA_DESTINATION,
         )

--- a/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/tests/fargate/test_validate_00_prepare.py
+++ b/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/tests/fargate/test_validate_00_prepare.py
@@ -1,12 +1,16 @@
 import json
 import unittest
-from unittest.mock import Mock, call, patch
+from datetime import date
+from unittest.mock import Mock, patch
 
 import polars as pl
 
 import projects._07_workforce_characteristics._01_starters_leavers_vacancies.fargate.validate_00_prepare as job
 from utils.column_names.cleaned_data_files.ascwds_workplace_cleaned import (
     AscwdsWorkplaceCleanedColumns as AWPClean,
+)
+from utils.column_names.cleaned_data_files.ascwds_workplace_job_roles import (
+    AscwdsWorkplaceJobRolesColumns as AWPJobRoles,
 )
 
 PATCH_PATH = "projects._07_workforce_characteristics._01_starters_leavers_vacancies.fargate.validate_00_prepare"
@@ -16,43 +20,65 @@ class ValidatePreparedSLVDataTests(unittest.TestCase):
     def setUp(self) -> None:
         source_schema = {
             AWPClean.establishment_id: pl.String,
+            AWPClean.ascwds_workplace_import_date: pl.Date,
+            AWPJobRoles.job_role_code: pl.String,
+            AWPJobRoles.employees: pl.Int16,
+            AWPJobRoles.starters: pl.Int16,
+            AWPJobRoles.leavers: pl.Int16,
+            AWPJobRoles.vacancies: pl.Int16,
         }
         source_rows = [
-            ("1-001"),
+            ("1-001", date(2026, 1, 1), "1", 5, 1, 0, 2),
         ]  # fmt: skip
         self.source_df = pl.DataFrame(source_rows, source_schema, orient="row")
         self.compare_df = self.source_df.select([AWPClean.establishment_id])
 
+        self.compare_schema = {
+            AWPClean.establishment_id: pl.String,
+            "jr01emp": pl.Int32,
+            "jr01strt": pl.Int32,
+            "jr01stop": pl.Int32,
+            "jr01vacy": pl.Int32,
+        }
+
     @patch(f"{PATCH_PATH}.vl.write_reports")
+    @patch(f"{PATCH_PATH}.utils.scan_parquet")
     @patch(f"{PATCH_PATH}.utils.read_parquet")
     def test_validation_runs(
         self,
         mock_read_parquet: Mock,
+        mock_scan_parquet: Mock,
         mock_write_reports: Mock,
     ):
-        mock_read_parquet.side_effect = [self.source_df, self.compare_df]
+        mock_read_parquet.return_value = self.source_df
+        mock_scan_parquet.return_value.collect_schema.return_value = self.compare_schema
+        mock_scan_parquet.return_value.select.return_value.collect.return_value.height = (
+            self.compare_df.height
+        )
+
         job.main("bucket", "my/source/", "my/compare/", "my/reports/")
 
-        self.assertEqual(mock_read_parquet.call_count, 2)
-        mock_read_parquet.assert_has_calls(
-            [
-                call(source="s3://bucket/my/source/"),
-                call(
-                    source="s3://bucket/my/compare/",
-                    selected_columns=job.COMPARE_COLS_TO_IMPORT,
-                ),
-            ]
+        mock_read_parquet.assert_called_once_with(source="s3://bucket/my/source/")
+        mock_scan_parquet.assert_called_once_with(source="s3://bucket/my/compare/")
+        mock_scan_parquet.return_value.select.assert_called_once_with(
+            job.COMPARE_COLS_TO_IMPORT
         )
         mock_write_reports.assert_called_once()
 
     @patch(f"{PATCH_PATH}.vl.write_reports")
+    @patch(f"{PATCH_PATH}.utils.scan_parquet")
     @patch(f"{PATCH_PATH}.utils.read_parquet")
     def test_validation_report_includes_expected_validations(
         self,
         mock_read_parquet: Mock,
+        mock_scan_parquet: Mock,
         mock_write_reports: Mock,
     ):
-        mock_read_parquet.side_effect = [self.source_df, self.compare_df]
+        mock_read_parquet.return_value = self.source_df
+        mock_scan_parquet.return_value.collect_schema.return_value = self.compare_schema
+        mock_scan_parquet.return_value.select.return_value.collect.return_value.height = (
+            self.compare_df.height
+        )
 
         job.main("bucket", "my/source/", "my/compare/", "my/reports/")
 
@@ -63,6 +89,9 @@ class ValidatePreparedSLVDataTests(unittest.TestCase):
 
         expected_assertions = {
             "row_count_match",
+            "rows_distinct",
+            "col_vals_not_null",
+            "col_vals_between",
         }
 
         for assertion in expected_assertions:

--- a/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/tests/fargate/test_validate_00_prepare.py
+++ b/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/tests/fargate/test_validate_00_prepare.py
@@ -41,6 +41,7 @@ class ValidatePreparedSLVDataTests(unittest.TestCase):
             "jr01vacy": pl.Int32,
         }
 
+    @patch("boto3.client", autospec=True)
     @patch(f"{PATCH_PATH}.vl.write_reports")
     @patch(f"{PATCH_PATH}.utils.scan_parquet")
     @patch(f"{PATCH_PATH}.utils.read_parquet")
@@ -49,6 +50,7 @@ class ValidatePreparedSLVDataTests(unittest.TestCase):
         mock_read_parquet: Mock,
         mock_scan_parquet: Mock,
         mock_write_reports: Mock,
+        mock_s3_client: Mock,
     ):
         mock_read_parquet.return_value = self.source_df
         mock_scan_parquet.return_value.collect_schema.return_value = self.compare_schema
@@ -65,6 +67,7 @@ class ValidatePreparedSLVDataTests(unittest.TestCase):
         )
         mock_write_reports.assert_called_once()
 
+    @patch("boto3.client", autospec=True)
     @patch(f"{PATCH_PATH}.vl.write_reports")
     @patch(f"{PATCH_PATH}.utils.scan_parquet")
     @patch(f"{PATCH_PATH}.utils.read_parquet")
@@ -73,6 +76,7 @@ class ValidatePreparedSLVDataTests(unittest.TestCase):
         mock_read_parquet: Mock,
         mock_scan_parquet: Mock,
         mock_write_reports: Mock,
+        mock_s3_client: Mock,
     ):
         mock_read_parquet.return_value = self.source_df
         mock_scan_parquet.return_value.collect_schema.return_value = self.compare_schema
@@ -89,7 +93,7 @@ class ValidatePreparedSLVDataTests(unittest.TestCase):
 
         expected_assertions = {
             "row_count_match",
-            "rows_distinct",
+            "specially",
             "col_vals_not_null",
             "col_vals_between",
         }

--- a/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/tests/fargate/utils/test_prepare_utils.py
+++ b/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/tests/fargate/utils/test_prepare_utils.py
@@ -1,6 +1,23 @@
+from dataclasses import dataclass
+
+import polars as pl
+import polars.testing as pl_testing
+import pytest
+
 import projects._07_workforce_characteristics._01_starters_leavers_vacancies.fargate.utils.prepare_utils as job
+from projects._07_workforce_characteristics.unittest_data.polars_slv_test_data import (
+    Data,
+)
+from projects._07_workforce_characteristics.unittest_data.polars_slv_test_schemas import (
+    Schemas,
+)
+from utils.column_names.cleaned_data_files.ascwds_workplace_cleaned import (
+    AscwdsWorkplaceCleanedColumns as AWPClean,
+)
 
 PATCH_PATH = "projects._07_workforce_characteristics._01_starters_leavers_vacancies.fargate.utils.prepare_utils"
+
+INDEX_COLS = [AWPClean.establishment_id, AWPClean.ascwds_workplace_import_date]
 
 
 class TestReduceToPublishedRoles:
@@ -8,11 +25,211 @@ class TestReduceToPublishedRoles:
         pass
 
 
-class TestPivotJobRoleColsToRows:
-    def test_pivot_job_role_cols_to_rows(self):
-        pass
+@dataclass
+class DiscoverJobRoleCodesTestCase:
+    id: str
+    schema: dict
+    expected_codes: list[str]
+
+    def as_pytest_param(self):
+        return pytest.param(self.schema, self.expected_codes, id=self.id)
 
 
-class TestConvertJobRoleStringsToNumberOnly:
-    def test_convert_job_role_strings_to_number_only(self):
-        pass
+discover_job_role_codes_cases = [
+    DiscoverJobRoleCodesTestCase(
+        id="discovers_non_contiguous_codes_and_orders_numerically",
+        schema={
+            AWPClean.establishment_id: pl.String,
+            "jr01emp": pl.Int32,
+            "jr01strt": pl.Int32,
+            "jr01stop": pl.Int32,
+            "jr01vacy": pl.Int32,
+            "jr45emp": pl.Int32,
+            "jr45strt": pl.Int32,
+            "jr45stop": pl.Int32,
+            "jr45vacy": pl.Int32,
+            "jr02emp": pl.Int32,
+            "jr02strt": pl.Int32,
+            "jr02stop": pl.Int32,
+            "jr02vacy": pl.Int32,
+        },
+        expected_codes=["1", "2", "45"],
+    ),
+    DiscoverJobRoleCodesTestCase(
+        id="ignores_columns_outside_the_slv_selector",
+        schema={
+            AWPClean.establishment_id: pl.String,
+            "jr01emp": pl.Int32,
+            "jr01strt": pl.Int32,
+            "jr01stop": pl.Int32,
+            "jr01vacy": pl.Int32,
+            "jr01temp": pl.Int32,  # excluded: ends with "temp"
+            "jr01flag": pl.Int32,  # excluded: not a metric suffix
+        },
+        expected_codes=["1"],
+    ),
+    DiscoverJobRoleCodesTestCase(
+        id="strips_leading_zeros_from_the_code",
+        schema={
+            "jr07emp": pl.Int32,
+            "jr07strt": pl.Int32,
+            "jr07stop": pl.Int32,
+            "jr07vacy": pl.Int32,
+        },
+        expected_codes=["7"],
+    ),
+]
+
+
+@dataclass
+class DiscoverJobRoleCodesRaisesTestCase:
+    id: str
+    schema: dict
+    match: str
+
+    def as_pytest_param(self):
+        return pytest.param(self.schema, self.match, id=self.id)
+
+
+discover_job_role_codes_raises_cases = [
+    DiscoverJobRoleCodesRaisesTestCase(
+        id="raises_when_no_slv_columns_are_found",
+        schema={AWPClean.establishment_id: pl.String},
+        match="No SLV job-role columns found",
+    ),
+    DiscoverJobRoleCodesRaisesTestCase(
+        id="raises_when_a_code_is_missing_one_of_its_metric_columns",
+        schema={
+            "jr01emp": pl.Int32,
+            "jr01strt": pl.Int32,
+        },
+        match="missing one or more",
+    ),
+    DiscoverJobRoleCodesRaisesTestCase(
+        id="raises_when_a_column_does_not_match_the_expected_naming_pattern",
+        schema={
+            "jrABemp": pl.Int32,
+        },
+        match="naming pattern",
+    ),
+    DiscoverJobRoleCodesRaisesTestCase(
+        id="raises_when_two_columns_collide_on_the_same_normalised_code",
+        schema={
+            "jr01emp": pl.Int32,
+            "jr01strt": pl.Int32,
+            "jr01stop": pl.Int32,
+            "jr01vacy": pl.Int32,
+            "jr1emp": pl.Int32,
+        },
+        match="both normalise to job role code",
+    ),
+]
+
+
+class TestDiscoverJobRoleCodes:
+    @pytest.mark.parametrize(
+        "schema,expected_codes",
+        [c.as_pytest_param() for c in discover_job_role_codes_cases],
+    )
+    def test_returns_expected_job_role_codes(self, schema, expected_codes):
+        discovered = job.discover_job_role_codes(schema)
+
+        assert [cols.job_role_code for cols in discovered] == expected_codes
+
+    @pytest.mark.parametrize(
+        "schema,match",
+        [c.as_pytest_param() for c in discover_job_role_codes_raises_cases],
+    )
+    def test_raises_value_error(self, schema, match):
+        with pytest.raises(ValueError, match=match):
+            job.discover_job_role_codes(schema)
+
+
+class TestConvertJobRoleColumnsToRows:
+    def test_reshapes_wide_job_role_columns_to_one_row_per_code(self):
+        job_role_columns = [
+            job.JobRoleCodeColumns(
+                job_role_code="1",
+                employees="jr01emp",
+                starters="jr01strt",
+                leavers="jr01stop",
+                vacancies="jr01vacy",
+            ),
+            job.JobRoleCodeColumns(
+                job_role_code="45",
+                employees="jr45emp",
+                starters="jr45strt",
+                leavers="jr45stop",
+                vacancies="jr45vacy",
+            ),
+        ]
+        workplace_lf = pl.LazyFrame(
+            Data.wide_two_job_roles_rows, schema=Schemas.wide_two_job_roles_schema
+        )
+
+        returned_lf = job.convert_job_role_columns_to_rows(
+            workplace_lf, INDEX_COLS, job_role_columns
+        )
+
+        expected_lf = pl.LazyFrame(
+            Data.expected_long_two_job_roles_rows, schema=Schemas.long_job_roles_schema
+        )
+
+        sort_keys = [AWPClean.establishment_id, "job_role_code"]
+        pl_testing.assert_frame_equal(
+            returned_lf.sort(sort_keys),
+            expected_lf.sort(sort_keys),
+            check_column_order=False,
+        )
+
+    def test_keeps_a_row_for_a_code_with_all_null_metrics(self):
+        job_role_columns = [
+            job.JobRoleCodeColumns(
+                job_role_code="1",
+                employees="jr01emp",
+                starters="jr01strt",
+                leavers="jr01stop",
+                vacancies="jr01vacy",
+            ),
+        ]
+        workplace_lf = pl.LazyFrame(
+            Data.wide_one_job_role_all_null_rows,
+            schema=Schemas.wide_one_job_role_all_null_schema,
+        )
+
+        returned_lf = job.convert_job_role_columns_to_rows(
+            workplace_lf, INDEX_COLS, job_role_columns
+        )
+
+        expected_lf = pl.LazyFrame(
+            Data.expected_long_one_job_role_all_null_rows,
+            schema=Schemas.long_job_roles_schema,
+        )
+
+        pl_testing.assert_frame_equal(
+            returned_lf, expected_lf, check_column_order=False
+        )
+
+    def test_downcasts_metric_columns_to_int16(self):
+        job_role_columns = [
+            job.JobRoleCodeColumns(
+                job_role_code="1",
+                employees="jr01emp",
+                starters="jr01strt",
+                leavers="jr01stop",
+                vacancies="jr01vacy",
+            ),
+        ]
+        workplace_lf = pl.LazyFrame(
+            Data.wide_one_job_role_all_null_rows,
+            schema=Schemas.wide_one_job_role_all_null_schema,
+        )
+
+        returned_schema = job.convert_job_role_columns_to_rows(
+            workplace_lf, INDEX_COLS, job_role_columns
+        ).collect_schema()
+
+        assert returned_schema["employees"] == pl.Int16
+        assert returned_schema["starters"] == pl.Int16
+        assert returned_schema["leavers"] == pl.Int16
+        assert returned_schema["vacancies"] == pl.Int16

--- a/projects/_07_workforce_characteristics/dockerfile_and_requirements/Dockerfile
+++ b/projects/_07_workforce_characteristics/dockerfile_and_requirements/Dockerfile
@@ -23,6 +23,16 @@ COPY projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/farga
 COPY projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/validate_02_clean.py /app/_01_starters_leavers_vacancies/fargate/validate_02_clean.py
 COPY projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/validate_03_impute.py /app/_01_starters_leavers_vacancies/fargate/validate_03_impute.py
 COPY projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/validate_04_estimate.py /app/_01_starters_leavers_vacancies/fargate/validate_04_estimate.py
+
+# TEMPORARY - ticket 1814 validate_00_prepare OOM isolation diagnostics.
+# Delete these 4 lines, the diag_0N_*.py scripts, fargate/utils/diag_helpers.py
+# and step-functions/dynamic/Ind-CQC-SLV-1814-oom-diag.json once the OOM root
+# cause has been isolated - none of this is meant to reach main.
+COPY projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/diag_01_read_parquet_only.py /app/_01_starters_leavers_vacancies/fargate/diag_01_read_parquet_only.py
+COPY projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/diag_02_rows_distinct_only.py /app/_01_starters_leavers_vacancies/fargate/diag_02_rows_distinct_only.py
+COPY projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/diag_03_cheap_checks_only.py /app/_01_starters_leavers_vacancies/fargate/diag_03_cheap_checks_only.py
+COPY projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/diag_04_full_instrumented.py /app/_01_starters_leavers_vacancies/fargate/diag_04_full_instrumented.py
+
 COPY projects/_07_workforce_characteristics/dockerfile_and_requirements/requirements.txt /app/requirements.txt
 
 RUN pip install --no-cache-dir -r requirements.txt

--- a/projects/_07_workforce_characteristics/unittest_data/polars_slv_test_data.py
+++ b/projects/_07_workforce_characteristics/unittest_data/polars_slv_test_data.py
@@ -1,0 +1,56 @@
+from dataclasses import dataclass
+from datetime import date
+
+from utils.column_names.cleaned_data_files.ascwds_workplace_cleaned import (
+    AscwdsWorkplaceCleanedColumns as AWPClean,
+)
+from utils.column_names.cleaned_data_files.ascwds_workplace_job_roles import (
+    AscwdsWorkplaceJobRolesColumns as AWPJobRoles,
+)
+
+IMPORT_DATE = date(2026, 1, 1)
+
+
+@dataclass
+class Data:
+    wide_two_job_roles_rows = {
+        AWPClean.establishment_id: ["1-001", "1-002"],
+        AWPClean.ascwds_workplace_import_date: [IMPORT_DATE, IMPORT_DATE],
+        "jr01emp": [5, 7],
+        "jr01strt": [1, 2],
+        "jr01stop": [0, 1],
+        "jr01vacy": [2, 0],
+        "jr45emp": [10, 3],
+        "jr45strt": [0, 1],
+        "jr45stop": [1, 0],
+        "jr45vacy": [0, 2],
+    }
+
+    expected_long_two_job_roles_rows = {
+        AWPClean.establishment_id: ["1-001", "1-001", "1-002", "1-002"],
+        AWPClean.ascwds_workplace_import_date: [IMPORT_DATE] * 4,
+        AWPJobRoles.job_role_code: ["1", "45", "1", "45"],
+        AWPJobRoles.employees: [5, 10, 7, 3],
+        AWPJobRoles.starters: [1, 0, 2, 1],
+        AWPJobRoles.leavers: [0, 1, 1, 0],
+        AWPJobRoles.vacancies: [2, 0, 0, 2],
+    }
+
+    wide_one_job_role_all_null_rows = {
+        AWPClean.establishment_id: ["1-001"],
+        AWPClean.ascwds_workplace_import_date: [IMPORT_DATE],
+        "jr01emp": [None],
+        "jr01strt": [None],
+        "jr01stop": [None],
+        "jr01vacy": [None],
+    }
+
+    expected_long_one_job_role_all_null_rows = {
+        AWPClean.establishment_id: ["1-001"],
+        AWPClean.ascwds_workplace_import_date: [IMPORT_DATE],
+        AWPJobRoles.job_role_code: ["1"],
+        AWPJobRoles.employees: [None],
+        AWPJobRoles.starters: [None],
+        AWPJobRoles.leavers: [None],
+        AWPJobRoles.vacancies: [None],
+    }

--- a/projects/_07_workforce_characteristics/unittest_data/polars_slv_test_schemas.py
+++ b/projects/_07_workforce_characteristics/unittest_data/polars_slv_test_schemas.py
@@ -1,0 +1,47 @@
+from dataclasses import dataclass
+
+import polars as pl
+
+from utils.column_names.cleaned_data_files.ascwds_workplace_cleaned import (
+    AscwdsWorkplaceCleanedColumns as AWPClean,
+)
+from utils.column_names.cleaned_data_files.ascwds_workplace_job_roles import (
+    AscwdsWorkplaceJobRolesColumns as AWPJobRoles,
+)
+
+INDEX_SCHEMA = {
+    AWPClean.establishment_id: pl.String,
+    AWPClean.ascwds_workplace_import_date: pl.Date,
+}
+
+
+@dataclass
+class Schemas:
+    wide_two_job_roles_schema = {
+        **INDEX_SCHEMA,
+        "jr01emp": pl.Int32,
+        "jr01strt": pl.Int32,
+        "jr01stop": pl.Int32,
+        "jr01vacy": pl.Int32,
+        "jr45emp": pl.Int32,
+        "jr45strt": pl.Int32,
+        "jr45stop": pl.Int32,
+        "jr45vacy": pl.Int32,
+    }
+
+    wide_one_job_role_all_null_schema = {
+        **INDEX_SCHEMA,
+        "jr01emp": pl.Int32,
+        "jr01strt": pl.Int32,
+        "jr01stop": pl.Int32,
+        "jr01vacy": pl.Int32,
+    }
+
+    long_job_roles_schema = {
+        **INDEX_SCHEMA,
+        AWPJobRoles.job_role_code: pl.String,
+        AWPJobRoles.employees: pl.Int16,
+        AWPJobRoles.starters: pl.Int16,
+        AWPJobRoles.leavers: pl.Int16,
+        AWPJobRoles.vacancies: pl.Int16,
+    }

--- a/terraform/pipeline/step-functions/dynamic/Ind-CQC-SLV-1814-oom-diag.json
+++ b/terraform/pipeline/step-functions/dynamic/Ind-CQC-SLV-1814-oom-diag.json
@@ -1,0 +1,170 @@
+{
+  "Comment": "TEMPORARY - throwaway diagnostic pipeline isolating the ticket 1814 validate_00_prepare OOM. Runs diag_01-04 sequentially against the real _00_prepare output already produced in this workspace; each stage's own Catch stops the chain cleanly at the first experiment that reproduces the OOM instead of erroring out. Delete this file, the diag_0N_*.py scripts, fargate/utils/diag_helpers.py and their Dockerfile COPY lines once the root cause is isolated - none of this is meant to reach main.",
+  "StartAt": "Diag 1 - Read Parquet Only",
+  "States": {
+    "Diag 1 - Read Parquet Only": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::ecs:runTask.sync",
+      "Parameters": {
+        "Cluster": "${polars_cluster_arn}",
+        "TaskDefinition": "${workforce_characteristics_task_arn}",
+        "LaunchType": "FARGATE",
+        "NetworkConfiguration": {
+          "AwsvpcConfiguration": {
+            "Subnets": ${public_subnet_ids},
+            "SecurityGroups": ["${workforce_characteristics_security_group_id}"],
+            "AssignPublicIp": "ENABLED"
+          }
+        },
+        "Overrides": {
+          "ContainerOverrides": [
+            {
+              "Name": "_07_workforce_characteristics-container",
+              "Command": [
+                "_01_starters_leavers_vacancies/fargate/diag_01_read_parquet_only.py",
+                "--bucket_name", "${dataset_bucket_name}",
+                "--source_path", "domain=workforce_characteristics/dataset=ind_cqc_slv_00_prepare/",
+                "--reports_path", "domain=data_validation_reports/dataset=diag_1814_oom/"
+              ]
+            }
+          ]
+        }
+      },
+      "Catch": [
+        {
+          "ErrorEquals": ["States.ALL"],
+          "Next": "Stopped After Diag 1 - Read Parquet Only",
+          "ResultPath": "$.error"
+        }
+      ],
+      "Next": "Diag 2 - Rows Distinct Only"
+    },
+    "Stopped After Diag 1 - Read Parquet Only": {
+      "Type": "Succeed"
+    },
+    "Diag 2 - Rows Distinct Only": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::ecs:runTask.sync",
+      "Parameters": {
+        "Cluster": "${polars_cluster_arn}",
+        "TaskDefinition": "${workforce_characteristics_task_arn}",
+        "LaunchType": "FARGATE",
+        "NetworkConfiguration": {
+          "AwsvpcConfiguration": {
+            "Subnets": ${public_subnet_ids},
+            "SecurityGroups": ["${workforce_characteristics_security_group_id}"],
+            "AssignPublicIp": "ENABLED"
+          }
+        },
+        "Overrides": {
+          "ContainerOverrides": [
+            {
+              "Name": "_07_workforce_characteristics-container",
+              "Command": [
+                "_01_starters_leavers_vacancies/fargate/diag_02_rows_distinct_only.py",
+                "--bucket_name", "${dataset_bucket_name}",
+                "--source_path", "domain=workforce_characteristics/dataset=ind_cqc_slv_00_prepare/",
+                "--reports_path", "domain=data_validation_reports/dataset=diag_1814_oom/"
+              ]
+            }
+          ]
+        }
+      },
+      "Catch": [
+        {
+          "ErrorEquals": ["States.ALL"],
+          "Next": "Stopped After Diag 2 - Rows Distinct Only",
+          "ResultPath": "$.error"
+        }
+      ],
+      "Next": "Diag 3 - Cheap Checks Only"
+    },
+    "Stopped After Diag 2 - Rows Distinct Only": {
+      "Type": "Succeed"
+    },
+    "Diag 3 - Cheap Checks Only": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::ecs:runTask.sync",
+      "Parameters": {
+        "Cluster": "${polars_cluster_arn}",
+        "TaskDefinition": "${workforce_characteristics_task_arn}",
+        "LaunchType": "FARGATE",
+        "NetworkConfiguration": {
+          "AwsvpcConfiguration": {
+            "Subnets": ${public_subnet_ids},
+            "SecurityGroups": ["${workforce_characteristics_security_group_id}"],
+            "AssignPublicIp": "ENABLED"
+          }
+        },
+        "Overrides": {
+          "ContainerOverrides": [
+            {
+              "Name": "_07_workforce_characteristics-container",
+              "Command": [
+                "_01_starters_leavers_vacancies/fargate/diag_03_cheap_checks_only.py",
+                "--bucket_name", "${dataset_bucket_name}",
+                "--source_path", "domain=workforce_characteristics/dataset=ind_cqc_slv_00_prepare/",
+                "--reports_path", "domain=data_validation_reports/dataset=diag_1814_oom/"
+              ]
+            }
+          ]
+        }
+      },
+      "Catch": [
+        {
+          "ErrorEquals": ["States.ALL"],
+          "Next": "Stopped After Diag 3 - Cheap Checks Only",
+          "ResultPath": "$.error"
+        }
+      ],
+      "Next": "Diag 4 - Full Instrumented"
+    },
+    "Stopped After Diag 3 - Cheap Checks Only": {
+      "Type": "Succeed"
+    },
+    "Diag 4 - Full Instrumented": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::ecs:runTask.sync",
+      "Parameters": {
+        "Cluster": "${polars_cluster_arn}",
+        "TaskDefinition": "${workforce_characteristics_task_arn}",
+        "LaunchType": "FARGATE",
+        "NetworkConfiguration": {
+          "AwsvpcConfiguration": {
+            "Subnets": ${public_subnet_ids},
+            "SecurityGroups": ["${workforce_characteristics_security_group_id}"],
+            "AssignPublicIp": "ENABLED"
+          }
+        },
+        "Overrides": {
+          "ContainerOverrides": [
+            {
+              "Name": "_07_workforce_characteristics-container",
+              "Command": [
+                "_01_starters_leavers_vacancies/fargate/diag_04_full_instrumented.py",
+                "--bucket_name", "${dataset_bucket_name}",
+                "--source_path", "domain=workforce_characteristics/dataset=ind_cqc_slv_00_prepare/",
+                "--compare_path", "domain=ASCWDS/dataset=workplace_cleaned/",
+                "--reports_path", "domain=data_validation_reports/dataset=diag_1814_oom/"
+              ]
+            }
+          ]
+        }
+      },
+      "Catch": [
+        {
+          "ErrorEquals": ["States.ALL"],
+          "Next": "Stopped After Diag 4 - Full Instrumented",
+          "ResultPath": "$.error"
+        }
+      ],
+      "Next": "All Diagnostics Completed"
+    },
+    "Stopped After Diag 4 - Full Instrumented": {
+      "Type": "Succeed"
+    },
+    "All Diagnostics Completed": {
+      "Type": "Succeed"
+    }
+  }
+}

--- a/tests/test_polars_utils/test_validation_actions.py
+++ b/tests/test_polars_utils/test_validation_actions.py
@@ -244,6 +244,101 @@ class TestMakeColHasFewerNullsValidator(TestValidate):
         self.assertFalse(result_fail)
 
 
+class TestHasNoDuplicateGrainRows:
+    columns = ["someId", "my_date"]
+    bucket_name = "bucket"
+    reports_path = "reports"
+    extract_key = "s3://bucket/reports/duplicate_grain_rows.parquet"
+
+    @patch("polars_utils.utils.write_to_parquet", autospec=True)
+    @patch("boto3.client", autospec=True)
+    def test_returns_true_and_deletes_stale_extract_when_no_duplicates(
+        self, mock_s3_client, mock_write_parquet
+    ):
+        df = pl.DataFrame({"someId": ["1", "2"], "my_date": ["a", "b"]})
+        validator = vl.has_no_duplicate_grain_rows(
+            self.columns, self.bucket_name, self.reports_path
+        )
+
+        result = validator(df)
+
+        assert result is True
+        mock_write_parquet.assert_not_called()
+        mock_s3_client.return_value.delete_object.assert_called_once_with(
+            Bucket=self.bucket_name, Key="reports/duplicate_grain_rows.parquet"
+        )
+
+    @patch("polars_utils.utils.write_to_parquet", autospec=True)
+    @patch("boto3.client", autospec=True)
+    def test_returns_false_and_writes_all_instances_when_duplicates_present(
+        self, mock_s3_client, mock_write_parquet
+    ):
+        df = pl.DataFrame({"someId": ["1", "1", "2"], "my_date": ["a", "a", "b"]})
+        validator = vl.has_no_duplicate_grain_rows(
+            self.columns, self.bucket_name, self.reports_path
+        )
+
+        result = validator(df)
+
+        assert result is False
+        written_df = mock_write_parquet.call_args[0][0]
+        pl_testing.assert_frame_equal(
+            written_df, pl.DataFrame({"someId": ["1", "1"], "my_date": ["a", "a"]})
+        )
+        mock_write_parquet.assert_called_once_with(
+            written_df, self.extract_key, append=False
+        )
+
+    @patch("polars_utils.utils.write_to_parquet", autospec=True)
+    @patch("boto3.client", autospec=True)
+    def test_truncates_extract_to_max_rows_to_extract(
+        self, mock_s3_client, mock_write_parquet
+    ):
+        df = pl.DataFrame({"someId": ["1", "1", "1"], "my_date": ["a", "a", "a"]})
+        validator = vl.has_no_duplicate_grain_rows(
+            self.columns, self.bucket_name, self.reports_path, max_rows_to_extract=2
+        )
+
+        validator(df)
+
+        written_df = mock_write_parquet.call_args[0][0]
+        assert written_df.height == 2
+
+    @patch("polars_utils.utils.write_to_parquet", autospec=True)
+    @patch("boto3.client", autospec=True)
+    def test_rows_sharing_a_null_grain_value_are_treated_as_duplicates(
+        self, mock_s3_client, mock_write_parquet
+    ):
+        df = pl.DataFrame(
+            {"someId": [None, None], "my_date": ["a", "a"]},
+            schema={"someId": pl.String, "my_date": pl.String},
+        )
+        validator = vl.has_no_duplicate_grain_rows(
+            self.columns, self.bucket_name, self.reports_path
+        )
+
+        result = validator(df)
+
+        assert result is False
+
+    @patch("polars_utils.utils.write_to_parquet", autospec=True)
+    @patch("boto3.client", autospec=True)
+    def test_row_with_a_unique_null_grain_value_is_not_a_duplicate(
+        self, mock_s3_client, mock_write_parquet
+    ):
+        df = pl.DataFrame(
+            {"someId": [None, "1"], "my_date": ["a", "b"]},
+            schema={"someId": pl.String, "my_date": pl.String},
+        )
+        validator = vl.has_no_duplicate_grain_rows(
+            self.columns, self.bucket_name, self.reports_path
+        )
+
+        result = validator(df)
+
+        assert result is True
+
+
 class TestMakeConvertColToIntegersPreprocessor:
     def test_make_convert_col_to_integers_preprocessor(self):
         preprocessor = job.make_convert_col_to_integers_preprocessor(PartitionKeys.year)

--- a/utils/column_names/cleaned_data_files/ascwds_workplace_job_roles.py
+++ b/utils/column_names/cleaned_data_files/ascwds_workplace_job_roles.py
@@ -1,0 +1,10 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class AscwdsWorkplaceJobRolesColumns:
+    job_role_code: str = "job_role_code"
+    employees: str = "employees"
+    starters: str = "starters"
+    leavers: str = "leavers"
+    vacancies: str = "vacancies"


### PR DESCRIPTION
## Description
Ticket 1814

Implements the production version of ticket 1797's decided design (Candidate B: `struct`+`concat_list`+`explode`+`unnest`) for reshaping the wide `jrNN{emp,strt,stop,vacy}` SLV job-role columns into a long-format table — one row per `establishment_id`/`ascwds_workplace_import_date`/`job_role_code`. Job-role codes are discovered dynamically from the schema at runtime, metrics are downcast to `Int16`, and `_01_merge.py`/`validate_00_prepare.py` are updated to read/validate the new shape.

Also includes fixes from a subsequent code review of this same diff:
- `discover_job_role_codes()` now raises on colliding job-role codes instead of silently overwriting one column's data.
- Removed two redundant `scan_parquet` calls that each fired a duplicate S3 existence check.
- Removed the now-redundant `convert_job_role_strings_to_number_only()` placeholder (ticket 1795) — the reshape already emits bare-number codes.
- `test_01_merge.py` migrated to pytest style; `TestDiscoverJobRoleCodes` parametrized per this repo's testing convention.

Job-role labelling (ticket 1794) remains an untouched placeholder — explicitly out of scope for this PR. Full design/decisions are in `SPEC.md` at the repo root.

## Testing
- [x] Unit tests passing
- [ ] Successful Step Function run
- [ ] Outputs checked in Athena

Not yet deployed to a real Fargate task in this environment (no AWS credentials available) — `pipenv run pytest projects/_07_workforce_characteristics` passes 31/31 locally.

## Checklist
- [x] Unit tests added/amended
- [x] Docstrings added/updated
- [x] Updated CHANGELOG
- [ ] Code reviewed by AI
- [ ] Moved Trello ticket to PR column

## Reviewer checklist
- [ ] PR solves the Trello ticket requirements
- [ ] Outputs appear reasonable and understandable
- [ ] The overall approach is appropriate and not over-engineered
- [ ] No obvious scalability, performance or interdependency concerns
- [ ] Tests appropriately cover the main behaviour/edge cases
- [ ] Naming and structure are broadly understandable and consistent
- [ ] Docstrings are sufficient for future maintenance
- [ ] Docstrings cover non-obvious behaviour