### PR TITLE
1822 followup fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ All notable changes to this project will be documented in this file.
 
 - Reduced the rows carried through the SLV prepare step to the same retention window the downstream job role estimates already use, and moved `reduced_data_filter_expr` into Polars Utils so both pipelines share one definition of that window.
 
+- Reduced the SLV prepare step further to one file per calendar month, matching the granularity the downstream job role estimates dataset already uses. Generalised the existing earliest-file-per-month reduction into a shared `earliest_file_per_month_filter_expr` in Polars Utils (alongside `reduced_data_filter_expr`) so both pipelines use the same definition, and updated its existing callers in the independent CQC clean job accordingly.
+
 ### Fixed
 - Fixed the Transform ASCWDS Data pipeline, which was failing due to an incorrect dataset name in Terraform and the clean workplace job dropping the `import_date` column that the clean worker job depends on. Corrected the Terraform dataset name and removed the drop statement for `import_date`.
 

--- a/polars_utils/cleaning_utils.py
+++ b/polars_utils/cleaning_utils.py
@@ -194,25 +194,6 @@ def calculate_filled_posts_per_bed_ratio(
     return lf
 
 
-def reduce_dataset_to_earliest_file_per_month(lf: pl.LazyFrame) -> pl.LazyFrame:
-    """
-    Reduce the dataset to the first file of every month.
-
-    This function identifies the date of the first import date in each month and then filters the dataset to those import dates only.
-
-    Args:
-        lf (pl.LazyFrame): A lazyframe containing the partition keys year, month and day.
-
-    Returns:
-        pl.LazyFrame: A lazyframe with only the first import date of each month.
-    """
-    date_col = pl.col(IndCQC.cqc_location_import_date)
-
-    expr = date_col.min().over(date_col.dt.year(), date_col.dt.month())
-
-    return lf.filter(date_col == expr)
-
-
 def create_banded_bed_count_column(
     input_lf: pl.LazyFrame, new_col: str, splits: List[float]
 ) -> pl.LazyFrame:

--- a/polars_utils/filtering_utils.py
+++ b/polars_utils/filtering_utils.py
@@ -156,3 +156,30 @@ def reduced_data_filter_expr(
     return (dt >= monthly_start) | (
         (dt < monthly_start) & (dt.dt.month().is_in(quarter_months))
     )
+
+
+def earliest_file_per_month_filter_expr(
+    date_col: str = IndCQC.cqc_location_import_date,
+) -> pl.Expr:
+    """
+    Build a Polars expression selecting only the earliest-dated row(s) of each calendar month.
+
+    This identifies the earliest date within each (year, month) group and keeps only rows
+    matching that date, reducing a dataset carrying multiple files per month down to one.
+
+    Returning an expression rather than a filtered LazyFrame lets callers attach it
+    directly to a `.filter()` chain alongside other predicates (e.g. reduced_data_filter_expr),
+    keeping the query lazy end-to-end.
+
+    Args:
+        date_col (str): Name of the date column to reduce on. Defaults to the CQC
+            location import date; datasets keyed on a different date column (e.g. the
+            SLV pipeline's ASCWDS workplace import date) pass their own.
+
+    Returns:
+        pl.Expr: A Polars boolean expression that can be used inside `.filter()` to select
+            rows whose date matches the minimum date within their (year, month) group.
+    """
+    dt = pl.col(date_col)
+
+    return dt == dt.min().over(dt.dt.year(), dt.dt.month())

--- a/projects/_02_sfc_internal/cqc_coverage/fargate/validate_merge_coverage_data.py
+++ b/projects/_02_sfc_internal/cqc_coverage/fargate/validate_merge_coverage_data.py
@@ -191,6 +191,10 @@ def main(
     vl.write_reports(validation, bucket_name, reports_path)
 
 
+# Note: this earliest-day-per-month logic duplicates the concept generalised into
+# polars_utils.filtering_utils.earliest_file_per_month_filter_expr (ticket 1822). Could be
+# unified if this function is changed to operate on a single date column instead of
+# separate year/month/day columns.
 def calculate_expected_size_of_merged_coverage_dataset(
     df: pl.DataFrame,
 ) -> int:

--- a/projects/_03_independent_cqc/_02_clean/fargate/clean_ind_cqc_filled_posts.py
+++ b/projects/_03_independent_cqc/_02_clean/fargate/clean_ind_cqc_filled_posts.py
@@ -2,6 +2,7 @@ import polars as pl
 
 import polars_utils.cleaning_utils as cUtils
 from polars_utils import utils
+from polars_utils.filtering_utils import earliest_file_per_month_filter_expr
 from projects._03_independent_cqc._02_clean.fargate.utils.ascwds_filled_posts_calculator import (
     calculate_ascwds_filled_posts,
 )
@@ -68,7 +69,7 @@ def main(
     locations_lf = utils.scan_parquet(merged_ind_cqc_source)
     print("Merged independent CQC location LazyFrame read in")
 
-    locations_lf = cUtils.reduce_dataset_to_earliest_file_per_month(locations_lf)
+    locations_lf = locations_lf.filter(earliest_file_per_month_filter_expr())
 
     locations_lf = calculate_time_registered_for(locations_lf)
     locations_lf = calculate_time_since_dormant(locations_lf)

--- a/projects/_03_independent_cqc/_02_clean/fargate/validate_cleaned_ind_cqc_data.py
+++ b/projects/_03_independent_cqc/_02_clean/fargate/validate_cleaned_ind_cqc_data.py
@@ -3,9 +3,9 @@ import sys
 import pointblank as pb
 import polars as pl
 
-import polars_utils.cleaning_utils as cUtils
 from polars_utils import utils
 from polars_utils.expressions import str_length_cols
+from polars_utils.filtering_utils import earliest_file_per_month_filter_expr
 from polars_utils.validation import actions as vl
 from polars_utils.validation.constants import GLOBAL_ACTIONS, GLOBAL_THRESHOLDS
 from projects._03_independent_cqc._02_clean.fargate.utils.clean_ind_cqc_filled_posts_utils import (
@@ -296,7 +296,7 @@ def get_expected_row_count(lf: pl.LazyFrame) -> int:
     Returns:
         int: The height of the comparator LazyFrame.
     """
-    lf = cUtils.reduce_dataset_to_earliest_file_per_month(lf)
+    lf = lf.filter(earliest_file_per_month_filter_expr())
     lf = remove_dual_registration_cqc_care_homes(lf)
 
     return lf.collect().height

--- a/projects/_03_independent_cqc/_02_clean/tests/fargate/test_clean_ind_cqc_filled_posts.py
+++ b/projects/_03_independent_cqc/_02_clean/tests/fargate/test_clean_ind_cqc_filled_posts.py
@@ -27,12 +27,12 @@ class MainTests(CleanIndFilledPostsTests):
     @patch(f"{PATCH_PATH}.remove_dual_registration_cqc_care_homes")
     @patch(f"{PATCH_PATH}.calculate_time_registered_for")
     @patch(f"{PATCH_PATH}.calculate_time_since_dormant")
-    @patch(f"{PATCH_PATH}.cUtils.reduce_dataset_to_earliest_file_per_month")
+    @patch(f"{PATCH_PATH}.earliest_file_per_month_filter_expr")
     @patch(f"{PATCH_PATH}.utils.scan_parquet")
     def test_main(
         self,
         scan_parquet_mock: Mock,
-        reduce_dataset_to_earliest_file_per_month_mock: Mock,
+        earliest_file_per_month_filter_expr_mock: Mock,
         calculate_time_since_dormant_mock: Mock,
         calculate_time_registered_for_mock: Mock,
         remove_dual_registration_cqc_care_homes_mock: Mock,
@@ -61,7 +61,7 @@ class MainTests(CleanIndFilledPostsTests):
             self.GROUPED_PROVIDERS_DESTINATION,
         )
 
-        reduce_dataset_to_earliest_file_per_month_mock.assert_called_once()
+        earliest_file_per_month_filter_expr_mock.assert_called_once()
         calculate_time_registered_for_mock.assert_called_once()
         calculate_time_since_dormant_mock.assert_called_once()
         remove_dual_registration_cqc_care_homes_mock.assert_called_once()

--- a/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/_00_prepare.py
+++ b/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/_00_prepare.py
@@ -17,8 +17,7 @@ def main(
     """Load the cleaned ASCWDS workplace dataset, reduce it, and save it.
 
     Rows are reduced to the same retention window the downstream job role estimates
-    already use, so the two datasets line up at the merge step, and further reduced to
-    one file per calendar month to match that dataset's monthly granularity. The retention
+    already use, and further reduced to one file per calendar month. The retention
     filter is applied first even though the two reductions are order-independent (retention
     keeps or drops whole months, never partial ones): it's a cheap date-range predicate that
     lets most of the older history get discarded before the more expensive per-month-min

--- a/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/_00_prepare.py
+++ b/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/_00_prepare.py
@@ -1,7 +1,10 @@
 import projects._07_workforce_characteristics._01_starters_leavers_vacancies.fargate.utils.prepare_utils as pUtils
 from polars_utils import utils
 from polars_utils.cleaning_utils import apply_categorical_labels
-from polars_utils.filtering_utils import reduced_data_filter_expr
+from polars_utils.filtering_utils import (
+    earliest_file_per_month_filter_expr,
+    reduced_data_filter_expr,
+)
 from utils.column_names.cleaned_data_files.ascwds_workplace_cleaned import (
     AscwdsWorkplaceCleanedColumns as AWPClean,
 )
@@ -14,8 +17,13 @@ def main(
     """Load the cleaned ASCWDS workplace dataset, reduce it, and save it.
 
     Rows are reduced to the same retention window the downstream job role estimates
-    already use, so the two datasets line up at the merge step. The filter is attached
-    directly to the scan so the predicate is pushed down to the parquet source rather
+    already use, so the two datasets line up at the merge step, and further reduced to
+    one file per calendar month to match that dataset's monthly granularity. The retention
+    filter is applied first even though the two reductions are order-independent (retention
+    keeps or drops whole months, never partial ones): it's a cheap date-range predicate that
+    lets most of the older history get discarded before the more expensive per-month-min
+    window used by the monthly reduction has to run over it. Both filters are attached
+    directly to the scan so the predicates are pushed down to the parquet source rather
     than running over a materialised frame - this dataset is both long and wide, so
     reading it in full before filtering is what we are avoiding.
 
@@ -23,8 +31,16 @@ def main(
         cleaned_ascwds_workplace_source (str): path to the cleaned ascwds workplace data
         prepared_data_destination (str): destination for output
     """
-    workplace_lf = utils.scan_parquet(cleaned_ascwds_workplace_source).filter(
-        reduced_data_filter_expr(date_col=AWPClean.ascwds_workplace_import_date)
+    workplace_lf = (
+        utils.scan_parquet(cleaned_ascwds_workplace_source)
+        .filter(
+            reduced_data_filter_expr(date_col=AWPClean.ascwds_workplace_import_date)
+        )
+        .filter(
+            earliest_file_per_month_filter_expr(
+                date_col=AWPClean.ascwds_workplace_import_date
+            )
+        )
     )
 
     # TODO: 1796 - Placeholder only.

--- a/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/validate_00_prepare.py
+++ b/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/validate_00_prepare.py
@@ -3,7 +3,10 @@ import sys
 import pointblank as pb
 
 from polars_utils import utils
-from polars_utils.filtering_utils import reduced_data_filter_expr
+from polars_utils.filtering_utils import (
+    earliest_file_per_month_filter_expr,
+    reduced_data_filter_expr,
+)
 from polars_utils.validation import actions as vl
 from polars_utils.validation.constants import GLOBAL_ACTIONS, GLOBAL_THRESHOLDS
 from utils.column_names.cleaned_data_files.ascwds_workplace_cleaned import (
@@ -23,9 +26,9 @@ def main(
         summary report as well as failure outputs.
 
     The compare dataset is the unreduced cleaned ASCWDS workplace data, so the same
-    reduction filter applied in _00_prepare is applied here before counting rows -
-    otherwise the expected count would include the historical rows the prepare step
-    deliberately drops.
+    reduction filters applied in _00_prepare are applied here before counting rows -
+    otherwise the expected count would include the historical rows and duplicate
+    monthly files the prepare step deliberately drops.
 
     Args:
         bucket_name (str): the bucket (name only) in which to source the dataset
@@ -36,10 +39,20 @@ def main(
         reports_path (str): the output path to write reports to
     """
     source_df = utils.read_parquet(source=f"s3://{bucket_name}/{source_path}")
-    compare_df = utils.read_parquet(
-        source=f"s3://{bucket_name}/{compare_path}",
-        selected_columns=COMPARE_COLS_TO_IMPORT,
-    ).filter(reduced_data_filter_expr(date_col=AWPClean.ascwds_workplace_import_date))
+    compare_df = (
+        utils.read_parquet(
+            source=f"s3://{bucket_name}/{compare_path}",
+            selected_columns=COMPARE_COLS_TO_IMPORT,
+        )
+        .filter(
+            reduced_data_filter_expr(date_col=AWPClean.ascwds_workplace_import_date)
+        )
+        .filter(
+            earliest_file_per_month_filter_expr(
+                date_col=AWPClean.ascwds_workplace_import_date
+            )
+        )
+    )
     expected_row_count = compare_df.height
 
     validation = (

--- a/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/tests/fargate/test_00_prepare.py
+++ b/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/tests/fargate/test_00_prepare.py
@@ -17,10 +17,14 @@ class TestPrepare:
     @patch(f"{PATCH_PATH}.pUtils.convert_job_role_strings_to_number_only")
     @patch(f"{PATCH_PATH}.pUtils.pivot_job_role_cols_to_rows")
     @patch(f"{PATCH_PATH}.pUtils.reduce_to_published_roles")
+    @patch(f"{PATCH_PATH}.earliest_file_per_month_filter_expr")
+    @patch(f"{PATCH_PATH}.reduced_data_filter_expr")
     @patch(f"{PATCH_PATH}.utils.scan_parquet")
     def test_main_runs(
         self,
         scan_parquet_mock: Mock,
+        reduced_data_filter_expr_mock: Mock,
+        earliest_file_per_month_filter_expr_mock: Mock,
         reduce_to_published_roles: Mock,
         pivot_job_role_cols_to_rows: Mock,
         convert_job_role_strings_to_number_only: Mock,
@@ -34,14 +38,25 @@ class TestPrepare:
 
         scan_parquet_mock.assert_called_once_with(self.CLEANED_ASCWDS_WORKPLACE_SOURCE)
 
-        # The filter must hang off the scan itself, otherwise the predicate is not
-        # pushed down to the parquet source and the full dataset is read first.
+        reduced_data_filter_expr_mock.assert_called_once_with(
+            date_col=AWPClean.ascwds_workplace_import_date
+        )
+        earliest_file_per_month_filter_expr_mock.assert_called_once_with(
+            date_col=AWPClean.ascwds_workplace_import_date
+        )
+
+        # The retention filter must run before the monthly reduction (cheap predicate
+        # first, so it can discard rows before the more expensive per-month-min window
+        # runs), and both must hang off the scan chain itself, otherwise the predicates
+        # are not pushed down to the parquet source and the full dataset is read first.
         scan_lf = scan_parquet_mock.return_value
-        scan_lf.filter.assert_called_once()
-        filter_expr = scan_lf.filter.call_args.args[0]
-        assert set(filter_expr.meta.root_names()) == {
-            AWPClean.ascwds_workplace_import_date
-        }
+        scan_lf.filter.assert_called_once_with(
+            reduced_data_filter_expr_mock.return_value
+        )
+        retention_filtered_lf = scan_lf.filter.return_value
+        retention_filtered_lf.filter.assert_called_once_with(
+            earliest_file_per_month_filter_expr_mock.return_value
+        )
 
         # TODO: Uncomment these assertions when the placeholder functions are implemented
         # reduce_to_published_roles.assert_called_once()
@@ -50,6 +65,6 @@ class TestPrepare:
         # apply_categorical_labels.assert_called_once()
 
         sink_to_parquet_mock.assert_called_once_with(
-            lazy_df=scan_lf.filter.return_value,
+            lazy_df=retention_filtered_lf.filter.return_value,
             output_path=self.PREPARED_DATA_DESTINATION,
         )

--- a/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/tests/fargate/test_validate_00_prepare.py
+++ b/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/tests/fargate/test_validate_00_prepare.py
@@ -23,15 +23,19 @@ class ValidatePreparedSLVDataTests(unittest.TestCase):
         ]  # fmt: skip
         self.source_df = pl.DataFrame(source_rows, source_schema, orient="row")
 
-        # The compare frame is the unreduced cleaned ASCWDS data, so it carries a row
-        # the reduction filter drops. Dates are chosen to stay stable as time passes:
+        # The compare frame is the unreduced cleaned ASCWDS data, so it carries rows
+        # the reduction filters drop. Dates are chosen to stay stable as time passes:
         # January always survives (quarterly sampling) and a pre-window May never does.
+        # 1-003 shares January with 1-001 but has a later date, so it's dropped by the
+        # earliest-file-per-month filter rather than the retention filter - proving the
+        # monthly reduction itself is exercised here, not just retention.
         compare_schema = {
             AWPClean.establishment_id: pl.String,
             AWPClean.ascwds_workplace_import_date: pl.Date,
         }
         compare_rows = [
             ("1-001", date(2026, 1, 1)),
+            ("1-003", date(2026, 1, 15)),  # same month as 1-001, later date -> dropped by monthly filter
             ("1-002", date(2020, 5, 1)),
         ]  # fmt: skip
         self.compare_df = pl.DataFrame(compare_rows, compare_schema, orient="row")

--- a/tests/test_polars_utils/test_cleaning_utils.py
+++ b/tests/test_polars_utils/test_cleaning_utils.py
@@ -292,22 +292,6 @@ class CalculateFilledPostsPerBedRatioTests(unittest.TestCase):
         pl_testing.assert_frame_equal(returned_lf, expected_lf)
 
 
-class ReduceDatasetToEarliestFilePerMonthTests(unittest.TestCase):
-    def test_reduce_dataset_to_earliest_file_per_month_returns_correct_rows(self):
-        test_lf = pl.LazyFrame(
-            Data.reduce_dataset_to_earliest_file_per_month_rows,
-            Schemas.reduce_dataset_to_earliest_file_per_month_schema,
-            orient="row",
-        )
-        returned_lf = job.reduce_dataset_to_earliest_file_per_month(test_lf)
-        expected_lf = pl.LazyFrame(
-            Data.expected_reduce_dataset_to_earliest_file_per_month_rows,
-            Schemas.reduce_dataset_to_earliest_file_per_month_schema,
-            orient="row",
-        )
-        pl_testing.assert_frame_equal(returned_lf, expected_lf)
-
-
 class CreateBandedBedCountColumnTests(unittest.TestCase):
     def test_create_banded_bed_count_column(self):
         expected_lf = pl.LazyFrame(

--- a/tests/test_polars_utils/test_filtering_utils.py
+++ b/tests/test_polars_utils/test_filtering_utils.py
@@ -258,19 +258,15 @@ class TestReducedDataFilterExpr:
 
 
 class TestEarliestFilePerMonthFilterExpr:
-    @pytest.mark.parametrize(
-        "case",
-        [
-            pytest.param(case, id=case.id)
-            for case in Data.earliest_file_per_month_test_cases
-        ],
-    )
-    def test_returns_only_earliest_file_per_month(self, case):
-        test_lf = pl.LazyFrame(case.data)
-        expected_lf = pl.LazyFrame(case.expected_data)
+    def test_returns_only_earliest_file_per_month(self):
+        test_lf = pl.LazyFrame(Data.earliest_file_per_month_rows)
+        expected_lf = pl.LazyFrame(Data.expected_earliest_file_per_month_rows)
 
-        returned_lf = test_lf.filter(
-            job.earliest_file_per_month_filter_expr(case.date_col)
-        )
+        returned_lf = test_lf.filter(job.earliest_file_per_month_filter_expr())
 
         pl_testing.assert_frame_equal(returned_lf, expected_lf)
+
+    def test_uses_the_passed_date_col(self):
+        expr = job.earliest_file_per_month_filter_expr("some_other_column")
+
+        assert set(expr.meta.root_names()) == {"some_other_column"}

--- a/tests/test_polars_utils/test_filtering_utils.py
+++ b/tests/test_polars_utils/test_filtering_utils.py
@@ -255,3 +255,22 @@ class TestReducedDataFilterExpr:
         result = df.with_columns(expr.alias("keep"))
 
         assert result["keep"].to_list() == case.expected
+
+
+class TestEarliestFilePerMonthFilterExpr:
+    @pytest.mark.parametrize(
+        "case",
+        [
+            pytest.param(case, id=case.id)
+            for case in Data.earliest_file_per_month_test_cases
+        ],
+    )
+    def test_returns_only_earliest_file_per_month(self, case):
+        test_lf = pl.LazyFrame(case.data)
+        expected_lf = pl.LazyFrame(case.expected_data)
+
+        returned_lf = test_lf.filter(
+            job.earliest_file_per_month_filter_expr(case.date_col)
+        )
+
+        pl_testing.assert_frame_equal(returned_lf, expected_lf)

--- a/tests/test_polars_utils_data.py
+++ b/tests/test_polars_utils_data.py
@@ -4,9 +4,6 @@ from datetime import date
 from pathlib import Path
 from typing import Any, Optional
 
-from utils.column_names.cleaned_data_files.ascwds_workplace_cleaned import (
-    AscwdsWorkplaceCleanedColumns as AWPClean,
-)
 from utils.column_names.cleaned_data_files.cqc_location_cleaned import (
     CqcLocationCleanedColumns as CQCLClean,
 )
@@ -292,14 +289,6 @@ class ReducedDataFilterCase:
 
 
 @dataclass
-class EarliestFilePerMonthCase:
-    id: str
-    date_col: str
-    data: dict[str, list]
-    expected_data: dict[str, list]
-
-
-@dataclass
 class FilteringUtilsData:
     add_filtering_column_rows = [
         ("loc 1", 10.0),
@@ -396,56 +385,23 @@ class FilteringUtilsData:
         ),
     ]  # fmt: skip
 
-    earliest_file_per_month_test_cases = [
-        EarliestFilePerMonthCase(
-            id="default_date_col_reduces_to_earliest_file_per_month",
-            date_col=CQCLClean.cqc_location_import_date,
-            data={
-                CQCLClean.location_id: [
-                    "loc 1",
-                    "loc 2",
-                    "loc 3",
-                    "loc 4",
-                    "loc 5",
-                    "loc 6",
-                ],
-                CQCLClean.cqc_location_import_date: [
-                    date(2022, 1, 1),
-                    date(2022, 1, 5),
-                    date(2022, 2, 5),
-                    date(2022, 2, 7),
-                    date(2022, 3, 1),
-                    date(2022, 4, 2),
-                ],
-            },
-            expected_data={
-                CQCLClean.location_id: ["loc 1", "loc 3", "loc 5", "loc 6"],
-                CQCLClean.cqc_location_import_date: [
-                    date(2022, 1, 1),
-                    date(2022, 2, 5),
-                    date(2022, 3, 1),
-                    date(2022, 4, 2),
-                ],
-            },
-        ),
-        EarliestFilePerMonthCase(
-            id="custom_date_col_reduces_to_earliest_file_per_month",
-            date_col=AWPClean.ascwds_workplace_import_date,
-            data={
-                AWPClean.establishment_id: ["est 1", "est 2", "est 3", "est 4"],
-                AWPClean.ascwds_workplace_import_date: [
-                    date(2022, 1, 1),
-                    date(2022, 1, 5),
-                    date(2022, 2, 5),
-                    date(2022, 2, 7),
-                ],
-            },
-            expected_data={
-                AWPClean.establishment_id: ["est 1", "est 3"],
-                AWPClean.ascwds_workplace_import_date: [
-                    date(2022, 1, 1),
-                    date(2022, 2, 5),
-                ],
-            },
-        ),
-    ]
+    earliest_file_per_month_rows = {
+        CQCLClean.location_id: ["loc 1", "loc 2", "loc 3", "loc 4", "loc 5", "loc 6"],
+        CQCLClean.cqc_location_import_date: [
+            date(2022, 1, 1),
+            date(2022, 1, 5),
+            date(2022, 2, 5),
+            date(2022, 2, 7),
+            date(2022, 3, 1),
+            date(2022, 4, 2),
+        ],
+    }
+    expected_earliest_file_per_month_rows = {
+        CQCLClean.location_id: ["loc 1", "loc 3", "loc 5", "loc 6"],
+        CQCLClean.cqc_location_import_date: [
+            date(2022, 1, 1),
+            date(2022, 2, 5),
+            date(2022, 3, 1),
+            date(2022, 4, 2),
+        ],
+    }

--- a/tests/test_polars_utils_data.py
+++ b/tests/test_polars_utils_data.py
@@ -4,6 +4,12 @@ from datetime import date
 from pathlib import Path
 from typing import Any, Optional
 
+from utils.column_names.cleaned_data_files.ascwds_workplace_cleaned import (
+    AscwdsWorkplaceCleanedColumns as AWPClean,
+)
+from utils.column_names.cleaned_data_files.cqc_location_cleaned import (
+    CqcLocationCleanedColumns as CQCLClean,
+)
 from utils.column_names.data_labels_columns import DataLabelsColumns as DLC
 from utils.column_names.ind_cqc_pipeline_columns import IndCqcColumns as IndCQC
 from utils.column_names.raw_data_files.ascwds_worker_columns import (
@@ -233,20 +239,6 @@ class CleaningUtilsData:
         ("1-000000010", 0.0, 0, CareHome.care_home, None),
         ("1-000000011", 4.0, 10, CareHome.not_care_home, None),
     ]
-    reduce_dataset_to_earliest_file_per_month_rows = [
-        ("loc 1", date(2022, 1, 1)),
-        ("loc 2", date(2022, 1, 5)),
-        ("loc 3", date(2022, 2, 5)),
-        ("loc 4", date(2022, 2, 7)),
-        ("loc 5", date(2022, 3, 1)),
-        ("loc 6", date(2022, 4, 2)),
-    ]
-    expected_reduce_dataset_to_earliest_file_per_month_rows = [
-        ("loc 1", date(2022, 1, 1)),
-        ("loc 3", date(2022, 2, 5)),
-        ("loc 5", date(2022, 3, 1)),
-        ("loc 6", date(2022, 4, 2)),
-    ]
     create_banded_bed_count_column_rows = [
         ("1-001", CareHome.care_home, 1),
         ("1-002", CareHome.care_home, 24),
@@ -297,6 +289,14 @@ class ReducedDataFilterCase:
     quarter_months: tuple[int, ...]
     input_data: list[date]
     expected: list[bool]
+
+
+@dataclass
+class EarliestFilePerMonthCase:
+    id: str
+    date_col: str
+    data: dict[str, list]
+    expected_data: dict[str, list]
 
 
 @dataclass
@@ -395,3 +395,57 @@ class FilteringUtilsData:
             expected=[True, True, False],
         ),
     ]  # fmt: skip
+
+    earliest_file_per_month_test_cases = [
+        EarliestFilePerMonthCase(
+            id="default_date_col_reduces_to_earliest_file_per_month",
+            date_col=CQCLClean.cqc_location_import_date,
+            data={
+                CQCLClean.location_id: [
+                    "loc 1",
+                    "loc 2",
+                    "loc 3",
+                    "loc 4",
+                    "loc 5",
+                    "loc 6",
+                ],
+                CQCLClean.cqc_location_import_date: [
+                    date(2022, 1, 1),
+                    date(2022, 1, 5),
+                    date(2022, 2, 5),
+                    date(2022, 2, 7),
+                    date(2022, 3, 1),
+                    date(2022, 4, 2),
+                ],
+            },
+            expected_data={
+                CQCLClean.location_id: ["loc 1", "loc 3", "loc 5", "loc 6"],
+                CQCLClean.cqc_location_import_date: [
+                    date(2022, 1, 1),
+                    date(2022, 2, 5),
+                    date(2022, 3, 1),
+                    date(2022, 4, 2),
+                ],
+            },
+        ),
+        EarliestFilePerMonthCase(
+            id="custom_date_col_reduces_to_earliest_file_per_month",
+            date_col=AWPClean.ascwds_workplace_import_date,
+            data={
+                AWPClean.establishment_id: ["est 1", "est 2", "est 3", "est 4"],
+                AWPClean.ascwds_workplace_import_date: [
+                    date(2022, 1, 1),
+                    date(2022, 1, 5),
+                    date(2022, 2, 5),
+                    date(2022, 2, 7),
+                ],
+            },
+            expected_data={
+                AWPClean.establishment_id: ["est 1", "est 3"],
+                AWPClean.ascwds_workplace_import_date: [
+                    date(2022, 1, 1),
+                    date(2022, 2, 5),
+                ],
+            },
+        ),
+    ]

--- a/tests/test_polars_utils_schemas.py
+++ b/tests/test_polars_utils_schemas.py
@@ -69,13 +69,6 @@ class CleaningUtilsSchemas:
         ]
     )
 
-    reduce_dataset_to_earliest_file_per_month_schema = pl.Schema(
-        [
-            (CQCLClean.location_id, pl.String()),
-            (CQCLClean.cqc_location_import_date, pl.Date()),
-        ]
-    )
-
     create_banded_bed_count_column_schema = pl.Schema(
         [
             (IndCQC.location_id, pl.String()),

--- a/utils/cleaning_utils.py
+++ b/utils/cleaning_utils.py
@@ -256,7 +256,7 @@ def add_aligned_date_column(
     return primary_df_with_aligned_dates
 
 
-# converted to polars -> polars_utils.cleaning_utils.reduce_dataset_to_earliest_file_per_month
+# converted to polars -> polars_utils.filtering_utils.earliest_file_per_month_filter_expr
 def reduce_dataset_to_earliest_file_per_month(df: DataFrame) -> DataFrame:
     """
     Reduce the dataset to the first file of every month.


### PR DESCRIPTION
## Description
Trello ticket [1822](https://trello.com/c/GYT62YLC)

Added additional filtering to the slv prepare job to reduce the cleaned workplace lazyframe to 1st import date per month.

This PR refactors reduce_dataset_to_earliest_file_per_month to return a polars expression, changes function name to earliest_file_per_month_filter_expr, and moves the function to polars untils > filtering utils.

Since the function was refactored, i've ran the jobs affected by the change (slv prepare and estimates pipeline to clean job).

## Testing
- [x] Unit tests passing
- [x] [SLV pipeline run](https://eu-west-2.console.aws.amazon.com/states/home?region=eu-west-2#/v2/executions/details/arn:aws:states:eu-west-2:856699698263:execution:1822-followup-fixes-Ind-CQC-SLV:11f45bee-c324-4161-abf0-16dffbdcee4b)
- [x] [Estimates pipeline to clean job](https://eu-west-2.console.aws.amazon.com/states/home?region=eu-west-2#/v2/executions/details/arn:aws:states:eu-west-2:856699698263:execution:1822-followup-fixes-Ind-CQC-Filled-Post-Estimates:eb051246-5b08-4a67-93e8-ff5b2241bf40)
- [x] Outputs checked in Athena

See Trello ticket Excel attachment for slv prepare output. Shows quarterly months prior to April 2024, then monthly from then on.

Cleaned ind cqc data in branch has same row count as main.

## Checklist (delete if not relevant)
- [x] Unit tests added/amended
- [x] Docstrings added/updated
- [x] Updated CHANGELOG
- [x] Code reviewed by AI
- [ ] Moved Trello ticket to PR column

## Reviewer checklist
- [ ] PR solves the Trello ticket requirements
- [ ] Outputs appear reasonable and understandable
- [ ] The overall approach is appropriate and not over-engineered
- [ ] No obvious scalability, performance or interdependency concerns
- [ ] Tests appropriately cover the main behaviour/edge cases
- [ ] Naming and structure are broadly understandable and consistent
- [ ] Docstrings are sufficient for future maintenance
- [ ] Docstrings cover non-obvious behaviour
