### PR TITLE
1792 - Only record grouped providers whose ASCWDS data was actually nulled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,7 @@ All notable changes to this project will be documented in this file.
 
 - Called merge_job_role_columns in slv prepare job to reduce job role columns to only published roles plus 'other direct care/manager/etc'
 
-- Changed the grouped provider history to only record locations whose ASCWDS data was actually nulled by `null_care_home_grouped_providers`/`null_non_residential_grouped_providers`, rather than every structurally-potential grouped provider. Also added the location name to the output.
+- Changed the grouped provider history to only record locations whose ASCWDS data was actually nulled by `null_care_home_grouped_providers`/`null_non_residential_grouped_providers`, rather than every structurally-potential grouped provider. Also reordered columns for ease of usage.
 
 ### Fixed
 - Fixed the Transform ASCWDS Data pipeline, which was failing due to an incorrect dataset name in Terraform and the clean workplace job dropping the `import_date` column that the clean worker job depends on. Corrected the Terraform dataset name and removed the drop statement for `import_date`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,8 @@ All notable changes to this project will be documented in this file.
 
 - Reduced the SLV prepare step further to one file per calendar month, matching the granularity the downstream job role estimates dataset already uses. Generalised the existing earliest-file-per-month reduction into a shared `earliest_file_per_month_filter_expr` in Polars Utils (alongside `reduced_data_filter_expr`) so both pipelines use the same definition, and updated its existing callers in the independent CQC clean job accordingly.
 
+- Changed the grouped provider history to only record locations whose ASCWDS data was actually nulled by `null_care_home_grouped_providers`/`null_non_residential_grouped_providers`, rather than every structurally-potential grouped provider.
+
 ### Fixed
 - Fixed the Transform ASCWDS Data pipeline, which was failing due to an incorrect dataset name in Terraform and the clean workplace job dropping the `import_date` column that the clean worker job depends on. Corrected the Terraform dataset name and removed the drop statement for `import_date`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,7 @@ All notable changes to this project will be documented in this file.
 
 - Called merge_job_role_columns in slv prepare job to reduce job role columns to only published roles plus 'other direct care/manager/etc'
 
-- Changed the grouped provider history to only record locations whose ASCWDS data was actually nulled by `null_care_home_grouped_providers`/`null_non_residential_grouped_providers`, rather than every structurally-potential grouped provider. Also reordered columns for ease of usage.
+- Changed the grouped provider history to only record locations whose ASCWDS data was actually nulled by `null_care_home_grouped_providers`/`null_non_residential_grouped_providers`, rather than every structurally-potential grouped provider. Also reordered columns for ease of usage, and made `GROUPED_PROVIDER_SCHEMA` the single source of truth.
 
 ### Fixed
 - Fixed the Transform ASCWDS Data pipeline, which was failing due to an incorrect dataset name in Terraform and the clean workplace job dropping the `import_date` column that the clean worker job depends on. Corrected the Terraform dataset name and removed the drop statement for `import_date`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,7 @@ All notable changes to this project will be documented in this file.
 
 - Called merge_job_role_columns in slv prepare job to reduce job role columns to only published roles plus 'other direct care/manager/etc'
 
-- Changed the grouped provider history to only record locations whose ASCWDS data was actually nulled by `null_care_home_grouped_providers`/`null_non_residential_grouped_providers`, rather than every structurally-potential grouped provider.
+- Changed the grouped provider history to only record locations whose ASCWDS data was actually nulled by `null_care_home_grouped_providers`/`null_non_residential_grouped_providers`, rather than every structurally-potential grouped provider. Also added the location name to the output.
 
 ### Fixed
 - Fixed the Transform ASCWDS Data pipeline, which was failing due to an incorrect dataset name in Terraform and the clean workplace job dropping the `import_date` column that the clean worker job depends on. Corrected the Terraform dataset name and removed the drop statement for `import_date`.

--- a/projects/_03_independent_cqc/_02_clean/fargate/clean_ind_cqc_filled_posts.py
+++ b/projects/_03_independent_cqc/_02_clean/fargate/clean_ind_cqc_filled_posts.py
@@ -29,9 +29,6 @@ from projects._03_independent_cqc._02_clean.fargate.utils.clean_ind_cqc_filled_p
 from projects._03_independent_cqc._02_clean.fargate.utils.utils import (
     create_column_with_repeated_values_removed,
 )
-from utils.column_names.cleaned_data_files.ascwds_workplace_cleaned import (
-    AscwdsWorkplaceCleanedColumns as AWPClean,
-)
 from utils.column_names.ind_cqc_pipeline_columns import IndCqcColumns as IndCQC
 
 
@@ -97,10 +94,9 @@ def main(
         grouped_providers_lf = pl.LazyFrame(schema=GROUPED_PROVIDER_SCHEMA)
         print("No existing grouped providers found, starting fresh")
 
-    locations_lf, grouped_providers = clean_ascwds_filled_post_outliers(
+    locations_lf, grouped_providers_lf = clean_ascwds_filled_post_outliers(
         locations_lf, grouped_providers_lf
     )
-    locations_lf = locations_lf.drop(AWPClean.nmds_id)
 
     locations_lf = cUtils.calculate_filled_posts_per_bed_ratio(
         locations_lf,
@@ -122,7 +118,7 @@ def main(
     )
 
     utils.sink_to_parquet(
-        grouped_providers,
+        grouped_providers_lf,
         grouped_providers_destination,
     )
 

--- a/projects/_03_independent_cqc/_02_clean/fargate/clean_ind_cqc_filled_posts.py
+++ b/projects/_03_independent_cqc/_02_clean/fargate/clean_ind_cqc_filled_posts.py
@@ -38,6 +38,7 @@ GROUPED_PROVIDER_SCHEMA = pl.Schema(
     [
         (IndCQC.location_id, pl.String()),
         (IndCQC.provider_id, pl.String()),
+        (IndCQC.name, pl.String()),
         (IndCQC.cqc_location_import_date, pl.Date()),
         (AWPClean.nmds_id, pl.String()),
         (NGPcol.potential_grouped_provider, pl.Boolean()),

--- a/projects/_03_independent_cqc/_02_clean/fargate/clean_ind_cqc_filled_posts.py
+++ b/projects/_03_independent_cqc/_02_clean/fargate/clean_ind_cqc_filled_posts.py
@@ -36,15 +36,16 @@ from utils.column_names.ind_cqc_pipeline_columns import (
 
 GROUPED_PROVIDER_SCHEMA = pl.Schema(
     [
-        (IndCQC.location_id, pl.String()),
-        (IndCQC.provider_id, pl.String()),
-        (IndCQC.name, pl.String()),
         (IndCQC.cqc_location_import_date, pl.Date()),
+        (IndCQC.provider_id, pl.String()),
+        (NGPcol.count_of_cqc_locations_in_provider, pl.UInt32()),
+        (IndCQC.location_id, pl.String()),
         (AWPClean.nmds_id, pl.String()),
-        (NGPcol.potential_grouped_provider, pl.Boolean()),
-        (IndCQC.ascwds_filled_posts_dedup_clean, pl.Float64()),
+        (IndCQC.name, pl.String()),
         (IndCQC.care_home, pl.String()),
+        (IndCQC.ascwds_filled_posts_dedup, pl.Float64()),
         (IndCQC.number_of_beds, pl.Int64()),
+        (NGPcol.location_pir_average, pl.Float64()),
         (NGPcol.grouped_provider_status, pl.String()),
         (NGPcol.grp_prov_identified_date, pl.Date()),
         (NGPcol.grp_prov_fixed_date, pl.Date()),

--- a/projects/_03_independent_cqc/_02_clean/fargate/clean_ind_cqc_filled_posts.py
+++ b/projects/_03_independent_cqc/_02_clean/fargate/clean_ind_cqc_filled_posts.py
@@ -9,6 +9,9 @@ from projects._03_independent_cqc._02_clean.fargate.utils.ascwds_filled_posts_ca
 from projects._03_independent_cqc._02_clean.fargate.utils.clean_ascwds_filled_post_outliers.clean_ascwds_filled_post_outliers import (
     clean_ascwds_filled_post_outliers,
 )
+from projects._03_independent_cqc._02_clean.fargate.utils.clean_ascwds_filled_post_outliers.null_grouped_providers import (
+    GROUPED_PROVIDER_SCHEMA,
+)
 from projects._03_independent_cqc._02_clean.fargate.utils.clean_ct_outliers.clean_ct_care_home_outliers import (
     clean_capacity_tracker_care_home_outliers,
 )
@@ -30,27 +33,6 @@ from utils.column_names.cleaned_data_files.ascwds_workplace_cleaned import (
     AscwdsWorkplaceCleanedColumns as AWPClean,
 )
 from utils.column_names.ind_cqc_pipeline_columns import IndCqcColumns as IndCQC
-from utils.column_names.ind_cqc_pipeline_columns import (
-    NullGroupedProviderColumns as NGPcol,
-)
-
-GROUPED_PROVIDER_SCHEMA = pl.Schema(
-    [
-        (IndCQC.cqc_location_import_date, pl.Date()),
-        (IndCQC.provider_id, pl.String()),
-        (NGPcol.count_of_cqc_locations_in_provider, pl.UInt32()),
-        (IndCQC.location_id, pl.String()),
-        (AWPClean.nmds_id, pl.String()),
-        (IndCQC.name, pl.String()),
-        (IndCQC.care_home, pl.String()),
-        (IndCQC.ascwds_filled_posts_dedup, pl.Float64()),
-        (IndCQC.number_of_beds, pl.Int64()),
-        (NGPcol.location_pir_average, pl.Float64()),
-        (NGPcol.grouped_provider_status, pl.String()),
-        (NGPcol.grp_prov_identified_date, pl.Date()),
-        (NGPcol.grp_prov_fixed_date, pl.Date()),
-    ]
-)
 
 
 def main(

--- a/projects/_03_independent_cqc/_02_clean/fargate/utils/clean_ascwds_filled_post_outliers/null_grouped_providers.py
+++ b/projects/_03_independent_cqc/_02_clean/fargate/utils/clean_ascwds_filled_post_outliers/null_grouped_providers.py
@@ -109,7 +109,7 @@ def null_grouped_providers(
     ngp_cols = {field.name for field in fields(NGPcol())}
     columns_to_drop = [c for c in lf.collect_schema().names() if c in ngp_cols]
 
-    lf = lf.drop(*columns_to_drop)
+    lf = lf.drop(*columns_to_drop).drop(AWPClean.nmds_id)
 
     return lf, updated_grouped_providers_lf
 

--- a/projects/_03_independent_cqc/_02_clean/fargate/utils/clean_ascwds_filled_post_outliers/null_grouped_providers.py
+++ b/projects/_03_independent_cqc/_02_clean/fargate/utils/clean_ascwds_filled_post_outliers/null_grouped_providers.py
@@ -86,11 +86,13 @@ def null_grouped_providers(
 
     Args:
         lf (pl.LazyFrame): A polars LazyFrame with independent cqc data.
-        grouped_providers_lf (pl.LazyFrame): A polars LazyFrame containing existing grouped providers.
+        grouped_providers_lf (pl.LazyFrame): A polars LazyFrame containing
+            existing grouped providers.
 
     Returns:
         tuple[pl.LazyFrame, pl.LazyFrame]: The input LazyFrame with grouped
-            providers' data nulled and a LazyFrame of grouped providers whose data was nulled.
+            providers' data nulled and a LazyFrame of grouped providers whose
+            data was nulled.
     """
     lf = calculate_data_for_grouped_provider_identification(lf)
 
@@ -201,10 +203,12 @@ def null_care_home_grouped_providers(lf: pl.LazyFrame) -> pl.LazyFrame:
     beds in that particular location.
 
     Args:
-        lf (pl.LazyFrame): A polars LazyFrame with independent CQC data and ASCWDS data.
+        lf (pl.LazyFrame): A polars LazyFrame with independent CQC data and
+            ASCWDS data.
 
     Returns:
-        pl.LazyFrame: A polars LazyFrame with grouped providers' care home data nulled.
+        pl.LazyFrame: A polars LazyFrame with grouped providers' care home data
+            nulled.
     """
     location_identified_as_a_potential_grouped_provider = (
         pl.col(NGPcol.potential_grouped_provider) == True
@@ -344,11 +348,12 @@ def select_grouped_providers(lf: pl.LazyFrame) -> pl.LazyFrame:
 
     Args:
         lf (pl.LazyFrame): A LazyFrame that has already been through
-            null_care_home_grouped_providers and null_non_residential_grouped_providers.
+            null_care_home_grouped_providers and
+            null_non_residential_grouped_providers.
 
     Returns:
-        pl.LazyFrame: The filtered input LazyFrame with `grouped_provider_status`
-            and `last_update_date` columns added.
+        pl.LazyFrame: The filtered input LazyFrame with
+            `grouped_provider_status` and `last_update_date` columns added.
     """
     was_nulled_as_grouped_provider = pl.col(IndCQC.ascwds_filtering_rule).is_in(
         [

--- a/projects/_03_independent_cqc/_02_clean/fargate/utils/clean_ascwds_filled_post_outliers/null_grouped_providers.py
+++ b/projects/_03_independent_cqc/_02_clean/fargate/utils/clean_ascwds_filled_post_outliers/null_grouped_providers.py
@@ -331,15 +331,16 @@ def select_grouped_providers(lf: pl.LazyFrame) -> pl.LazyFrame:
             and `last_update_date` columns added.
     """
     cols_to_select = [
-        IndCQC.location_id,
-        IndCQC.provider_id,
-        IndCQC.name,
         IndCQC.cqc_location_import_date,
+        IndCQC.provider_id,
+        NGPcol.count_of_cqc_locations_in_provider,
+        IndCQC.location_id,
         AWPClean.nmds_id,
-        NGPcol.potential_grouped_provider,
-        IndCQC.ascwds_filled_posts_dedup,
+        IndCQC.name,
         IndCQC.care_home,
+        IndCQC.ascwds_filled_posts_dedup,
         IndCQC.number_of_beds,
+        NGPcol.location_pir_average,
     ]
 
     was_nulled_as_grouped_provider = pl.col(IndCQC.ascwds_filtering_rule).is_in(

--- a/projects/_03_independent_cqc/_02_clean/fargate/utils/clean_ascwds_filled_post_outliers/null_grouped_providers.py
+++ b/projects/_03_independent_cqc/_02_clean/fargate/utils/clean_ascwds_filled_post_outliers/null_grouped_providers.py
@@ -70,19 +70,19 @@ def null_grouped_providers(
 
     Returns:
         tuple[pl.LazyFrame, pl.LazyFrame]: The input LazyFrame with grouped
-            providers' data nulled and a LazyFrame of potential grouped providers prior to nulling.
+            providers' data nulled and a LazyFrame of grouped providers whose data was nulled.
     """
     lf = calculate_data_for_grouped_provider_identification(lf)
 
     lf = identify_potential_grouped_providers(lf)
 
+    lf = null_care_home_grouped_providers(lf)
+    lf = null_non_residential_grouped_providers(lf)
+
     new_grouped_providers = select_grouped_providers(lf)
     updated_grouped_providers_lf = update_grouped_providers_history(
         new_grouped_providers, grouped_providers_lf
     )
-
-    lf = null_care_home_grouped_providers(lf)
-    lf = null_non_residential_grouped_providers(lf)
 
     ngp_cols = {field.name for field in fields(NGPcol())}
     columns_to_drop = [c for c in lf.collect_schema().names() if c in ngp_cols]
@@ -311,11 +311,20 @@ def null_non_residential_grouped_providers(lf: pl.LazyFrame) -> pl.LazyFrame:
 def select_grouped_providers(lf: pl.LazyFrame) -> pl.LazyFrame:
     """
     Filters the input LazyFrame to the following:
-        - potential_grouped_provider is True
+        - ASCWDS data was actually nulled by null_care_home_grouped_providers or
+          null_non_residential_grouped_providers.
         - cqc_location_import_date equal to max year/month across dataset.
 
+    A location can be a potential_grouped_provider without its data being
+    nulled, since null_care_home_grouped_providers and
+    null_non_residential_grouped_providers only null the data when further
+    evidence (bed counts or PIR submissions) corroborates it. This function
+    must run after those two functions, so it can filter to only the
+    locations they actually nulled.
+
     Args:
-        lf (pl.LazyFrame): A LazyFrame with potential_grouped_provider column.
+        lf (pl.LazyFrame): A LazyFrame that has already been through
+            null_care_home_grouped_providers and null_non_residential_grouped_providers.
 
     Returns:
         pl.LazyFrame: The filtered input LazyFrame with `grouped_provider_status`
@@ -327,16 +336,23 @@ def select_grouped_providers(lf: pl.LazyFrame) -> pl.LazyFrame:
         IndCQC.cqc_location_import_date,
         AWPClean.nmds_id,
         NGPcol.potential_grouped_provider,
-        IndCQC.ascwds_filled_posts_dedup_clean,
+        IndCQC.ascwds_filled_posts_dedup,
         IndCQC.care_home,
         IndCQC.number_of_beds,
     ]
+
+    was_nulled_as_grouped_provider = pl.col(IndCQC.ascwds_filtering_rule).is_in(
+        [
+            AscwdsFilteringRule.care_home_location_was_grouped_provider,
+            AscwdsFilteringRule.non_res_location_was_grouped_provider,
+        ]
+    )
 
     date_col = pl.col(IndCQC.cqc_location_import_date)
     trunc_date_col = date_col.dt.truncate("1mo")  # E.g. 2026-01-05 becomes 2026-01-01.
 
     return (
-        lf.filter(pl.col(NGPcol.potential_grouped_provider))
+        lf.filter(was_nulled_as_grouped_provider)
         .filter(trunc_date_col == trunc_date_col.max())
         .select(cols_to_select)
         .with_columns(

--- a/projects/_03_independent_cqc/_02_clean/fargate/utils/clean_ascwds_filled_post_outliers/null_grouped_providers.py
+++ b/projects/_03_independent_cqc/_02_clean/fargate/utils/clean_ascwds_filled_post_outliers/null_grouped_providers.py
@@ -16,6 +16,26 @@ from utils.column_names.ind_cqc_pipeline_columns import (
 )
 from utils.column_values.categorical_column_values import AscwdsFilteringRule
 
+# The single source of truth for the grouped providers history dataset's shape.
+# Used both to build the new snapshot and to read/write that dataset.
+GROUPED_PROVIDER_SCHEMA = pl.Schema(
+    [
+        (IndCQC.cqc_location_import_date, pl.Date()),
+        (IndCQC.provider_id, pl.String()),
+        (NGPcol.count_of_cqc_locations_in_provider, pl.UInt32()),
+        (IndCQC.location_id, pl.String()),
+        (AWPClean.nmds_id, pl.String()),
+        (IndCQC.name, pl.String()),
+        (IndCQC.care_home, pl.String()),
+        (IndCQC.ascwds_filled_posts_dedup, pl.Float64()),
+        (IndCQC.number_of_beds, pl.Int64()),
+        (NGPcol.location_pir_average, pl.Float64()),
+        (NGPcol.grouped_provider_status, pl.String()),
+        (NGPcol.grp_prov_identified_date, pl.Date()),
+        (NGPcol.grp_prov_fixed_date, pl.Date()),
+    ]
+)
+
 
 @dataclass
 class NullGroupedProvidersConfig:
@@ -82,7 +102,7 @@ def null_grouped_providers(
     new_grouped_providers = select_grouped_providers(lf)
     updated_grouped_providers_lf = update_grouped_providers_history(
         new_grouped_providers, grouped_providers_lf
-    )
+    ).select(GROUPED_PROVIDER_SCHEMA.names())
 
     ngp_cols = {field.name for field in fields(NGPcol())}
     columns_to_drop = [c for c in lf.collect_schema().names() if c in ngp_cols]
@@ -330,19 +350,6 @@ def select_grouped_providers(lf: pl.LazyFrame) -> pl.LazyFrame:
         pl.LazyFrame: The filtered input LazyFrame with `grouped_provider_status`
             and `last_update_date` columns added.
     """
-    cols_to_select = [
-        IndCQC.cqc_location_import_date,
-        IndCQC.provider_id,
-        NGPcol.count_of_cqc_locations_in_provider,
-        IndCQC.location_id,
-        AWPClean.nmds_id,
-        IndCQC.name,
-        IndCQC.care_home,
-        IndCQC.ascwds_filled_posts_dedup,
-        IndCQC.number_of_beds,
-        NGPcol.location_pir_average,
-    ]
-
     was_nulled_as_grouped_provider = pl.col(IndCQC.ascwds_filtering_rule).is_in(
         [
             AscwdsFilteringRule.care_home_location_was_grouped_provider,
@@ -356,7 +363,6 @@ def select_grouped_providers(lf: pl.LazyFrame) -> pl.LazyFrame:
     return (
         lf.filter(was_nulled_as_grouped_provider)
         .filter(trunc_date_col == trunc_date_col.max())
-        .select(cols_to_select)
         .with_columns(
             pl.lit("problem").alias(NGPcol.grouped_provider_status),
             pl.col(IndCQC.cqc_location_import_date).alias(
@@ -364,6 +370,7 @@ def select_grouped_providers(lf: pl.LazyFrame) -> pl.LazyFrame:
             ),
             pl.lit(None).cast(pl.Date).alias(NGPcol.grp_prov_fixed_date),
         )
+        .select(GROUPED_PROVIDER_SCHEMA.names())
     )
 
 

--- a/projects/_03_independent_cqc/_02_clean/fargate/utils/clean_ascwds_filled_post_outliers/null_grouped_providers.py
+++ b/projects/_03_independent_cqc/_02_clean/fargate/utils/clean_ascwds_filled_post_outliers/null_grouped_providers.py
@@ -333,6 +333,7 @@ def select_grouped_providers(lf: pl.LazyFrame) -> pl.LazyFrame:
     cols_to_select = [
         IndCQC.location_id,
         IndCQC.provider_id,
+        IndCQC.name,
         IndCQC.cqc_location_import_date,
         AWPClean.nmds_id,
         NGPcol.potential_grouped_provider,

--- a/projects/_03_independent_cqc/_02_clean/fargate/utils/clean_ascwds_filled_post_outliers/null_grouped_providers.py
+++ b/projects/_03_independent_cqc/_02_clean/fargate/utils/clean_ascwds_filled_post_outliers/null_grouped_providers.py
@@ -16,8 +16,6 @@ from utils.column_names.ind_cqc_pipeline_columns import (
 )
 from utils.column_values.categorical_column_values import AscwdsFilteringRule
 
-# The single source of truth for the grouped providers history dataset's shape.
-# Used both to build the new snapshot and to read/write that dataset.
 GROUPED_PROVIDER_SCHEMA = pl.Schema(
     [
         (IndCQC.cqc_location_import_date, pl.Date()),

--- a/projects/_03_independent_cqc/_02_clean/tests/fargate/utils/clean_ascwds_filled_post_outliers/test_null_grouped_providers.py
+++ b/projects/_03_independent_cqc/_02_clean/tests/fargate/utils/clean_ascwds_filled_post_outliers/test_null_grouped_providers.py
@@ -3,6 +3,7 @@ from unittest.mock import Mock, patch
 
 import polars as pl
 import polars.testing as pl_testing
+import pytest
 
 import projects._03_independent_cqc._02_clean.fargate.utils.clean_ascwds_filled_post_outliers.null_grouped_providers as job
 from projects._03_independent_cqc.unittest_data.polars_ind_cqc_test_file_data import (
@@ -85,20 +86,20 @@ class MainTests(unittest.TestCase):
     ):
         self.assertEqual(self.grouped_providers.collect().height, 2)
 
-    @patch(f"{PATCH_PATH}.null_non_residential_grouped_providers")
-    @patch(f"{PATCH_PATH}.null_care_home_grouped_providers")
     @patch(f"{PATCH_PATH}.update_grouped_providers_history")
     @patch(f"{PATCH_PATH}.select_grouped_providers")
+    @patch(f"{PATCH_PATH}.null_non_residential_grouped_providers")
+    @patch(f"{PATCH_PATH}.null_care_home_grouped_providers")
     @patch(f"{PATCH_PATH}.identify_potential_grouped_providers")
     @patch(f"{PATCH_PATH}.calculate_data_for_grouped_provider_identification")
     def test_null_grouped_providers_calls_functions(
         self,
         calculate_data_for_grouped_provider_identification_mock: Mock,
         identify_potential_grouped_providers_mock: Mock,
-        select_grouped_providers_mock: Mock,
-        update_grouped_providers_history_mock: Mock,
         null_care_home_grouped_providers_mock: Mock,
         null_non_residential_grouped_providers_mock: Mock,
+        select_grouped_providers_mock: Mock,
+        update_grouped_providers_history_mock: Mock,
     ):
         job.null_grouped_providers(self.test_lf, self.grouped_providers_lf)
 
@@ -106,10 +107,10 @@ class MainTests(unittest.TestCase):
             self.test_lf
         )
         identify_potential_grouped_providers_mock.assert_called_once()
-        select_grouped_providers_mock.assert_called_once()
-        update_grouped_providers_history_mock.assert_called_once()
         null_care_home_grouped_providers_mock.assert_called_once()
         null_non_residential_grouped_providers_mock.assert_called_once()
+        select_grouped_providers_mock.assert_called_once()
+        update_grouped_providers_history_mock.assert_called_once()
 
 
 class CalculateDataForGroupedProviderIdentificationTests(unittest.TestCase):
@@ -203,20 +204,28 @@ class NullNonResidentialGroupedProvidersTests(unittest.TestCase):
         pl_testing.assert_frame_equal(returned_lf.sort(IndCQC.location_id), test_lf)
 
 
-class SelectGroupedProviders(unittest.TestCase):
-    def test_function_returns_expected_rows(self):
+class TestSelectGroupedProviders:
+    CASES = [
+        pytest.param(case, id=case.id)
+        for case in Data.select_grouped_providers_test_cases
+    ]
+
+    @pytest.mark.parametrize("case", CASES)
+    def test_function_returns_expected_rows(self, case):
         input_lf = pl.LazyFrame(
-            Data.select_grouped_providers_rows,
-            Schemas.select_grouped_providers_schema,
+            case.input_rows,
+            Schemas.select_grouped_providers_input_schema,
             orient="row",
         )
-        returned_lf = job.select_grouped_providers(input_lf)
         expected_lf = pl.LazyFrame(
-            Data.expected_select_grouped_providers_rows,
+            case.expected_rows,
             Schemas.final_grouped_providers_schema,
             orient="row",
         )
-        pl_testing.assert_frame_equal(returned_lf, expected_lf)
+
+        returned_lf = job.select_grouped_providers(input_lf)
+
+        pl_testing.assert_frame_equal(returned_lf, expected_lf, check_row_order=False)
 
 
 class UpdateGropupedProvidersHistory(unittest.TestCase):

--- a/projects/_03_independent_cqc/unittest_data/polars_ind_cqc_test_file_data.py
+++ b/projects/_03_independent_cqc/unittest_data/polars_ind_cqc_test_file_data.py
@@ -1204,71 +1204,71 @@ class NullGroupedProvidersData:
         SelectGroupedProvidersCase(
             id="keeps_care_home_location_actually_nulled_at_max_import_date",
             input_rows=[
-                ("1-004", "prov-1", "Location Four", date(2026, 2, 1), "nmdsid_4", True, 1.0, "N", 0, AscwdsFilteringRule.care_home_location_was_grouped_provider),
+                (date(2026, 2, 1), "prov-1", 2, "1-004", "nmdsid_4", "Location Four", "N", 1.0, 0, None, AscwdsFilteringRule.care_home_location_was_grouped_provider),
             ],
             expected_rows=[
-                ("1-004", "prov-1", "Location Four", date(2026, 2, 1), "nmdsid_4", True, 1.0, "N", 0, "problem", date(2026, 2, 1), None),
+                (date(2026, 2, 1), "prov-1", 2, "1-004", "nmdsid_4", "Location Four", "N", 1.0, 0, None, "problem", date(2026, 2, 1), None),
             ],
         ),
         SelectGroupedProvidersCase(
             id="keeps_non_res_location_actually_nulled_at_max_import_date",
             input_rows=[
-                ("1-005", "prov-2", "Location Five", date(2026, 2, 1), "nmdsid_5", True, 1.0, "N", 0, AscwdsFilteringRule.non_res_location_was_grouped_provider),
+                (date(2026, 2, 1), "prov-2", 2, "1-005", "nmdsid_5", "Location Five", "N", 1.0, 0, None, AscwdsFilteringRule.non_res_location_was_grouped_provider),
             ],
             expected_rows=[
-                ("1-005", "prov-2", "Location Five", date(2026, 2, 1), "nmdsid_5", True, 1.0, "N", 0, "problem", date(2026, 2, 1), None),
+                (date(2026, 2, 1), "prov-2", 2, "1-005", "nmdsid_5", "Location Five", "N", 1.0, 0, None, "problem", date(2026, 2, 1), None),
             ],
         ),
         SelectGroupedProvidersCase(
             id="excludes_potential_grouped_provider_that_was_not_actually_nulled",
             input_rows=[
-                ("1-002", "prov-1", "Location Two", date(2026, 2, 1), "nmdsid_2", True, 1.0, "N", 0, AscwdsFilteringRule.populated),
+                (date(2026, 2, 1), "prov-1", 2, "1-002", "nmdsid_2", "Location Two", "N", 1.0, 0, None, AscwdsFilteringRule.populated),
             ],
             expected_rows=[],
         ),
         SelectGroupedProvidersCase(
             id="excludes_location_nulled_at_an_earlier_import_date_than_the_latest_snapshot",
             input_rows=[
-                ("1-001", "prov-1", "Location One", date(2026, 1, 1), "nmdsid_1", True, 1.0, "N", 0, AscwdsFilteringRule.care_home_location_was_grouped_provider),
-                ("1-004", "prov-1", "Location Four", date(2026, 2, 1), "nmdsid_4", True, 1.0, "N", 0, AscwdsFilteringRule.care_home_location_was_grouped_provider),
+                (date(2026, 1, 1), "prov-1", 2, "1-001", "nmdsid_1", "Location One", "N", 1.0, 0, None, AscwdsFilteringRule.care_home_location_was_grouped_provider),
+                (date(2026, 2, 1), "prov-1", 2, "1-004", "nmdsid_4", "Location Four", "N", 1.0, 0, None, AscwdsFilteringRule.care_home_location_was_grouped_provider),
             ],
             expected_rows=[
-                ("1-004", "prov-1", "Location Four", date(2026, 2, 1), "nmdsid_4", True, 1.0, "N", 0, "problem", date(2026, 2, 1), None),
+                (date(2026, 2, 1), "prov-1", 2, "1-004", "nmdsid_4", "Location Four", "N", 1.0, 0, None, "problem", date(2026, 2, 1), None),
             ],
         ),
         SelectGroupedProvidersCase(
             id="excludes_earlier_year_row_even_when_month_number_is_higher",
             input_rows=[
-                ("1-004", "prov-1", "Location Four", date(2026, 2, 1), "nmdsid_4", True, 1.0, "N", 0, AscwdsFilteringRule.care_home_location_was_grouped_provider),
-                ("1-008", "prov-1", "Location Eight", date(2025, 3, 1), "nmdsid_7", True, 1.0, "N", 0, AscwdsFilteringRule.non_res_location_was_grouped_provider),
+                (date(2026, 2, 1), "prov-1", 2, "1-004", "nmdsid_4", "Location Four", "N", 1.0, 0, None, AscwdsFilteringRule.care_home_location_was_grouped_provider),
+                (date(2025, 3, 1), "prov-1", 2, "1-008", "nmdsid_7", "Location Eight", "N", 1.0, 0, None, AscwdsFilteringRule.non_res_location_was_grouped_provider),
             ],
             expected_rows=[
-                ("1-004", "prov-1", "Location Four", date(2026, 2, 1), "nmdsid_4", True, 1.0, "N", 0, "problem", date(2026, 2, 1), None),
+                (date(2026, 2, 1), "prov-1", 2, "1-004", "nmdsid_4", "Location Four", "N", 1.0, 0, None, "problem", date(2026, 2, 1), None),
             ],
         ),
     ]  # fmt: skip
 
     # All rows have grouped_provider_status = "problem" and last_update_date = their import date.
     new_grouped_providers_rows = [
-        ("1-001", "prov-1", "Location One", date(2026, 2, 1), "nmds_1", True, 10.0, "N", 0, "problem", date(2026, 2, 1), None),
-        ("1-003", "prov-2", "Location Three", date(2026, 2, 1), "nmds_3", True, 30.0, "N", 0, "problem", date(2026, 2, 1), None),
-        ("1-004", "prov-3", "Location Four", date(2026, 2, 1), "nmds_4", True, 40.0, "N", 0, "problem", date(2026, 2, 1), None),
+        (date(2026, 2, 1), "prov-1", 2, "1-001", "nmds_1", "Location One", "N", 10.0, 0, None, "problem", date(2026, 2, 1), None),
+        (date(2026, 2, 1), "prov-2", 2, "1-003", "nmds_3", "Location Three", "N", 30.0, 0, None, "problem", date(2026, 2, 1), None),
+        (date(2026, 2, 1), "prov-3", 2, "1-004", "nmds_4", "Location Four", "N", 40.0, 0, None, "problem", date(2026, 2, 1), None),
     ]  # fmt: skip
 
     # historical_grouped_providers_rows: what was previously saved to the grouped providers dataset.
     historical_grouped_providers_rows = [
-        ("1-001", "prov-1", "Location One", date(2026, 1, 1), "nmds_1", True, 10.0, "N", 0, "problem", date(2026, 1, 1), None), # Still active problem — should be retained as-is (oldest kept, last_update_date stays same).
-        ("1-002", "prov-1", "Location Two", date(2026, 1, 1), "nmds_2", True, 20.0, "N", 0, "problem", date(2026, 1, 1), None), # Dropped off — not in new snapshot, should be flipped to "fixed".
-        ("1-003", "prov-2", "Location Three", date(2026, 1, 1), "nmds_3", True, 30.0, "N", 0, "fixed", date(2026, 1, 1), date(2026, 1, 1)), # Re-appearing — was fixed, now back as "problem" in new snapshot; new row appended.
+        (date(2026, 1, 1), "prov-1", 2, "1-001", "nmds_1", "Location One", "N", 10.0, 0, None, "problem", date(2026, 1, 1), None), # Still active problem — should be retained as-is (oldest kept, last_update_date stays same).
+        (date(2026, 1, 1), "prov-1", 2, "1-002", "nmds_2", "Location Two", "N", 20.0, 0, None, "problem", date(2026, 1, 1), None), # Dropped off — not in new snapshot, should be flipped to "fixed".
+        (date(2026, 1, 1), "prov-2", 2, "1-003", "nmds_3", "Location Three", "N", 30.0, 0, None, "fixed", date(2026, 1, 1), date(2026, 1, 1)), # Re-appearing — was fixed, now back as "problem" in new snapshot; new row appended.
     ]  # fmt: skip
 
     # expected_update_grouped_providers_history_rows: full history after update.
     expected_update_grouped_providers_history_rows = [
-        ("1-001", "prov-1", "Location One", date(2026, 1, 1), "nmds_1", True, 10.0, "N", 0, "problem", date(2026, 1, 1), None), # Retained — oldest "problem" record kept, last_update_date unchanged.
-        ("1-002", "prov-1", "Location Two", date(2026, 1, 1), "nmds_2", True, 20.0, "N", 0, "fixed", date(2026, 1, 1), date(2026, 2, 1)), # Flipped — was "problem", now "fixed" with last_update_date = new snapshot date.
-        ("1-003", "prov-2", "Location Three", date(2026, 1, 1), "nmds_3", True, 30.0, "N", 0, "fixed", date(2026, 1, 1), date(2026, 1, 1)), # Preserved — old "fixed" row kept as part of full history.
-        ("1-003", "prov-2", "Location Three", date(2026, 2, 1), "nmds_3", True, 30.0, "N", 0, "problem", date(2026, 2, 1), None), # Re-appeared — new "problem" row appended alongside the old "fixed" row.
-        ("1-004", "prov-3", "Location Four", date(2026, 2, 1), "nmds_4", True, 40.0, "N", 0, "problem", date(2026, 2, 1), None), # New — first time seen, added with "problem" status.
+        (date(2026, 1, 1), "prov-1", 2, "1-001", "nmds_1", "Location One", "N", 10.0, 0, None, "problem", date(2026, 1, 1), None), # Retained — oldest "problem" record kept, last_update_date unchanged.
+        (date(2026, 1, 1), "prov-1", 2, "1-002", "nmds_2", "Location Two", "N", 20.0, 0, None, "fixed", date(2026, 1, 1), date(2026, 2, 1)), # Flipped — was "problem", now "fixed" with last_update_date = new snapshot date.
+        (date(2026, 1, 1), "prov-2", 2, "1-003", "nmds_3", "Location Three", "N", 30.0, 0, None, "fixed", date(2026, 1, 1), date(2026, 1, 1)), # Preserved — old "fixed" row kept as part of full history.
+        (date(2026, 2, 1), "prov-2", 2, "1-003", "nmds_3", "Location Three", "N", 30.0, 0, None, "problem", date(2026, 2, 1), None), # Re-appeared — new "problem" row appended alongside the old "fixed" row.
+        (date(2026, 2, 1), "prov-3", 2, "1-004", "nmds_4", "Location Four", "N", 40.0, 0, None, "problem", date(2026, 2, 1), None), # New — first time seen, added with "problem" status.
     ]  # fmt: skip
 
 

--- a/projects/_03_independent_cqc/unittest_data/polars_ind_cqc_test_file_data.py
+++ b/projects/_03_independent_cqc/unittest_data/polars_ind_cqc_test_file_data.py
@@ -1099,13 +1099,13 @@ class NullGroupedProvidersData:
     # and loc 1's Jan row (below the minimum-size threshold) do not, so
     # select_grouped_providers should return exactly those 2 actually-nulled rows.
     null_grouped_providers_rows = [
-        ("loc 1", "prov 1", date(2024, 1, 1), "Y", "estab 1", "nmdsid_1", 13.0, 13.0, 4, 3.25, AscwdsFilteringRule.populated, 1.0),
-        ("loc 2", "prov 1", date(2024, 1, 1), "Y", None, None, None,  None, 4, None, AscwdsFilteringRule.missing_data, 1.0),
-        ("loc 3", "prov 1", date(2024, 1, 1), "Y", None, None, None, None, 4, None, AscwdsFilteringRule.missing_data, 1.0),
-        ("loc 1", "prov 1", date(2024, 2, 1), "Y", "estab 1", "nmdsid_1", 40.0, 40.0, 4, 10.0, AscwdsFilteringRule.populated, 1.0),
-        ("loc 2", "prov 1", date(2024, 2, 1), "Y", None, None, None, None, 4, None, AscwdsFilteringRule.missing_data, 1.0),
-        ("loc 4", "prov 2", date(2024, 2, 1), "N", "estab 4", "nmdsid_2", 60.0, 60.0, None, None, AscwdsFilteringRule.populated, 10.0),
-        ("loc 5", "prov 2", date(2024, 2, 1), "N", None, None, None, None, None, None, AscwdsFilteringRule.missing_data, None),
+        ("loc 1", "prov 1", "Location One", date(2024, 1, 1), "Y", "estab 1", "nmdsid_1", 13.0, 13.0, 4, 3.25, AscwdsFilteringRule.populated, 1.0),
+        ("loc 2", "prov 1", "Location Two", date(2024, 1, 1), "Y", None, None, None,  None, 4, None, AscwdsFilteringRule.missing_data, 1.0),
+        ("loc 3", "prov 1", "Location Three", date(2024, 1, 1), "Y", None, None, None, None, 4, None, AscwdsFilteringRule.missing_data, 1.0),
+        ("loc 1", "prov 1", "Location One", date(2024, 2, 1), "Y", "estab 1", "nmdsid_1", 40.0, 40.0, 4, 10.0, AscwdsFilteringRule.populated, 1.0),
+        ("loc 2", "prov 1", "Location Two", date(2024, 2, 1), "Y", None, None, None, None, 4, None, AscwdsFilteringRule.missing_data, 1.0),
+        ("loc 4", "prov 2", "Location Four", date(2024, 2, 1), "N", "estab 4", "nmdsid_2", 60.0, 60.0, None, None, AscwdsFilteringRule.populated, 10.0),
+        ("loc 5", "prov 2", "Location Five", date(2024, 2, 1), "N", None, None, None, None, None, None, AscwdsFilteringRule.missing_data, None),
     ] # fmt: skip
 
     input_grouped_provider_rows = [
@@ -1204,71 +1204,71 @@ class NullGroupedProvidersData:
         SelectGroupedProvidersCase(
             id="keeps_care_home_location_actually_nulled_at_max_import_date",
             input_rows=[
-                ("1-004", "prov-1", date(2026, 2, 1), "nmdsid_4", True, 1.0, "N", 0, AscwdsFilteringRule.care_home_location_was_grouped_provider),
+                ("1-004", "prov-1", "Location Four", date(2026, 2, 1), "nmdsid_4", True, 1.0, "N", 0, AscwdsFilteringRule.care_home_location_was_grouped_provider),
             ],
             expected_rows=[
-                ("1-004", "prov-1", date(2026, 2, 1), "nmdsid_4", True, 1.0, "N", 0, "problem", date(2026, 2, 1), None),
+                ("1-004", "prov-1", "Location Four", date(2026, 2, 1), "nmdsid_4", True, 1.0, "N", 0, "problem", date(2026, 2, 1), None),
             ],
         ),
         SelectGroupedProvidersCase(
             id="keeps_non_res_location_actually_nulled_at_max_import_date",
             input_rows=[
-                ("1-005", "prov-2", date(2026, 2, 1), "nmdsid_5", True, 1.0, "N", 0, AscwdsFilteringRule.non_res_location_was_grouped_provider),
+                ("1-005", "prov-2", "Location Five", date(2026, 2, 1), "nmdsid_5", True, 1.0, "N", 0, AscwdsFilteringRule.non_res_location_was_grouped_provider),
             ],
             expected_rows=[
-                ("1-005", "prov-2", date(2026, 2, 1), "nmdsid_5", True, 1.0, "N", 0, "problem", date(2026, 2, 1), None),
+                ("1-005", "prov-2", "Location Five", date(2026, 2, 1), "nmdsid_5", True, 1.0, "N", 0, "problem", date(2026, 2, 1), None),
             ],
         ),
         SelectGroupedProvidersCase(
             id="excludes_potential_grouped_provider_that_was_not_actually_nulled",
             input_rows=[
-                ("1-002", "prov-1", date(2026, 2, 1), "nmdsid_2", True, 1.0, "N", 0, AscwdsFilteringRule.populated),
+                ("1-002", "prov-1", "Location Two", date(2026, 2, 1), "nmdsid_2", True, 1.0, "N", 0, AscwdsFilteringRule.populated),
             ],
             expected_rows=[],
         ),
         SelectGroupedProvidersCase(
             id="excludes_location_nulled_at_an_earlier_import_date_than_the_latest_snapshot",
             input_rows=[
-                ("1-001", "prov-1", date(2026, 1, 1), "nmdsid_1", True, 1.0, "N", 0, AscwdsFilteringRule.care_home_location_was_grouped_provider),
-                ("1-004", "prov-1", date(2026, 2, 1), "nmdsid_4", True, 1.0, "N", 0, AscwdsFilteringRule.care_home_location_was_grouped_provider),
+                ("1-001", "prov-1", "Location One", date(2026, 1, 1), "nmdsid_1", True, 1.0, "N", 0, AscwdsFilteringRule.care_home_location_was_grouped_provider),
+                ("1-004", "prov-1", "Location Four", date(2026, 2, 1), "nmdsid_4", True, 1.0, "N", 0, AscwdsFilteringRule.care_home_location_was_grouped_provider),
             ],
             expected_rows=[
-                ("1-004", "prov-1", date(2026, 2, 1), "nmdsid_4", True, 1.0, "N", 0, "problem", date(2026, 2, 1), None),
+                ("1-004", "prov-1", "Location Four", date(2026, 2, 1), "nmdsid_4", True, 1.0, "N", 0, "problem", date(2026, 2, 1), None),
             ],
         ),
         SelectGroupedProvidersCase(
             id="excludes_earlier_year_row_even_when_month_number_is_higher",
             input_rows=[
-                ("1-004", "prov-1", date(2026, 2, 1), "nmdsid_4", True, 1.0, "N", 0, AscwdsFilteringRule.care_home_location_was_grouped_provider),
-                ("1-008", "prov-1", date(2025, 3, 1), "nmdsid_7", True, 1.0, "N", 0, AscwdsFilteringRule.non_res_location_was_grouped_provider),
+                ("1-004", "prov-1", "Location Four", date(2026, 2, 1), "nmdsid_4", True, 1.0, "N", 0, AscwdsFilteringRule.care_home_location_was_grouped_provider),
+                ("1-008", "prov-1", "Location Eight", date(2025, 3, 1), "nmdsid_7", True, 1.0, "N", 0, AscwdsFilteringRule.non_res_location_was_grouped_provider),
             ],
             expected_rows=[
-                ("1-004", "prov-1", date(2026, 2, 1), "nmdsid_4", True, 1.0, "N", 0, "problem", date(2026, 2, 1), None),
+                ("1-004", "prov-1", "Location Four", date(2026, 2, 1), "nmdsid_4", True, 1.0, "N", 0, "problem", date(2026, 2, 1), None),
             ],
         ),
     ]  # fmt: skip
 
     # All rows have grouped_provider_status = "problem" and last_update_date = their import date.
     new_grouped_providers_rows = [
-        ("1-001", "prov-1", date(2026, 2, 1), "nmds_1", True, 10.0, "N", 0, "problem", date(2026, 2, 1), None),
-        ("1-003", "prov-2", date(2026, 2, 1), "nmds_3", True, 30.0, "N", 0, "problem", date(2026, 2, 1), None),
-        ("1-004", "prov-3", date(2026, 2, 1), "nmds_4", True, 40.0, "N", 0, "problem", date(2026, 2, 1), None),
+        ("1-001", "prov-1", "Location One", date(2026, 2, 1), "nmds_1", True, 10.0, "N", 0, "problem", date(2026, 2, 1), None),
+        ("1-003", "prov-2", "Location Three", date(2026, 2, 1), "nmds_3", True, 30.0, "N", 0, "problem", date(2026, 2, 1), None),
+        ("1-004", "prov-3", "Location Four", date(2026, 2, 1), "nmds_4", True, 40.0, "N", 0, "problem", date(2026, 2, 1), None),
     ]  # fmt: skip
 
     # historical_grouped_providers_rows: what was previously saved to the grouped providers dataset.
     historical_grouped_providers_rows = [
-        ("1-001", "prov-1", date(2026, 1, 1), "nmds_1", True, 10.0, "N", 0, "problem", date(2026, 1, 1), None), # Still active problem — should be retained as-is (oldest kept, last_update_date stays same).
-        ("1-002", "prov-1", date(2026, 1, 1), "nmds_2", True, 20.0, "N", 0, "problem", date(2026, 1, 1), None), # Dropped off — not in new snapshot, should be flipped to "fixed".
-        ("1-003", "prov-2", date(2026, 1, 1), "nmds_3", True, 30.0, "N", 0, "fixed", date(2026, 1, 1), date(2026, 1, 1)), # Re-appearing — was fixed, now back as "problem" in new snapshot; new row appended.
+        ("1-001", "prov-1", "Location One", date(2026, 1, 1), "nmds_1", True, 10.0, "N", 0, "problem", date(2026, 1, 1), None), # Still active problem — should be retained as-is (oldest kept, last_update_date stays same).
+        ("1-002", "prov-1", "Location Two", date(2026, 1, 1), "nmds_2", True, 20.0, "N", 0, "problem", date(2026, 1, 1), None), # Dropped off — not in new snapshot, should be flipped to "fixed".
+        ("1-003", "prov-2", "Location Three", date(2026, 1, 1), "nmds_3", True, 30.0, "N", 0, "fixed", date(2026, 1, 1), date(2026, 1, 1)), # Re-appearing — was fixed, now back as "problem" in new snapshot; new row appended.
     ]  # fmt: skip
 
     # expected_update_grouped_providers_history_rows: full history after update.
     expected_update_grouped_providers_history_rows = [
-        ("1-001", "prov-1", date(2026, 1, 1), "nmds_1", True, 10.0, "N", 0, "problem", date(2026, 1, 1), None), # Retained — oldest "problem" record kept, last_update_date unchanged.
-        ("1-002", "prov-1", date(2026, 1, 1), "nmds_2", True, 20.0, "N", 0, "fixed", date(2026, 1, 1), date(2026, 2, 1)), # Flipped — was "problem", now "fixed" with last_update_date = new snapshot date.
-        ("1-003", "prov-2", date(2026, 1, 1), "nmds_3", True, 30.0, "N", 0, "fixed", date(2026, 1, 1), date(2026, 1, 1)), # Preserved — old "fixed" row kept as part of full history.
-        ("1-003", "prov-2", date(2026, 2, 1), "nmds_3", True, 30.0, "N", 0, "problem", date(2026, 2, 1), None), # Re-appeared — new "problem" row appended alongside the old "fixed" row.
-        ("1-004", "prov-3", date(2026, 2, 1), "nmds_4", True, 40.0, "N", 0, "problem", date(2026, 2, 1), None), # New — first time seen, added with "problem" status.
+        ("1-001", "prov-1", "Location One", date(2026, 1, 1), "nmds_1", True, 10.0, "N", 0, "problem", date(2026, 1, 1), None), # Retained — oldest "problem" record kept, last_update_date unchanged.
+        ("1-002", "prov-1", "Location Two", date(2026, 1, 1), "nmds_2", True, 20.0, "N", 0, "fixed", date(2026, 1, 1), date(2026, 2, 1)), # Flipped — was "problem", now "fixed" with last_update_date = new snapshot date.
+        ("1-003", "prov-2", "Location Three", date(2026, 1, 1), "nmds_3", True, 30.0, "N", 0, "fixed", date(2026, 1, 1), date(2026, 1, 1)), # Preserved — old "fixed" row kept as part of full history.
+        ("1-003", "prov-2", "Location Three", date(2026, 2, 1), "nmds_3", True, 30.0, "N", 0, "problem", date(2026, 2, 1), None), # Re-appeared — new "problem" row appended alongside the old "fixed" row.
+        ("1-004", "prov-3", "Location Four", date(2026, 2, 1), "nmds_4", True, 40.0, "N", 0, "problem", date(2026, 2, 1), None), # New — first time seen, added with "problem" status.
     ]  # fmt: skip
 
 

--- a/projects/_03_independent_cqc/unittest_data/polars_ind_cqc_test_file_data.py
+++ b/projects/_03_independent_cqc/unittest_data/polars_ind_cqc_test_file_data.py
@@ -1084,14 +1084,28 @@ class NullFilledPostsUsingInvalidMissingDataCodeData:
 
 
 @dataclass
+class SelectGroupedProvidersCase:
+    id: str
+    input_rows: list[tuple]
+    expected_rows: list[tuple]
+
+
+@dataclass
 class NullGroupedProvidersData:
 
+    # Feb 2024 (the max date) is designed so that loc 1 (care home) and loc 4 (non-res)
+    # actually get nulled by null_care_home_grouped_providers /
+    # null_non_residential_grouped_providers, while loc 2, 3 and 5 (no ASCWDS data)
+    # and loc 1's Jan row (below the minimum-size threshold) do not, so
+    # select_grouped_providers should return exactly those 2 actually-nulled rows.
     null_grouped_providers_rows = [
         ("loc 1", "prov 1", date(2024, 1, 1), "Y", "estab 1", "nmdsid_1", 13.0, 13.0, 4, 3.25, AscwdsFilteringRule.populated, 1.0),
         ("loc 2", "prov 1", date(2024, 1, 1), "Y", None, None, None,  None, 4, None, AscwdsFilteringRule.missing_data, 1.0),
         ("loc 3", "prov 1", date(2024, 1, 1), "Y", None, None, None, None, 4, None, AscwdsFilteringRule.missing_data, 1.0),
-        ("loc 1", "prov 1", date(2024, 2, 1), "Y", "estab 1", "nmdsid_1", 12.0, 12.0, 4, 3.0, AscwdsFilteringRule.populated, 1.0),
+        ("loc 1", "prov 1", date(2024, 2, 1), "Y", "estab 1", "nmdsid_1", 40.0, 40.0, 4, 10.0, AscwdsFilteringRule.populated, 1.0),
         ("loc 2", "prov 1", date(2024, 2, 1), "Y", None, None, None, None, 4, None, AscwdsFilteringRule.missing_data, 1.0),
+        ("loc 4", "prov 2", date(2024, 2, 1), "N", "estab 4", "nmdsid_2", 60.0, 60.0, None, None, AscwdsFilteringRule.populated, 10.0),
+        ("loc 5", "prov 2", date(2024, 2, 1), "N", None, None, None, None, None, None, AscwdsFilteringRule.missing_data, None),
     ] # fmt: skip
 
     input_grouped_provider_rows = [
@@ -1184,20 +1198,55 @@ class NullGroupedProvidersData:
         ("1-008", CareHome.not_care_home, True, 50.0, None, 10.0, 2, 25.0, AscwdsFilteringRule.contained_invalid_missing_data_code),  # already filtered
     ] # fmt: skip
 
-    select_grouped_providers_rows = [
-        ("1-001", "prov-1", date(2026, 1, 1), "nmdsid_1", True, 1.0, "N", 0), # Grouped provider but undesired import date.
-        ("1-002", "prov-1", date(2026, 1, 1), "nmdsid_2", False, 1.0, "N", 0), # Not grouped provider and undesired import date.
-        ("1-003", "prov-1", date(2026, 2, 1), "nmdsid_3", False, 1.0, "N", 0), # Desired date but not grouped provider.
-        ("1-004", "prov-1", date(2026, 2, 1), "nmdsid_4", True, 1.0, "N", 0), # Keep
-        ("1-005", "prov-2", date(2026, 2, 1), "nmdsid_5", True, 1.0, "N", 0), # Keep (different provider)
-        ("1-006", "prov-1", date(2025, 1, 1), "nmdsid_6", True, 1.0, "N", 0), # Incorrect date with lower year and month than desired.
-        ("1-008", "prov-1", date(2025, 3, 1), "nmdsid_7", True, 1.0, "N", 0), # Incorrect date with lower year and higher month than desired.
-    ] # fmt: skip
-
-    expected_select_grouped_providers_rows = [
-        ("1-004", "prov-1", date(2026, 2, 1), "nmdsid_4", True, 1.0, "N", 0, "problem", date(2026, 2, 1), None),
-        ("1-005", "prov-2", date(2026, 2, 1), "nmdsid_5", True, 1.0, "N", 0, "problem", date(2026, 2, 1), None),
-    ] # fmt: skip
+    # Each case includes an unrelated anchor row at the max import date (2026-02-01)
+    # so that the max-date filter has something real to compare against.
+    select_grouped_providers_test_cases = [
+        SelectGroupedProvidersCase(
+            id="keeps_care_home_location_actually_nulled_at_max_import_date",
+            input_rows=[
+                ("1-004", "prov-1", date(2026, 2, 1), "nmdsid_4", True, 1.0, "N", 0, AscwdsFilteringRule.care_home_location_was_grouped_provider),
+            ],
+            expected_rows=[
+                ("1-004", "prov-1", date(2026, 2, 1), "nmdsid_4", True, 1.0, "N", 0, "problem", date(2026, 2, 1), None),
+            ],
+        ),
+        SelectGroupedProvidersCase(
+            id="keeps_non_res_location_actually_nulled_at_max_import_date",
+            input_rows=[
+                ("1-005", "prov-2", date(2026, 2, 1), "nmdsid_5", True, 1.0, "N", 0, AscwdsFilteringRule.non_res_location_was_grouped_provider),
+            ],
+            expected_rows=[
+                ("1-005", "prov-2", date(2026, 2, 1), "nmdsid_5", True, 1.0, "N", 0, "problem", date(2026, 2, 1), None),
+            ],
+        ),
+        SelectGroupedProvidersCase(
+            id="excludes_potential_grouped_provider_that_was_not_actually_nulled",
+            input_rows=[
+                ("1-002", "prov-1", date(2026, 2, 1), "nmdsid_2", True, 1.0, "N", 0, AscwdsFilteringRule.populated),
+            ],
+            expected_rows=[],
+        ),
+        SelectGroupedProvidersCase(
+            id="excludes_location_nulled_at_an_earlier_import_date_than_the_latest_snapshot",
+            input_rows=[
+                ("1-001", "prov-1", date(2026, 1, 1), "nmdsid_1", True, 1.0, "N", 0, AscwdsFilteringRule.care_home_location_was_grouped_provider),
+                ("1-004", "prov-1", date(2026, 2, 1), "nmdsid_4", True, 1.0, "N", 0, AscwdsFilteringRule.care_home_location_was_grouped_provider),
+            ],
+            expected_rows=[
+                ("1-004", "prov-1", date(2026, 2, 1), "nmdsid_4", True, 1.0, "N", 0, "problem", date(2026, 2, 1), None),
+            ],
+        ),
+        SelectGroupedProvidersCase(
+            id="excludes_earlier_year_row_even_when_month_number_is_higher",
+            input_rows=[
+                ("1-004", "prov-1", date(2026, 2, 1), "nmdsid_4", True, 1.0, "N", 0, AscwdsFilteringRule.care_home_location_was_grouped_provider),
+                ("1-008", "prov-1", date(2025, 3, 1), "nmdsid_7", True, 1.0, "N", 0, AscwdsFilteringRule.non_res_location_was_grouped_provider),
+            ],
+            expected_rows=[
+                ("1-004", "prov-1", date(2026, 2, 1), "nmdsid_4", True, 1.0, "N", 0, "problem", date(2026, 2, 1), None),
+            ],
+        ),
+    ]  # fmt: skip
 
     # All rows have grouped_provider_status = "problem" and last_update_date = their import date.
     new_grouped_providers_rows = [

--- a/projects/_03_independent_cqc/unittest_data/polars_ind_cqc_test_file_schemas.py
+++ b/projects/_03_independent_cqc/unittest_data/polars_ind_cqc_test_file_schemas.py
@@ -1006,15 +1006,16 @@ class NullGroupedProvidersSchema:
 
     select_grouped_providers_schema = pl.Schema(
         [
-            (IndCQC.location_id, pl.String()),
-            (IndCQC.provider_id, pl.String()),
-            (IndCQC.name, pl.String()),
             (IndCQC.cqc_location_import_date, pl.Date()),
+            (IndCQC.provider_id, pl.String()),
+            (NGPcol.count_of_cqc_locations_in_provider, pl.UInt32()),
+            (IndCQC.location_id, pl.String()),
             (AWPClean.nmds_id, pl.String()),
-            (NGPcol.potential_grouped_provider, pl.Boolean()),
-            (IndCQC.ascwds_filled_posts_dedup, pl.Float64()),
+            (IndCQC.name, pl.String()),
             (IndCQC.care_home, pl.String()),
+            (IndCQC.ascwds_filled_posts_dedup, pl.Float64()),
             (IndCQC.number_of_beds, pl.Int64()),
+            (NGPcol.location_pir_average, pl.Float64()),
         ]
     )
 

--- a/projects/_03_independent_cqc/unittest_data/polars_ind_cqc_test_file_schemas.py
+++ b/projects/_03_independent_cqc/unittest_data/polars_ind_cqc_test_file_schemas.py
@@ -1010,10 +1010,15 @@ class NullGroupedProvidersSchema:
             (IndCQC.cqc_location_import_date, pl.Date()),
             (AWPClean.nmds_id, pl.String()),
             (NGPcol.potential_grouped_provider, pl.Boolean()),
-            (IndCQC.ascwds_filled_posts_dedup_clean, pl.Float64()),
+            (IndCQC.ascwds_filled_posts_dedup, pl.Float64()),
             (IndCQC.care_home, pl.String()),
             (IndCQC.number_of_beds, pl.Int64()),
         ]
+    )
+
+    select_grouped_providers_input_schema = pl.Schema(
+        list(select_grouped_providers_schema.items())
+        + [(IndCQC.ascwds_filtering_rule, pl.String())]
     )
 
     final_grouped_providers_schema = pl.Schema(

--- a/projects/_03_independent_cqc/unittest_data/polars_ind_cqc_test_file_schemas.py
+++ b/projects/_03_independent_cqc/unittest_data/polars_ind_cqc_test_file_schemas.py
@@ -922,6 +922,7 @@ class NullGroupedProvidersSchema:
         [
             (IndCQC.location_id, pl.String()),
             (IndCQC.provider_id, pl.String()),
+            (IndCQC.name, pl.String()),
             (IndCQC.cqc_location_import_date, pl.Date()),
             (IndCQC.care_home, pl.String()),
             (IndCQC.establishment_id, pl.String()),
@@ -1007,6 +1008,7 @@ class NullGroupedProvidersSchema:
         [
             (IndCQC.location_id, pl.String()),
             (IndCQC.provider_id, pl.String()),
+            (IndCQC.name, pl.String()),
             (IndCQC.cqc_location_import_date, pl.Date()),
             (AWPClean.nmds_id, pl.String()),
             (NGPcol.potential_grouped_provider, pl.Boolean()),


### PR DESCRIPTION
## Description
Trello ticket [#1792](https://trello.com/c/KZ6cCn14/1792-m-grouped-providers-only-select-providers-where-ascwdsfilteringrule-says-grouped-provider)

Only records a location in the grouped providers history table if its ASCWDS data was actually nulled by `null_care_home_grouped_providers`/`null_non_residential_grouped_providers` — previously it recorded every structurally-potential grouped provider, even ones that weren't actually nulled.

Reordered `null_grouped_providers` so nulling runs first, and filtered `select_grouped_providers` on `ascwds_filtering_rule` instead of `potential_grouped_provider`.

Also: added `name`, `count_of_cqc_locations_in_provider`, `location_pir_average` to the output; dropped `potential_grouped_provider` (always true so unnecessary); consolidated `GROUPED_PROVIDER_SCHEMA` into one definition shared by both save and load; moved the `nmds_id` drop alongside the other grouped-provider cleanup.

The old grouped-providers parquet dataset will need deleting from S3 when this is merged in (I've done it once, but double check it hasn't been recreated since.

## Testing
- [X] Unit tests passing
- [X] Successful [Step Function run](https://eu-west-2.console.aws.amazon.com/states/home?region=eu-west-2#/v2/executions/details/arn:aws:states:eu-west-2:856699698263:execution:1792-grp-prov-Ind-CQC-Filled-Post-Estimates:e6e1b040-22b0-44ba-b1eb-50bd4c85d1b1)
- [X] Outputs checked in Athena

New output file attached to Trello card

## Checklist (delete if not relevant)
- [X] Unit tests added/amended
- [X] Docstrings added/updated
- [X] Updated CHANGELOG
- [X] Code reviewed by AI
- [X] Moved Trello ticket to PR column

## Reviewer checklist
- [ ] PR solves the Trello ticket requirements
- [ ] Outputs appear reasonable and understandable
- [ ] The overall approach is appropriate and not over-engineered
- [ ] No obvious scalability, performance or interdependency concerns
- [ ] Tests appropriately cover the main behaviour/edge cases
- [ ] Naming and structure are broadly understandable and consistent
- [ ] Docstrings are sufficient for future maintenance
- [ ] Docstrings cover non-obvious behaviour
