### PR TITLE
1827 - Move CategoricalColumnTypes polars dtype constants into polars_utils

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ All notable changes to this project will be documented in this file.
 - Added merge_job_role_columns function to polars_utils > cleaning_utils and called it in clean_ascwds_workplace job.
 
 ### Changed
+- Moved the `CategoricalColumnTypes` polars dtype constants from the Estimate Filled Posts by Job Role fargate job into Polars Utils, so they're available repo-wide without importing from that project.
+
 - Pull clean workplace columns into merge job within SLV pipeline.
 
 - Updated references from workplace data for 'reconciliation' process to 'SfC internal' as the dataset is used in multiple jobs

--- a/polars_utils/column_types.py
+++ b/polars_utils/column_types.py
@@ -1,0 +1,54 @@
+from dataclasses import dataclass
+
+import polars as pl
+
+from utils.column_values.categorical_column_values import (
+    EstimateFilledPostsSource,
+    PrimaryServiceType,
+)
+from utils.column_values.categorical_columns_by_dataset import (
+    EstimatedIndCQCFilledPostsByJobRoleCategoricalValues as CatVals,
+)
+
+
+@dataclass
+class CategoricalColumnTypes:
+    LocationCatType = pl.Categorical(
+        pl.Categories("location", namespace="filled_posts")
+    )
+    EstablishmentCatType = pl.Categorical(
+        pl.Categories("establishment", namespace="filled_posts")
+    )
+    ProviderCatType = pl.Categorical(
+        pl.Categories("provider", namespace="filled_posts")
+    )
+    BrandCatType = pl.Categorical(pl.Categories("brand", namespace="filled_posts"))
+    JobRoleEnumType = pl.Enum(
+        CatVals.main_job_role_labels_column_values.categorical_values
+    )
+    JobGroupEnumType = pl.Enum(
+        CatVals.main_job_group_labels_column_values.categorical_values
+    )
+    EstimatesFilledPostSourceEnumType = pl.Enum(
+        [
+            EstimateFilledPostsSource.imputed_pir_filled_posts_model,
+            EstimateFilledPostsSource.ascwds_pir_merged,
+            EstimateFilledPostsSource.imputed_posts_care_home_model,
+            EstimateFilledPostsSource.care_home_model,
+            EstimateFilledPostsSource.imputed_posts_non_res_combined_model,
+            EstimateFilledPostsSource.non_res_combined_model,
+            EstimateFilledPostsSource.posts_rolling_average_model,
+        ]
+    )
+    PrimaryServiceEnumType = pl.Enum(
+        [
+            PrimaryServiceType.care_home_only,
+            PrimaryServiceType.care_home_with_nursing,
+            PrimaryServiceType.non_residential,
+        ]
+    )
+    JobRoleFilteringRuleCatType = pl.Categorical(
+        pl.Categories(
+            "job_role_filtering_rule", namespace="filled_posts", physical=pl.UInt8
+        )
+    )

--- a/polars_utils/column_types.py
+++ b/polars_utils/column_types.py
@@ -13,6 +13,8 @@ from utils.column_values.categorical_columns_by_dataset import (
 
 @dataclass
 class CategoricalColumnTypes:
+    """Reusable polars Categorical and Enum dtype constants."""
+
     LocationCatType = pl.Categorical(
         pl.Categories("location", namespace="filled_posts")
     )

--- a/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/_01_merge.py
+++ b/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/_01_merge.py
@@ -1,12 +1,10 @@
 import polars as pl
 
 from polars_utils import utils
+from polars_utils.column_types import CategoricalColumnTypes as CatColType
 from polars_utils.filtering_utils import reduced_data_filter_expr
 from projects._03_independent_cqc._07_estimate_filled_posts_by_job_role.fargate.utils.merge_utils import (
     join_estimates_to_ascwds,
-)
-from projects._03_independent_cqc._07_estimate_filled_posts_by_job_role.fargate.utils.utils import (
-    CategoricalColumnTypes as CatColType,
 )
 from utils.column_names.ind_cqc_pipeline_columns import IndCqcColumns as IndCQC
 

--- a/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/_02_clean.py
+++ b/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/_02_clean.py
@@ -2,11 +2,9 @@ import polars as pl
 
 import projects._03_independent_cqc._07_estimate_filled_posts_by_job_role.fargate.utils.clean_utils as cUtils
 from polars_utils import utils
+from polars_utils.column_types import CategoricalColumnTypes as CatColType
 from polars_utils.filtering_utils import (
     add_filtering_rule_column,
-)
-from projects._03_independent_cqc._07_estimate_filled_posts_by_job_role.fargate.utils.utils import (
-    CategoricalColumnTypes as CatColType,
 )
 from projects._03_independent_cqc._07_estimate_filled_posts_by_job_role.fargate.utils.utils import (
     add_job_role_groups_column,

--- a/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/utils/clean_utils.py
+++ b/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/utils/clean_utils.py
@@ -1,9 +1,7 @@
 import polars as pl
 
+from polars_utils.column_types import CategoricalColumnTypes as CatColType
 from polars_utils.filtering_utils import update_filtering_rule
-from projects._03_independent_cqc._07_estimate_filled_posts_by_job_role.fargate.utils.utils import (
-    CategoricalColumnTypes as CatColType,
-)
 from utils.column_names.ind_cqc_pipeline_columns import IndCqcColumns as IndCQC
 from utils.column_values.categorical_column_values import (
     EstimateFilledPostsSource,

--- a/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/utils/utils.py
+++ b/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/utils/utils.py
@@ -1,17 +1,10 @@
-from dataclasses import dataclass
 from datetime import date
 
 import polars as pl
 
+from polars_utils.column_types import CategoricalColumnTypes
 from utils.column_names.ind_cqc_pipeline_columns import IndCqcColumns as IndCQC
-from utils.column_values.categorical_column_values import (
-    EstimateFilledPostsSource,
-    MainJobRoleLabels,
-    PrimaryServiceType,
-)
-from utils.column_values.categorical_columns_by_dataset import (
-    EstimatedIndCQCFilledPostsByJobRoleCategoricalValues as CatVals,
-)
+from utils.column_values.categorical_column_values import MainJobRoleLabels
 from utils.value_labels.ascwds_worker.ascwds_worker_jobgroup_dictionary import (
     AscwdsWorkerValueLabelsJobGroup,
 )
@@ -128,46 +121,3 @@ class HistoricJobRoleAdjustmentConfig:
             },
         },
     }
-
-
-@dataclass
-class CategoricalColumnTypes:
-    LocationCatType = pl.Categorical(
-        pl.Categories("location", namespace="filled_posts")
-    )
-    EstablishmentCatType = pl.Categorical(
-        pl.Categories("establishment", namespace="filled_posts")
-    )
-    ProviderCatType = pl.Categorical(
-        pl.Categories("provider", namespace="filled_posts")
-    )
-    BrandCatType = pl.Categorical(pl.Categories("brand", namespace="filled_posts"))
-    JobRoleEnumType = pl.Enum(
-        CatVals.main_job_role_labels_column_values.categorical_values
-    )
-    JobGroupEnumType = pl.Enum(
-        CatVals.main_job_group_labels_column_values.categorical_values
-    )
-    EstimatesFilledPostSourceEnumType = pl.Enum(
-        [
-            EstimateFilledPostsSource.imputed_pir_filled_posts_model,
-            EstimateFilledPostsSource.ascwds_pir_merged,
-            EstimateFilledPostsSource.imputed_posts_care_home_model,
-            EstimateFilledPostsSource.care_home_model,
-            EstimateFilledPostsSource.imputed_posts_non_res_combined_model,
-            EstimateFilledPostsSource.non_res_combined_model,
-            EstimateFilledPostsSource.posts_rolling_average_model,
-        ]
-    )
-    PrimaryServiceEnumType = pl.Enum(
-        [
-            PrimaryServiceType.care_home_only,
-            PrimaryServiceType.care_home_with_nursing,
-            PrimaryServiceType.non_residential,
-        ]
-    )
-    JobRoleFilteringRuleCatType = pl.Categorical(
-        pl.Categories(
-            "job_role_filtering_rule", namespace="filled_posts", physical=pl.UInt8
-        )
-    )

--- a/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/validate_01_merge.py
+++ b/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/validate_01_merge.py
@@ -5,12 +5,10 @@ import pointblank as pb
 import polars as pl
 
 from polars_utils import utils
+from polars_utils.column_types import CategoricalColumnTypes
 from polars_utils.filtering_utils import reduced_data_filter_expr
 from polars_utils.validation import actions as vl
 from polars_utils.validation.constants import GLOBAL_ACTIONS, GLOBAL_THRESHOLDS
-from projects._03_independent_cqc._07_estimate_filled_posts_by_job_role.fargate.utils.utils import (
-    CategoricalColumnTypes,
-)
 from utils.column_names.ind_cqc_pipeline_columns import IndCqcColumns
 from utils.column_values.categorical_columns_by_dataset import (
     EstimatedIndCQCFilledPostsByJobRoleCategoricalValues as CatValues,

--- a/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/validate_01_merge_metadata.py
+++ b/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/validate_01_merge_metadata.py
@@ -5,15 +5,13 @@ import pointblank as pb
 from dateutil.relativedelta import relativedelta
 
 from polars_utils import utils
+from polars_utils.column_types import CategoricalColumnTypes
 from polars_utils.filtering_utils import reduced_data_filter_expr
 from polars_utils.validation import actions as vl
 from polars_utils.validation.actions import (
     add_list_column_validation_check_flags,
 )
 from polars_utils.validation.constants import GLOBAL_ACTIONS, GLOBAL_THRESHOLDS
-from projects._03_independent_cqc._07_estimate_filled_posts_by_job_role.fargate.utils.utils import (
-    CategoricalColumnTypes,
-)
 from utils.column_names.cleaned_data_files.cqc_location_cleaned import (
     CqcLocationCleanedNewValidationColumns as CQCLVal,
 )

--- a/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/validate_02_clean.py
+++ b/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/validate_02_clean.py
@@ -5,11 +5,9 @@ import pointblank as pb
 import polars as pl
 
 from polars_utils import utils
+from polars_utils.column_types import CategoricalColumnTypes
 from polars_utils.validation import actions as vl
 from polars_utils.validation.constants import GLOBAL_ACTIONS, GLOBAL_THRESHOLDS
-from projects._03_independent_cqc._07_estimate_filled_posts_by_job_role.fargate.utils.utils import (
-    CategoricalColumnTypes,
-)
 from utils.column_names.ind_cqc_pipeline_columns import IndCqcColumns
 from utils.column_values.categorical_column_values import JobRoleFilteringRule
 from utils.column_values.categorical_columns_by_dataset import (

--- a/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/validate_03_impute.py
+++ b/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/validate_03_impute.py
@@ -5,11 +5,9 @@ import pointblank as pb
 import polars as pl
 
 from polars_utils import utils
+from polars_utils.column_types import CategoricalColumnTypes
 from polars_utils.validation import actions as vl
 from polars_utils.validation.constants import GLOBAL_ACTIONS, GLOBAL_THRESHOLDS
-from projects._03_independent_cqc._07_estimate_filled_posts_by_job_role.fargate.utils.utils import (
-    CategoricalColumnTypes,
-)
 from utils.column_names.ind_cqc_pipeline_columns import IndCqcColumns
 from utils.column_values.categorical_column_values import JobRoleFilteringRule
 from utils.column_values.categorical_columns_by_dataset import (

--- a/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/validate_04_estimates.py
+++ b/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/validate_04_estimates.py
@@ -5,11 +5,9 @@ import pointblank as pb
 import polars as pl
 
 from polars_utils import utils
+from polars_utils.column_types import CategoricalColumnTypes
 from polars_utils.validation import actions as vl
 from polars_utils.validation.constants import GLOBAL_ACTIONS, GLOBAL_THRESHOLDS
-from projects._03_independent_cqc._07_estimate_filled_posts_by_job_role.fargate.utils.utils import (
-    CategoricalColumnTypes,
-)
 from utils.column_names.ind_cqc_pipeline_columns import IndCqcColumns, PartitionKeys
 from utils.column_values.categorical_column_values import (
     JobGroupLabels,

--- a/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/tests/fargate/test_validate_01_merge.py
+++ b/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/tests/fargate/test_validate_01_merge.py
@@ -6,9 +6,7 @@ from unittest.mock import Mock, call, patch
 import polars as pl
 
 import projects._03_independent_cqc._07_estimate_filled_posts_by_job_role.fargate.validate_01_merge as job
-from projects._03_independent_cqc._07_estimate_filled_posts_by_job_role.fargate.utils.utils import (
-    CategoricalColumnTypes,
-)
+from polars_utils.column_types import CategoricalColumnTypes
 from utils.column_names.ind_cqc_pipeline_columns import IndCqcColumns
 from utils.column_values.categorical_column_values import (
     EstimateFilledPostsSource,

--- a/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/tests/fargate/test_validate_02_clean.py
+++ b/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/tests/fargate/test_validate_02_clean.py
@@ -6,9 +6,7 @@ from unittest.mock import Mock, call, patch
 import polars as pl
 
 import projects._03_independent_cqc._07_estimate_filled_posts_by_job_role.fargate.validate_02_clean as job
-from projects._03_independent_cqc._07_estimate_filled_posts_by_job_role.fargate.utils.utils import (
-    CategoricalColumnTypes,
-)
+from polars_utils.column_types import CategoricalColumnTypes
 from utils.column_names.ind_cqc_pipeline_columns import IndCqcColumns
 from utils.column_values.categorical_column_values import (
     JobRoleFilteringRule,

--- a/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/tests/fargate/test_validate_03_impute.py
+++ b/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/tests/fargate/test_validate_03_impute.py
@@ -6,9 +6,7 @@ from unittest.mock import Mock, call, patch
 import polars as pl
 
 import projects._03_independent_cqc._07_estimate_filled_posts_by_job_role.fargate.validate_03_impute as job
-from projects._03_independent_cqc._07_estimate_filled_posts_by_job_role.fargate.utils.utils import (
-    CategoricalColumnTypes,
-)
+from polars_utils.column_types import CategoricalColumnTypes
 from utils.column_names.ind_cqc_pipeline_columns import IndCqcColumns
 
 PATCH_PATH = "projects._03_independent_cqc._07_estimate_filled_posts_by_job_role.fargate.validate_03_impute"

--- a/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/tests/fargate/test_validate_04_estimates.py
+++ b/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/tests/fargate/test_validate_04_estimates.py
@@ -8,9 +8,7 @@ import polars.testing as pl_testing
 import pytest
 
 import projects._03_independent_cqc._07_estimate_filled_posts_by_job_role.fargate.validate_04_estimates as job
-from projects._03_independent_cqc._07_estimate_filled_posts_by_job_role.fargate.utils.utils import (
-    CategoricalColumnTypes,
-)
+from polars_utils.column_types import CategoricalColumnTypes
 from utils.column_names.ind_cqc_pipeline_columns import IndCqcColumns, PartitionKeys
 from utils.column_values.categorical_column_values import (
     JobGroupLabels,

--- a/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/tests/fargate/utils/test_utils.py
+++ b/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/tests/fargate/utils/test_utils.py
@@ -3,6 +3,7 @@ import polars.testing as pl_testing
 import pytest
 
 import projects._03_independent_cqc._07_estimate_filled_posts_by_job_role.fargate.utils.utils as job
+from polars_utils.column_types import CategoricalColumnTypes
 from projects._03_independent_cqc.unittest_data.polars_ind_cqc_test_file_data import (
     ImputeJobRoleData as Data,
 )
@@ -59,8 +60,8 @@ class TestAddJobRoleGroupsColumn:
             )
         ]
         expected_schema = {
-            IndCQC.main_job_role_clean_labelled: job.CategoricalColumnTypes.JobRoleEnumType,
-            self.job_group_col: job.CategoricalColumnTypes.JobGroupEnumType,
+            IndCQC.main_job_role_clean_labelled: CategoricalColumnTypes.JobRoleEnumType,
+            self.job_group_col: CategoricalColumnTypes.JobGroupEnumType,
         }
         expected_lf = pl.LazyFrame(
             data=expected_data, schema=expected_schema, orient="row"

--- a/projects/_03_independent_cqc/unittest_data/polars_ind_cqc_test_file_schemas.py
+++ b/projects/_03_independent_cqc/unittest_data/polars_ind_cqc_test_file_schemas.py
@@ -2,11 +2,9 @@ from dataclasses import dataclass
 
 import polars as pl
 
+from polars_utils.column_types import CategoricalColumnTypes as CatColType
 from projects._03_independent_cqc._07_estimate_filled_posts_by_job_role.fargate.utils.clean_utils import (
     FilterJobRoleGroupExpressions as TempCols,
-)
-from projects._03_independent_cqc._07_estimate_filled_posts_by_job_role.fargate.utils.utils import (
-    CategoricalColumnTypes as CatColType,
 )
 from utils.column_names.capacity_tracker_columns import (
     CapacityTrackerCareHomeCleanColumns as CTCHClean,

--- a/tests/test_polars_utils/test_column_types.py
+++ b/tests/test_polars_utils/test_column_types.py
@@ -1,0 +1,107 @@
+from dataclasses import dataclass
+from typing import Any
+
+import polars as pl
+import pytest
+
+from polars_utils.column_types import CategoricalColumnTypes as CatColType
+from utils.column_values.categorical_column_values import (
+    EstimateFilledPostsSource,
+    PrimaryServiceType,
+)
+from utils.column_values.categorical_columns_by_dataset import (
+    EstimatedIndCQCFilledPostsByJobRoleCategoricalValues as CatVals,
+)
+
+
+@dataclass
+class CategoricalColumnTypeTestCase:
+    id: str
+    actual: Any
+    expected: Any
+
+    def as_pytest_param(self):
+        """Return test case as pytest ParameterSet."""
+        return pytest.param(self.actual, self.expected, id=self.id)
+
+
+categorical_column_type_test_cases = [
+    CategoricalColumnTypeTestCase(
+        id="location_cat_type_uses_filled_posts_namespace",
+        actual=CatColType.LocationCatType,
+        expected=pl.Categorical(pl.Categories("location", namespace="filled_posts")),
+    ),
+    CategoricalColumnTypeTestCase(
+        id="establishment_cat_type_uses_filled_posts_namespace",
+        actual=CatColType.EstablishmentCatType,
+        expected=pl.Categorical(
+            pl.Categories("establishment", namespace="filled_posts")
+        ),
+    ),
+    CategoricalColumnTypeTestCase(
+        id="provider_cat_type_uses_filled_posts_namespace",
+        actual=CatColType.ProviderCatType,
+        expected=pl.Categorical(pl.Categories("provider", namespace="filled_posts")),
+    ),
+    CategoricalColumnTypeTestCase(
+        id="brand_cat_type_uses_filled_posts_namespace",
+        actual=CatColType.BrandCatType,
+        expected=pl.Categorical(pl.Categories("brand", namespace="filled_posts")),
+    ),
+    CategoricalColumnTypeTestCase(
+        id="job_role_enum_type_matches_main_job_role_labels_values",
+        actual=CatColType.JobRoleEnumType,
+        expected=pl.Enum(CatVals.main_job_role_labels_column_values.categorical_values),
+    ),
+    CategoricalColumnTypeTestCase(
+        id="job_group_enum_type_matches_main_job_group_labels_values",
+        actual=CatColType.JobGroupEnumType,
+        expected=pl.Enum(
+            CatVals.main_job_group_labels_column_values.categorical_values
+        ),
+    ),
+    CategoricalColumnTypeTestCase(
+        id="estimates_filled_post_source_enum_type_covers_all_sources",
+        actual=CatColType.EstimatesFilledPostSourceEnumType,
+        expected=pl.Enum(
+            [
+                EstimateFilledPostsSource.imputed_pir_filled_posts_model,
+                EstimateFilledPostsSource.ascwds_pir_merged,
+                EstimateFilledPostsSource.imputed_posts_care_home_model,
+                EstimateFilledPostsSource.care_home_model,
+                EstimateFilledPostsSource.imputed_posts_non_res_combined_model,
+                EstimateFilledPostsSource.non_res_combined_model,
+                EstimateFilledPostsSource.posts_rolling_average_model,
+            ]
+        ),
+    ),
+    CategoricalColumnTypeTestCase(
+        id="primary_service_enum_type_covers_all_service_types",
+        actual=CatColType.PrimaryServiceEnumType,
+        expected=pl.Enum(
+            [
+                PrimaryServiceType.care_home_only,
+                PrimaryServiceType.care_home_with_nursing,
+                PrimaryServiceType.non_residential,
+            ]
+        ),
+    ),
+    CategoricalColumnTypeTestCase(
+        id="job_role_filtering_rule_cat_type_uses_uint8_physical_type",
+        actual=CatColType.JobRoleFilteringRuleCatType,
+        expected=pl.Categorical(
+            pl.Categories(
+                "job_role_filtering_rule", namespace="filled_posts", physical=pl.UInt8
+            )
+        ),
+    ),
+]
+
+
+class TestCategoricalColumnTypes:
+    @pytest.mark.parametrize(
+        "actual, expected",
+        [case.as_pytest_param() for case in categorical_column_type_test_cases],
+    )
+    def test_constant_matches_expected_dtype(self, actual, expected):
+        assert actual == expected

--- a/tests/test_polars_utils/test_column_types.py
+++ b/tests/test_polars_utils/test_column_types.py
@@ -1,107 +1,12 @@
-from dataclasses import dataclass
-from typing import Any
-
-import polars as pl
 import pytest
 
-from polars_utils.column_types import CategoricalColumnTypes as CatColType
-from utils.column_values.categorical_column_values import (
-    EstimateFilledPostsSource,
-    PrimaryServiceType,
-)
-from utils.column_values.categorical_columns_by_dataset import (
-    EstimatedIndCQCFilledPostsByJobRoleCategoricalValues as CatVals,
-)
-
-
-@dataclass
-class CategoricalColumnTypeTestCase:
-    id: str
-    actual: Any
-    expected: Any
-
-    def as_pytest_param(self):
-        """Return test case as pytest ParameterSet."""
-        return pytest.param(self.actual, self.expected, id=self.id)
-
-
-categorical_column_type_test_cases = [
-    CategoricalColumnTypeTestCase(
-        id="location_cat_type_uses_filled_posts_namespace",
-        actual=CatColType.LocationCatType,
-        expected=pl.Categorical(pl.Categories("location", namespace="filled_posts")),
-    ),
-    CategoricalColumnTypeTestCase(
-        id="establishment_cat_type_uses_filled_posts_namespace",
-        actual=CatColType.EstablishmentCatType,
-        expected=pl.Categorical(
-            pl.Categories("establishment", namespace="filled_posts")
-        ),
-    ),
-    CategoricalColumnTypeTestCase(
-        id="provider_cat_type_uses_filled_posts_namespace",
-        actual=CatColType.ProviderCatType,
-        expected=pl.Categorical(pl.Categories("provider", namespace="filled_posts")),
-    ),
-    CategoricalColumnTypeTestCase(
-        id="brand_cat_type_uses_filled_posts_namespace",
-        actual=CatColType.BrandCatType,
-        expected=pl.Categorical(pl.Categories("brand", namespace="filled_posts")),
-    ),
-    CategoricalColumnTypeTestCase(
-        id="job_role_enum_type_matches_main_job_role_labels_values",
-        actual=CatColType.JobRoleEnumType,
-        expected=pl.Enum(CatVals.main_job_role_labels_column_values.categorical_values),
-    ),
-    CategoricalColumnTypeTestCase(
-        id="job_group_enum_type_matches_main_job_group_labels_values",
-        actual=CatColType.JobGroupEnumType,
-        expected=pl.Enum(
-            CatVals.main_job_group_labels_column_values.categorical_values
-        ),
-    ),
-    CategoricalColumnTypeTestCase(
-        id="estimates_filled_post_source_enum_type_covers_all_sources",
-        actual=CatColType.EstimatesFilledPostSourceEnumType,
-        expected=pl.Enum(
-            [
-                EstimateFilledPostsSource.imputed_pir_filled_posts_model,
-                EstimateFilledPostsSource.ascwds_pir_merged,
-                EstimateFilledPostsSource.imputed_posts_care_home_model,
-                EstimateFilledPostsSource.care_home_model,
-                EstimateFilledPostsSource.imputed_posts_non_res_combined_model,
-                EstimateFilledPostsSource.non_res_combined_model,
-                EstimateFilledPostsSource.posts_rolling_average_model,
-            ]
-        ),
-    ),
-    CategoricalColumnTypeTestCase(
-        id="primary_service_enum_type_covers_all_service_types",
-        actual=CatColType.PrimaryServiceEnumType,
-        expected=pl.Enum(
-            [
-                PrimaryServiceType.care_home_only,
-                PrimaryServiceType.care_home_with_nursing,
-                PrimaryServiceType.non_residential,
-            ]
-        ),
-    ),
-    CategoricalColumnTypeTestCase(
-        id="job_role_filtering_rule_cat_type_uses_uint8_physical_type",
-        actual=CatColType.JobRoleFilteringRuleCatType,
-        expected=pl.Categorical(
-            pl.Categories(
-                "job_role_filtering_rule", namespace="filled_posts", physical=pl.UInt8
-            )
-        ),
-    ),
-]
+from tests.test_polars_utils_data import ColumnTypesData as Data
 
 
 class TestCategoricalColumnTypes:
     @pytest.mark.parametrize(
-        "actual, expected",
-        [case.as_pytest_param() for case in categorical_column_type_test_cases],
+        "case",
+        [pytest.param(case, id=case.id) for case in Data.categorical_column_type_cases],
     )
-    def test_constant_matches_expected_dtype(self, actual, expected):
-        assert actual == expected
+    def test_constant_matches_expected_dtype(self, case):
+        assert case.actual == case.expected

--- a/tests/test_polars_utils/test_filtering_utils.py
+++ b/tests/test_polars_utils/test_filtering_utils.py
@@ -5,9 +5,7 @@ import polars.testing as pl_testing
 import pytest
 
 from polars_utils import filtering_utils as job
-from projects._03_independent_cqc._07_estimate_filled_posts_by_job_role.fargate.utils.utils import (
-    CategoricalColumnTypes as CatColType,
-)
+from polars_utils.column_types import CategoricalColumnTypes as CatColType
 from tests.test_polars_utils_data import FilteringUtilsData as Data
 from tests.test_polars_utils_schemas import FilteringUtilsSchemas as Schemas
 from utils.column_names.ind_cqc_pipeline_columns import IndCqcColumns as IndCQC

--- a/tests/test_polars_utils_data.py
+++ b/tests/test_polars_utils_data.py
@@ -4,6 +4,9 @@ from datetime import date
 from pathlib import Path
 from typing import Any, Optional
 
+import polars as pl
+
+from polars_utils.column_types import CategoricalColumnTypes as CatColType
 from utils.column_names.cleaned_data_files.cqc_location_cleaned import (
     CqcLocationCleanedColumns as CQCLClean,
 )
@@ -16,7 +19,12 @@ from utils.column_values.categorical_column_values import (
     AscwdsFilteringRule,
     CareHome,
     ContemporaryCSSR,
+    EstimateFilledPostsSource,
     JobRoleFilteringRule,
+    PrimaryServiceType,
+)
+from utils.column_values.categorical_columns_by_dataset import (
+    EstimatedIndCQCFilledPostsByJobRoleCategoricalValues as CatVals,
 )
 
 
@@ -405,3 +413,93 @@ class FilteringUtilsData:
             date(2022, 4, 2),
         ],
     }
+
+
+@dataclass
+class CategoricalColumnTypeCase:
+    id: str
+    actual: Any
+    expected: Any
+
+
+@dataclass
+class ColumnTypesData:
+    categorical_column_type_cases = [
+        CategoricalColumnTypeCase(
+            id="location_cat_type_uses_filled_posts_namespace",
+            actual=CatColType.LocationCatType,
+            expected=pl.Categorical(
+                pl.Categories("location", namespace="filled_posts")
+            ),
+        ),
+        CategoricalColumnTypeCase(
+            id="establishment_cat_type_uses_filled_posts_namespace",
+            actual=CatColType.EstablishmentCatType,
+            expected=pl.Categorical(
+                pl.Categories("establishment", namespace="filled_posts")
+            ),
+        ),
+        CategoricalColumnTypeCase(
+            id="provider_cat_type_uses_filled_posts_namespace",
+            actual=CatColType.ProviderCatType,
+            expected=pl.Categorical(
+                pl.Categories("provider", namespace="filled_posts")
+            ),
+        ),
+        CategoricalColumnTypeCase(
+            id="brand_cat_type_uses_filled_posts_namespace",
+            actual=CatColType.BrandCatType,
+            expected=pl.Categorical(pl.Categories("brand", namespace="filled_posts")),
+        ),
+        CategoricalColumnTypeCase(
+            id="job_role_enum_type_matches_main_job_role_labels_values",
+            actual=CatColType.JobRoleEnumType,
+            expected=pl.Enum(
+                CatVals.main_job_role_labels_column_values.categorical_values
+            ),
+        ),
+        CategoricalColumnTypeCase(
+            id="job_group_enum_type_matches_main_job_group_labels_values",
+            actual=CatColType.JobGroupEnumType,
+            expected=pl.Enum(
+                CatVals.main_job_group_labels_column_values.categorical_values
+            ),
+        ),
+        CategoricalColumnTypeCase(
+            id="estimates_filled_post_source_enum_type_covers_all_sources",
+            actual=CatColType.EstimatesFilledPostSourceEnumType,
+            expected=pl.Enum(
+                [
+                    EstimateFilledPostsSource.imputed_pir_filled_posts_model,
+                    EstimateFilledPostsSource.ascwds_pir_merged,
+                    EstimateFilledPostsSource.imputed_posts_care_home_model,
+                    EstimateFilledPostsSource.care_home_model,
+                    EstimateFilledPostsSource.imputed_posts_non_res_combined_model,
+                    EstimateFilledPostsSource.non_res_combined_model,
+                    EstimateFilledPostsSource.posts_rolling_average_model,
+                ]
+            ),
+        ),
+        CategoricalColumnTypeCase(
+            id="primary_service_enum_type_covers_all_service_types",
+            actual=CatColType.PrimaryServiceEnumType,
+            expected=pl.Enum(
+                [
+                    PrimaryServiceType.care_home_only,
+                    PrimaryServiceType.care_home_with_nursing,
+                    PrimaryServiceType.non_residential,
+                ]
+            ),
+        ),
+        CategoricalColumnTypeCase(
+            id="job_role_filtering_rule_cat_type_uses_uint8_physical_type",
+            actual=CatColType.JobRoleFilteringRuleCatType,
+            expected=pl.Categorical(
+                pl.Categories(
+                    "job_role_filtering_rule",
+                    namespace="filled_posts",
+                    physical=pl.UInt8,
+                )
+            ),
+        ),
+    ]

--- a/tests/test_polars_utils_schemas.py
+++ b/tests/test_polars_utils_schemas.py
@@ -2,9 +2,7 @@ from dataclasses import dataclass
 
 import polars as pl
 
-from projects._03_independent_cqc._07_estimate_filled_posts_by_job_role.fargate.utils.utils import (
-    CategoricalColumnTypes as CatColType,
-)
+from polars_utils.column_types import CategoricalColumnTypes as CatColType
 from utils.column_names.cleaned_data_files.ascwds_workplace_cleaned import (
     AscwdsWorkplaceCleanedColumns as AWPClean,
 )


### PR DESCRIPTION
## Description
Ticket [#1827](https://trello.com/c/pnIlEinb/1827-s-move-all-polars-column-type-definitions-to-polars-utils-script-one-source-of-truth)

Moves the `CategoricalColumnTypes` dataclass (reusable `pl.Categorical`/`pl.Enum` dtype constants for location/establishment/provider/brand IDs and job-role/job-group/estimate-source/primary-service enums) out of `projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/utils/utils.py` into a new `polars_utils/column_types.py`. `polars_utils`' own test suite was already importing this dataclass cross-project from that single downstream project, which was a layering inversion for a repo-wide shared module. All ~15 importers are updated to the new location.

## Testing
- [x] Unit tests passing
- [x] Successful Step Function runs:
https://eu-west-2.console.aws.amazon.com/states/home?region=eu-west-2#/v2/executions/details/arn:aws:states:eu-west-2:856699698263:execution:1827-coltypes-Ind-CQC-SLV:70912ed9-3e8d-4f73-8f8d-d108e0113dbb
https://eu-west-2.console.aws.amazon.com/states/home?region=eu-west-2#/v2/executions/details/arn:aws:states:eu-west-2:856699698263:execution:1827-coltypes-Ind-CQC-Filled-Post-Estimates-By-Role:42e1bfee-12cb-4bca-821a-8b8d9e6db069
- [ ] Outputs checked in Athena

No pipeline behaviour changes here — this is a pure code relocation (same dtype constants, same values), so no Athena check was needed.

- Grepped repo for `CategoricalColumnTypes` to confirm no import still points at the old location

## Checklist
- [x] Unit tests added/amended
- [x] Docstrings added/updated
- [x] Updated CHANGELOG
- [x] Code reviewed by AI
- [x] Moved Trello ticket to PR column

## Reviewer checklist
- [ ] PR solves the Trello ticket requirements
- [ ] Outputs appear reasonable and understandable
- [ ] The overall approach is appropriate and not over-engineered
- [ ] No obvious scalability, performance or interdependency concerns
- [ ] Tests appropriately cover the main behaviour/edge cases
- [ ] Naming and structure are broadly understandable and consistent
- [ ] Docstrings are sufficient for future maintenance
- [ ] Docstrings cover non-obvious behaviour

🤖 Generated with [Claude Code](https://claude.com/claude-code)
