### PR TITLE
1846 - Replace join with over in rate of change trendline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,9 @@ All notable changes to this project will be documented in this file.
 
 - Migrated dependency and tool management to `uv`
 
+### Improved
+- Replaced the fan-out join that broadcast the primary service rate of change trendline back onto every location row with an `.over()`-based broadcast computed in place, reducing peak memory in the imputation pipeline.
+
 ### Fixed
 - Fixed the Transform ASCWDS Data pipeline, which was failing due to an incorrect dataset name in Terraform and the clean workplace job dropping the `import_date` column that the clean worker job depends on. Corrected the Terraform dataset name and removed the drop statement for `import_date`.
 

--- a/projects/_03_independent_cqc/_03_impute/fargate/utils/primary_service_rate_of_change.py
+++ b/projects/_03_independent_cqc/_03_impute/fargate/utils/primary_service_rate_of_change.py
@@ -28,20 +28,23 @@ def model_primary_service_rate_of_change_trendline(
 
     The steps in this function are:
     1. Create a banded bed count column for grouping.
-    2. Prepare the data by selecting relevant columns and calculating
-        submission counts.
-    3. Filter to eligible rows (consistent care home status with at least two
-        submissions).
-    4. Apply interpolation to the current period values where needed.
-    5. Calculate the previous period values using a lag.
-    6. Clean the rate of change values for non-residential locations using
+    2. Null-mask the value column for ineligible rows (inconsistent care home
+        status, or fewer than two submissions) rather than filtering them out,
+        so every row of `lf` stays present throughout and the trendline can be
+        broadcast back onto it with `.over()` instead of a join.
+    3. Apply interpolation to the current period values where needed.
+    4. Calculate the previous period values using a lag.
+    5. Clean the rate of change values for non-residential locations using
         percentile-based thresholds.
-    7. Calculate rolling sums of current and previous values over the specified
+    6. Calculate rolling sums of current and previous values over the specified
         number of days, grouped by service type and bed band.
-    8. Compute the single period rate of change as the ratio of rolling current
+    7. Compute the single period rate of change as the ratio of rolling current
         sum to rolling previous sum.
-    9. Calculate the trendline by taking the cumulative product of the single
-        period rate of change values, grouped by service type and bed band.
+    8. Calculate the trendline by taking the cumulative product of the single
+        period rate of change values, grouped by service type and bed band,
+        broadcasting the result onto every row (eligible or not) that shares a
+        service type, bed band, and import date. Rows with no eligible peer at
+        all for their group and date fall back to 1.0.
 
     Example:
         Given a rate of change sequence:
@@ -73,34 +76,22 @@ def model_primary_service_rate_of_change_trendline(
         IndCqc.number_of_beds_banded_roc,
     ]
 
-    roc_lf = (
-        lf.select(
-            IndCqc.location_id,
-            IndCqc.care_home,
-            IndCqc.care_home_status_count,
-            IndCqc.primary_service_type,
-            IndCqc.number_of_beds_banded_roc,
-            IndCqc.cqc_location_import_date,
-            value_col,
-        )
-        .rename({value_col: TempCol.current_period})
-        .with_columns(
-            pl.len()
-            .over([IndCqc.location_id, IndCqc.care_home])
-            .alias(TempCol.submission_count)
-        )
-    )
-
     # The measurements differ for care home vs non-residential so only locations
-    # with a single care home status are included.
+    # with a single care home status contribute.
     # At least two submissions are required to measure change.
-    roc_lf = roc_lf.filter(
-        (pl.col(IndCqc.care_home_status_count) == 1)
-        & (pl.col(TempCol.submission_count) >= 2)
+    is_eligible = (pl.col(IndCqc.care_home_status_count) == 1) & (
+        pl.len().over([IndCqc.location_id, IndCqc.care_home]) >= 2
     )
 
-    roc_lf = model_interpolation(
-        roc_lf,
+    lf = lf.with_columns(
+        pl.when(is_eligible)
+        .then(pl.col(value_col))
+        .otherwise(None)
+        .alias(TempCol.current_period)
+    )
+
+    lf = model_interpolation(
+        lf,
         TempCol.current_period,
         method="straight",
         new_column_name=TempCol.current_period_interpolated,
@@ -114,7 +105,7 @@ def model_primary_service_rate_of_change_trendline(
         .alias(TempCol.current_period_interpolated)
     )
 
-    roc_lf = roc_lf.with_columns(
+    lf = lf.with_columns(
         pl.col(TempCol.current_period_interpolated)
         .sort_by(IndCqc.cqc_location_import_date)
         .shift(1)
@@ -123,11 +114,11 @@ def model_primary_service_rate_of_change_trendline(
         .alias(TempCol.previous_period_interpolated)
     )
 
-    roc_lf = clean_non_residential_rate_of_change(roc_lf)
+    lf = clean_non_residential_rate_of_change(lf)
 
-    roc_lf = calculate_rolling_sums(roc_lf, days, aggregation_group_cols)
+    lf = calculate_rolling_sums(lf, days, aggregation_group_cols)
 
-    roc_lf = roc_lf.with_columns(
+    lf = lf.with_columns(
         pl.when(pl.col(TempCol.rolling_previous_sum) != 0)
         .then(
             pl.col(TempCol.rolling_current_sum) / pl.col(TempCol.rolling_previous_sum)
@@ -136,17 +127,16 @@ def model_primary_service_rate_of_change_trendline(
         .alias(IndCqc.single_period_rate_of_change)
     ).drop(TempCol.rolling_current_sum, TempCol.rolling_previous_sum)
 
-    roc_lf = calculate_trendline(roc_lf, out_col, aggregation_group_cols)
+    lf = calculate_trendline(lf, out_col, aggregation_group_cols)
 
-    lf = lf.join(
-        roc_lf,
-        [
-            IndCqc.primary_service_type,
-            IndCqc.number_of_beds_banded_roc,
-            IndCqc.cqc_location_import_date,
-        ],
-        "left",
-    ).drop(IndCqc.number_of_beds_banded_roc)
+    lf = lf.drop(
+        IndCqc.number_of_beds_banded_roc,
+        TempCol.current_period,
+        TempCol.current_period_interpolated,
+        TempCol.previous_period_interpolated,
+        TempCol.current_period_cleaned,
+        TempCol.previous_period_cleaned,
+    )
 
     return lf.with_columns(pl.col(out_col).fill_null(1.0))
 
@@ -157,28 +147,22 @@ def calculate_rolling_sums(
     group_cols: list[str],
 ) -> pl.LazyFrame:
     """
-    Calculates the rolling sum of the current and previous period values
-    partitioned by primary service type.
+    Adds the rolling sum of the current and previous period values, broadcast
+    onto every row via `.over()`, partitioned by primary service type.
 
-    The rolling sum is calculated over a specified number of days, and the input
-    rows are sorted by the grouping columns and import date to ensure stable and
-    deterministic results even when input rows arrive out of order.
-
-    The function first filters the input LazyFrame to include only rows where
-    both the current and previous period interpolated values are known
-    (non-null). It then computes the rolling sum of the current and previous
-    period values over the defined period. Finally, it drops duplicate rows
-    based on the partitioning columns and import date to ensure one row per
-    primary service type, number of beds band, and time period, and drops
-    non-aggregated columns that are no longer needed for subsequent
-    calculations.
-
-    Rolling returns one row per contributing source row so `.unique()` is used
-    to deduplicate to one row per group and import date.
+    The rolling sum is calculated over a specified number of days using
+    `rolling_sum_by`, which reasons off the import date column's actual values
+    rather than physical row position, so no upfront sort is needed. Only rows
+    where both the current and previous period cleaned values are known
+    (non-null) contribute their value to the sum — an unpaired first
+    submission, or a null-masked ineligible row, contributes nothing, matching
+    the previous row-filtering behaviour without removing rows. Every row,
+    including rows that don't themselves contribute, still receives the
+    correct broadcast sum for its own group and import date.
 
     Args:
         lf (pl.LazyFrame): The input LazyFrame containing the current and
-            previous period values.
+            previous period cleaned values.
         days (int): The number of days over which to compute the rolling sum.
         group_cols (list[str]): The columns to group by for the rolling sum
             calculation.
@@ -187,28 +171,28 @@ def calculate_rolling_sums(
         pl.LazyFrame: The LazyFrame with the rolling sums of current and
             previous period values added.
     """
-    return (
-        lf.filter(
-            pl.col(TempCol.current_period_cleaned).is_not_null()
-            & pl.col(TempCol.previous_period_cleaned).is_not_null()
-        )
-        .sort(group_cols + [IndCqc.cqc_location_import_date])
-        .rolling(
-            index_column=IndCqc.cqc_location_import_date,
-            period=f"{days}d",
-            group_by=group_cols,
-        )
-        .agg(
-            [
-                pl.sum(TempCol.current_period_cleaned)
-                .cast(pl.Float32)
-                .alias(TempCol.rolling_current_sum),
-                pl.sum(TempCol.previous_period_cleaned)
-                .cast(pl.Float32)
-                .alias(TempCol.rolling_previous_sum),
-            ]
-        )
-    ).unique(group_cols + [IndCqc.cqc_location_import_date])
+    paired = (
+        pl.col(TempCol.current_period_cleaned).is_not_null()
+        & pl.col(TempCol.previous_period_cleaned).is_not_null()
+    )
+    window = f"{days}d"
+
+    return lf.with_columns(
+        pl.when(paired)
+        .then(pl.col(TempCol.current_period_cleaned))
+        .otherwise(None)
+        .rolling_sum_by(by=IndCqc.cqc_location_import_date, window_size=window)
+        .over(group_cols)
+        .cast(pl.Float32)
+        .alias(TempCol.rolling_current_sum),
+        pl.when(paired)
+        .then(pl.col(TempCol.previous_period_cleaned))
+        .otherwise(None)
+        .rolling_sum_by(by=IndCqc.cqc_location_import_date, window_size=window)
+        .over(group_cols)
+        .cast(pl.Float32)
+        .alias(TempCol.rolling_previous_sum),
+    )
 
 
 def clean_non_residential_rate_of_change(
@@ -329,9 +313,17 @@ def calculate_trendline(
     calculated by taking the exponential of the sum of the logarithms of the
     values.
 
-    The input rows are sorted by the grouping columns and import date before the
-    cumulative sum is computed. This ensures stable and deterministic trendline
-    values even when input rows arrive out of order.
+    Multiple rows can share the same group_cols and import date (e.g. many
+    locations under one primary service/bed band triple), each already carrying
+    an identical single_period_rate_of_change broadcast by calculate_rolling_sums.
+    Only the first row of each such tie (by row order, since `.over()` uses
+    `order_by` rather than a physical sort) is allowed to contribute that date's
+    value to the cumulative sum, the rest contribute 0.0 — this avoids
+    double-counting a date once per tied row, while every row in the tie still
+    ends up with the same cumulative total once the whole date has been counted.
+    A null rate (no eligible data at all for that group and date) nulls out the
+    contribution for every row sharing the tie, not just the first, so the whole
+    group of rows falls through to the caller's `fill_null(1.0)`.
 
     Args:
         lf (pl.LazyFrame): The input LazyFrame.
@@ -342,11 +334,20 @@ def calculate_trendline(
         pl.LazyFrame: The LazyFrame with the trendline column added.
     """
     rate_col = IndCqc.single_period_rate_of_change
+    date_col = IndCqc.cqc_location_import_date
 
-    rolling_product = pl.col(rate_col).log().cum_sum().over(group_cols).exp()
-
-    return (
-        lf.sort(group_cols + [IndCqc.cqc_location_import_date])
-        .with_columns(rolling_product.alias(out_col))
-        .drop(rate_col)
+    is_first_of_date_group = (
+        pl.cum_count(date_col).over(group_cols + [date_col], order_by=date_col) == 1
     )
+
+    contribution = (
+        pl.when(pl.col(rate_col).is_null())
+        .then(None)
+        .when(is_first_of_date_group)
+        .then(pl.col(rate_col).log())
+        .otherwise(0.0)
+    )
+
+    rolling_product = contribution.cum_sum().over(group_cols, order_by=date_col).exp()
+
+    return lf.with_columns(rolling_product.alias(out_col)).drop(rate_col)

--- a/projects/_03_independent_cqc/_03_impute/tests/fargate/utils/test_primary_service_rate_of_change.py
+++ b/projects/_03_independent_cqc/_03_impute/tests/fargate/utils/test_primary_service_rate_of_change.py
@@ -49,11 +49,11 @@ class TestModelPrimaryServiceRateOfChangeTrendline:
 
 class TestCalculateRollingSums:
     @pytest.mark.parametrize(
-        "input_data, expected_data",
+        "input_data, expected_data, group_cols",
         [case.as_pytest_param() for case in Data.calculate_rolling_sums_test_cases],
     )
     def test_calculate_rolling_sums_returns_expected_output(
-        self, input_data, expected_data
+        self, input_data, expected_data, group_cols
     ):
         expected_lf = pl.LazyFrame(
             expected_data,
@@ -68,7 +68,8 @@ class TestCalculateRollingSums:
         returned_lf = job.calculate_rolling_sums(
             input_lf,
             days=3,
-            group_cols=[
+            group_cols=group_cols
+            or [
                 IndCQC.location_id,
                 IndCQC.primary_service_type,
                 IndCQC.number_of_beds_banded_roc,
@@ -108,11 +109,11 @@ class TestCleanNonResidentialRateOfChange:
 
 class TestCalculateTrendline:
     @pytest.mark.parametrize(
-        "input_data, expected_data",
+        "input_data, expected_data, group_cols",
         [case.as_pytest_param() for case in Data.calculate_trendline_test_cases],
     )
     def test_calculate_trendline_returns_expected_output(
-        self, input_data, expected_data
+        self, input_data, expected_data, group_cols
     ):
         expected_lf = pl.LazyFrame(
             expected_data,
@@ -127,7 +128,8 @@ class TestCalculateTrendline:
         returned_lf = job.calculate_trendline(
             input_lf,
             out_col=IndCQC.ascwds_rate_of_change_trendline_model,
-            group_cols=[
+            group_cols=group_cols
+            or [
                 IndCQC.primary_service_type,
                 IndCQC.number_of_beds_banded_roc,
             ],

--- a/projects/_03_independent_cqc/unittest_data/polars_ind_cqc_test_file_data.py
+++ b/projects/_03_independent_cqc/unittest_data/polars_ind_cqc_test_file_data.py
@@ -2803,9 +2803,12 @@ class ModelRateOfChangeInputOutputTestCase:
     id: str
     input_data: list[Any]
     expected_data: list[Any]
+    group_cols: Optional[list[str]] = None
 
     def as_pytest_param(self):
-        return pytest.param(self.input_data, self.expected_data, id=self.id)
+        return pytest.param(
+            self.input_data, self.expected_data, self.group_cols, id=self.id
+        )
 
 
 @dataclass
@@ -2893,9 +2896,9 @@ class ModelRateOfChangeData:
                 ("1-001", "CHO", 10, date(2026, 1, 3), 3.3, 2.7),
             ],
             expected_data=[
-                ("1-001", "CHO", 10, date(2026, 1, 1), 3.0, 2.0),
-                ("1-001", "CHO", 10, date(2026, 1, 2), 5.7, 5.0),
-                ("1-001", "CHO", 10, date(2026, 1, 3), 9.0, 7.7),
+                ("1-001", "CHO", 10, date(2026, 1, 1), 3.0, 2.0, 3.0, 2.0),
+                ("1-001", "CHO", 10, date(2026, 1, 2), 2.7, 3.0, 5.7, 5.0),
+                ("1-001", "CHO", 10, date(2026, 1, 3), 3.3, 2.7, 9.0, 7.7),
             ],
         ),
         ModelRateOfChangeInputOutputTestCase(
@@ -2907,10 +2910,10 @@ class ModelRateOfChangeData:
                 ("1-002", "NR",  20, date(2026, 1, 2), 1.2, 1.0),
             ],
             expected_data=[
-                ("1-001", "CHO", 10, date(2026, 1, 1), 3.0, 2.0),
-                ("1-001", "CHO", 10, date(2026, 1, 2), 5.7, 5.0),
-                ("1-002", "NR",  20, date(2026, 1, 1), 1.0, 1.5),
-                ("1-002", "NR",  20, date(2026, 1, 2), 2.2, 2.5),
+                ("1-001", "CHO", 10, date(2026, 1, 1), 3.0, 2.0, 3.0, 2.0),
+                ("1-001", "CHO", 10, date(2026, 1, 2), 2.7, 3.0, 5.7, 5.0),
+                ("1-002", "NR",  20, date(2026, 1, 1), 1.0, 1.5, 1.0, 1.5),
+                ("1-002", "NR",  20, date(2026, 1, 2), 1.2, 1.0, 2.2, 2.5),
             ],
         ),
         ModelRateOfChangeInputOutputTestCase(
@@ -2923,11 +2926,26 @@ class ModelRateOfChangeData:
                 ("1-001", "CHO", 10, date(2026, 1, 5), 2.6, 6.0),
             ],
             expected_data=[
-                ("1-001", "CHO", 10, date(2026, 1, 1), 3.0,  2.0),
-                ("1-001", "CHO", 10, date(2026, 1, 2), 5.9,  5.0), # sum of 1st - 2nd Jan (tests based on a 3 day window)
-                ("1-001", "CHO", 10, date(2026, 1, 3), 8.7,  9.0), # sum of 1st - 3rd Jan
-                ("1-001", "CHO", 10, date(2026, 1, 4), 8.4, 12.0), # sum of 2nd - 4th Jan
-                ("1-001", "CHO", 10, date(2026, 1, 5), 8.1, 15.0), # sum of 3rd - 5th Jan
+                ("1-001", "CHO", 10, date(2026, 1, 1), 3.0, 2.0, 3.0,  2.0),
+                ("1-001", "CHO", 10, date(2026, 1, 2), 2.9, 3.0, 5.9,  5.0), # sum of 1st - 2nd Jan (tests based on a 3 day window)
+                ("1-001", "CHO", 10, date(2026, 1, 3), 2.8, 4.0, 8.7,  9.0), # sum of 1st - 3rd Jan
+                ("1-001", "CHO", 10, date(2026, 1, 4), 2.7, 5.0, 8.4, 12.0), # sum of 2nd - 4th Jan
+                ("1-001", "CHO", 10, date(2026, 1, 5), 2.6, 6.0, 8.1, 15.0), # sum of 3rd - 5th Jan
+            ],
+        ),
+        ModelRateOfChangeInputOutputTestCase(
+            id="fan_out_across_locations_shares_rolling_sum",
+            group_cols=[IndCQC.primary_service_type, IndCQC.number_of_beds_banded_roc],
+            input_data=[
+                ("1-001", "CHO", 10, date(2026, 1, 1), 3.0, 2.0),
+                ("1-002", "CHO", 10, date(2026, 1, 1), 1.0, 1.0),
+                ("1-001", "CHO", 10, date(2026, 1, 2), 2.0, 1.0),
+            ],
+            expected_data=[
+                # both 1-001 and 1-002 share (CHO, 10, 1st Jan) so both broadcast the same combined sum
+                ("1-001", "CHO", 10, date(2026, 1, 1), 3.0, 2.0, 4.0, 3.0),
+                ("1-002", "CHO", 10, date(2026, 1, 1), 1.0, 1.0, 4.0, 3.0),
+                ("1-001", "CHO", 10, date(2026, 1, 2), 2.0, 1.0, 6.0, 4.0),
             ],
         ),
     ] # fmt: skip
@@ -2991,6 +3009,36 @@ class ModelRateOfChangeData:
                 ("CHO", 2, date(2026, 1, 2), 1.1),
                 ("NR", 1, date(2026, 1, 1), 1.0),
                 ("NR", 1, date(2026, 1, 2), 0.8),
+            ],
+        ),
+        ModelRateOfChangeInputOutputTestCase(
+            id="duplicate_group_and_date_rows_share_trendline",
+            input_data=[
+                ("CHO", 1, date(2026, 1, 1), 1.0),
+                ("CHO", 1, date(2026, 1, 2), 1.2),
+                ("CHO", 1, date(2026, 1, 2), 1.2),  # fan-out: two locations, one triple
+                ("CHO", 1, date(2026, 1, 3), 1.0),
+            ],
+            expected_data=[
+                ("CHO", 1, date(2026, 1, 1), 1.0),
+                ("CHO", 1, date(2026, 1, 2), 1.2),
+                ("CHO", 1, date(2026, 1, 2), 1.2),
+                ("CHO", 1, date(2026, 1, 3), 1.2),
+            ],
+        ),
+        ModelRateOfChangeInputOutputTestCase(
+            id="null_rate_nulls_every_row_sharing_the_tie",
+            input_data=[
+                ("CHO", 1, date(2026, 1, 1), 1.0),
+                ("CHO", 1, date(2026, 1, 2), None),
+                ("CHO", 1, date(2026, 1, 2), None),  # no eligible peer for this triple
+                ("CHO", 1, date(2026, 1, 3), 1.1),
+            ],
+            expected_data=[
+                ("CHO", 1, date(2026, 1, 1), 1.0),
+                ("CHO", 1, date(2026, 1, 2), None),
+                ("CHO", 1, date(2026, 1, 2), None),
+                ("CHO", 1, date(2026, 1, 3), 1.1),
             ],
         ),
     ]

--- a/projects/_03_independent_cqc/unittest_data/polars_ind_cqc_test_file_schemas.py
+++ b/projects/_03_independent_cqc/unittest_data/polars_ind_cqc_test_file_schemas.py
@@ -1689,6 +1689,8 @@ class ModelRateOfChangeSchemas:
         IndCQC.primary_service_type: pl.String,
         IndCQC.number_of_beds_banded_roc: pl.Int32,
         IndCQC.cqc_location_import_date: pl.Date,
+        ROC_TempCol.current_period_cleaned: pl.Float32,
+        ROC_TempCol.previous_period_cleaned: pl.Float32,
         ROC_TempCol.rolling_current_sum: pl.Float32,
         ROC_TempCol.rolling_previous_sum: pl.Float32,
     }


### PR DESCRIPTION
## Description
Trello ticket [#1846](https://trello.com/c/eJ9NtGH9/1846-refactor-modelprimaryservicerateofchangetrendline-to-help-with-oom)

Replaced the fan-out join that broadcast the primary service rate of change trendline back onto every location row with an `.over()`-based broadcast computed in place, reducing peak memory in the imputation pipeline.

Time to run impute job:
Current (main) job ran in 3m 28s
This branch ran in 2m 37s on the same set of data

## Testing
- [X] Unit tests passing
- [X] Successful [Step Function run](https://eu-west-2.console.aws.amazon.com/states/home?region=eu-west-2#/v2/executions/details/arn:aws:states:eu-west-2:856699698263:execution:1846-roc-over-Ind-CQC-Filled-Post-Estimates:af70e2cc-e8b3-4cca-81b4-f7360038cd5d)
- [] Outputs checked in Athena (TO DO)

## Checklist (delete if not relevant)
- [X] Unit tests added/amended
- [X] Docstrings added/updated
- [X] Updated CHANGELOG
- [X] Code reviewed by AI
- [X] Moved Trello ticket to PR column

## Reviewer checklist
- [ ] PR solves the Trello ticket requirements
- [ ] Outputs appear reasonable and understandable
- [ ] The overall approach is appropriate and not over-engineered
- [ ] No obvious scalability, performance or interdependency concerns
- [ ] Tests appropriately cover the main behaviour/edge cases
- [ ] Naming and structure are broadly understandable and consistent
- [ ] Docstrings are sufficient for future maintenance
- [ ] Docstrings cover non-obvious behaviour
