### PR TITLE
1829 - Add PublishedJobRoleLabels categorical values class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ All notable changes to this project will be documented in this file.
 
 - Added merge_job_role_columns function to polars_utils > cleaning_utils and called it in clean_ascwds_workplace job.
 
+- Added `PublishedJobRoleID` categorical values class defining the canonical set of published ASC-WDS job role codes.
+
 ### Changed
 - Pull clean workplace columns into merge job within SLV pipeline.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ All notable changes to this project will be documented in this file.
 
 - Added merge_job_role_columns function to polars_utils > cleaning_utils and called it in clean_ascwds_workplace job.
 
-- Added `PublishedJobRoleID` categorical values class defining the canonical set of published ASC-WDS job role codes.
+- Added `PublishedJobRoleLabels` categorical values class defining the canonical set of published ASC-WDS job role labels.
 
 ### Changed
 - Pull clean workplace columns into merge job within SLV pipeline.

--- a/tests/unit/test_categorical_column_values.py
+++ b/tests/unit/test_categorical_column_values.py
@@ -1,6 +1,6 @@
 import unittest
 
-from utils.column_values.categorical_column_values import Dormancy
+from utils.column_values.categorical_column_values import Dormancy, PublishedJobRoleID
 
 
 class ListValuesTests(unittest.TestCase):
@@ -76,6 +76,29 @@ class CountValuesTests(unittest.TestCase):
             test_object.count_of_categorical_values,
             self.expected_filtered_count_with_null_values,
         )
+
+
+class TestPublishedJobRoleID:
+    def test_pins_the_published_job_role_id_values(self):
+        test_object = PublishedJobRoleID("test_column")
+        expected_values = [
+            "1",
+            "4",
+            "6",
+            "7",
+            "8",
+            "9",
+            "15",
+            "16",
+            "17",
+            "43",
+            "52",
+            "1001",
+            "1002",
+            "1003",
+            "1004",
+        ]
+        assert test_object.categorical_values == expected_values
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_categorical_column_values.py
+++ b/tests/unit/test_categorical_column_values.py
@@ -1,6 +1,9 @@
 import unittest
 
-from utils.column_values.categorical_column_values import Dormancy, PublishedJobRoleID
+from utils.column_values.categorical_column_values import (
+    Dormancy,
+    PublishedJobRoleLabels,
+)
 
 
 class ListValuesTests(unittest.TestCase):
@@ -78,25 +81,25 @@ class CountValuesTests(unittest.TestCase):
         )
 
 
-class TestPublishedJobRoleID:
-    def test_pins_the_published_job_role_id_values(self):
-        test_object = PublishedJobRoleID("test_column")
+class TestPublishedJobRoleLabels:
+    def test_pins_the_published_job_role_label_values(self):
+        test_object = PublishedJobRoleLabels("test_column")
         expected_values = [
-            "1",
-            "4",
-            "6",
-            "7",
-            "8",
-            "9",
-            "15",
-            "16",
-            "17",
-            "43",
-            "52",
-            "1001",
-            "1002",
-            "1003",
-            "1004",
+            "senior_management",
+            "registered_manager",
+            "social_worker",
+            "senior_care_worker",
+            "care_worker",
+            "community_support_and_outreach",
+            "occupational_therapist",
+            "registered_nurse",
+            "allied_health_professional",
+            "deputy_manager",
+            "support_worker",
+            "other_managers",
+            "other_regulated_professions",
+            "other_direct_care",
+            "other",
         ]
         assert test_object.categorical_values == expected_values
 

--- a/utils/column_values/categorical_column_values.py
+++ b/utils/column_values/categorical_column_values.py
@@ -279,24 +279,26 @@ class MainJobRoleID(ColumnValues):
 
 
 @dataclass
-class PublishedJobRoleID(ColumnValues):
-    """The possible values of the published job role code column in the SLV job-role merge/reshape"""
+class PublishedJobRoleLabels(ColumnValues):
+    """The possible values of the published job role label column in the SLV job-role merge/reshape"""
 
-    senior_management: str = "1"
-    registered_manager: str = "4"
-    social_worker: str = "6"
-    senior_care_worker: str = "7"
-    care_worker: str = "8"
-    community_support_and_outreach: str = "9"
-    occupational_therapist: str = "15"
-    registered_nurse: str = "16"
-    allied_health_professional: str = "17"
-    deputy_manager: str = "43"
-    support_worker: str = "52"
-    other_managers: str = "1001"
-    other_regulated_professions: str = "1002"
-    other_direct_care: str = "1003"
-    other: str = "1004"
+    senior_management: str = MainJobRoleLabels.senior_management
+    registered_manager: str = MainJobRoleLabels.registered_manager
+    social_worker: str = MainJobRoleLabels.social_worker
+    senior_care_worker: str = MainJobRoleLabels.senior_care_worker
+    care_worker: str = MainJobRoleLabels.care_worker
+    community_support_and_outreach: str = (
+        MainJobRoleLabels.community_support_and_outreach
+    )
+    occupational_therapist: str = MainJobRoleLabels.occupational_therapist
+    registered_nurse: str = MainJobRoleLabels.registered_nurse
+    allied_health_professional: str = MainJobRoleLabels.allied_health_professional
+    deputy_manager: str = MainJobRoleLabels.deputy_manager
+    support_worker: str = MainJobRoleLabels.support_worker
+    other_managers: str = "other_managers"
+    other_regulated_professions: str = "other_regulated_professions"
+    other_direct_care: str = "other_direct_care"
+    other: str = "other"
 
 
 @dataclass

--- a/utils/column_values/categorical_column_values.py
+++ b/utils/column_values/categorical_column_values.py
@@ -279,6 +279,27 @@ class MainJobRoleID(ColumnValues):
 
 
 @dataclass
+class PublishedJobRoleID(ColumnValues):
+    """The possible values of the published job role code column in the SLV job-role merge/reshape"""
+
+    senior_management: str = "1"
+    registered_manager: str = "4"
+    social_worker: str = "6"
+    senior_care_worker: str = "7"
+    care_worker: str = "8"
+    community_support_and_outreach: str = "9"
+    occupational_therapist: str = "15"
+    registered_nurse: str = "16"
+    allied_health_professional: str = "17"
+    deputy_manager: str = "43"
+    support_worker: str = "52"
+    other_managers: str = "1001"
+    other_regulated_professions: str = "1002"
+    other_direct_care: str = "1003"
+    other: str = "1004"
+
+
+@dataclass
 class Region(ColumnValues):
     """The possible values of the region columns in ONS data"""
 


### PR DESCRIPTION
## Description
Trello ticket [#1829](https://trello.com/c/6gtFieB4/1829-spivot-add-published-job-roles-class-to-categorical-labels)

Adds a new `PublishedJobRoleLabels` categorical values class to `utils/column_values/categorical_column_values.py`, defining the canonical set of 15 "published" ASC-WDS job-role labels. 11 of the 15 reuse existing `MainJobRoleLabels` constants directly; the remaining 4 are new synthetic merge-summary labels (`other_managers`, `other_regulated_professions`, `other_direct_care`, `other`) with no prior definition elsewhere in the repo.

This is standalone groundwork for the SLV job-role reshape (ticket 1814) — its PR (#1440) was closed for rework, so this class is not yet wired into any pipeline; there's no live `job_role_code`/label column to attach it to yet.

## Testing
- [x] Unit tests passing
- [ ] Successful [Step Function run](add link) — N/A, no pipeline wiring in this PR
- [ ] Outputs checked in Athena — N/A, no pipeline wiring in this PR

New pinning test (`TestPublishedJobRoleLabels`) added to `tests/unit/test_categorical_column_values.py`, asserting the exact expected label list.

## Checklist (delete if not relevant)
- [x] Unit tests added/amended
- [x] Docstrings added/updated
- [x] Updated CHANGELOG
- [x] Code reviewed by AI
- [x] Moved Trello ticket to PR column

## Reviewer checklist
- [ ] PR solves the Trello ticket requirements
- [ ] Outputs appear reasonable and understandable
- [ ] The overall approach is appropriate and not over-engineered
- [ ] No obvious scalability, performance or interdependency concerns
- [ ] Tests appropriately cover the main behaviour/edge cases
- [ ] Naming and structure are broadly understandable and consistent
- [ ] Docstrings are sufficient for future maintenance
- [ ] Docstrings cover non-obvious behaviour