### PR TITLE
1847 - Remove mid-chain collects from imputation ratio/threshold logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,9 @@ All notable changes to this project will be documented in this file.
 
 - Migrated dependency and tool management to `uv`
 
+### Improved
+- Removed mid-pipeline LazyFrame collects from the PIR-to-filled-posts ratio and non-residential rate-of-change cleaning steps in the imputation pipeline, computing them as lazy expressions instead so the query stays fused end-to-end.
+
 ### Fixed
 - Fixed the Transform ASCWDS Data pipeline, which was failing due to an incorrect dataset name in Terraform and the clean workplace job dropping the `import_date` column that the clean worker job depends on. Corrected the Terraform dataset name and removed the drop statement for `import_date`.
 

--- a/projects/_03_independent_cqc/_03_impute/fargate/utils/convert_pir_people_to_filled_posts.py
+++ b/projects/_03_independent_cqc/_03_impute/fargate/utils/convert_pir_people_to_filled_posts.py
@@ -11,8 +11,8 @@ def convert_pir_to_filled_posts(lf: pl.LazyFrame) -> pl.LazyFrame:
     """
     Converts PIR people to filled posts using a global ratio.
 
-    The ratio is calculated using a filtered subset of valid rows and then
-    applied only to non-care home locations where PIR people is present.
+    The ratio is calculated using only valid rows and then applied only to
+    non-care home locations where PIR people is present.
 
     Args:
         lf (pl.LazyFrame): input dataframe with PIR people and ASC-WDS
@@ -21,8 +21,7 @@ def convert_pir_to_filled_posts(lf: pl.LazyFrame) -> pl.LazyFrame:
     Returns:
         pl.LazyFrame: input dataframe with estimated PIR filled posts.
     """
-    ratio = compute_global_ratio(lf)
-    print(f"PIR people to filled posts ratio: {ratio:.4f}")
+    ratio = compute_global_ratio()
 
     return lf.with_columns(
         pl.when(is_not_care_home() & people_col.is_not_null() & (people_col > 0))
@@ -31,10 +30,10 @@ def convert_pir_to_filled_posts(lf: pl.LazyFrame) -> pl.LazyFrame:
     )
 
 
-def compute_global_ratio(lf: pl.LazyFrame) -> float:
+def compute_global_ratio() -> pl.Expr:
     """
-    Computes the global ratio of filled posts to PIR people using only valid
-    rows.
+    Builds a lazy expression for the global ratio of filled posts to PIR
+    people using only valid rows.
 
     Valid rows are defined as locations which:
         - are non-care home
@@ -45,19 +44,27 @@ def compute_global_ratio(lf: pl.LazyFrame) -> float:
           than or equal to the number of people. We filter out rows where this
           ratio is less than 0.75 to exclude potentially poor quality data
           whilst allowing for some variance in the relationship.
+
+    Invalid rows are masked to null rather than filtered out, so the
+    resulting expression can be evaluated as part of the same lazy chain as
+    the frame it will be applied to, rather than requiring an early collect.
+
+    Returns:
+        pl.Expr: A scalar expression for the global ratio, which broadcasts
+            across all rows when used in a `with_columns`/`when` context.
     """
     quality_filter_expr = posts_col.truediv(people_col) >= 0.75
 
-    return (
-        lf.filter(
-            is_not_care_home()
-            & people_col.is_not_null()
-            & (people_col > 0)
-            & posts_col.is_not_null()
-            & (posts_col > 0)
-            & quality_filter_expr
-        )
-        .select((posts_col.sum().truediv(people_col.sum())))
-        .collect()
-        .item()
+    valid_row_expr = (
+        is_not_care_home()
+        & people_col.is_not_null()
+        & (people_col > 0)
+        & posts_col.is_not_null()
+        & (posts_col > 0)
+        & quality_filter_expr
     )
+
+    valid_posts_sum = pl.when(valid_row_expr).then(posts_col).otherwise(None).sum()
+    valid_people_sum = pl.when(valid_row_expr).then(people_col).otherwise(None).sum()
+
+    return valid_posts_sum.truediv(valid_people_sum)

--- a/projects/_03_independent_cqc/_03_impute/fargate/utils/primary_service_rate_of_change.py
+++ b/projects/_03_independent_cqc/_03_impute/fargate/utils/primary_service_rate_of_change.py
@@ -227,6 +227,13 @@ def clean_non_residential_rate_of_change(
     rows. A lower threshold for percentage change is also calculated as the
     reciprocal of the upper percentage change threshold.
 
+    Rows outside the qualifying population (see below) are masked to null
+    rather than filtered out before the percentile thresholds are computed,
+    so the thresholds are evaluated as part of the same lazy chain as the
+    rest of the frame rather than requiring an early collect. If no rows
+    qualify, both thresholds are null and non-residential rows are only kept
+    via the small-location passthrough below.
+
     Small locations are removed from the threshold calculations as minor changes
     in these locations can result in large percentage changes which would widen
     the thresholds and reduce the effectiveness of the cleaning. However, small
@@ -261,26 +268,35 @@ def clean_non_residential_rate_of_change(
         ]
     )
 
-    abs_change_upper_threshold, perc_change_upper_threshold = (
-        lf.filter(
-            is_non_res
-            & pl.col(prev).is_not_null()
-            & pl.col(curr).is_not_null()
-            & (
-                (pl.col(prev) > SMALL_NON_RES_THRESHOLD)
-                | (pl.col(curr) > SMALL_NON_RES_THRESHOLD)
-            )
-            & (pl.col(prev) != pl.col(curr))
+    qualifying_row_expr = (
+        is_non_res
+        & pl.col(prev).is_not_null()
+        & pl.col(curr).is_not_null()
+        & (
+            (pl.col(prev) > SMALL_NON_RES_THRESHOLD)
+            | (pl.col(curr) > SMALL_NON_RES_THRESHOLD)
         )
-        .select(
-            [
-                pl.col(TempCol.abs_change).quantile(abs_percentile),
-                pl.col(TempCol.perc_change).quantile(perc_percentile),
-            ]
-        )
-        .collect()
-        .row(0)
+        & (pl.col(prev) != pl.col(curr))
     )
+
+    lf = lf.with_columns(
+        [
+            pl.when(qualifying_row_expr)
+            .then(pl.col(TempCol.abs_change))
+            .otherwise(None)
+            .quantile(abs_percentile)
+            .alias(TempCol.abs_pct),
+            pl.when(qualifying_row_expr)
+            .then(pl.col(TempCol.perc_change))
+            .otherwise(None)
+            .quantile(perc_percentile)
+            .alias(TempCol.perc_pct),
+        ]
+    )
+
+    abs_change_upper_threshold = pl.col(TempCol.abs_pct)
+    perc_change_upper_threshold = pl.col(TempCol.perc_pct)
+    perc_change_lower_threshold = 1 / perc_change_upper_threshold
 
     is_small_non_res = (
         is_non_res
@@ -288,16 +304,14 @@ def clean_non_residential_rate_of_change(
         & (pl.col(curr) <= SMALL_NON_RES_THRESHOLD)
     )
 
-    if abs_change_upper_threshold is None or perc_change_upper_threshold is None:
-        is_valid_non_res = pl.lit(False)
-    else:
-        perc_change_lower_threshold = 1 / perc_change_upper_threshold
-        is_valid_non_res = (
-            is_non_res
-            & (pl.col(TempCol.abs_change) <= abs_change_upper_threshold)
-            & (pl.col(TempCol.perc_change) <= perc_change_upper_threshold)
-            & (pl.col(TempCol.perc_change) >= perc_change_lower_threshold)
-        )
+    is_valid_non_res = (
+        is_non_res
+        & abs_change_upper_threshold.is_not_null()
+        & perc_change_upper_threshold.is_not_null()
+        & (pl.col(TempCol.abs_change) <= abs_change_upper_threshold)
+        & (pl.col(TempCol.perc_change) <= perc_change_upper_threshold)
+        & (pl.col(TempCol.perc_change) >= perc_change_lower_threshold)
+    )
 
     keep = is_care_home | is_small_non_res | is_valid_non_res
 
@@ -314,7 +328,7 @@ def clean_non_residential_rate_of_change(
             .cast(pl.Float32)
             .alias(TempCol.current_period_cleaned),
         ]
-    ).drop(TempCol.abs_change, TempCol.perc_change)
+    ).drop(TempCol.abs_change, TempCol.perc_change, TempCol.abs_pct, TempCol.perc_pct)
 
 
 def calculate_trendline(

--- a/projects/_03_independent_cqc/_03_impute/tests/fargate/utils/test_convert_pir_people_to_filled_posts.py
+++ b/projects/_03_independent_cqc/_03_impute/tests/fargate/utils/test_convert_pir_people_to_filled_posts.py
@@ -130,5 +130,5 @@ class TestComputeGlobalRatio:
             orient="row",
         )
 
-        ratio = job.compute_global_ratio(lf)
+        ratio = lf.select(job.compute_global_ratio()).collect().item()
         assert ratio == pytest.approx(case.expected_ratio)

--- a/projects/_03_independent_cqc/_03_impute/tests/fargate/utils/test_primary_service_rate_of_change.py
+++ b/projects/_03_independent_cqc/_03_impute/tests/fargate/utils/test_primary_service_rate_of_change.py
@@ -1,4 +1,5 @@
 import math
+from datetime import date
 
 import polars as pl
 import polars.testing as pl_testing
@@ -12,6 +13,7 @@ from projects._03_independent_cqc.unittest_data.polars_ind_cqc_test_file_schemas
     ModelRateOfChangeSchemas as Schemas,
 )
 from utils.column_names.ind_cqc_pipeline_columns import IndCqcColumns as IndCQC
+from utils.column_values.categorical_column_values import CareHome
 
 
 class TestModelPrimaryServiceRateOfChangeTrendline:
@@ -99,6 +101,33 @@ class TestCleanNonResidentialRateOfChange:
             job.TempCol.previous_period_cleaned, job.TempCol.current_period_cleaned
         )
         returned_lf = job.clean_non_residential_rate_of_change(input_lf)
+        pl_testing.assert_frame_equal(
+            returned_lf,
+            expected_lf,
+            check_row_order=False,
+        )
+
+    def test_large_non_residential_change_above_percentile_is_rejected(self):
+        expected_data = [
+            ("2-001", CareHome.not_care_home, date(2026, 1, 1), 20.0, 21.0, 20.0, 21.0),
+            ("2-002", CareHome.not_care_home, date(2026, 1, 2), 20.0, 21.0, 20.0, 21.0),
+            ("2-003", CareHome.not_care_home, date(2026, 1, 3), 20.0, 21.0, 20.0, 21.0),
+            ("2-004", CareHome.not_care_home, date(2026, 1, 4), 20.0, 21.0, 20.0, 21.0),
+            ("2-005", CareHome.not_care_home, date(2026, 1, 5), 20.0, 100.0, None, None),
+        ]  # fmt: skip
+        expected_lf = pl.LazyFrame(
+            expected_data,
+            Schemas.expected_clean_non_residential_rate_of_change_schema,
+            orient="row",
+        )
+        input_lf = expected_lf.drop(
+            job.TempCol.previous_period_cleaned, job.TempCol.current_period_cleaned
+        )
+
+        returned_lf = job.clean_non_residential_rate_of_change(
+            input_lf, abs_percentile=0.5, perc_percentile=0.5
+        )
+
         pl_testing.assert_frame_equal(
             returned_lf,
             expected_lf,

--- a/projects/_03_independent_cqc/_03_impute/tests/fargate/utils/test_primary_service_rate_of_change.py
+++ b/projects/_03_independent_cqc/_03_impute/tests/fargate/utils/test_primary_service_rate_of_change.py
@@ -1,5 +1,4 @@
 import math
-from datetime import date
 
 import polars as pl
 import polars.testing as pl_testing
@@ -13,7 +12,6 @@ from projects._03_independent_cqc.unittest_data.polars_ind_cqc_test_file_schemas
     ModelRateOfChangeSchemas as Schemas,
 )
 from utils.column_names.ind_cqc_pipeline_columns import IndCqcColumns as IndCQC
-from utils.column_values.categorical_column_values import CareHome
 
 
 class TestModelPrimaryServiceRateOfChangeTrendline:
@@ -83,51 +81,26 @@ class TestCalculateRollingSums:
 
 class TestCleanNonResidentialRateOfChange:
     @pytest.mark.parametrize(
-        "expected_data",
+        "case",
         [
-            case.as_pytest_param()
+            pytest.param(case, id=case.id)
             for case in Data.clean_non_residential_rate_of_change_test_cases
         ],
     )
-    def test_clean_non_residential_rate_of_change_returns_expected_output(
-        self, expected_data
-    ):
+    def test_clean_non_residential_rate_of_change_returns_expected_output(self, case):
         expected_lf = pl.LazyFrame(
-            expected_data,
+            case.data,
             Schemas.expected_clean_non_residential_rate_of_change_schema,
             orient="row",
         )
         input_lf = expected_lf.drop(
             job.TempCol.previous_period_cleaned, job.TempCol.current_period_cleaned
         )
-        returned_lf = job.clean_non_residential_rate_of_change(input_lf)
-        pl_testing.assert_frame_equal(
-            returned_lf,
-            expected_lf,
-            check_row_order=False,
-        )
-
-    def test_large_non_residential_change_above_percentile_is_rejected(self):
-        expected_data = [
-            ("2-001", CareHome.not_care_home, date(2026, 1, 1), 20.0, 21.0, 20.0, 21.0),
-            ("2-002", CareHome.not_care_home, date(2026, 1, 2), 20.0, 21.0, 20.0, 21.0),
-            ("2-003", CareHome.not_care_home, date(2026, 1, 3), 20.0, 21.0, 20.0, 21.0),
-            ("2-004", CareHome.not_care_home, date(2026, 1, 4), 20.0, 21.0, 20.0, 21.0),
-            ("2-005", CareHome.not_care_home, date(2026, 1, 5), 20.0, 100.0, None, None),
-        ]  # fmt: skip
-        expected_lf = pl.LazyFrame(
-            expected_data,
-            Schemas.expected_clean_non_residential_rate_of_change_schema,
-            orient="row",
-        )
-        input_lf = expected_lf.drop(
-            job.TempCol.previous_period_cleaned, job.TempCol.current_period_cleaned
-        )
-
         returned_lf = job.clean_non_residential_rate_of_change(
-            input_lf, abs_percentile=0.5, perc_percentile=0.5
+            input_lf,
+            abs_percentile=case.abs_percentile,
+            perc_percentile=case.perc_percentile,
         )
-
         pl_testing.assert_frame_equal(
             returned_lf,
             expected_lf,

--- a/projects/_03_independent_cqc/unittest_data/polars_ind_cqc_test_file_data.py
+++ b/projects/_03_independent_cqc/unittest_data/polars_ind_cqc_test_file_data.py
@@ -2812,6 +2812,8 @@ class ModelRateOfChangeInputOutputTestCase:
 class ModelRateOfChangeOutputOnlyTestCase:
     id: str
     data: list[Any]
+    abs_percentile: float = 0.99
+    perc_percentile: float = 0.99
 
     def as_pytest_param(self):
         return pytest.param(self.data, id=self.id)
@@ -2955,6 +2957,18 @@ class ModelRateOfChangeData:
             data=[
                 ("1-001", CareHome.care_home, date(2026, 1, 1), 10.0, 1000.0, 10.0, 1000.0),
             ],
+        ),
+        ModelRateOfChangeOutputOnlyTestCase(
+            id="large_non_residential_change_above_percentile_is_rejected",
+            data=[
+                ("2-001", CareHome.not_care_home, date(2026, 1, 1), 20.0, 21.0, 20.0, 21.0),
+                ("2-002", CareHome.not_care_home, date(2026, 1, 2), 20.0, 21.0, 20.0, 21.0),
+                ("2-003", CareHome.not_care_home, date(2026, 1, 3), 20.0, 21.0, 20.0, 21.0),
+                ("2-004", CareHome.not_care_home, date(2026, 1, 4), 20.0, 21.0, 20.0, 21.0),
+                ("2-005", CareHome.not_care_home, date(2026, 1, 5), 20.0, 100.0, None, None), # outlier: rejected by median threshold
+            ],
+            abs_percentile=0.5,
+            perc_percentile=0.5,
         ),
     ] # fmt: skip
 


### PR DESCRIPTION
## Description
Trello ticket [#1847](https://trello.com/c/4QxeET1K/1847-remove-mid-chain-collect-calls)

Removes the two mid-chain `.collect()` calls in the `_03_impute` Polars pipeline (`compute_global_ratio` and `clean_non_residential_rate_of_change`), each of which broke the lazy chain by materializing a filtered/aggregated scalar (a ratio, or two quantile thresholds) via `.collect()` before reusing it in further logic on the same LazyFrame. Both are now expressed as lazy `pl.Expr` aggregates — invalid/non-qualifying rows are masked to null rather than filtered, so `.sum()`/`.quantile()` skip them exactly as a filter would, and the whole computation stays fused with the rest of the pipeline.

The diagnostic print in `convert_pir_to_filled_posts` was dropped, it's not something we actively monitor.

## Testing
- [x] Unit tests passing
- [x] Successful [Step Function run](https://eu-west-2.console.aws.amazon.com/states/home?region=eu-west-2#/v2/executions/details/arn:aws:states:eu-west-2:856699698263:execution:1847-lazyfix-Ind-CQC-Filled-Post-Estimates:57e3eb01-49a7-4496-a6d1-7395b2432349)
- [x] Outputs checked in Athena

Added a new test case (`large_non_residential_change_above_percentile_is_rejected`) covering a previously-untested branch: a non-small, non-care-home row actually getting rejected by the percentile thresholds.

## Checklist
- [x] Unit tests added/amended
- [x] Docstrings added/updated
- [x] Updated CHANGELOG
- [x] Code reviewed by AI
- [x] Moved Trello ticket to PR column

## Reviewer checklist
- [ ] PR solves the Trello ticket requirements
- [ ] Outputs appear reasonable and understandable
- [ ] The overall approach is appropriate and not over-engineered
- [ ] No obvious scalability, performance or interdependency concerns
- [ ] Tests appropriately cover the main behaviour/edge cases
- [ ] Naming and structure are broadly understandable and consistent
- [ ] Docstrings are sufficient for future maintenance
- [ ] Docstrings cover non-obvious behaviour
