### PR TITLE
1857 - Consolidate personal and repo ticket-lifecycle skills

### DIFF
--- a/.claude/skills/commit-push/SKILL.md
+++ b/.claude/skills/commit-push/SKILL.md
@@ -1,14 +1,88 @@
 ---
 name: commit-push
-description: Use when committing and pushing a chunk of work — "/commit-push", "commit and push this". Run repeatedly through a ticket, once per logical change, not just at the end. Pairs with `new-ticket` and `open-pr`.
+description: Commit the current repo's pending changes with a descriptive message and push them to the remote, in one step. Use this whenever the user says something like "/commit-push", "commit and push this", "ship this", or otherwise clearly wants their local changes both committed AND sent to the remote in the same request — not just staged or committed locally. Running this skill is itself the user's explicit go-ahead to push, so don't re-ask for push confirmation once it's invoked. Run repeatedly through a ticket, once per logical change, not just at the end. Pairs with `new-ticket` and `open-pr`.
 ---
 
-# Committing and pushing
+# Commit and push
 
-1. Show `git status` (staged/unstaged/untracked). Stage specific relevant files — never a blind `git add -A`.
-2. Parse the ticket number from the current branch name (leading digits before the first `-`).
-3. Draft the commit message as `<ticket-number> - <Description>`, matching this repo's existing log convention — short, plain-sentence, no trailing period.
-4. Before committing:
-   - Update `CHANGELOG.md`'s `Unreleased` section if this is a substantive change (see CLAUDE.md's Changelog section for the format).
-   - Run the relevant unit tests.
-5. Commit, then push. Confirm with the user before pushing — same as any push, this isn't bypassed by the skill.
+The user invoked this skill because they want their pending changes committed and pushed in one
+go, without being asked to confirm the push separately — that confirmation is baked into calling
+this skill. Everything else about safe git usage still applies: real commits (never amend), no
+skipped hooks, no force-push, and a careful eye before staging anything that might be a secret.
+
+## 1. Gather context
+
+Run these in parallel, in the target repo:
+
+- `git status` (never `-uall` — it can be slow/memory-heavy on large repos)
+- `git diff` — both staged and unstaged changes
+- `git log` — recent commits, to confirm the `<ticket-number> - <Description>` convention below
+
+If `git status` shows nothing to commit **other than `SPEC.md`**, say so and stop — there's
+nothing to push either. (See step 3 — `SPEC.md` is a working ticket doc that stays local, never
+committed.)
+
+## 2. Draft the commit message
+
+Parse the ticket number from the current branch name (leading digits before the first `-`), and
+format the message as `<ticket-number> - <Description>` — this repo's existing log convention
+(see CLAUDE.md's "Environment & workflow"): short, plain-sentence, no trailing period, explaining
+*why* the change was made rather than restating the diff.
+
+## 3. Stage deliberately
+
+Add the specific changed files by name or path. Never `git add -A` or `git add .` — a blanket add
+is how unrelated work-in-progress files or stray local config end up in a commit. After staging,
+look at what's actually included (`git status`), and if anything looks like it could hold a
+secret — `.env` files, credentials, tokens, keys, even under an innocuous-looking name — open it
+and check before committing. If it does contain something sensitive, stop and tell the user rather
+than committing it.
+
+In this repo's git worktrees, the `.venv` directory uv creates is gitignored, so
+it shouldn't reach staging at all — never force-add it (`-f`/`--force` would be
+needed) and don't report it as a possible secret leak. A `.env` file, if present,
+follows the same rule as any other config file per the paragraph above: check its
+contents before staging rather than assuming it's safe or unsafe by name alone.
+
+**Never stage or commit `SPEC.md`.** It's a working ticket doc (seeded by the `new-ticket` skill)
+that's meant to stay local to the worktree — never part of the committed history. Leave it out of
+`git add` even if it's modified or untracked, regardless of whether the user's request mentioned
+it by name. If `SPEC.md` is already tracked in the repo's history (check with
+`git ls-files --error-unmatch SPEC.md`), don't try to silently un-track it as part of this skill —
+flag it to the user instead, since removing a tracked file is its own decision.
+
+## 4. Before committing
+
+- Update `CHANGELOG.md`'s `Unreleased` section if this is a substantive change (see CLAUDE.md's
+  Changelog section for the format).
+- Run the relevant unit tests.
+
+## 5. Commit
+
+Create a new commit (never `--amend` — amending can silently rewrite or drop a commit the user
+didn't ask you to touch). Never pass `--no-verify` or `--no-gpg-sign`, and don't bypass a failing
+hook — fix whatever it's complaining about and make a new commit instead. Pass the message via a
+heredoc so multi-line formatting survives, and end it with:
+
+```
+Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
+```
+
+## 6. Decide whether to push
+
+Check the current branch name.
+
+- **`main` or `master`:** stop here — don't push. These branches are usually protected or shared
+  in a way that makes a direct push risky (bypassing PR review, clashing with others' work). Tell
+  the user the commit landed locally and that they should push it themselves, or move the work to
+  a feature branch first.
+- **Any other branch:** push it — no separate confirmation needed, per this skill's own invocation.
+  Use `git push`, or `git push -u origin <branch>` if it has no upstream tracking branch yet. Never
+  force-push (`--force`/`--force-with-lease`) — if a normal push is rejected (e.g. remote has
+  diverged), stop and explain the situation to the user rather than overwriting remote history.
+
+## 7. Confirm and report back
+
+After pushing, check `git status` (and/or `git log`) to confirm it actually landed. Report back
+concisely: the commit hash and message used, and whether/where it was pushed — or, if it was
+blocked on `main`/`master`, say that plainly so the user knows the push step didn't happen.

--- a/.claude/skills/continue-ticket/SKILL.md
+++ b/.claude/skills/continue-ticket/SKILL.md
@@ -1,0 +1,210 @@
+---
+name: continue-ticket
+description: Use this skill whenever the user wants to pick back up on a ticket they (or someone else) already started in this DataEngineering repo — phrases like "continue ticket 1814", "let's get back to 1793", "where did I leave off", "pick this ticket back up", "resume work on the SLV reshape", or just opening a session in an existing ticket worktree and asking "what's the state of this?". It reconstructs context from git (branch/worktree, uncommitted diffs, commit history vs. main), GitHub (open PR, draft/review/CI status), the auto-memory system (any project memory already written for this ticket), and any working SPEC.md, checks the worktree actually has a usable Python environment, then produces a concise "where you left off" summary with a suggested next step. Always reach for this skill instead of just running a couple of `git log`/`git status` commands and guessing — the point is to pull together everything that's scattered across git, GitHub, memory, and SPEC.md before answering, not just whichever one is fastest to check.
+---
+
+# Continuing a ticket
+
+This repo (Skills for Care Workforce Intelligence Team) tracks work as numbered
+tickets, each developed on its own branch in its own git worktree (see the
+`new-ticket` skill for how these get set up: sibling worktree directory
+`DataEngineering-<ticket>-<slug>`, branch `<ticket>-<slug>`, a working
+`SPEC.md` at the worktree root, a seeded project memory file). This skill is
+the mirror image: reconstructing what's already true about a ticket instead of
+setting one up.
+
+The reason this needs its own pass rather than a quick `git log` is that the
+real state of a ticket is scattered across four places that can each be stale
+or incomplete on their own — the working tree, GitHub, the memory file
+written at some earlier point, and a SPEC.md that may not reflect later
+decisions. Cross-check them against each other rather than trusting whichever
+one you read first.
+
+## 1. Identify the ticket and its worktree
+
+If the user gave a ticket number, find its worktree and branch:
+
+```
+git worktree list
+```
+
+Match by ticket-number prefix on the branch name (`1814-slv-reshp`,
+`1793-empstat`, etc.) or by the sibling directory name
+(`DataEngineering-<ticket>-<slug>`). If nothing matches, don't assume the
+ticket doesn't exist — check for a merged-and-removed branch first
+(`git branch -a --contains main` won't help here since it's gone; instead
+try `git log --all --oneline --grep="<ticket>"` and `gh pr list --state all
+--search "<ticket>"`) before telling the user it's not found.
+
+If the user didn't give a number, infer it from the current directory:
+
+```
+git rev-parse --show-toplevel
+git branch --show-current
+```
+
+The current worktree's branch name and directory name (per the convention
+above) tell you the ticket number and slug directly. If the current directory
+is the main repo checkout (branch `main`), there's no ticket to infer — ask
+which one they mean rather than guessing.
+
+If more than one ticket plausibly matches (e.g. the user says "the SLV one"
+and there are two candidate branches), ask rather than picking — this skill's
+whole job is avoiding wrong assumptions about state, so don't start by
+guessing which ticket "state" even refers to.
+
+## 2. Read the working tree
+
+From inside the ticket's worktree:
+
+```
+git status
+git log main..HEAD --oneline
+git diff main...HEAD --stat
+git diff
+```
+
+This tells you: anything uncommitted right now, what's been committed on this
+branch that isn't on `main` yet, and the shape of that diff. Note explicitly
+whether the working tree is clean or has pending changes — "uncommitted work
+exists" is one of the most important facts in the summary, since it's the
+thing most likely to get silently lost if the user starts a fresh session
+elsewhere.
+
+Don't stop at commit titles from `--oneline` — read the full body of the most
+recent handful of commits (`git show --stat <sha>` or `git log -3 -p main..HEAD`
+on the tail end). Investigation tickets in this repo often show up as a short
+run of commits that read like a diagnostic log ("adds diagnostic pipeline",
+"OOM'd again after the fix", "prototypes fallback in diag file only") — the
+titles alone tell you *that* something happened across several commits, but
+the bodies are where you find out whether the last one actually resolved it
+or just tried something new. This is exactly the kind of detail that makes
+step 4's memory reconciliation actually work instead of rubber-stamping
+whatever the memory file already claims.
+
+Check the worktree has a working Python environment before you rely on it. A
+worktree that's never had `uv sync` run in it won't have a `.venv` yet:
+
+```
+uv run python -c "import polars, boto3"
+```
+
+`uv run` auto-syncs against `uv.lock` before running, so this single command both
+checks and — if needed — provisions the environment (typically ~1 minute on a
+brand-new worktree on this machine, mostly linking from uv's global package
+cache rather than downloading). That's non-destructive and safe to just run, so
+do it and mention it in the summary if it had to provision anything — no need to
+ask first. This is the one setup action this skill should take on its own; it's
+a precondition for reading state accurately, not a step toward implementing the
+ticket.
+
+Check for a working `SPEC.md` at the worktree root — if present, read it in
+full. It's the closest thing to a design doc for the ticket and should cover
+scope, key decisions, and what's explicitly out of scope. Per this repo's
+convention, `SPEC.md` is a temporary file removed at merge time, so its
+absence doesn't mean the ticket is undocumented — it may just mean the memory
+file (step 4) is now the primary record, or the ticket never needed one.
+
+## 3. Check GitHub for an open PR
+
+```
+gh pr view <branch> --json state,isDraft,statusCheckRollup,reviews,title,url
+```
+
+If a PR exists, note: draft vs. ready for review, CI status, any unresolved
+review comments. If no PR exists yet, that's itself a fact worth surfacing —
+per this repo's standing convention, PRs are opened as **drafts by default**,
+so "no PR yet" plus "commits exist on the branch" often just means the next
+step is opening one, not that something was forgotten.
+
+If `gh` isn't available or the check fails, don't block on it — note in the
+summary that PR status couldn't be checked rather than silently omitting it.
+
+## 4. Check memory for prior context
+
+Read `MEMORY.md` in the auto-memory directory shown in your system context,
+and grep it (and the memory directory itself) for the ticket number and any
+slug/keywords from the branch name. If a matching project memory file exists,
+read it in full — it may contain decisions, known bugs, or "still open" notes
+from a previous session that aren't visible in git or GitHub at all (e.g. "fix
+is written but deliberately left uncommitted for review," or "diagnostic
+pipeline still needs removing before merge").
+
+Treat the memory file as a *claim about a past state*, not current truth —
+it may predate commits you just read in step 2. Reconcile the two explicitly:
+if memory says "uncommitted fix for X" and the working tree is now clean with
+a new commit mentioning X, the fix has likely been committed since; if memory
+says "OOM fixed" but you can't find a corresponding commit or diff, flag that
+mismatch rather than trusting either source blindly.
+
+If you find memory is now stale (git state has clearly moved past what it
+describes), **don't update the memory file yourself** — surface the
+discrepancy in the summary (step 5) and ask the user whether to update it,
+and how. Memory edits are meant to capture the user's own understanding of a
+ticket, not whatever a status-check run happened to infer; auto-correcting it
+risks writing something confidently wrong into a file future sessions will
+treat as ground truth, with no one having actually reviewed it. This applies
+even when the drift seems obvious and well-evidenced from git — showing your
+reasoning and asking is cheap, an unreviewed memory edit is not.
+
+## 5. Synthesize the "where you left off" summary
+
+Report back using this structure:
+
+```markdown
+## Ticket <number>: <title>
+**Branch:** <branch> · **Worktree:** <path>
+**PR:** <link + draft/ready + CI status, or "not yet opened">
+
+### Done
+<what's committed and confirmed working>
+
+### Uncommitted
+<what's in the working tree right now, if anything — be explicit that this
+exists so it doesn't get lost>
+
+### Outstanding
+<bugs found but not fixed, tests not run/passing, cleanup items (e.g.
+diagnostic scaffolding to remove before merge), anything SPEC.md or memory
+flagged as "still open">
+
+### Memory discrepancy (only if step 4 found one)
+<what memory claims vs. what git/GitHub actually show now, with the specific
+commits/diffs backing your read — then ask directly whether to update the
+memory file, and to what>
+
+### Suggested next step
+<one concrete next action, not a full plan>
+```
+
+Keep it concise — this is a status report to re-orient someone, not a full
+re-derivation of the ticket's history. Link out to `SPEC.md` or the memory
+file for anyone who wants the full detail rather than repeating it all here.
+
+## 6. Apply repo conventions when suggesting the next step
+
+A few standing rules shape what "next step" should look like, and are easy to
+get wrong if you reason about the ticket in isolation:
+
+- **PySpark vs. Polars:** if outstanding work touches a `jobs/` (PySpark) file,
+  don't suggest introducing new PySpark code unless the ticket is already
+  scoped that way — CLAUDE.md's migration direction is Polars for anything
+  new.
+- **pytest migration:** if outstanding work includes writing new tests,
+  they should be pytest-style (dataclass-driven `@pytest.mark.parametrize`
+  cases), not `unittest.TestCase`, unless the ticket's own memory/SPEC.md
+  already committed to a different call for that file.
+- **Draft PRs by default:** if "open a PR" is the suggested next step, say so
+  as a draft PR, not ready-for-review, unless memory or the user has said
+  otherwise for this specific ticket.
+- **CLAUDE.md conflicts:** if anything in SPEC.md, memory, or the git history
+  contradicts an explicit CLAUDE.md rule (not just a general principle), flag
+  the conflict directly rather than silently picking a side or resolving it
+  yourself.
+
+## 7. Don't start implementing unprompted
+
+This skill's job ends at producing the summary and a suggested next step —
+not at doing that next step. Wait for the user to confirm direction before
+writing code, committing, or opening/updating a PR, even if the next step
+seems obvious from the summary.

--- a/.claude/skills/new-ticket/SKILL.md
+++ b/.claude/skills/new-ticket/SKILL.md
@@ -1,32 +1,262 @@
 ---
 name: new-ticket
-description: Use when starting a new piece of work — "/new-ticket", "start a new ticket", "let's start on ticket 1234". Runs branch check → short interview → hands off to Plan Mode for the SPEC. Pairs with the `commit-push` and `open-pr` skills for the rest of the cycle.
+description: Use this skill whenever the user wants to start work on a new ticket in this DataEngineering repo — phrases like "new ticket", "start ticket 1850", "let's kick off 1862", "set up a branch for ticket NNNN", or "I need to begin work on ticket X". It sets up the branch and git worktree following this repo's exact naming conventions, provisions the worktree's Python environment via `uv sync`, runs a scoping interview via Plan Mode, writes a working SPEC.md from the approved plan, and seeds a project memory file so the ticket's context survives across sessions. Always reach for this skill instead of improvising ad hoc `git branch`/`git worktree` commands when a ticket number is mentioned — the naming rules here (16-char branch limit, sibling worktree directory) are easy to get wrong by hand, and a fresh worktree has no `.venv` until `uv sync` creates one. Pairs with the `commit-push` and `open-pr` skills for the rest of the cycle.
 ---
 
 # Starting a new ticket
 
-## 1. Branch check
+This repo (Skills for Care Workforce Intelligence Team) tracks work as numbered
+tickets, each developed on its own branch in its own git worktree. This skill
+reproduces the pattern already established by tickets like `1793-empstat` and
+`1814-slv-reshp`: a short branch name, a sibling worktree directory with its own
+provisioned virtualenv, a scoping interview via Plan Mode, a temporary
+`SPEC.md`, and a memory file so a later session (or a different person) can pick
+the ticket back up without re-deriving context.
 
-- `git status` must be clean before switching branches — if not, stop and flag it rather than discarding anything.
-- Fetch and pull the latest `main`. If not currently on `main`, confirm before switching.
+Work through the steps below in order. Don't skip the interview even if the
+ticket sounds simple — it's what makes the seeded memory file and SPEC.md
+useful later, and it's cheap compared to discovering a scope misunderstanding
+mid-implementation.
 
-## 2. Interview
+## 1. Get the ticket number and a short title
 
 Ask two short questions, one at a time (see CLAUDE.md's Output style):
 
 1. Trello card number?
 2. One-line description of the work?
 
-Don't try to gather full requirements here — that's what Plan Mode does next.
+Don't try to look this up from GitHub issues or any other tracker — in this
+repo, ticket info always comes from the user typing it in. Don't try to gather
+full requirements here — that's what step 5's Plan Mode interview does.
 
-## 3. Derive the branch name
+## 2. Derive the branch name and check the length limit
 
-`<trello-number>-<short-description>`, slug hyphenated and truncated to fit the repo's 16-character limit (see "Environment & workflow" in CLAUDE.md). Create and check out the branch from latest `main`.
+Branch names in this repo follow `<ticket-number>-<short-slug>` and must be
+**16 characters or fewer in total** (this is a hard constraint seen across the
+whole branch history — e.g. `1132-rm-cqc-tasks`
+would actually be too long and need trimming). Build the slug by:
 
-## 4. Hand off to Plan Mode for the SPEC
+- Lowercasing, hyphenating, stripping filler words.
+- Abbreviating aggressively if needed (`starters-leavers-vacancies` → `slv`,
+  `reshape` → `reshp`, `employee-status` → `empstat`) — this repo's history
+  favors short, slightly-cryptic slugs over readable-but-long ones.
 
-Call `EnterPlanMode` and let Claude Code's normal phased workflow (Explore → Design → Review → Final Plan → `ExitPlanMode`) do the deeper requirements interview and produce the plan. Don't build a separate SPEC format — the plan file is the SPEC.
+Compute the full branch name and count its characters. If it already fits in
+16, proceed without asking. If you had to abbreviate hard enough that the
+result feels unclear, show the user the proposed branch name and confirm
+before creating anything — a bad branch name is annoying to rename later
+(see the `1797-a-unpivot`/`1797-b-struct` rename precedent: renaming a
+branch after it's pushed means deleting and recreating the remote branch).
 
-## 5. After the plan is approved
+## 3. Create the branch and worktree
 
-Implement, then use `commit-push` (repeatedly, per logical change) and `open-pr` (once, at the end) to finish the cycle. There's no automatic memory save at any point — only save something to memory if it looks genuinely useful, and ask first.
+The convention is a **sibling worktree directory** next to the main repo
+checkout, named to match the branch: `DataEngineering-<ticket>-<slug>`.
+
+This must run from the **main repo checkout on the `main` branch**, not from
+inside another worktree (`git worktree add` targets the repository the command
+is run from, and you want the new worktree to branch off an up-to-date
+`main`). Find the main checkout with `git worktree list` — it's the entry with
+branch `main` — and check its status before creating anything, per this
+repo's git safety protocol: uncommitted or unpushed work sitting on `main`
+would be worth flagging to the user first, not silently working around.
+
+```
+git -C <main-repo-path> status
+git -C <main-repo-path> fetch origin main
+git -C <main-repo-path> worktree add ../DataEngineering-<ticket>-<slug> -b <ticket>-<slug> main
+```
+
+(Adjust the relative path if the main checkout's parent directory differs —
+the goal is a sibling of the main checkout, matching where
+`DataEngineering-1793-empstat` and `DataEngineering-1814-slv-reshp` already
+sit.)
+
+This is a local, reversible operation (new branch + new worktree directory),
+so it's fine to do without extra confirmation once the branch name is settled.
+Don't push the new branch to `origin` as part of this step — that happens
+later, when there's actual work to push, not at ticket setup.
+
+Note that `git worktree add` branches off whatever the **local** `main` ref
+points at, which the preceding `fetch` may have just left behind `origin/main`.
+Check, and fast-forward if so — a plain `merge --ff-only`, no history rewrite:
+
+```
+git -C <new-worktree-path> merge --ff-only origin/main
+```
+
+Tell the user the worktree path once it's created — that's where all
+subsequent work on this ticket happens.
+
+## 4. Provision the worktree's virtualenv
+
+**Don't skip this.** uv keys its default virtualenv (`.venv`) to the project
+*directory*, so a brand-new worktree starts with no environment of its own.
+Left unprovisioned, the first `uv run ...` in that worktree still works — `uv
+run` auto-syncs against the repo's `uv.lock` before running — but that means the
+session's first command pays the sync cost instead of it being paid upfront.
+
+Run from the new worktree root:
+
+```
+uv sync
+```
+
+This is fast even as a genuine first run in a brand-new worktree: `uv` resolves
+against `uv.lock` (typically single-digit milliseconds — it's a lockfile read,
+not a solve) and installs from its own global package cache (`%LOCALAPPDATA%\uv\cache`
+on Windows), so most of the cost is linking already-downloaded packages rather
+than re-downloading them. Measured ~55s for a full 119-package install into a
+brand-new worktree on this machine. There's no cross-worktree pointer file or
+shared venv involved — each worktree just gets its own local `.venv` — and `uv`'s
+`python-preference = "only-managed"` setting (see `pyproject.toml`) means it
+installs its own managed Python 3.11 build rather than depending on whatever
+`pyenv`/system Python happens to be on `PATH`, so there's no equivalent of the
+old pipenv/pyenv-win interpreter-mismatch failure mode to guard against.
+
+Verify with:
+
+```
+uv run python -c "import polars, boto3"
+```
+
+Don't try to share one worktree's `.venv` with another (e.g. via uv's
+`UV_PROJECT_ENVIRONMENT` env var, the direct analogue of pipenv's old
+`PIPENV_CUSTOM_VENV_NAME` trick) — a per-worktree install is cheap enough on this
+machine's warm cache that the coordination overhead and blast-radius risk
+(deleting one worktree's env taking out another's) isn't worth it. If `uv sync`
+ever becomes slow enough that this stops being true — a machine with a cold
+cache, or a much larger dependency set — that's worth revisiting, but don't
+pre-optimize for it now.
+
+## 5. Run the scoping interview via Plan Mode
+
+Before any code gets written, enter plan mode (`EnterPlanMode`) and let Claude
+Code's normal phased workflow (Explore → Design → Review → Final Plan →
+`ExitPlanMode`) drive the interview. Plan mode is the right container for
+this: the output of this step is a design to align on, not code, and it keeps
+you from accidentally starting to implement mid-interview.
+
+Don't just run the generic plan-mode flow unprompted, though — seed it with
+this repo's own checklist, using `AskUserQuestion` (or plain back-and-forth
+chat, if a question doesn't fit multiple-choice well) so the design phase
+actually covers:
+
+- **Where does this land?** Which project/pipeline stage does the ticket
+  touch (see the `projects/<project>/_NN_stage/{jobs,fargate,utils}` layout in
+  CLAUDE.md)? This decides where new helpers belong.
+- **What does "done" look like?** A one-to-two sentence scope statement.
+- **What's explicitly out of scope?** Things that sound related but should be
+  deferred to a follow-up ticket — this repo's history shows scope creep is a
+  real risk here (e.g. ticket 1793 deliberately left `join_datasets()` as a
+  placeholder rather than implementing it as part of the CSV-load ticket).
+- **Any decisions already made vs. still open?** E.g. PySpark vs. Polars is
+  already decided by CLAUDE.md (new work is Polars unless touching existing
+  PySpark code) — but ticket-specific choices like data types, column
+  placement, or which of several approaches to prototype are worth surfacing
+  now rather than assuming.
+- **Facts about the data that the repo can't tell you.** Anything relevant to
+  this ticket that only the user knows because it isn't derivable from code —
+  e.g. dataset size (row/column counts, whether it's the kind of scale that
+  triggers this repo's OOM concerns), the actual structure/shape of a source
+  file the ticket touches (wide vs. long, schema quirks, cardinality of a
+  column that's about to become a join key or `.over()` partition), or
+  upstream data-quality issues. Ask only what's actually relevant to this
+  ticket — don't run through a generic checklist — but do ask, since guessing
+  at data shape has caused real production issues here before (see the
+  `validate_00_prepare` OOM in ticket 1814, and the join-broadcast pattern
+  CLAUDE.md documents from a prior incident).
+
+If a genuine CLAUDE.md conflict comes up during this interview (the user's
+answer contradicts an explicit repo rule), flag it rather than silently
+picking one — see the empstat-rates ticket, where column-name-class placement
+almost went to the wrong directory before this got caught.
+
+Exit plan mode once the interview is done and the design is confirmed, before
+moving on to writing `SPEC.md`.
+
+## 6. Write SPEC.md from the approved plan
+
+Write a `SPEC.md` at the **new worktree's root** (not the main repo) capturing
+the plan's outcome. This is a working document, not committed history —
+tickets in this repo remove it as cleanup once the ticket merges (precedent:
+ticket 1809). Structure it loosely as:
+
+```markdown
+# Ticket <number>: <title>
+
+## Scope
+<one-two sentence "done" statement>
+
+## Where this lands
+<project/stage, which files are likely touched>
+
+## Key decisions
+<bullets — anything settled during the interview>
+
+## Data characteristics
+<facts about the data the user supplied that aren't derivable from the repo —
+row/column counts, structure/shape, cardinality, known quality issues. Omit
+this section if the ticket doesn't touch a dataset directly.>
+
+## Explicitly out of scope
+<bullets — deferred items, follow-up tickets>
+
+## Open questions
+<anything still unresolved, to revisit during implementation>
+
+---
+Remove this file before merging to main.
+```
+
+## 7. Seed a memory file
+
+Create `ticket_<number>_<slug>.md` in the auto-memory directory shown in your
+system context (a personal, per-user path outside this repo — don't hardcode
+a specific username's path; use whatever this session's context indicates).
+Use the `project`-type memory format:
+
+```markdown
+---
+name: ticket-<number>-<slug>
+description: "Ticket <number> — <one-line summary>, on branch <branch-name> / worktree <path>"
+metadata:
+  type: project
+---
+
+Ticket <number>: <scope statement>. Branch `<branch-name>`, worktree
+`<worktree-path>`. `SPEC.md` at the worktree root has the full design —
+**Why:** <the driving reason/motivation from the interview, e.g. a deadline,
+a bug, a dependency on another ticket>.
+
+**How to apply:** if this ticket is picked up again, read `SPEC.md` first (or
+this memory if the file's already been cleaned up post-merge), check
+`git log`/`git branch` to see how far implementation got, and treat the
+interview decisions above as closed — don't re-litigate them without new
+information.
+
+Key decisions: <bullets from the interview>
+Explicitly out of scope: <bullets>
+
+<Link to related tickets with [[ticket-name]] if this one shares files, data,
+or scope with something already in memory — e.g. two tickets touching the
+same SLV project.>
+```
+
+Then add a one-line pointer to `MEMORY.md`:
+
+```
+- [Ticket <number> <short-title>](ticket_<number>_<slug>.md) — <one-line hook>
+```
+
+## 8. Report back
+
+Summarize for the user: branch name, worktree path, that the virtualenv is
+provisioned and verified, where `SPEC.md` lives, and that the memory file's been
+seeded. If the branch had to be fast-forwarded past commits the fetch pulled in,
+say so.
+
+## 9. After the plan is approved
+
+Implement, then use `commit-push` (repeatedly, per logical change) and
+`open-pr` (once, at the end) to finish the cycle.

--- a/.claude/skills/open-pr/SKILL.md
+++ b/.claude/skills/open-pr/SKILL.md
@@ -5,7 +5,15 @@ description: Use when a ticket's work is ready for review — "/open-pr", "open 
 
 # Opening a PR
 
-1. Confirm the branch is pushed and up to date with remote — run `commit-push` first if not.
+1. Confirm the branch is pushed and up to date with remote:
+   - Uncommitted changes present → run `commit-push` to commit and push them. That skill's own
+     "invocation = go-ahead to push" applies as normal here, since committing pending work is
+     exactly what `commit-push` is for.
+   - Everything already committed but the branch is ahead of its upstream (or has no upstream
+     yet) → push it directly (`git push` / `git push -u origin <branch>`), but confirm with the
+     user first. Opening a PR doesn't itself imply consent to push — that implicit consent is
+     specific to invoking `commit-push` for its own sake, not something this skill can borrow as
+     a side effect.
 2. Run a sub-agent review of the diff against `main`, following the `review-checklist` skill. This is what satisfies the "Code reviewed by AI" checklist item on the PR template — don't tick it without actually running this.
    - Any **Critical** finding: stop and resolve or discuss with the user before continuing.
    - Important/Optional findings: show them, then continue regardless.
@@ -17,4 +25,8 @@ description: Use when a ticket's work is ready for review — "/open-pr", "open 
    - Description of the work.
    - Testing checklist, ticked to what was actually done.
    - "Code reviewed by AI" — ticked, since step 2 just did it.
-5. Create the PR with `gh pr create` using the populated title/body. Confirm with the user before creating it — same as any PR, this isn't bypassed by the skill.
+5. Create the PR as a **draft** by default (`gh pr create --draft`) using the populated
+   title/body — this repo's standing convention (see `continue-ticket`'s "Draft PRs by default"
+   note). Only skip `--draft` if the user's own request made it clear they want it ready for
+   review immediately. Confirm with the user before creating it either way — same as any PR,
+   this isn't bypassed by the skill.

--- a/.claude/skills/post-merge-cleanup/SKILL.md
+++ b/.claude/skills/post-merge-cleanup/SKILL.md
@@ -1,0 +1,181 @@
+---
+name: post-merge-cleanup
+description: Use this skill whenever the user wants to tidy up after a ticket's PR has been merged in this DataEngineering repo — phrases like "PR for 1793 merged, clean it up", "close out ticket 1814", "tidy up now that this merged", "can you clean up the worktree for X", or "1731 is merged, deal with the leftovers". It verifies the PR actually merged, refreshes main, removes the ticket's git worktree and local branch (its local `.venv` goes with it automatically), flags anything that needs the user's own decision (an un-auto-deleted remote branch, a stray uncommitted SPEC.md, a ticket memory file that should be archived), and reports what it did. Always reach for this skill instead of ad hoc `git worktree remove`/`git branch -d` — the point is to check for unmerged work and unresolved shared-state changes *before* deleting anything, not to assume a merged PR means everything underneath it is safe to remove.
+---
+
+# Cleaning up after a merged PR
+
+This repo (Skills for Care Workforce Intelligence Team) develops each ticket on
+its own branch in its own sibling git worktree (`DataEngineering-<ticket>-<slug>`,
+branch `<ticket>-<slug>` — see the `new-ticket` skill for how these get set
+up). Once a ticket's PR merges, that worktree, branch, and any related
+scratch state (`SPEC.md`, the ticket's memory file) become stale and should be
+cleared out — but several of those removals are destructive or affect shared
+state, so this skill checks before acting rather than assuming a green PR
+means everything underneath it is disposable.
+
+## 1. Identify the ticket, branch, and worktree
+
+If the user gave a ticket number, find the matching worktree:
+
+```
+git worktree list
+```
+
+Match by ticket-number prefix on the branch name (`1814-slv-reshp`) or the
+sibling directory name (`DataEngineering-<ticket>-<slug>`). If the user didn't
+give a number, infer it from the current directory the same way `continue-ticket`
+does:
+
+```
+git rev-parse --show-toplevel
+git branch --show-current
+```
+
+If you can't find a matching worktree at all, check whether it was already
+removed in a prior cleanup pass before telling the user nothing's there —
+`git branch -a --contains main` plus `gh pr list --state merged --search
+"<ticket>"` will confirm the ticket merged even if the worktree is already
+gone, which just means there's nothing left to clean up.
+
+## 2. Confirm the PR actually merged — don't assume
+
+```
+gh pr view <branch> --json state,mergedAt,baseRefName,url
+```
+
+If `state` isn't `MERGED`, stop and tell the user — this skill's whole reason
+to exist is not deleting work that isn't actually landed. A closed-but-not-merged
+PR, or an open PR the user is misremembering as merged, is exactly the case
+this check exists to catch.
+
+## 3. Check the worktree for anything not actually merged
+
+Before removing anything, check the ticket's worktree per this repo's git
+safety protocol:
+
+```
+git -C <worktree-path> status
+git -C <worktree-path> log <base-branch>..HEAD --oneline
+```
+
+If `status` shows uncommitted changes, or the branch has commits that don't
+appear in the merged PR (e.g. someone pushed a follow-up after the PR's last
+review), stop and surface this to the user before deleting anything — removing
+the worktree would discard it. Don't rely on the PR being merged as proof the
+worktree is clean; the two can drift.
+
+The worktree's gitignored `.venv` and `.vscode/` don't need any handling here —
+they're local environment config, and being gitignored they neither show up in
+`git status` nor block `git worktree remove`. Each worktree has its own local
+`.venv` (uv's default, not a shared one), so there's no cross-worktree venv to
+identify or account for before removing it — step 5's removal takes care of it
+automatically.
+
+## 4. Refresh the main checkout
+
+Find the main repo checkout (the `git worktree list` entry with branch `main`)
+and bring it up to date before removing the ticket's worktree:
+
+```
+git -C <main-repo-path> status
+git -C <main-repo-path> fetch origin main
+git -C <main-repo-path> pull --ff-only origin main
+```
+
+Check `status` first per the same safety protocol — don't fast-forward over
+uncommitted work sitting on `main`, flag it instead.
+
+## 5. Remove the ticket's worktree, local branch, and its virtualenv
+
+`git worktree remove` must run from a *different* worktree than the one being
+removed — if the user is currently inside the ticket's own worktree, this has
+to run from the main checkout (or another worktree) instead. Say so explicitly
+if that's the case, rather than letting the command fail confusingly.
+
+```
+git -C <main-repo-path> worktree remove <worktree-path>
+git -C <main-repo-path> branch -d <ticket>-<slug>
+```
+
+Use `branch -d` (lowercase), not `-D` — it refuses to delete a branch with
+unmerged commits, which is exactly the safety net this step wants given step 3
+already confirmed things look merged. If `-d` refuses, that's a signal step 3
+missed something; stop and re-check rather than escalating to `-D`.
+
+This is a local, reversible-in-spirit pair of operations (the branch and
+worktree only ever pointed at commits that are now on `main` anyway), so it's
+fine to do without extra confirmation once steps 2–4 have passed. Since each
+worktree's `.venv` is a local subdirectory rather than a venv shared across
+worktrees, `git worktree remove` deletes it along with everything else — there's
+no separate virtualenv cleanup step needed here, and no risk of taking out
+another worktree's environment by mistake.
+
+## 6. Check the remote branch
+
+GitHub often auto-deletes the head branch on merge, but not always (repo
+setting, or a fork-based PR). Check:
+
+```
+git ls-remote --heads origin <ticket>-<slug>
+```
+
+If it still exists, **ask the user before deleting it** — deleting a remote
+branch is a shared-state change per this repo's safety rules, not a local
+cleanup step, even though the branch is dead weight. Don't delete it silently
+just because the local half is gone.
+
+## 7. Check for a stray SPEC.md
+
+Ticket worktrees carry a working `SPEC.md` that's meant to be removed before
+merging (per the `new-ticket` skill's template and precedent from ticket
+1809). Check whether it actually got removed:
+
+```
+git -C <main-repo-path> log --oneline -1 -- projects/**/SPEC.md SPEC.md
+```
+
+or simply check the merged PR's file list via `gh pr view <branch> --json
+files`. If `SPEC.md` is present on `main` after the merge, flag it to the user
+— removing it now needs its own small commit on `main`, which isn't something
+to do silently as a side effect of cleanup. Offer to make that commit, but
+wait for a yes.
+
+## 8. Handle the ticket's memory file
+
+Grep `MEMORY.md` and the memory directory (shown in your system context) for
+the ticket number. If a project memory file exists for this ticket, don't
+delete or rewrite it yourself — per the same reasoning `continue-ticket`
+already applies to memory edits, that file may hold context worth keeping
+(e.g. a bug found and fixed, a decision that'll matter if a near-identical
+ticket comes up later) even after the ticket itself is closed.
+
+Instead, tell the user it exists, summarize what it currently says, and ask
+whether to:
+- leave it as-is (most memories linked from `MEMORY.md` are cheap to keep),
+- add a one-line "merged, see PR <url>" note to the top of the file, or
+- remove it entirely (and its `MEMORY.md` pointer) if it was purely
+  ticket-scoped scratch context with nothing worth keeping for the future.
+
+## 9. Report back
+
+Summarize what happened, structured so the user can see what's done vs. what
+still needs their call:
+
+```markdown
+## Cleanup for ticket <number>: <title>
+**PR:** <url> — merged into `<base-branch>`
+
+### Done
+- Removed worktree `<path>` (including its local `.venv`)
+- Deleted local branch `<branch>`
+- Refreshed `main` in `<main-repo-path>`
+
+### Needs your decision
+- Remote branch `<branch>` still exists on origin — delete it?
+- `SPEC.md` is still present on `main` — remove it in a follow-up commit?
+- Memory file `<file>` — keep, annotate, or remove?
+```
+
+Only include a "Needs your decision" line for things step 2–8 actually found;
+don't pad the report with checks that came back clean.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,8 +22,10 @@ All notable changes to this project will be documented in this file.
 
 - Added `PublishedJobRoleLabels` categorical values class defining the canonical set of published ASC-WDS job role labels.
 
+- Added `continue-ticket` and `post-merge-cleanup` Claude Code skills to the repo (moved over from a personal skills directory, unchanged) so resuming a ticket or tidying up after a merge follows the same shared workflow as `new-ticket`/`commit-push`/`open-pr`.
+
 ### Changed
-- Consolidated the personal `new-ticket` and `commit-and-push` Claude Code skills back into their repo-level counterparts (kept the worktree/SPEC.md/memory-seeding workflow and no-reconfirm push, adopted the repo's Plan-Mode interview and ticket-number commit format), and moved `continue-ticket`/`post-merge-cleanup` into the repo so all ticket-lifecycle skills live in one shared place.
+- Consolidated the personal `new-ticket` and `commit-and-push` Claude Code skills back into their repo-level counterparts: kept the worktree/SPEC.md/memory-seeding workflow and no-reconfirm push, adopted the repo's Plan-Mode interview and ticket-number commit format. Also updated `open-pr` to confirm separately before any push it triggers itself (rather than inheriting `commit-push`'s implicit consent) and to open PRs as drafts by default, matching the convention `continue-ticket` already assumed.
 
 - Moved the `CategoricalColumnTypes` polars dtype constants from the Estimate Filled Posts by Job Role fargate job into Polars Utils, so they're available repo-wide without importing from that project.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ All notable changes to this project will be documented in this file.
 - Added `PublishedJobRoleLabels` categorical values class defining the canonical set of published ASC-WDS job role labels.
 
 ### Changed
+- Consolidated the personal `new-ticket` and `commit-and-push` Claude Code skills back into their repo-level counterparts (kept the worktree/SPEC.md/memory-seeding workflow and no-reconfirm push, adopted the repo's Plan-Mode interview and ticket-number commit format), and moved `continue-ticket`/`post-merge-cleanup` into the repo so all ticket-lifecycle skills live in one shared place.
+
 - Moved the `CategoricalColumnTypes` polars dtype constants from the Estimate Filled Posts by Job Role fargate job into Polars Utils, so they're available repo-wide without importing from that project.
 
 - Updated polars to 1.41.2 and pointblank to 0.24.0, and reworked `split_dataset_for_imputation` to use a semi/anti join instead of an `.over()`-based window filter, avoiding both a polars optimiser crash on the newer version and reducing peak memory under the streaming engine. Fargate Docker requirements are now split between a shared `docker_requirements/requirements.txt` for deps common to every project and small per-project `requirements-extra.txt` files for the two projects with additional deps (cqc_api; _04_model), instead of one shared file installing every project's deps everywhere.


### PR DESCRIPTION
## Description
Trello ticket [#1857](add link)

Merges the personal (user-level) `new-ticket` and `commit-and-push` skills with the simpler repo-level versions added in ticket 1816, so there's a single source of truth for each. Kept the worktree/`SPEC.md`/auto-seeded-memory workflow and "commit-push invocation = go-ahead to push" behavior; adopted the repo's `EnterPlanMode`-driven scoping interview and ticket-number commit format. Also moved `continue-ticket` and `post-merge-cleanup` into the repo unchanged, since they had no repo-level counterpart to conflict with. All five ticket-lifecycle skills now live solely in `.claude/skills/`.

A follow-up commit fixes two gaps a review of the first commit found: `open-pr` was silently inheriting `commit-push`'s no-reconfirm push even when the user only asked to open a PR, and it wasn't actually opening PRs as drafts despite `continue-ticket` claiming that convention. `open-pr` now confirms separately before any push it triggers itself, and opens PRs as drafts by default.

## Testing
No pipeline/data code is touched — this PR only changes Claude Code skill docs and the changelog.
- Exercised the merged `commit-push` skill live in this session to commit and push both commits on this branch.
- Exercised the merged `open-pr` skill live in this session to open this PR (as a draft).
- Reviewed the diff via a sub-agent per the `review-checklist` skill; no Critical findings. The two Important findings raised were fixed in the second commit; the one Optional finding (CHANGELOG categorization) was also fixed.

## Checklist
- [x] Updated CHANGELOG
- [x] Code reviewed by AI
- [ ] Moved Trello ticket to PR column

## Reviewer checklist
- [ ] PR solves the Trello ticket requirements
- [ ] Outputs appear reasonable and understandable
- [ ] The overall approach is appropriate and not over-engineered
- [ ] No obvious scalability, performance or interdependency concerns
- [ ] Tests appropriately cover the main behaviour/edge cases
- [ ] Naming and structure are broadly understandable and consistent
- [ ] Docstrings are sufficient for future maintenance
- [ ] Docstrings cover non-obvious behaviour