### PR TITLE
1858 - CircleCI - Add test job dependency caching

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,11 +83,11 @@ jobs:
             - v1-test-deps-{{ checksum "uv.lock" }}
       - run:
           name: install dependencies
-          command: time uv sync --locked
+          command: uv sync --locked
       # Download the pydeequ dependency and configure.
       - run:
             name: Fetch Spark JARs
-            command: time uv run python scripts/fetch_spark_dependencies.py
+            command: uv run python scripts/fetch_spark_dependencies.py
       - save_cache:
           key: v1-test-deps-{{ checksum "uv.lock" }}
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,7 +80,7 @@ jobs:
             apt-get install -y default-jre-headless
       - restore_cache:
           keys:
-            - v99-test-deps-{{ checksum "uv.lock" }}
+            - v1-test-deps-{{ checksum "uv.lock" }}
       - run:
           name: install dependencies
           command: time uv sync --locked
@@ -89,7 +89,7 @@ jobs:
             name: Fetch Spark JARs
             command: time uv run python scripts/fetch_spark_dependencies.py
       - save_cache:
-          key: v99-test-deps-{{ checksum "uv.lock" }}
+          key: v1-test-deps-{{ checksum "uv.lock" }}
           paths:
             - /root/.cache/uv
             - /root/.ivy2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,13 +78,21 @@ jobs:
           command: |
             apt-get update
             apt-get install -y default-jre-headless
+      - restore_cache:
+          keys:
+            - v1-test-deps-{{ checksum "uv.lock" }}
       - run:
           name: install dependencies
-          command: uv sync --locked
+          command: time uv sync --locked
       # Download the pydeequ dependency and configure.
       - run:
             name: Fetch Spark JARs
-            command: uv run python scripts/fetch_spark_dependencies.py
+            command: time uv run python scripts/fetch_spark_dependencies.py
+      - save_cache:
+          key: v1-test-deps-{{ checksum "uv.lock" }}
+          paths:
+            - /root/.cache/uv
+            - /root/.ivy2
       - run:
           name: Run unit tests and generate coverage
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,7 +80,7 @@ jobs:
             apt-get install -y default-jre-headless
       - restore_cache:
           keys:
-            - v1-test-deps-{{ checksum "uv.lock" }}
+            - v99-test-deps-{{ checksum "uv.lock" }}
       - run:
           name: install dependencies
           command: time uv sync --locked
@@ -89,7 +89,7 @@ jobs:
             name: Fetch Spark JARs
             command: time uv run python scripts/fetch_spark_dependencies.py
       - save_cache:
-          key: v1-test-deps-{{ checksum "uv.lock" }}
+          key: v99-test-deps-{{ checksum "uv.lock" }}
           paths:
             - /root/.cache/uv
             - /root/.ivy2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Added
+- Added dependency caching (`uv` and Spark/Ivy JARs, keyed on `uv.lock`) to the `test` job, plus timing output around the `install dependencies` and `Fetch Spark JARs` steps, to measure whether caching actually reduces the job's runtime before deciding whether to keep it (split out from 1852 pending that data).
+
 - Added `new-ticket`, `commit-push`, and `open-pr` Claude Code skills to run the ticket workflow (branch → SPEC → commits → PR) consistently, and an output-style guideline in CLAUDE.md. Trimmed the existing skills to cross-reference CLAUDE.md/PR templates instead of restating them, and updated remaining `pipenv` mentions to their `uv` equivalents.
 
 - Added a skeleton `_00_prepare` task (with validation) ahead of the merge step in the SLV pipeline, and rewired the merge step to read its output.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,7 +56,7 @@ All notable changes to this project will be documented in this file.
 - Split the shared `merge_job_role_columns` function in Polars Utils into two independent copies, one per calling pipeline: `merge_legacy_job_role_columns` in the ASCWDS ingest clean job, and `reduce_to_published_roles` in the SLV prepare job. This removes the shared dependency ahead of a future refactor of the SLV pipeline's job role handling.
 
 ### Improved
-- Added dependency caching (`uv` and Spark/Ivy JARs, keyed on `uv.lock`) to the CircleCI `test` job, cutting the `install dependencies` and `Fetch Spark JARs` steps' combined time (including cache restore/save overhead) from ~43s to ~20-23s per run, measured directly across cache-hit and forced cache-miss runs.
+- Added dependency caching (`uv` and Spark/Ivy JARs, keyed on `uv.lock`) to the CircleCI `test` job, saving ~10-13s per run on the `install dependencies` and `Fetch Spark JARs` steps versus no caching at all, measured directly across cache-hit and forced cache-miss runs including restore/save overhead.
 
 - Replaced the fan-out join that broadcast the primary service rate of change trendline back onto every location row with an `.over()`-based broadcast computed in place, reducing peak memory in the imputation pipeline.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,6 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Added
-- Added dependency caching (`uv` and Spark/Ivy JARs, keyed on `uv.lock`) to the `test` job.
-
 - Added `new-ticket`, `commit-push`, and `open-pr` Claude Code skills to run the ticket workflow (branch → SPEC → commits → PR) consistently, and an output-style guideline in CLAUDE.md. Trimmed the existing skills to cross-reference CLAUDE.md/PR templates instead of restating them, and updated remaining `pipenv` mentions to their `uv` equivalents.
 
 - Added a skeleton `_00_prepare` task (with validation) ahead of the merge step in the SLV pipeline, and rewired the merge step to read its output.
@@ -58,6 +56,8 @@ All notable changes to this project will be documented in this file.
 - Split the shared `merge_job_role_columns` function in Polars Utils into two independent copies, one per calling pipeline: `merge_legacy_job_role_columns` in the ASCWDS ingest clean job, and `reduce_to_published_roles` in the SLV prepare job. This removes the shared dependency ahead of a future refactor of the SLV pipeline's job role handling.
 
 ### Improved
+- Added dependency caching (`uv` and Spark/Ivy JARs, keyed on `uv.lock`) to the CircleCI `test` job, cutting the `install dependencies` and `Fetch Spark JARs` steps' combined time (including cache restore/save overhead) from ~43s to ~20-23s per run, measured directly across cache-hit and forced cache-miss runs.
+
 - Replaced the fan-out join that broadcast the primary service rate of change trendline back onto every location row with an `.over()`-based broadcast computed in place, reducing peak memory in the imputation pipeline.
 
 - Removed mid-pipeline LazyFrame collects from the PIR-to-filled-posts ratio and non-residential rate-of-change cleaning steps in the imputation pipeline, computing them as lazy expressions instead so the query stays fused end-to-end.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Added
-- Added dependency caching (`uv` and Spark/Ivy JARs, keyed on `uv.lock`) to the `test` job, plus timing output around the `install dependencies` and `Fetch Spark JARs` steps, to measure whether caching actually reduces the job's runtime before deciding whether to keep it (split out from 1852 pending that data).
+- Added dependency caching (`uv` and Spark/Ivy JARs, keyed on `uv.lock`) to the `test` job.
 
 - Added `new-ticket`, `commit-push`, and `open-pr` Claude Code skills to run the ticket workflow (branch → SPEC → commits → PR) consistently, and an output-style guideline in CLAUDE.md. Trimmed the existing skills to cross-reference CLAUDE.md/PR templates instead of restating them, and updated remaining `pipenv` mentions to their `uv` equivalents.
 


### PR DESCRIPTION
## Description
Trello ticket [#1858](https://trello.com/c/edggQ06i/1858-add-circleci-dependency-caching-to-the-test-job)

Added `restore_cache`/`save_cache` to the `test` job (the only `resource_class: large` job) around the existing `uv sync --locked` and Spark/Ivy JAR fetch steps, keyed on `uv.lock`'s checksum, so dependencies aren't re-downloaded from scratch on every run.

Measured directly: temporarily wrapped the `install dependencies` and `Fetch Spark JARs` steps in `time`, then compared a forced cache-miss run against two cache-hit runs, including `restore_cache`/`save_cache` step overhead.

| Run | restore_cache | install deps | Fetch Spark JARs | save_cache | Total |
|---|---|---|---|---|---|
| 1 (hit) | 13s | 1.6s | 8.4s | 0s | 23.0s |
| 2 (miss) | 0s | 23.8s | 9.2s | 10s | 43.0s |
| 3 (hit) | 12s | 1.8s | 6.5s | 0s | 20.2s |

`main` today has no caching at all, so its equivalent baseline is just `install deps` + `Fetch Spark JARs` with no cache steps — ~33.0s (the miss run's fetch time, minus the 10s `save_cache` upload main never pays). Against that true baseline, this saves **~10-13s per run** (~20.2-23.0s vs ~33.0s). The timing instrumentation has been removed now the result is confirmed — this PR just adds the caching itself.

## Testing
Verified directly against real CircleCI runs (see timings above) rather than local testing.

## Checklist
- [x] Updated CHANGELOG
- [x] Code reviewed by AI
- [x] Moved Trello ticket to PR column
