### PR TITLE
1835 - Filter SLV prepare job to non-null location_id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,8 @@ All notable changes to this project will be documented in this file.
 
 - Added missing error notifications for the CQC/ASC-WDS orchestrator and crawler-refresh steps in three ingestion pipelines, and a bounded timeout for the ASC-WDS worker/workplace file-arrival polling loops.
 
+- Fixed the SLV prepare step to exclude ASCWDS workplace records for non-CQC locations (null `location_id`), adding a reusable `not_null_filter_expr` to Polars Utils.
+
 ## [v2026.06.0] - 15/07/2026
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ All notable changes to this project will be documented in this file.
 
 - Added `PublishedJobRoleLabels` categorical values class defining the canonical set of published ASC-WDS job role labels.
 
+- Added a reusable `not_null_filter_expr` to Polars Utils, and used it in the SLV prepare step to exclude ASCWDS workplace records for non-CQC locations (null `location_id`).
+
 ### Changed
 - Moved the `CategoricalColumnTypes` polars dtype constants from the Estimate Filled Posts by Job Role fargate job into Polars Utils, so they're available repo-wide without importing from that project.
 
@@ -74,8 +76,6 @@ All notable changes to this project will be documented in this file.
 - Fixed Schema mismatch error while generating grouped providers output.
 
 - Added missing error notifications for the CQC/ASC-WDS orchestrator and crawler-refresh steps in three ingestion pipelines, and a bounded timeout for the ASC-WDS worker/workplace file-arrival polling loops.
-
-- Fixed the SLV prepare step to exclude ASCWDS workplace records for non-CQC locations (null `location_id`), adding a reusable `not_null_filter_expr` to Polars Utils.
 
 ## [v2026.06.0] - 15/07/2026
 

--- a/polars_utils/filtering_utils.py
+++ b/polars_utils/filtering_utils.py
@@ -183,3 +183,21 @@ def earliest_file_per_month_filter_expr(
     dt = pl.col(date_col)
 
     return dt == dt.min().over(dt.dt.year(), dt.dt.month())
+
+
+def not_null_filter_expr(column: str) -> pl.Expr:
+    """
+    Build a Polars expression selecting only rows where `column` is not null.
+
+    Returning an expression rather than a filtered LazyFrame lets callers attach it
+    directly to a `.filter()` chain alongside other predicates (e.g.
+    reduced_data_filter_expr), keeping the query lazy end-to-end.
+
+    Args:
+        column (str): Name of the column to check for non-null values.
+
+    Returns:
+        pl.Expr: A Polars boolean expression that can be used inside `.filter()` to
+            select rows where `column` is populated.
+    """
+    return pl.col(column).is_not_null()

--- a/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/_00_prepare.py
+++ b/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/_00_prepare.py
@@ -5,6 +5,7 @@ from polars_utils import utils
 from polars_utils.cleaning_utils import apply_categorical_labels
 from polars_utils.filtering_utils import (
     earliest_file_per_month_filter_expr,
+    not_null_filter_expr,
     reduced_data_filter_expr,
 )
 from utils.column_names.cleaned_data_files.ascwds_workplace_cleaned import (
@@ -24,6 +25,7 @@ def main(
     prepared_data_destination: str,
 ) -> None:
     """Load the cleaned ASCWDS workplace dataset and then:
+        - remove rows with a null location_id (ASCWDS includes non-CQC locations).
         - reduce rows to quarterly import dates before two previous financial years
           and then earliest import day per month.
         - merge unpublished roles into 'other' groups
@@ -34,6 +36,7 @@ def main(
     """
     workplace_lf = (
         utils.scan_parquet(cleaned_ascwds_workplace_source)
+        .filter(not_null_filter_expr(column=AWPClean.location_id))
         .filter(
             reduced_data_filter_expr(date_col=AWPClean.ascwds_workplace_import_date)
         )

--- a/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/validate_00_prepare.py
+++ b/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/validate_00_prepare.py
@@ -17,6 +17,7 @@ from utils.column_names.cleaned_data_files.ascwds_workplace_cleaned import (
 COMPARE_COLS_TO_IMPORT = [
     AWPClean.establishment_id,
     AWPClean.ascwds_workplace_import_date,
+    AWPClean.location_id,
 ]
 
 

--- a/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/validate_00_prepare.py
+++ b/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/validate_00_prepare.py
@@ -5,6 +5,7 @@ import pointblank as pb
 from polars_utils import utils
 from polars_utils.filtering_utils import (
     earliest_file_per_month_filter_expr,
+    not_null_filter_expr,
     reduced_data_filter_expr,
 )
 from polars_utils.validation import actions as vl
@@ -44,6 +45,7 @@ def main(
             source=f"s3://{bucket_name}/{compare_path}",
             selected_columns=COMPARE_COLS_TO_IMPORT,
         )
+        .filter(not_null_filter_expr(column=AWPClean.location_id))
         .filter(
             reduced_data_filter_expr(date_col=AWPClean.ascwds_workplace_import_date)
         )

--- a/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/tests/fargate/test_00_prepare.py
+++ b/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/tests/fargate/test_00_prepare.py
@@ -19,10 +19,12 @@ class TestPrepare:
     @patch(f"{PATCH_PATH}.pUtils.reduce_to_published_roles")
     @patch(f"{PATCH_PATH}.earliest_file_per_month_filter_expr")
     @patch(f"{PATCH_PATH}.reduced_data_filter_expr")
+    @patch(f"{PATCH_PATH}.not_null_filter_expr")
     @patch(f"{PATCH_PATH}.utils.scan_parquet")
     def test_main_runs(
         self,
         scan_parquet_mock: Mock,
+        not_null_filter_expr_mock: Mock,
         reduced_data_filter_expr_mock: Mock,
         earliest_file_per_month_filter_expr_mock: Mock,
         reduce_to_published_roles_mock: Mock,
@@ -38,6 +40,7 @@ class TestPrepare:
 
         scan_parquet_mock.assert_called_once_with(self.CLEANED_ASCWDS_WORKPLACE_SOURCE)
 
+        not_null_filter_expr_mock.assert_called_once_with(column=AWPClean.location_id)
         reduced_data_filter_expr_mock.assert_called_once_with(
             date_col=AWPClean.ascwds_workplace_import_date
         )
@@ -45,15 +48,17 @@ class TestPrepare:
             date_col=AWPClean.ascwds_workplace_import_date
         )
 
-        # The retention filter must run before the monthly reduction (cheap predicate
-        # first, so it can discard rows before the more expensive per-month-min window
-        # runs), and both must hang off the scan chain itself, otherwise the predicates
-        # are not pushed down to the parquet source and the full dataset is read first.
+        # The null-location filter runs first (cheapest predicate), then the retention
+        # filter, then the monthly reduction (most expensive), and all three must hang
+        # off the scan chain itself, otherwise the predicates are not pushed down to
+        # the parquet source and the full dataset is read first.
         scan_lf = scan_parquet_mock.return_value
-        scan_lf.filter.assert_called_once_with(
+        scan_lf.filter.assert_called_once_with(not_null_filter_expr_mock.return_value)
+        location_filtered_lf = scan_lf.filter.return_value
+        location_filtered_lf.filter.assert_called_once_with(
             reduced_data_filter_expr_mock.return_value
         )
-        retention_filtered_lf = scan_lf.filter.return_value
+        retention_filtered_lf = location_filtered_lf.filter.return_value
         retention_filtered_lf.filter.assert_called_once_with(
             earliest_file_per_month_filter_expr_mock.return_value
         )

--- a/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/tests/fargate/test_validate_00_prepare.py
+++ b/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/tests/fargate/test_validate_00_prepare.py
@@ -16,10 +16,11 @@ PATCH_PATH = "projects._07_workforce_characteristics._01_starters_leavers_vacanc
 class ValidatePreparedSLVDataTests(unittest.TestCase):
     def setUp(self) -> None:
         source_schema = {
+            AWPClean.location_id: pl.String,
             AWPClean.establishment_id: pl.String,
         }
         source_rows = [
-            ("1-001"),
+            ("Loc-001", "1-001"),
         ]  # fmt: skip
         self.source_df = pl.DataFrame(source_rows, source_schema, orient="row")
 
@@ -30,13 +31,14 @@ class ValidatePreparedSLVDataTests(unittest.TestCase):
         # earliest-file-per-month filter rather than the retention filter - proving the
         # monthly reduction itself is exercised here, not just retention.
         compare_schema = {
+            AWPClean.location_id: pl.String,
             AWPClean.establishment_id: pl.String,
             AWPClean.ascwds_workplace_import_date: pl.Date,
         }
         compare_rows = [
-            ("1-001", date(2026, 1, 1)),
-            ("1-003", date(2026, 1, 15)),  # same month as 1-001, later date -> dropped by monthly filter
-            ("1-002", date(2020, 5, 1)),
+            ("Loc-001", "1-001", date(2026, 1, 1)),
+            ("Loc-003", "1-003", date(2026, 1, 15)),  # same month as 1-001, later date -> dropped by monthly filter
+            ("Loc-002", "1-002", date(2020, 5, 1)),
         ]  # fmt: skip
         self.compare_df = pl.DataFrame(compare_rows, compare_schema, orient="row")
 

--- a/tests/test_polars_utils/test_filtering_utils.py
+++ b/tests/test_polars_utils/test_filtering_utils.py
@@ -268,3 +268,18 @@ class TestEarliestFilePerMonthFilterExpr:
         expr = job.earliest_file_per_month_filter_expr("some_other_column")
 
         assert set(expr.meta.root_names()) == {"some_other_column"}
+
+
+class TestNotNullFilterExpr:
+    def test_returns_only_rows_where_column_is_not_null(self):
+        test_lf = pl.LazyFrame({"location_id": [1, None, 3]})
+        expected_lf = pl.LazyFrame({"location_id": [1, 3]})
+
+        returned_lf = test_lf.filter(job.not_null_filter_expr("location_id"))
+
+        pl_testing.assert_frame_equal(returned_lf, expected_lf)
+
+    def test_uses_the_passed_column(self):
+        expr = job.not_null_filter_expr("some_other_column")
+
+        assert set(expr.meta.root_names()) == {"some_other_column"}


### PR DESCRIPTION
## Description
Trello ticket [#1835](https://trello.com/c/a6l3rg7W/1835-prepare-filter-to-non-null-location-ids)

Filters the ASCWDS workplace data in the SLV pipeline `_00_prepare` job to rows where `location_id` is not null (ASCWDS includes non-CQC locations, which shouldn't flow into this pipeline). Added a reusable `not_null_filter_expr` to Polars Utils (`polars_utils/filtering_utils.py`) rather than an inline one-off filter.

## Testing
- [x] Unit tests passing
- [x] Successful [Step Function run](https://eu-west-2.console.aws.amazon.com/states/home?region=eu-west-2#/v2/executions/details/arn:aws:states:eu-west-2:856699698263:execution:1835-null-locid-Ind-CQC-SLV:2ab9e6fe-3381-4860-b09f-e8d77b5d21b9)
- [x] Outputs checked in Athena


## Checklist (delete if not relevant)
- [x] Unit tests added/amended
- [x] Docstrings added/updated
- [x] Updated CHANGELOG
- [x] Code reviewed by AI
- [x] Moved Trello ticket to PR column

## Reviewer checklist
- [ ] PR solves the Trello ticket requirements
- [ ] Outputs appear reasonable and understandable
- [ ] The overall approach is appropriate and not over-engineered
- [ ] No obvious scalability, performance or interdependency concerns
- [ ] Tests appropriately cover the main behaviour/edge cases
- [ ] Naming and structure are broadly understandable and consistent
- [ ] Docstrings are sufficient for future maintenance
- [ ] Docstrings cover non-obvious behaviour