### PR TITLE
1845 - Derive SLV job-role mapping from published role classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,8 @@ All notable changes to this project will be documented in this file.
 
 - Split the shared `merge_job_role_columns` function in Polars Utils into two independent copies, one per calling pipeline: `merge_legacy_job_role_columns` in the ASCWDS ingest clean job, and `reduce_to_published_roles` in the SLV prepare job. This removes the shared dependency ahead of a future refactor of the SLV pipeline's job role handling.
 
+- Reworked `reduce_to_published_roles` in the SLV prepare job to derive which raw ASC-WDS job role codes are published versus fold into an 'other' group from the team's own `PublishedJobRoleLabels`/job-group definitions, instead of a hand-maintained mapping dict that needed manual upkeep whenever ASC-WDS's raw job role codes changed.
+
 ### Improved
 - Replaced the fan-out join that broadcast the primary service rate of change trendline back onto every location row with an `.over()`-based broadcast computed in place, reducing peak memory in the imputation pipeline.
 

--- a/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/_00_prepare.py
+++ b/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/_00_prepare.py
@@ -11,13 +11,6 @@ from utils.column_names.cleaned_data_files.ascwds_workplace_cleaned import (
     AscwdsWorkplaceCleanedColumns as AWPClean,
 )
 
-unpublished_roles_mapping = {
-    "1001": ["02", "03", "05", "24", "45", "47", "49", "50"], # other managers
-    "1002": ["35", "37"], # other regulated professions
-    "1003": ["10", "11", "23", "38"], # other direct care
-    "1004": ["25", "26", "27", "34", "36", "39", "40", "42", "44", "46", "48", "51"], # other
-} # fmt: skip
-
 
 def main(
     cleaned_ascwds_workplace_source: str,
@@ -44,15 +37,14 @@ def main(
         )
     )
 
-    workplace_lf = pUtils.reduce_to_published_roles(
-        workplace_lf, unpublished_roles_mapping
-    )
+    # These columns refer to the total for all job roles (28) and the total for job groups (29-32).
+    # They are not real ASC-WDS job role codes (not in MainJobRoleID), so they must be
+    # dropped before reduce_to_published_roles runs - otherwise its uncatalogued-code
+    # check would reject them. Matches every suffix, not just emp/strt/stop/vacy, since
+    # these totals aren't job roles regardless of suffix.
+    workplace_lf = workplace_lf.drop(cs.matches(r"^jr(28|29|30|31|32)"))
 
-    # These columns refer to the toal for all job roles (28) and the total for job groups (29-32).
-    # They are not required because we only want job roles at this stage.
-    workplace_lf = workplace_lf.drop(
-        cs.matches(r"^jr(28|29|30|31|32)(emp|strt|stop|vacy)$")
-    )
+    workplace_lf = pUtils.reduce_to_published_roles(workplace_lf)
 
     # TODO: Backlog ticket/no number - Placeholder only.
     # pUtils.pivot_job_role_cols_to_rows()

--- a/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/_00_prepare.py
+++ b/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/_00_prepare.py
@@ -39,9 +39,7 @@ def main(
 
     # These columns refer to the total for all job roles (28) and the total for job groups (29-32).
     # They are not real ASC-WDS job role codes (not in MainJobRoleID), so they must be
-    # dropped before reduce_to_published_roles runs - otherwise its uncatalogued-code
-    # check would reject them. Matches every suffix, not just emp/strt/stop/vacy, since
-    # these totals aren't job roles regardless of suffix.
+    # dropped before reduce_to_published_roles runs.
     workplace_lf = workplace_lf.drop(cs.matches(r"^jr(28|29|30|31|32)"))
 
     workplace_lf = pUtils.reduce_to_published_roles(workplace_lf)

--- a/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/utils/prepare_utils.py
+++ b/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/utils/prepare_utils.py
@@ -6,6 +6,9 @@ from utils.column_values.categorical_column_values import (
     JobGroupLabels,
     PublishedJobRoleLabels,
 )
+from utils.column_values.categorical_columns_by_dataset import (
+    SLVPrepareCategoricalValues,
+)
 from utils.value_labels.ascwds_worker.ascwds_worker_jobgroup_dictionary import (
     AscwdsWorkerValueLabelsJobGroup,
 )
@@ -13,57 +16,37 @@ from utils.value_labels.ascwds_worker.ascwds_worker_mainjrid import (
     AscwdsWorkerValueLabelsMainjrid,
 )
 
-_other_role_code_by_job_group = {
+
+other_role_code_by_job_group = {
     JobGroupLabels.managers: "1001",
     JobGroupLabels.regulated_professions: "1002",
     JobGroupLabels.direct_care: "1003",
     JobGroupLabels.other: "1004",
 }
 
-# PublishedJobRoleLabels' 4 synthetic other_* fields aren't real ASCWDS labels,
-# so intersecting with real job-role labels drops them without needing to name
-# them.
-_published_labels = {
-    value
-    for name, value in vars(PublishedJobRoleLabels).items()
-    if not name.startswith("_")
-} & set(AscwdsWorkerValueLabelsMainjrid.labels_dict.values())
-
-# Every ASC-WDS job role code with a known label and job-group classification,
-# zero-padded to match real column names (labels_dict stores bare codes, e.g.
-# "1", not "01"). `technician`(22)/`care_navigator`(41) are real MainJobRoleID
-# codes with no label/job-group entry here - they're already merged upstream
-# into other codes by clean_ascwds_workplace.py's legacy_job_roles_dict during
-# ASCWDS ingest cleaning, so they're not expected to reach this function; if
-# they ever did, they should error the same as any other uncatalogued code.
-ALL_CATALOGUED_JOB_ROLE_CODES = {
-    code.zfill(2) for code in AscwdsWorkerValueLabelsMainjrid.labels_dict
-}
-
-# Published roles are left untouched by reduce_to_published_roles.
-PUBLISHED_JOB_ROLE_CODES = {
-    code.zfill(2)
+# Excludes `technician`(22)/`care_navigator`(41) which are already merged upstream
+all_zero_filled_job_role_codes_and_labels: dict[str, str] = {
+    code.zfill(2): label
     for code, label in AscwdsWorkerValueLabelsMainjrid.labels_dict.items()
-    if label in _published_labels
+}
+published_job_role_labels = (
+    SLVPrepareCategoricalValues.published_job_role_labels_column_values.categorical_values
+)
+published_job_role_codes_and_labels: dict[str, str] = {
+    code: label
+    for code, label in all_zero_filled_job_role_codes_and_labels.items()
+    if label in published_job_role_labels
 }
 
-# Raw code -> synthetic "other_*" job role code it folds into (jr1001-jr1004;
-# not real ASC-WDS codes). Codes absent from this dict - published roles, and
-# the technician/care_navigator gap above - are left untouched by
-# reduce_to_published_roles.
-#
-# NOTE: ticket 1794 (separate, unmerged branch) independently introduces its
-# own reference to these same 4 codes for a later column-relabelling step -
-# this is deliberate, accepted duplication, not to be unified here.
-CODE_TO_OTHER_ROLE_CODE = {
-    code.zfill(2): _other_role_code_by_job_group[
+job_role_code_to_other_bucket_code = {
+    code: other_role_code_by_job_group[
         AscwdsWorkerValueLabelsJobGroup.job_role_to_job_group_dict[label]
     ]
-    for code, label in AscwdsWorkerValueLabelsMainjrid.labels_dict.items()
-    if label not in _published_labels
+    for code, label in all_zero_filled_job_role_codes_and_labels.items()
+    if label not in published_job_role_labels
 }
 
-_JOB_ROLE_COLUMN_PATTERN = re.compile(r"^jr(\d+)([a-z]+)$")
+JOB_ROLE_COLUMN_PATTERN = re.compile(r"^jr(\d+)([a-z]+)$")
 
 
 def reduce_to_published_roles(lf: pl.LazyFrame) -> pl.LazyFrame:
@@ -89,14 +72,14 @@ def reduce_to_published_roles(lf: pl.LazyFrame) -> pl.LazyFrame:
             team hasn't catalogued yet).
     """
     job_role_matches = {
-        col: _JOB_ROLE_COLUMN_PATTERN.match(col)
+        col: JOB_ROLE_COLUMN_PATTERN.match(col)
         for col in lf.collect_schema().names()
         if col.startswith("jr")
     }
 
     unknown_codes = {
         match.group(1) for match in job_role_matches.values()
-    } - ALL_CATALOGUED_JOB_ROLE_CODES
+    } - all_zero_filled_job_role_codes_and_labels.keys()
     if unknown_codes:
         raise ValueError(
             f"Unrecognised ASC-WDS job role code(s) {sorted(unknown_codes)} found in "
@@ -109,7 +92,7 @@ def reduce_to_published_roles(lf: pl.LazyFrame) -> pl.LazyFrame:
     merge_groups: dict[tuple[str, str], list[str]] = {}
     for col, match in job_role_matches.items():
         code, suffix = match.groups()
-        other_role_code = CODE_TO_OTHER_ROLE_CODE.get(code)
+        other_role_code = job_role_code_to_other_bucket_code.get(code)
         if other_role_code:
             merge_groups.setdefault((other_role_code, suffix), []).append(col)
 

--- a/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/utils/prepare_utils.py
+++ b/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/utils/prepare_utils.py
@@ -24,7 +24,9 @@ other_role_code_by_job_group = {
     JobGroupLabels.other: "1004",
 }
 
-# Excludes `technician`(22)/`care_navigator`(41) which are already merged upstream
+# Excludes codes clean_ascwds_workplace.py's legacy_job_roles_dict already merges
+# upstream during ASCWDS ingest cleaning (e.g. `technician`(22)/`care_navigator`(41)),
+# since they're not expected to reach this stage as their own columns.
 all_zero_filled_job_role_codes_and_labels: dict[str, str] = {
     code.zfill(2): label
     for code, label in AscwdsWorkerValueLabelsMainjrid.labels_dict.items()
@@ -38,13 +40,20 @@ published_job_role_codes_and_labels: dict[str, str] = {
     if label in published_job_role_labels
 }
 
-job_role_code_to_other_bucket_code = {
-    code: other_role_code_by_job_group[
-        AscwdsWorkerValueLabelsJobGroup.job_role_to_job_group_dict[label]
-    ]
-    for code, label in all_zero_filled_job_role_codes_and_labels.items()
-    if label not in published_job_role_labels
-}
+job_role_code_to_other_bucket_code: dict[str, str] = {}
+for _code, _label in all_zero_filled_job_role_codes_and_labels.items():
+    if _label in published_job_role_labels:
+        continue
+    if _label not in AscwdsWorkerValueLabelsJobGroup.job_role_to_job_group_dict:
+        raise KeyError(
+            f"Job role label {_label!r} (code {_code}) is in "
+            "AscwdsWorkerValueLabelsMainjrid.labels_dict but has no entry in "
+            "AscwdsWorkerValueLabelsJobGroup.job_role_to_job_group_dict. Add it there, "
+            "or as a new published role in PublishedJobRoleLabels, before this module "
+            "can be imported."
+        )
+    _job_group = AscwdsWorkerValueLabelsJobGroup.job_role_to_job_group_dict[_label]
+    job_role_code_to_other_bucket_code[_code] = other_role_code_by_job_group[_job_group]
 
 JOB_ROLE_COLUMN_PATTERN = re.compile(r"^jr(\d+)([a-z]+)$")
 

--- a/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/utils/prepare_utils.py
+++ b/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/utils/prepare_utils.py
@@ -1,78 +1,206 @@
+import dataclasses
 import re
 from typing import Generator
 
 import polars as pl
 import polars.selectors as cs
 
+from utils.column_values.categorical_column_values import (
+    JobGroupLabels,
+    MainJobRoleID,
+    MainJobRoleLabels,
+    PublishedJobRoleLabels,
+)
+from utils.value_labels.ascwds_worker.ascwds_worker_jobgroup_dictionary import (
+    AscwdsWorkerValueLabelsJobGroup,
+)
 
-def reduce_to_published_roles(
-    lf: pl.LazyFrame, job_role_mapping: dict[str, list[str]]
-) -> pl.LazyFrame:
+_COLUMN_VALUES_BASE_FIELD_NAMES = {
+    "column_name",
+    "value_to_remove",
+    "contains_null_values",
+}
+
+
+def _field_name_to_code(column_values_cls) -> dict[str, str]:
+    """Return {field_name: default_value} for a ColumnValues subclass's own fields.
+
+    Reads class-level dataclass field defaults directly rather than instantiating
+    the class, since `ColumnValues` requires a `column_name` to instantiate and
+    these code lists span many raw columns, not one.
+    """
+    return {
+        field.name: field.default
+        for field in dataclasses.fields(column_values_cls)
+        if field.name not in _COLUMN_VALUES_BASE_FIELD_NAMES
+    }
+
+
+_MAIN_JOB_ROLE_ID_BY_FIELD = _field_name_to_code(MainJobRoleID)
+_MAIN_JOB_ROLE_LABEL_BY_FIELD = _field_name_to_code(MainJobRoleLabels)
+
+# Excludes PublishedJobRoleLabels' 4 synthetic other_* fields, which have no
+# MainJobRoleID equivalent.
+_PUBLISHED_JOB_ROLE_FIELD_NAMES = set(
+    _field_name_to_code(PublishedJobRoleLabels)
+) & set(_MAIN_JOB_ROLE_ID_BY_FIELD)
+
+# Every raw ASC-WDS job role code this team has catalogued, zero-padded to match
+# real column names (MainJobRoleID stores bare codes, e.g. "1", not "01").
+ALL_CATALOGUED_JOB_ROLE_CODES = {
+    code.zfill(2) for code in _MAIN_JOB_ROLE_ID_BY_FIELD.values()
+}
+
+# Published roles are left untouched by reduce_to_published_roles.
+PUBLISHED_JOB_ROLE_CODES = {
+    _MAIN_JOB_ROLE_ID_BY_FIELD[field_name].zfill(2)
+    for field_name in _PUBLISHED_JOB_ROLE_FIELD_NAMES
+}
+
+# Job group -> synthetic "other_*" job role code it merges into. These 4 codes
+# are not real ASC-WDS codes. NOTE: ticket 1794 (separate, unmerged branch)
+# independently introduces its own reference to these same 4 codes for a later
+# column-relabelling step - this is deliberate, accepted duplication, not to be
+# unified here.
+_JOB_GROUP_TO_OTHER_ROLE_CODE = {
+    JobGroupLabels.managers: "1001",
+    JobGroupLabels.regulated_professions: "1002",
+    JobGroupLabels.direct_care: "1003",
+    JobGroupLabels.other: "1004",
+}
+
+# Raw code -> synthetic other_* code it folds into. Only covers codes with both
+# a MainJobRoleLabels entry and a job-group classification, excluding published
+# roles. `technician` (code 22) and `care_navigator` (code 41) exist in
+# MainJobRoleID but have neither - they are already merged upstream into other
+# codes by clean_ascwds_workplace.py's legacy_job_roles_dict during ASCWDS
+# ingest cleaning, so they never reach this function as their own columns.
+_UNPUBLISHED_JOB_ROLE_CODE_TO_OTHER_ROLE_CODE = {
+    _MAIN_JOB_ROLE_ID_BY_FIELD[field_name].zfill(2): _JOB_GROUP_TO_OTHER_ROLE_CODE[
+        AscwdsWorkerValueLabelsJobGroup.job_role_to_job_group_dict[label]
+    ]
+    for field_name, label in _MAIN_JOB_ROLE_LABEL_BY_FIELD.items()
+    if field_name not in _PUBLISHED_JOB_ROLE_FIELD_NAMES
+}
+
+# Grouped the other way round, {other_role_code: [unpublished_codes]}, which is
+# the shape reduce_to_published_roles_expressions sums over.
+OTHER_ROLE_CODE_TO_UNPUBLISHED_JOB_ROLE_CODES: dict[str, list[str]] = {}
+for _raw_code, _other_code in sorted(
+    _UNPUBLISHED_JOB_ROLE_CODE_TO_OTHER_ROLE_CODE.items()
+):
+    OTHER_ROLE_CODE_TO_UNPUBLISHED_JOB_ROLE_CODES.setdefault(_other_code, []).append(
+        _raw_code
+    )
+
+
+def reduce_to_published_roles(lf: pl.LazyFrame) -> pl.LazyFrame:
     """
     Merge ASC-WDS workplace job role columns down to published roles.
 
-    For each key job role code in job_role_mapping, sums the key job role
-    together with all the listed job role columns. This sum then replaces the
-    key job roles value. The listed job role columns are then dropped, leaving
-    only published roles plus the 'other' groups (other_dc/other_man etc.).
+    Published job roles (PublishedJobRoleLabels) are left untouched. Every
+    other catalogued raw job role (MainJobRoleID) is summed into whichever of
+    the 4 'other_*' synthetic roles (jr1001/jr1002/jr1003/jr1004) its job group
+    (AscwdsWorkerValueLabelsJobGroup) maps to, then dropped. A sum is null only
+    when all of its contributing columns are null. Raises ValueError (via
+    `_raise_if_uncatalogued_job_role_codes`) if a job role column's code isn't
+    in MainJobRoleID.
 
     Args:
         lf (pl.LazyFrame): ASC-WDS workplace LazyFrame.
-        job_role_mapping (dict[str, list[str]]): A mapping of job roles.
-            E.g. {role_to_merge_and_keep: [role_1_to_merge_and_drop, role_2_to_merge_and_drop...]}
 
     Returns:
-        pl.LazyFrame: Input LazyFrame in which columns have been merged and
-            removed.
+        pl.LazyFrame: Input LazyFrame in which unpublished job role columns
+            have been merged into the other_* roles and removed.
     """
-    job_role_cols = lf.collect_schema().names()
-    job_role_suffixes = list(
-        {re.sub(r"^jr\d+", "", col) for col in job_role_cols if col.startswith("jr")}
-    )
+    job_role_cols = [col for col in lf.collect_schema().names() if col.startswith("jr")]
+    _raise_if_uncatalogued_job_role_codes(job_role_cols)
+    existing_job_role_cols = set(job_role_cols)
+
+    job_role_suffixes = sorted({re.sub(r"^jr\d+", "", col) for col in job_role_cols})
 
     lf = lf.with_columns(
-        reduce_to_published_roles_expressions(job_role_mapping, job_role_suffixes),
+        reduce_to_published_roles_expressions(
+            OTHER_ROLE_CODE_TO_UNPUBLISHED_JOB_ROLE_CODES,
+            job_role_suffixes,
+            existing_job_role_cols,
+        ),
     )
 
-    # Flatten job role lists from job_role_mapping into single list, format them
-    # to match column names, then drop those columns.
-    old_roles = [old for olds in job_role_mapping.values() for old in olds]
+    unpublished_roles = list(_UNPUBLISHED_JOB_ROLE_CODE_TO_OTHER_ROLE_CODE)
     roles_to_drop = [
-        f"jr{role}{suffix}" for role in old_roles for suffix in job_role_suffixes
+        f"jr{role}{suffix}"
+        for role in unpublished_roles
+        for suffix in job_role_suffixes
     ]
     lf = lf.drop(cs.by_name(*roles_to_drop, require_all=False))
 
     return lf
 
 
-def reduce_to_published_roles_expressions(
-    job_role_mapping: dict[str, list[str]], slv_suffixes: list[str]
-) -> Generator[pl.Expr, None, None]:
+def _raise_if_uncatalogued_job_role_codes(job_role_cols: list[str]) -> None:
     """
-    A generator function that yields Polars expressions that sum
-    ASC-WDS workplace job role columns in the given mapping dictionary
-    that have the given slv_suffixes.
-
-    When all columns to sum are null then expression produces null.
+    Raise if any job role column's code isn't in MainJobRoleID.
 
     Args:
-        job_role_mapping (dict[str, list[str]]): A mapping of job roles.
-            E.g. {role_to_merge_and_keep: [role_1_to_merge_and_drop, role_2_to_merge_and_drop...]}
+        job_role_cols (list[str]): Column names starting with 'jr'.
+
+    Raises:
+        ValueError: If one or more codes aren't catalogued.
+    """
+    codes = {re.match(r"^jr(\d+)", col).group(1) for col in job_role_cols}
+    unknown_codes = codes - ALL_CATALOGUED_JOB_ROLE_CODES
+    if unknown_codes:
+        raise ValueError(
+            f"Unrecognised ASC-WDS job role code(s) {sorted(unknown_codes)} found in "
+            "input columns. Add them to MainJobRoleID and classify them (either as a "
+            "new published role in PublishedJobRoleLabels, or via MainJobRoleLabels + "
+            "AscwdsWorkerValueLabelsJobGroup) before running reduce_to_published_roles."
+        )
+
+
+def reduce_to_published_roles_expressions(
+    other_role_code_to_unpublished_codes: dict[str, list[str]],
+    slv_suffixes: list[str],
+    existing_job_role_cols: set[str],
+) -> Generator[pl.Expr, None, None]:
+    """
+    A generator function that yields Polars expressions that sum each other_*
+    role's unpublished source columns (across the given suffixes) into that
+    other_* role's column.
+
+    When all columns to sum are null then expression produces null. A suffix
+    is skipped entirely for a given other_* role if none of its unpublished
+    source columns are present for that suffix (e.g. a test fixture, or a
+    dataset extract, that doesn't carry every ASC-WDS job role column) -
+    `sum_horizontal` requires at least one input.
+
+    Args:
+        other_role_code_to_unpublished_codes (dict[str, list[str]]): Mapping of
+            synthetic other_* role code (e.g. "1001") to the raw unpublished
+            job role codes that fold into it.
         slv_suffixes (list[str]): A list of ASC-WDS workplace job role column suffixes.
             E.g. ["flag", "emp", "work"]
+        existing_job_role_cols (set[str]): Job role column names present in the
+            input LazyFrame.
 
     Yields:
         pl.Expr: Polars expressions for summing columns.
 
     """
-    for role_to_keep, roles_to_merge in job_role_mapping.items():
+    for role_to_keep, roles_to_merge in other_role_code_to_unpublished_codes.items():
         for suffix in slv_suffixes:
-            prefixes = [f"jr{role_to_keep}"] + [f"jr{old}" for old in roles_to_merge]
-            cols = cs.starts_with(*prefixes) & cs.ends_with(suffix)
+            source_cols = [
+                f"jr{old}{suffix}"
+                for old in roles_to_merge
+                if f"jr{old}{suffix}" in existing_job_role_cols
+            ]
+            if not source_cols:
+                continue
             yield (
-                pl.when(pl.all_horizontal(cols.is_null()))
+                pl.when(pl.all_horizontal(pl.col(source_cols).is_null()))
                 .then(pl.lit(None))
-                .otherwise(pl.sum_horizontal(cols))
+                .otherwise(pl.sum_horizontal(source_cols))
                 .alias(f"jr{role_to_keep}{suffix}")
             )
 

--- a/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/utils/prepare_utils.py
+++ b/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/utils/prepare_utils.py
@@ -4,45 +4,14 @@ import polars as pl
 
 from utils.column_values.categorical_column_values import (
     JobGroupLabels,
-    MainJobRoleID,
-    MainJobRoleLabels,
     PublishedJobRoleLabels,
 )
 from utils.value_labels.ascwds_worker.ascwds_worker_jobgroup_dictionary import (
     AscwdsWorkerValueLabelsJobGroup,
 )
-
-
-def _codes(column_values_cls) -> dict[str, str]:
-    """Return {field_name: code} for a ColumnValues subclass's own fields.
-
-    `vars()` on a dataclass returns only that class's own attributes, not
-    inherited ones, so this naturally excludes ColumnValues' base fields
-    (column_name, value_to_remove, contains_null_values) without needing to
-    name them.
-    """
-    return {
-        name: value
-        for name, value in vars(column_values_cls).items()
-        if not name.startswith("_")
-    }
-
-
-_role_id_by_name = _codes(MainJobRoleID)
-_role_label_by_name = _codes(MainJobRoleLabels)
-
-# PublishedJobRoleLabels' 4 synthetic other_* fields have no MainJobRoleID
-# equivalent, so intersecting drops them without needing to name them either.
-_published_names = set(_codes(PublishedJobRoleLabels)) & set(_role_id_by_name)
-
-# Every raw ASC-WDS job role code this team has catalogued, zero-padded to
-# match real column names (MainJobRoleID stores bare codes, e.g. "1", not "01").
-ALL_CATALOGUED_JOB_ROLE_CODES = {code.zfill(2) for code in _role_id_by_name.values()}
-
-# Published roles are left untouched by reduce_to_published_roles.
-PUBLISHED_JOB_ROLE_CODES = {
-    _role_id_by_name[name].zfill(2) for name in _published_names
-}
+from utils.value_labels.ascwds_worker.ascwds_worker_mainjrid import (
+    AscwdsWorkerValueLabelsMainjrid,
+)
 
 _other_role_code_by_job_group = {
     JobGroupLabels.managers: "1001",
@@ -51,23 +20,47 @@ _other_role_code_by_job_group = {
     JobGroupLabels.other: "1004",
 }
 
+# PublishedJobRoleLabels' 4 synthetic other_* fields aren't real ASCWDS labels,
+# so intersecting with real job-role labels drops them without needing to name
+# them.
+_published_labels = {
+    value
+    for name, value in vars(PublishedJobRoleLabels).items()
+    if not name.startswith("_")
+} & set(AscwdsWorkerValueLabelsMainjrid.labels_dict.values())
+
+# Every ASC-WDS job role code with a known label and job-group classification,
+# zero-padded to match real column names (labels_dict stores bare codes, e.g.
+# "1", not "01"). `technician`(22)/`care_navigator`(41) are real MainJobRoleID
+# codes with no label/job-group entry here - they're already merged upstream
+# into other codes by clean_ascwds_workplace.py's legacy_job_roles_dict during
+# ASCWDS ingest cleaning, so they're not expected to reach this function; if
+# they ever did, they should error the same as any other uncatalogued code.
+ALL_CATALOGUED_JOB_ROLE_CODES = {
+    code.zfill(2) for code in AscwdsWorkerValueLabelsMainjrid.labels_dict
+}
+
+# Published roles are left untouched by reduce_to_published_roles.
+PUBLISHED_JOB_ROLE_CODES = {
+    code.zfill(2)
+    for code, label in AscwdsWorkerValueLabelsMainjrid.labels_dict.items()
+    if label in _published_labels
+}
+
 # Raw code -> synthetic "other_*" job role code it folds into (jr1001-jr1004;
 # not real ASC-WDS codes). Codes absent from this dict - published roles, and
-# `technician`(22)/`care_navigator`(41) which have no MainJobRoleLabels/job-group
-# entry - are left untouched by reduce_to_published_roles. technician/
-# care_navigator are already merged upstream into other codes by
-# clean_ascwds_workplace.py's legacy_job_roles_dict during ASCWDS ingest
-# cleaning, so they never reach this function as their own columns in practice.
+# the technician/care_navigator gap above - are left untouched by
+# reduce_to_published_roles.
 #
 # NOTE: ticket 1794 (separate, unmerged branch) independently introduces its
 # own reference to these same 4 codes for a later column-relabelling step -
 # this is deliberate, accepted duplication, not to be unified here.
 CODE_TO_OTHER_ROLE_CODE = {
-    _role_id_by_name[name].zfill(2): _other_role_code_by_job_group[
+    code.zfill(2): _other_role_code_by_job_group[
         AscwdsWorkerValueLabelsJobGroup.job_role_to_job_group_dict[label]
     ]
-    for name, label in _role_label_by_name.items()
-    if name not in _published_names
+    for code, label in AscwdsWorkerValueLabelsMainjrid.labels_dict.items()
+    if label not in _published_labels
 }
 
 _JOB_ROLE_COLUMN_PATTERN = re.compile(r"^jr(\d+)([a-z]+)$")
@@ -78,10 +71,10 @@ def reduce_to_published_roles(lf: pl.LazyFrame) -> pl.LazyFrame:
     Merge ASC-WDS workplace job role columns down to published roles.
 
     Published job roles (PublishedJobRoleLabels) are left untouched. Every
-    other catalogued raw job role (MainJobRoleID) is summed into whichever of
-    the 4 'other_*' synthetic roles (jr1001/jr1002/jr1003/jr1004) its job group
-    (AscwdsWorkerValueLabelsJobGroup) maps to, then dropped. A sum is null only
-    when all of its contributing columns are null.
+    other catalogued raw job role (AscwdsWorkerValueLabelsMainjrid) is summed
+    into whichever of the 4 'other_*' synthetic roles (jr1001/jr1002/jr1003/
+    jr1004) its job group (AscwdsWorkerValueLabelsJobGroup) maps to, then
+    dropped. A sum is null only when all of its contributing columns are null.
 
     Args:
         lf (pl.LazyFrame): ASC-WDS workplace LazyFrame.
@@ -91,8 +84,9 @@ def reduce_to_published_roles(lf: pl.LazyFrame) -> pl.LazyFrame:
             have been merged into the other_* roles and removed.
 
     Raises:
-        ValueError: If a job role column's code isn't in MainJobRoleID (an
-            ASC-WDS code this team hasn't catalogued yet).
+        ValueError: If a job role column's code isn't in
+            AscwdsWorkerValueLabelsMainjrid.labels_dict (an ASC-WDS code this
+            team hasn't catalogued yet).
     """
     job_role_matches = {
         col: _JOB_ROLE_COLUMN_PATTERN.match(col)
@@ -106,9 +100,10 @@ def reduce_to_published_roles(lf: pl.LazyFrame) -> pl.LazyFrame:
     if unknown_codes:
         raise ValueError(
             f"Unrecognised ASC-WDS job role code(s) {sorted(unknown_codes)} found in "
-            "input columns. Add them to MainJobRoleID and classify them (either as a "
-            "new published role in PublishedJobRoleLabels, or via MainJobRoleLabels + "
-            "AscwdsWorkerValueLabelsJobGroup) before running reduce_to_published_roles."
+            "input columns. Add them to AscwdsWorkerValueLabelsMainjrid.labels_dict and "
+            "classify them (either as a new published role in PublishedJobRoleLabels, "
+            "or via AscwdsWorkerValueLabelsJobGroup) before running "
+            "reduce_to_published_roles."
         )
 
     merge_groups: dict[tuple[str, str], list[str]] = {}

--- a/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/utils/prepare_utils.py
+++ b/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/utils/prepare_utils.py
@@ -1,4 +1,3 @@
-import dataclasses
 import re
 from typing import Generator
 
@@ -15,46 +14,36 @@ from utils.value_labels.ascwds_worker.ascwds_worker_jobgroup_dictionary import (
     AscwdsWorkerValueLabelsJobGroup,
 )
 
-_COLUMN_VALUES_BASE_FIELD_NAMES = {
-    "column_name",
-    "value_to_remove",
-    "contains_null_values",
-}
 
+def _codes(column_values_cls) -> dict[str, str]:
+    """Return {field_name: code} for a ColumnValues subclass's own fields.
 
-def _field_name_to_code(column_values_cls) -> dict[str, str]:
-    """Return {field_name: default_value} for a ColumnValues subclass's own fields.
-
-    Reads class-level dataclass field defaults directly rather than instantiating
-    the class, since `ColumnValues` requires a `column_name` to instantiate and
-    these code lists span many raw columns, not one.
+    `vars()` on a dataclass returns only that class's own attributes, not
+    inherited ones, so this naturally excludes ColumnValues' base fields
+    (column_name, value_to_remove, contains_null_values) without needing to
+    name them.
     """
     return {
-        field.name: field.default
-        for field in dataclasses.fields(column_values_cls)
-        if field.name not in _COLUMN_VALUES_BASE_FIELD_NAMES
+        name: value
+        for name, value in vars(column_values_cls).items()
+        if not name.startswith("_")
     }
 
 
-_MAIN_JOB_ROLE_ID_BY_FIELD = _field_name_to_code(MainJobRoleID)
-_MAIN_JOB_ROLE_LABEL_BY_FIELD = _field_name_to_code(MainJobRoleLabels)
+_role_id_by_name = _codes(MainJobRoleID)
+_role_label_by_name = _codes(MainJobRoleLabels)
 
-# Excludes PublishedJobRoleLabels' 4 synthetic other_* fields, which have no
-# MainJobRoleID equivalent.
-_PUBLISHED_JOB_ROLE_FIELD_NAMES = set(
-    _field_name_to_code(PublishedJobRoleLabels)
-) & set(_MAIN_JOB_ROLE_ID_BY_FIELD)
+# PublishedJobRoleLabels' 4 synthetic other_* fields have no MainJobRoleID
+# equivalent, so intersecting drops them without needing to name them either.
+_published_names = set(_codes(PublishedJobRoleLabels)) & set(_role_id_by_name)
 
-# Every raw ASC-WDS job role code this team has catalogued, zero-padded to match
-# real column names (MainJobRoleID stores bare codes, e.g. "1", not "01").
-ALL_CATALOGUED_JOB_ROLE_CODES = {
-    code.zfill(2) for code in _MAIN_JOB_ROLE_ID_BY_FIELD.values()
-}
+# Every raw ASC-WDS job role code this team has catalogued, zero-padded to
+# match real column names (MainJobRoleID stores bare codes, e.g. "1", not "01").
+_ALL_CATALOGUED_JOB_ROLE_CODES = {code.zfill(2) for code in _role_id_by_name.values()}
 
 # Published roles are left untouched by reduce_to_published_roles.
 PUBLISHED_JOB_ROLE_CODES = {
-    _MAIN_JOB_ROLE_ID_BY_FIELD[field_name].zfill(2)
-    for field_name in _PUBLISHED_JOB_ROLE_FIELD_NAMES
+    _role_id_by_name[name].zfill(2) for name in _published_names
 }
 
 # Job group -> synthetic "other_*" job role code it merges into. These 4 codes
@@ -62,35 +51,28 @@ PUBLISHED_JOB_ROLE_CODES = {
 # independently introduces its own reference to these same 4 codes for a later
 # column-relabelling step - this is deliberate, accepted duplication, not to be
 # unified here.
-_JOB_GROUP_TO_OTHER_ROLE_CODE = {
+_other_role_code_by_job_group = {
     JobGroupLabels.managers: "1001",
     JobGroupLabels.regulated_professions: "1002",
     JobGroupLabels.direct_care: "1003",
     JobGroupLabels.other: "1004",
 }
 
-# Raw code -> synthetic other_* code it folds into. Only covers codes with both
-# a MainJobRoleLabels entry and a job-group classification, excluding published
-# roles. `technician` (code 22) and `care_navigator` (code 41) exist in
-# MainJobRoleID but have neither - they are already merged upstream into other
-# codes by clean_ascwds_workplace.py's legacy_job_roles_dict during ASCWDS
-# ingest cleaning, so they never reach this function as their own columns.
-_UNPUBLISHED_JOB_ROLE_CODE_TO_OTHER_ROLE_CODE = {
-    _MAIN_JOB_ROLE_ID_BY_FIELD[field_name].zfill(2): _JOB_GROUP_TO_OTHER_ROLE_CODE[
-        AscwdsWorkerValueLabelsJobGroup.job_role_to_job_group_dict[label]
-    ]
-    for field_name, label in _MAIN_JOB_ROLE_LABEL_BY_FIELD.items()
-    if field_name not in _PUBLISHED_JOB_ROLE_FIELD_NAMES
-}
-
-# Grouped the other way round, {other_role_code: [unpublished_codes]}, which is
-# the shape reduce_to_published_roles_expressions sums over.
+# {other_role_code: [unpublished_raw_codes]}, the shape
+# reduce_to_published_roles_expressions sums over. Built from every
+# MainJobRoleLabels role that isn't published, bucketed via its job group.
+# `technician` (code 22) and `care_navigator` (code 41) exist in MainJobRoleID
+# but have no MainJobRoleLabels entry, so this loop never sees them - they're
+# already merged upstream into other codes by clean_ascwds_workplace.py's
+# legacy_job_roles_dict during ASCWDS ingest cleaning, before this stage runs.
 OTHER_ROLE_CODE_TO_UNPUBLISHED_JOB_ROLE_CODES: dict[str, list[str]] = {}
-for _raw_code, _other_code in sorted(
-    _UNPUBLISHED_JOB_ROLE_CODE_TO_OTHER_ROLE_CODE.items()
-):
+for _name, _label in sorted(_role_label_by_name.items()):
+    if _name in _published_names:
+        continue
+    _job_group = AscwdsWorkerValueLabelsJobGroup.job_role_to_job_group_dict[_label]
+    _other_code = _other_role_code_by_job_group[_job_group]
     OTHER_ROLE_CODE_TO_UNPUBLISHED_JOB_ROLE_CODES.setdefault(_other_code, []).append(
-        _raw_code
+        _role_id_by_name[_name].zfill(2)
     )
 
 
@@ -127,7 +109,11 @@ def reduce_to_published_roles(lf: pl.LazyFrame) -> pl.LazyFrame:
         ),
     )
 
-    unpublished_roles = list(_UNPUBLISHED_JOB_ROLE_CODE_TO_OTHER_ROLE_CODE)
+    unpublished_roles = [
+        code
+        for codes in OTHER_ROLE_CODE_TO_UNPUBLISHED_JOB_ROLE_CODES.values()
+        for code in codes
+    ]
     roles_to_drop = [
         f"jr{role}{suffix}"
         for role in unpublished_roles
@@ -149,7 +135,7 @@ def _raise_if_uncatalogued_job_role_codes(job_role_cols: list[str]) -> None:
         ValueError: If one or more codes aren't catalogued.
     """
     codes = {re.match(r"^jr(\d+)", col).group(1) for col in job_role_cols}
-    unknown_codes = codes - ALL_CATALOGUED_JOB_ROLE_CODES
+    unknown_codes = codes - _ALL_CATALOGUED_JOB_ROLE_CODES
     if unknown_codes:
         raise ValueError(
             f"Unrecognised ASC-WDS job role code(s) {sorted(unknown_codes)} found in "

--- a/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/utils/prepare_utils.py
+++ b/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/utils/prepare_utils.py
@@ -1,8 +1,6 @@
 import re
-from typing import Generator
 
 import polars as pl
-import polars.selectors as cs
 
 from utils.column_values.categorical_column_values import (
     JobGroupLabels,
@@ -39,18 +37,13 @@ _published_names = set(_codes(PublishedJobRoleLabels)) & set(_role_id_by_name)
 
 # Every raw ASC-WDS job role code this team has catalogued, zero-padded to
 # match real column names (MainJobRoleID stores bare codes, e.g. "1", not "01").
-_ALL_CATALOGUED_JOB_ROLE_CODES = {code.zfill(2) for code in _role_id_by_name.values()}
+ALL_CATALOGUED_JOB_ROLE_CODES = {code.zfill(2) for code in _role_id_by_name.values()}
 
 # Published roles are left untouched by reduce_to_published_roles.
 PUBLISHED_JOB_ROLE_CODES = {
     _role_id_by_name[name].zfill(2) for name in _published_names
 }
 
-# Job group -> synthetic "other_*" job role code it merges into. These 4 codes
-# are not real ASC-WDS codes. NOTE: ticket 1794 (separate, unmerged branch)
-# independently introduces its own reference to these same 4 codes for a later
-# column-relabelling step - this is deliberate, accepted duplication, not to be
-# unified here.
 _other_role_code_by_job_group = {
     JobGroupLabels.managers: "1001",
     JobGroupLabels.regulated_professions: "1002",
@@ -58,22 +51,26 @@ _other_role_code_by_job_group = {
     JobGroupLabels.other: "1004",
 }
 
-# {other_role_code: [unpublished_raw_codes]}, the shape
-# reduce_to_published_roles_expressions sums over. Built from every
-# MainJobRoleLabels role that isn't published, bucketed via its job group.
-# `technician` (code 22) and `care_navigator` (code 41) exist in MainJobRoleID
-# but have no MainJobRoleLabels entry, so this loop never sees them - they're
-# already merged upstream into other codes by clean_ascwds_workplace.py's
-# legacy_job_roles_dict during ASCWDS ingest cleaning, before this stage runs.
-OTHER_ROLE_CODE_TO_UNPUBLISHED_JOB_ROLE_CODES: dict[str, list[str]] = {}
-for _name, _label in sorted(_role_label_by_name.items()):
-    if _name in _published_names:
-        continue
-    _job_group = AscwdsWorkerValueLabelsJobGroup.job_role_to_job_group_dict[_label]
-    _other_code = _other_role_code_by_job_group[_job_group]
-    OTHER_ROLE_CODE_TO_UNPUBLISHED_JOB_ROLE_CODES.setdefault(_other_code, []).append(
-        _role_id_by_name[_name].zfill(2)
-    )
+# Raw code -> synthetic "other_*" job role code it folds into (jr1001-jr1004;
+# not real ASC-WDS codes). Codes absent from this dict - published roles, and
+# `technician`(22)/`care_navigator`(41) which have no MainJobRoleLabels/job-group
+# entry - are left untouched by reduce_to_published_roles. technician/
+# care_navigator are already merged upstream into other codes by
+# clean_ascwds_workplace.py's legacy_job_roles_dict during ASCWDS ingest
+# cleaning, so they never reach this function as their own columns in practice.
+#
+# NOTE: ticket 1794 (separate, unmerged branch) independently introduces its
+# own reference to these same 4 codes for a later column-relabelling step -
+# this is deliberate, accepted duplication, not to be unified here.
+CODE_TO_OTHER_ROLE_CODE = {
+    _role_id_by_name[name].zfill(2): _other_role_code_by_job_group[
+        AscwdsWorkerValueLabelsJobGroup.job_role_to_job_group_dict[label]
+    ]
+    for name, label in _role_label_by_name.items()
+    if name not in _published_names
+}
+
+_JOB_ROLE_COLUMN_PATTERN = re.compile(r"^jr(\d+)([a-z]+)$")
 
 
 def reduce_to_published_roles(lf: pl.LazyFrame) -> pl.LazyFrame:
@@ -84,9 +81,7 @@ def reduce_to_published_roles(lf: pl.LazyFrame) -> pl.LazyFrame:
     other catalogued raw job role (MainJobRoleID) is summed into whichever of
     the 4 'other_*' synthetic roles (jr1001/jr1002/jr1003/jr1004) its job group
     (AscwdsWorkerValueLabelsJobGroup) maps to, then dropped. A sum is null only
-    when all of its contributing columns are null. Raises ValueError (via
-    `_raise_if_uncatalogued_job_role_codes`) if a job role column's code isn't
-    in MainJobRoleID.
+    when all of its contributing columns are null.
 
     Args:
         lf (pl.LazyFrame): ASC-WDS workplace LazyFrame.
@@ -94,48 +89,20 @@ def reduce_to_published_roles(lf: pl.LazyFrame) -> pl.LazyFrame:
     Returns:
         pl.LazyFrame: Input LazyFrame in which unpublished job role columns
             have been merged into the other_* roles and removed.
-    """
-    job_role_cols = [col for col in lf.collect_schema().names() if col.startswith("jr")]
-    _raise_if_uncatalogued_job_role_codes(job_role_cols)
-    existing_job_role_cols = set(job_role_cols)
-
-    job_role_suffixes = sorted({re.sub(r"^jr\d+", "", col) for col in job_role_cols})
-
-    lf = lf.with_columns(
-        reduce_to_published_roles_expressions(
-            OTHER_ROLE_CODE_TO_UNPUBLISHED_JOB_ROLE_CODES,
-            job_role_suffixes,
-            existing_job_role_cols,
-        ),
-    )
-
-    unpublished_roles = [
-        code
-        for codes in OTHER_ROLE_CODE_TO_UNPUBLISHED_JOB_ROLE_CODES.values()
-        for code in codes
-    ]
-    roles_to_drop = [
-        f"jr{role}{suffix}"
-        for role in unpublished_roles
-        for suffix in job_role_suffixes
-    ]
-    lf = lf.drop(cs.by_name(*roles_to_drop, require_all=False))
-
-    return lf
-
-
-def _raise_if_uncatalogued_job_role_codes(job_role_cols: list[str]) -> None:
-    """
-    Raise if any job role column's code isn't in MainJobRoleID.
-
-    Args:
-        job_role_cols (list[str]): Column names starting with 'jr'.
 
     Raises:
-        ValueError: If one or more codes aren't catalogued.
+        ValueError: If a job role column's code isn't in MainJobRoleID (an
+            ASC-WDS code this team hasn't catalogued yet).
     """
-    codes = {re.match(r"^jr(\d+)", col).group(1) for col in job_role_cols}
-    unknown_codes = codes - _ALL_CATALOGUED_JOB_ROLE_CODES
+    job_role_matches = {
+        col: _JOB_ROLE_COLUMN_PATTERN.match(col)
+        for col in lf.collect_schema().names()
+        if col.startswith("jr")
+    }
+
+    unknown_codes = {
+        match.group(1) for match in job_role_matches.values()
+    } - ALL_CATALOGUED_JOB_ROLE_CODES
     if unknown_codes:
         raise ValueError(
             f"Unrecognised ASC-WDS job role code(s) {sorted(unknown_codes)} found in "
@@ -144,51 +111,23 @@ def _raise_if_uncatalogued_job_role_codes(job_role_cols: list[str]) -> None:
             "AscwdsWorkerValueLabelsJobGroup) before running reduce_to_published_roles."
         )
 
+    merge_groups: dict[tuple[str, str], list[str]] = {}
+    for col, match in job_role_matches.items():
+        code, suffix = match.groups()
+        other_role_code = CODE_TO_OTHER_ROLE_CODE.get(code)
+        if other_role_code:
+            merge_groups.setdefault((other_role_code, suffix), []).append(col)
 
-def reduce_to_published_roles_expressions(
-    other_role_code_to_unpublished_codes: dict[str, list[str]],
-    slv_suffixes: list[str],
-    existing_job_role_cols: set[str],
-) -> Generator[pl.Expr, None, None]:
-    """
-    A generator function that yields Polars expressions that sum each other_*
-    role's unpublished source columns (across the given suffixes) into that
-    other_* role's column.
+    lf = lf.with_columns(
+        pl.when(pl.all_horizontal(pl.col(source_cols).is_null()))
+        .then(pl.lit(None))
+        .otherwise(pl.sum_horizontal(source_cols))
+        .alias(f"jr{other_role_code}{suffix}")
+        for (other_role_code, suffix), source_cols in merge_groups.items()
+    )
+    lf = lf.drop([col for source_cols in merge_groups.values() for col in source_cols])
 
-    When all columns to sum are null then expression produces null. A suffix
-    is skipped entirely for a given other_* role if none of its unpublished
-    source columns are present for that suffix (e.g. a test fixture, or a
-    dataset extract, that doesn't carry every ASC-WDS job role column) -
-    `sum_horizontal` requires at least one input.
-
-    Args:
-        other_role_code_to_unpublished_codes (dict[str, list[str]]): Mapping of
-            synthetic other_* role code (e.g. "1001") to the raw unpublished
-            job role codes that fold into it.
-        slv_suffixes (list[str]): A list of ASC-WDS workplace job role column suffixes.
-            E.g. ["flag", "emp", "work"]
-        existing_job_role_cols (set[str]): Job role column names present in the
-            input LazyFrame.
-
-    Yields:
-        pl.Expr: Polars expressions for summing columns.
-
-    """
-    for role_to_keep, roles_to_merge in other_role_code_to_unpublished_codes.items():
-        for suffix in slv_suffixes:
-            source_cols = [
-                f"jr{old}{suffix}"
-                for old in roles_to_merge
-                if f"jr{old}{suffix}" in existing_job_role_cols
-            ]
-            if not source_cols:
-                continue
-            yield (
-                pl.when(pl.all_horizontal(pl.col(source_cols).is_null()))
-                .then(pl.lit(None))
-                .otherwise(pl.sum_horizontal(source_cols))
-                .alias(f"jr{role_to_keep}{suffix}")
-            )
+    return lf
 
 
 def pivot_job_role_cols_to_rows():

--- a/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/tests/fargate/test_00_prepare.py
+++ b/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/tests/fargate/test_00_prepare.py
@@ -1,5 +1,7 @@
 from unittest.mock import ANY, Mock, patch
 
+import polars.selectors as cs
+
 import projects._07_workforce_characteristics._01_starters_leavers_vacancies.fargate._00_prepare as job
 from utils.column_names.cleaned_data_files.ascwds_workplace_cleaned import (
     AscwdsWorkplaceCleanedColumns as AWPClean,
@@ -61,8 +63,13 @@ class TestPrepare:
 
         # The job-role totals columns (28-32) are dropped before reduce_to_published_roles
         # runs, since they aren't real job role codes and would otherwise fail its
-        # uncatalogued-code check.
+        # uncatalogued-code check. Polars selectors overload `==` to build a new
+        # expression rather than compare equal/unequal, so `assert_called_once_with`
+        # can't be used directly here (it raises on the ambiguous-truth-value check) -
+        # compare reprs instead.
         month_filtered_lf.drop.assert_called_once()
+        actual_drop_selector = month_filtered_lf.drop.call_args.args[0]
+        assert repr(actual_drop_selector) == repr(cs.matches(r"^jr(28|29|30|31|32)"))
         dropped_totals_lf = month_filtered_lf.drop.return_value
 
         # TODO: Uncomment these assertions when the placeholder functions are implemented

--- a/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/tests/fargate/test_00_prepare.py
+++ b/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/tests/fargate/test_00_prepare.py
@@ -57,17 +57,22 @@ class TestPrepare:
         retention_filtered_lf.filter.assert_called_once_with(
             earliest_file_per_month_filter_expr_mock.return_value
         )
+        month_filtered_lf = retention_filtered_lf.filter.return_value
+
+        # The job-role totals columns (28-32) are dropped before reduce_to_published_roles
+        # runs, since they aren't real job role codes and would otherwise fail its
+        # uncatalogued-code check.
+        month_filtered_lf.drop.assert_called_once()
+        dropped_totals_lf = month_filtered_lf.drop.return_value
 
         # TODO: Uncomment these assertions when the placeholder functions are implemented
-        reduce_to_published_roles_mock.assert_called_once()
+        reduce_to_published_roles_mock.assert_called_once_with(dropped_totals_lf)
         merged_jr_cols_lf = reduce_to_published_roles_mock.return_value
-        merged_jr_cols_lf.drop.assert_called_once()
-        dropped_cols_lf = merged_jr_cols_lf.drop.return_value
         # pivot_job_role_cols_to_rows_mock.assert_called_once()
         # convert_job_role_strings_to_number_only_mock.assert_called_once()
         # apply_categorical_labels_mock.assert_called_once()
 
         sink_to_parquet_mock.assert_called_once_with(
-            lazy_df=dropped_cols_lf,
+            lazy_df=merged_jr_cols_lf,
             output_path=self.PREPARED_DATA_DESTINATION,
         )

--- a/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/tests/fargate/utils/test_prepare_utils.py
+++ b/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/tests/fargate/utils/test_prepare_utils.py
@@ -40,7 +40,7 @@ class TestJobRoleCodeDerivation:
         assert "02" not in job.PUBLISHED_JOB_ROLE_CODES
 
     def test_unpublished_role_code_maps_to_expected_other_role_code(self):
-        assert "02" in job.OTHER_ROLE_CODE_TO_UNPUBLISHED_JOB_ROLE_CODES["1001"]
+        assert job.CODE_TO_OTHER_ROLE_CODE["02"] == "1001"
 
 
 class TestPivotJobRoleColsToRows:

--- a/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/tests/fargate/utils/test_prepare_utils.py
+++ b/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/tests/fargate/utils/test_prepare_utils.py
@@ -45,13 +45,13 @@ class TestReduceToPublishedRoles:
 
 class TestJobRoleCodeDerivation:
     def test_published_role_code_is_in_published_job_role_codes(self):
-        assert "01" in job.PUBLISHED_JOB_ROLE_CODES
+        assert "01" in job.published_job_role_codes_and_labels.keys()
 
     def test_unpublished_role_code_is_not_in_published_job_role_codes(self):
-        assert "02" not in job.PUBLISHED_JOB_ROLE_CODES
+        assert "02" not in job.published_job_role_codes_and_labels.keys()
 
     def test_unpublished_role_code_maps_to_expected_other_role_code(self):
-        assert job.CODE_TO_OTHER_ROLE_CODE["02"] == "1001"
+        assert job.job_role_code_to_other_bucket_code["02"] == "1001"
 
 
 class TestPivotJobRoleColsToRows:

--- a/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/tests/fargate/utils/test_prepare_utils.py
+++ b/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/tests/fargate/utils/test_prepare_utils.py
@@ -54,6 +54,15 @@ class TestJobRoleCodeDerivation:
     def test_unpublished_role_code_maps_to_expected_other_role_code(self):
         assert job.job_role_code_to_other_bucket_code["02"] == "1001"
 
+    def test_every_catalogued_code_is_published_or_bucketed_exactly_once(self):
+        published_codes = set(job.published_job_role_codes_and_labels)
+        bucketed_codes = set(job.job_role_code_to_other_bucket_code)
+
+        assert not (published_codes & bucketed_codes)
+        assert published_codes | bucketed_codes == set(
+            job.all_zero_filled_job_role_codes_and_labels
+        )
+
 
 class TestPivotJobRoleColsToRows:
     def test_pivot_job_role_cols_to_rows(self):

--- a/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/tests/fargate/utils/test_prepare_utils.py
+++ b/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/tests/fargate/utils/test_prepare_utils.py
@@ -26,9 +26,20 @@ class TestReduceToPublishedRoles:
         pl_testing.assert_frame_equal(returned_lf, expected_lf)
 
     def test_raises_value_error_for_uncatalogued_job_role_code(self):
-        test_lf = pl.LazyFrame({"jr98emp": 1})  # 98 isn't a MainJobRoleID code
+        test_lf = pl.LazyFrame(
+            {"jr98emp": 1}
+        )  # not an AscwdsWorkerValueLabelsMainjrid code
 
         with pytest.raises(ValueError, match="98"):
+            job.reduce_to_published_roles(test_lf)
+
+    def test_raises_value_error_for_technician_and_care_navigator_codes(self):
+        # 22 (technician) and 41 (care_navigator) have no label/job-group entry,
+        # so they're treated the same as any other uncatalogued code. They're
+        # already merged upstream before reaching this function in practice.
+        test_lf = pl.LazyFrame({"jr22emp": 1, "jr41emp": 2})
+
+        with pytest.raises(ValueError, match="22"):
             job.reduce_to_published_roles(test_lf)
 
 

--- a/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/tests/fargate/utils/test_prepare_utils.py
+++ b/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/tests/fargate/utils/test_prepare_utils.py
@@ -21,9 +21,26 @@ class TestReduceToPublishedRoles:
     def test_reduce_to_published_roles(self, case):
         test_lf = pl.LazyFrame(case.input_data)
         expected_lf = pl.LazyFrame(case.expected_data)
-        returned_lf = job.reduce_to_published_roles(test_lf, case.mapping)
+        returned_lf = job.reduce_to_published_roles(test_lf)
 
         pl_testing.assert_frame_equal(returned_lf, expected_lf)
+
+    def test_raises_value_error_for_uncatalogued_job_role_code(self):
+        test_lf = pl.LazyFrame({"jr98emp": 1})  # 98 isn't a MainJobRoleID code
+
+        with pytest.raises(ValueError, match="98"):
+            job.reduce_to_published_roles(test_lf)
+
+
+class TestJobRoleCodeDerivation:
+    def test_published_role_code_is_in_published_job_role_codes(self):
+        assert "01" in job.PUBLISHED_JOB_ROLE_CODES
+
+    def test_unpublished_role_code_is_not_in_published_job_role_codes(self):
+        assert "02" not in job.PUBLISHED_JOB_ROLE_CODES
+
+    def test_unpublished_role_code_maps_to_expected_other_role_code(self):
+        assert "02" in job.OTHER_ROLE_CODE_TO_UNPUBLISHED_JOB_ROLE_CODES["1001"]
 
 
 class TestPivotJobRoleColsToRows:

--- a/projects/_07_workforce_characteristics/dockerfile_and_requirements/Dockerfile
+++ b/projects/_07_workforce_characteristics/dockerfile_and_requirements/Dockerfile
@@ -10,6 +10,7 @@ ENV PYTHONPATH=/app
 COPY polars_utils /app/polars_utils
 COPY utils/column_names /app/utils/column_names/
 COPY utils/column_values /app/utils/column_values/
+COPY utils/value_labels/ascwds_worker /app/utils/value_labels/ascwds_worker/
 COPY projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/utils /app/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/utils
 
 # Copy python jobs to WORKDIR

--- a/projects/_07_workforce_characteristics/unittest_data/polars_slv_test_data.py
+++ b/projects/_07_workforce_characteristics/unittest_data/polars_slv_test_data.py
@@ -9,7 +9,6 @@ from utils.column_names.cleaned_data_files.ascwds_workplace_cleaned import (
 @dataclass
 class ReduceToPublishedRolesTestCase:
     id: str
-    mapping: dict[str, list[str]]
     input_data: dict[str, Any]
     expected_data: dict[str, Any]
 
@@ -18,106 +17,75 @@ class ReduceToPublishedRolesTestCase:
 class TestPrepareUtilsData:
     reduce_to_published_roles_test_cases = [
         ReduceToPublishedRolesTestCase(
-            id="merges_one_role_to_one_role",
-            mapping={"01": ["02"]},
+            id="leaves_published_role_untouched",
             input_data={
-                AWPClean.job_role_01_employees: 1,
-                AWPClean.job_role_02_employees: 2,
+                AWPClean.job_role_01_employees: 1,  # senior_management - published
             },
             expected_data={
-                AWPClean.job_role_01_employees: 3,
+                AWPClean.job_role_01_employees: 1,
             },
         ),
         ReduceToPublishedRolesTestCase(
-            id="merges_many_roles_to_one_role",
-            mapping={"01": ["02", "03"]},
+            id="folds_single_unpublished_role_into_its_job_group",
             input_data={
-                AWPClean.job_role_01_employees: 1,
-                AWPClean.job_role_02_employees: 2,
-                AWPClean.job_role_03_employees: 3,
+                AWPClean.job_role_35_employees: 5,  # safeguarding_officer -> regulated_professions
             },
             expected_data={
-                AWPClean.job_role_01_employees: 6,
+                "jr1002emp": 5,
+            },
+        ),
+        ReduceToPublishedRolesTestCase(
+            id="sums_multiple_unpublished_roles_into_same_job_group",
+            input_data={
+                AWPClean.job_role_02_employees: 2,  # middle_management -> managers
+                AWPClean.job_role_03_employees: 3,  # first_line_manager -> managers
+            },
+            expected_data={
+                "jr1001emp": 5,
             },
         ),
         ReduceToPublishedRolesTestCase(
             id="ignores_null_values_in_sum",
-            mapping={"01": ["02"]},
             input_data={
-                AWPClean.job_role_01_employees: 1,
-                AWPClean.job_role_02_employees: None,
-            },
-            expected_data={
-                AWPClean.job_role_01_employees: 1,
-            },
-        ),
-        ReduceToPublishedRolesTestCase(
-            id="returns_null_when_all_roles_are_null",
-            mapping={"01": ["02"]},
-            input_data={
-                AWPClean.job_role_01_employees: None,
-                AWPClean.job_role_02_employees: None,
-            },
-            expected_data={
-                AWPClean.job_role_01_employees: None,
-            },
-        ),
-        ReduceToPublishedRolesTestCase(
-            id="ignores_roles_in_mapping_but_not_in_input_data",
-            mapping={"01": ["02"]},
-            input_data={
-                AWPClean.job_role_01_employees: 1,
-            },
-            expected_data={
-                AWPClean.job_role_01_employees: 1,
-            },
-        ),
-        ReduceToPublishedRolesTestCase(
-            id="creates_target_role_when_missing",
-            mapping={"99": ["01", "02"]},
-            input_data={
-                AWPClean.job_role_01_employees: 1,
                 AWPClean.job_role_02_employees: 2,
+                AWPClean.job_role_03_employees: None,
             },
             expected_data={
-                "jr99emp": 3,
+                "jr1001emp": 2,
+            },
+        ),
+        ReduceToPublishedRolesTestCase(
+            id="returns_null_when_all_unpublished_roles_are_null",
+            input_data={
+                AWPClean.job_role_02_employees: None,
+                AWPClean.job_role_03_employees: None,
+            },
+            expected_data={
+                "jr1001emp": None,
             },
         ),
         ReduceToPublishedRolesTestCase(
             id="merges_all_matching_suffixes",
-            mapping={"01": ["02"]},
             input_data={
-                AWPClean.job_role_01_employees: 1,
                 AWPClean.job_role_02_employees: 2,
-                AWPClean.job_role_01_starters: 3,
+                AWPClean.job_role_03_employees: 3,
                 AWPClean.job_role_02_starters: 4,
+                AWPClean.job_role_03_starters: 5,
             },
             expected_data={
-                AWPClean.job_role_01_employees: 3,
-                AWPClean.job_role_01_starters: 7,
+                "jr1001emp": 5,
+                "jr1001strt": 9,
             },
         ),
         ReduceToPublishedRolesTestCase(
-            id="handles_extra_columns_in_input_data",
-            mapping={"01": ["02"]},
+            id="handles_extra_non_job_role_columns_in_input_data",
             input_data={
                 AWPClean.job_role_01_employees: 1,
-                AWPClean.job_role_02_employees: 2,
                 "not_a_job_role_column": "A",
             },
             expected_data={
-                AWPClean.job_role_01_employees: 3,
+                AWPClean.job_role_01_employees: 1,
                 "not_a_job_role_column": "A",
-            },
-        ),
-        ReduceToPublishedRolesTestCase(
-            id="handles_job_roles_with_same_characters",
-            mapping={"101": ["10"]},
-            input_data={
-                AWPClean.job_role_10_employees: 10,
-            },
-            expected_data={
-                "jr101emp": 10,
             },
         ),
     ]

--- a/projects/_07_workforce_characteristics/unittest_data/polars_slv_test_data.py
+++ b/projects/_07_workforce_characteristics/unittest_data/polars_slv_test_data.py
@@ -53,6 +53,24 @@ class TestPrepareUtilsData:
             },
         ),
         ReduceToPublishedRolesTestCase(
+            id="folds_direct_care_group_role_into_its_job_group",
+            input_data={
+                AWPClean.job_role_10_employees: 7,  # employment_support -> direct_care
+            },
+            expected_data={
+                "jr1003emp": 7,
+            },
+        ),
+        ReduceToPublishedRolesTestCase(
+            id="folds_other_group_role_into_its_job_group",
+            input_data={
+                AWPClean.job_role_25_employees: 4,  # admin_staff -> other
+            },
+            expected_data={
+                "jr1004emp": 4,
+            },
+        ),
+        ReduceToPublishedRolesTestCase(
             id="ignores_null_values_in_sum",
             input_data={
                 AWPClean.job_role_02_employees: 2,

--- a/utils/column_values/categorical_columns_by_dataset.py
+++ b/utils/column_values/categorical_columns_by_dataset.py
@@ -39,6 +39,7 @@ from utils.column_values.categorical_column_values import (
     ParentPermission,
     PrimaryServiceType,
     PrimaryServiceTypeSecondLevel,
+    PublishedJobRoleLabels,
     Region,
     RegistrationStatus,
     RegistrationType,
@@ -285,4 +286,11 @@ class DiagnosticOnKnownFilledPostsCategoricalValues:
     estimate_filled_posts_source_column_values = EstimateFilledPostsSource(
         IndCQC.estimate_filled_posts_source,
         value_to_remove=EstimateFilledPostsSource.ascwds_pir_merged,
+    )
+
+
+@dataclass
+class SLVPrepareCategoricalValues:
+    published_job_role_labels_column_values = PublishedJobRoleLabels(
+        AWKClean.main_job_role_clean_labelled
     )


### PR DESCRIPTION
## Description
Trello ticket [#1845](https://trello.com/c/y8nEA6S3/1845-pivot-refactor-mergejobrolecolumns)

Refactors `reduce_to_published_roles` in the SLV prepare stage (`_00_prepare.py`/`prepare_utils.py`) to derive which raw ASC-WDS job-role codes are published vs. need folding into one of 4 synthetic "other_*" buckets from existing static classes (`AscwdsWorkerValueLabelsMainjrid.labels_dict`, `AscwdsWorkerValueLabelsJobGroup.job_role_to_job_group_dict`, `SLVPrepareCategoricalValues.published_job_role_labels_column_values`), instead of a hand-maintained hardcoded mapping. Published job roles are defined and controlled by this team and rarely change; raw ASC-WDS codes are controlled externally and can be added/retired independent of us, so a hand-copied snapshot mapping needed manual upkeep whenever ASC-WDS's codebook changed.

Also fixes a bug in `_00_prepare.py`'s job-role totals-column drop (codes 28-32), which previously only stripped 4 of ~11 real suffixes and ran after the merge step; it's now widened to catch every suffix and moved to run before `reduce_to_published_roles`.

## Testing
- [x] Unit tests passing
- [x] Successful [Step Function run](https://eu-west-2.console.aws.amazon.com/states/home?region=eu-west-2#/v2/executions/details/arn:aws:states:eu-west-2:856699698263:execution:1845-reduce-pjr-Ind-CQC-SLV:5d55baff-6e50-4bc0-ae6e-5d55c1546c7f)
- [x] Outputs checked in Athena

## Checklist (delete if not relevant)
- [x] Unit tests added/amended
- [x] Docstrings added/updated
- [x] Updated CHANGELOG
- [x] Code reviewed by AI
- [x] Moved Trello ticket to PR column

## Reviewer checklist
- [ ] PR solves the Trello ticket requirements
- [ ] Outputs appear reasonable and understandable
- [ ] The overall approach is appropriate and not over-engineered
- [ ] No obvious scalability, performance or interdependency concerns
- [ ] Tests appropriately cover the main behaviour/edge cases
- [ ] Naming and structure are broadly understandable and consistent
- [ ] Docstrings are sufficient for future maintenance
- [ ] Docstrings cover non-obvious behaviour