### PR TITLE
1837 - Join job role estimates with metadata in SLV merge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Added
+- Joined job role estimates with metadata (on `id_per_locationid_import_date`) in the SLV merge job.
+
 - Added `new-ticket`, `commit-push`, and `open-pr` Claude Code skills to run the ticket workflow (branch → SPEC → commits → PR) consistently, and an output-style guideline in CLAUDE.md. Trimmed the existing skills to cross-reference CLAUDE.md/PR templates instead of restating them, and updated remaining `pipenv` mentions to their `uv` equivalents.
 
 - Added a skeleton `_00_prepare` task (with validation) ahead of the merge step in the SLV pipeline, and rewired the merge step to read its output.

--- a/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/_01_merge.py
+++ b/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/_01_merge.py
@@ -73,6 +73,13 @@ def main(
     job_role_estimates_lf = utils.scan_parquet(
         source=job_role_estimates_source, selected_columns=job_role_estimates_columns
     )
+
+    job_role_estimates_lf = job_role_estimates_lf.join(
+        metadata_lf,
+        on=IndCQC.id_per_locationid_import_date,
+        how="left",
+    )
+
     cleaned_ascwds_workplace_lf = utils.scan_parquet(
         prepared_slv_dataset_source
     ).select(

--- a/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/tests/fargate/test_01_merge.py
+++ b/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/tests/fargate/test_01_merge.py
@@ -1,4 +1,4 @@
-from unittest.mock import ANY, Mock, call, patch
+from unittest.mock import ANY, Mock, patch
 
 import projects._07_workforce_characteristics._01_starters_leavers_vacancies.fargate._01_merge as job
 
@@ -37,15 +37,14 @@ class TestMain:
 
         assert len(scan_parquet_mock.call_args_list) == 3
 
-        scan_calls = [
-            call(source=self.METADATA_SOURCE, selected_columns=job.metadata_columns),
-            call(
-                source=self.JOB_ROLE_ESTIMATES_SOURCE,
-                selected_columns=job.job_role_estimates_columns,
-            ),
-            call(self.PREPARED_SLV_DATASET_SOURCE),
-        ]
-        scan_parquet_mock.assert_has_calls(scan_calls)
+        scan_parquet_mock.assert_any_call(
+            source=self.METADATA_SOURCE, selected_columns=job.metadata_columns
+        )
+        scan_parquet_mock.assert_any_call(
+            source=self.JOB_ROLE_ESTIMATES_SOURCE,
+            selected_columns=job.job_role_estimates_columns,
+        )
+        scan_parquet_mock.assert_any_call(self.PREPARED_SLV_DATASET_SOURCE)
 
         # TODO: Uncomment these assertions when the placeholder functions are implemented
         is_slv_job_role_column_mock.assert_called_once()


### PR DESCRIPTION
## Description
Trello ticket [#1837](https://trello.com/c/WbBNHvWE/1837-s-merge1-join-job-role-estimates-data-and-metadata)

Joins `job_role_estimates_lf` with `metadata_lf` on `id_per_locationid_import_date` in the SLV merge job (`_01_merge.py`), immediately after both are scanned in. `metadata_lf` is validated unique per key upstream, so this is a fan-out-free left join. 

## Testing
- [x] Unit tests passing
- [x] Successful [Step Function run](https://eu-west-2.console.aws.amazon.com/states/home?region=eu-west-2#/v2/executions/details/arn:aws:states:eu-west-2:856699698263:execution:1837-est-meta-Ind-CQC-SLV:ce6b50d9-0635-4f32-90ed-a4da8d307d65)
- [x] Outputs checked in Athena


## Checklist (delete if not relevant)
- [x] Unit tests added/amended
- [x] Updated CHANGELOG
- [x] Code reviewed by AI
- [x] Moved Trello ticket to PR column

## Reviewer checklist
- [ ] PR solves the Trello ticket requirements
- [ ] Outputs appear reasonable and understandable
- [ ] The overall approach is appropriate and not over-engineered
- [ ] No obvious scalability, performance or interdependency concerns
- [ ] Tests appropriately cover the main behaviour/edge cases
- [ ] Naming and structure are broadly understandable and consistent
- [ ] Docstrings are sufficient for future maintenance
- [ ] Docstrings cover non-obvious behaviour
