### PR TITLE
1814 - Reshape wide SLV job role columns into rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ All notable changes to this project will be documented in this file.
 
 - Added a reusable `not_null_filter_expr` to Polars Utils, and used it in the SLV prepare step to exclude ASCWDS workplace records for non-CQC locations (null `location_id`).
 
+- Added `pivot_job_role_cols_to_rows` to the SLV prepare job, reshaping wide per-job-role columns into one row per establishment/date/job-role label, wired in after job-role relabelling; updated the merge step and prepare validation to match the new long-format output.
+
 ### Changed
 - Moved the `CategoricalColumnTypes` polars dtype constants from the Estimate Filled Posts by Job Role fargate job into Polars Utils, so they're available repo-wide without importing from that project.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ All notable changes to this project will be documented in this file.
 
 - Added a reusable `not_null_filter_expr` to Polars Utils, and used it in the SLV prepare step to exclude ASCWDS workplace records for non-CQC locations (null `location_id`).
 
-- Added `pivot_job_role_cols_to_rows` to the SLV prepare job, reshaping wide per-job-role columns into one row per establishment/date/job-role label, wired in after job-role relabelling; updated the merge step and prepare validation to match the new long-format output.
+- Added `reshape_job_role_cols_to_rows` to the SLV prepare job, reshaping wide per-job-role columns into one row per establishment/date/job-role label, wired in after job-role relabelling; updated the merge step and prepare validation to match the new long-format output.
 
 ### Changed
 - Moved the `CategoricalColumnTypes` polars dtype constants from the Estimate Filled Posts by Job Role fargate job into Polars Utils, so they're available repo-wide without importing from that project.

--- a/polars_utils/column_types.py
+++ b/polars_utils/column_types.py
@@ -8,6 +8,7 @@ from utils.column_values.categorical_column_values import (
 )
 from utils.column_values.categorical_columns_by_dataset import (
     EstimatedIndCQCFilledPostsByJobRoleCategoricalValues as CatVals,
+    SLVPrepareCategoricalValues,
 )
 
 
@@ -30,6 +31,9 @@ class CategoricalColumnTypes:
     )
     JobGroupEnumType = pl.Enum(
         CatVals.main_job_group_labels_column_values.categorical_values
+    )
+    PublishedJobRoleLabelEnumType = pl.Enum(
+        SLVPrepareCategoricalValues.published_job_role_labels_column_values.categorical_values
     )
     EstimatesFilledPostSourceEnumType = pl.Enum(
         [

--- a/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/_00_prepare.py
+++ b/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/_00_prepare.py
@@ -22,6 +22,7 @@ def main(
           and then earliest import day per month.
         - merge unpublished roles into 'other' groups
         - relabel job role columns from jrNN codes to published labels
+        - pivot job role columns into one row per job role
 
     Args:
         cleaned_ascwds_workplace_source (str): path to the cleaned ascwds workplace data
@@ -46,14 +47,11 @@ def main(
     workplace_lf = workplace_lf.drop(cs.matches(r"^jr(28|29|30|31|32)"))
 
     workplace_lf = pUtils.reduce_to_published_roles(workplace_lf)
-
-    # TODO: Backlog ticket/no number - Placeholder only.
-    # pUtils.pivot_job_role_cols_to_rows()
-
     workplace_lf = pUtils.relabel_job_role_columns(workplace_lf)
+    workplace_job_role_lf = pUtils.pivot_job_role_cols_to_rows(workplace_lf)
 
     utils.sink_to_parquet(
-        lazy_df=workplace_lf,
+        lazy_df=workplace_job_role_lf,
         output_path=prepared_data_destination,
     )
 

--- a/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/_00_prepare.py
+++ b/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/_00_prepare.py
@@ -22,7 +22,7 @@ def main(
           and then earliest import day per month.
         - merge unpublished roles into 'other' groups
         - relabel job role columns from jrNN codes to published labels
-        - pivot job role columns into one row per job role
+        - reshape job role columns into one row per job role
 
     Args:
         cleaned_ascwds_workplace_source (str): path to the cleaned ascwds workplace data
@@ -48,7 +48,7 @@ def main(
 
     workplace_lf = pUtils.reduce_to_published_roles(workplace_lf)
     workplace_lf = pUtils.relabel_job_role_columns(workplace_lf)
-    workplace_job_role_lf = pUtils.pivot_job_role_cols_to_rows(workplace_lf)
+    workplace_job_role_lf = pUtils.reshape_job_role_cols_to_rows(workplace_lf)
 
     utils.sink_to_parquet(
         lazy_df=workplace_job_role_lf,

--- a/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/_01_merge.py
+++ b/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/_01_merge.py
@@ -1,7 +1,6 @@
 import polars as pl
 
 import projects._07_workforce_characteristics._01_starters_leavers_vacancies.fargate.utils.merge_utils as mUtils
-from polars_utils import expressions as expr
 from polars_utils import utils
 from utils.column_names.cleaned_data_files.ascwds_workplace_cleaned import (
     AscwdsWorkplaceCleanedColumns as AWPClean,
@@ -73,12 +72,7 @@ def main(
     job_role_estimates_lf = utils.scan_parquet(
         source=job_role_estimates_source, selected_columns=job_role_estimates_columns
     )
-    cleaned_ascwds_workplace_lf = utils.scan_parquet(
-        prepared_slv_dataset_source
-    ).select(
-        *[AWPClean.establishment_id, AWPClean.ascwds_workplace_import_date],
-        expr.is_slv_job_role_column(),
-    )
+    cleaned_ascwds_workplace_lf = utils.scan_parquet(prepared_slv_dataset_source)
 
     # The source CSV is expected to already be trimmed to exactly these columns, in this
     # order, and to only the current weighting year's rows — scan_csv's schema is matched

--- a/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/utils/prepare_utils.py
+++ b/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/utils/prepare_utils.py
@@ -157,6 +157,9 @@ def reshape_job_role_cols_to_rows(lf: pl.LazyFrame) -> pl.LazyFrame:
         SLVCols.vacancies: "vacy",
     }
 
+    # One struct per published label, e.g. {job_role_label: "care_worker",
+    # employees: 5, starters: 1, leavers: 0, vacancies: 2} - concat_list+explode
+    # below turns this list-of-structs-per-row into one row per label.
     label_structs = [
         pl.struct(
             pl.lit(label).alias(SLVCols.job_role_label),

--- a/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/utils/prepare_utils.py
+++ b/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/utils/prepare_utils.py
@@ -158,10 +158,6 @@ def pivot_job_role_cols_to_rows(lf: pl.LazyFrame) -> pl.LazyFrame:
             ascwds_workplace_import_date, job_role_label, employees,
             starters, leavers, vacancies. One row per label per input row
             (dense - includes all-null metric rows).
-
-    Raises:
-        ValueError: if none of the expected {label}_{suffix} columns are
-            found in the input schema (schema-regression guard).
     """
     metric_suffixes = {
         SLVCols.employees: "emp",
@@ -169,17 +165,6 @@ def pivot_job_role_cols_to_rows(lf: pl.LazyFrame) -> pl.LazyFrame:
         SLVCols.leavers: "stop",
         SLVCols.vacancies: "vacy",
     }
-    schema_cols = set(lf.collect_schema().names())
-
-    if not any(
-        f"{label}_{suffix}" in schema_cols
-        for label in published_job_role_labels
-        for suffix in metric_suffixes.values()
-    ):
-        raise ValueError(
-            "No published job role columns found to pivot - expected columns "
-            "named '{label}_{suffix}'. Has relabel_job_role_columns run yet?"
-        )
 
     label_structs = [
         pl.struct(

--- a/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/utils/prepare_utils.py
+++ b/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/utils/prepare_utils.py
@@ -129,25 +129,15 @@ def reduce_to_published_roles(lf: pl.LazyFrame) -> pl.LazyFrame:
     return lf
 
 
-def pivot_job_role_cols_to_rows(lf: pl.LazyFrame) -> pl.LazyFrame:
+def reshape_job_role_cols_to_rows(lf: pl.LazyFrame) -> pl.LazyFrame:
     """Reshapes wide per-job-role columns into one row per job role.
 
-    Must run after relabel_job_role_columns: that step has already enforced
-    every job role column's prefix is one of the 15 known
-    PublishedJobRoleLabels values, which is what lets this function trust
-    published_job_role_labels as its column-discovery source rather than
-    pattern-matching raw codes.
-
-    Uses a struct-per-label -> concat_list -> explode -> unnest reshape (no
-    joins, no group_by) - proven in prior production testing to hold ~14GB
-    peak RSS at ~6.6M-row/210-col scale, versus an immediate OOM for an
-    unpivot()+join alternative at the same scale.
-
-    Grain columns (establishment_id, job_role_label) are cast to
-    Categorical/Enum here, not left as String - required to avoid the OOM
-    previously hit in this exact reshape's downstream grain-uniqueness
-    check at ~370M output rows, confirmed to be caused by hashing/grouping
-    String grain columns at that cardinality.
+    Must run after relabel_job_role_columns, which guarantees every job role
+    column's prefix is one of the known PublishedJobRoleLabels values - this
+    function trusts that instead of pattern-matching raw codes. Grain columns
+    (establishment_id, job_role_label) are Categorical/Enum rather than
+    String to keep downstream uniqueness checks cheap at this dataset's
+    scale.
 
     Args:
         lf (pl.LazyFrame): LazyFrame with columns already relabelled to
@@ -212,7 +202,7 @@ def relabel_job_role_columns(lf: pl.LazyFrame) -> pl.LazyFrame:
 
     Args:
         lf (pl.LazyFrame): LazyFrame with jrNN{suffix} columns reduced to
-            published roles, before any pivot.
+            published roles, before any reshape.
 
     Returns:
         pl.LazyFrame: Input LazyFrame with job role columns renamed to

--- a/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/utils/prepare_utils.py
+++ b/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/utils/prepare_utils.py
@@ -134,8 +134,9 @@ def reshape_job_role_cols_to_rows(lf: pl.LazyFrame) -> pl.LazyFrame:
 
     Must run after relabel_job_role_columns, which guarantees every job role
     column's prefix is one of the known PublishedJobRoleLabels values - this
-    function trusts that instead of pattern-matching raw codes. Grain columns
-    (establishment_id, job_role_label) are Categorical/Enum rather than
+    function trusts that instead of pattern-matching raw codes. Of the grain
+    columns (establishment_id, ascwds_workplace_import_date, job_role_label),
+    establishment_id and job_role_label are Categorical/Enum rather than
     String to keep downstream uniqueness checks cheap at this dataset's
     scale.
 

--- a/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/utils/prepare_utils.py
+++ b/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/utils/prepare_utils.py
@@ -2,6 +2,11 @@ import re
 
 import polars as pl
 
+from polars_utils.column_types import CategoricalColumnTypes as CatColType
+from utils.column_names.cleaned_data_files.ascwds_workplace_cleaned import (
+    AscwdsWorkplaceCleanedColumns as AWPClean,
+)
+from utils.column_names.slv_job_role_columns import SLVJobRoleColumns as SLVCols
 from utils.column_values.categorical_column_values import (
     JobGroupLabels,
     PublishedJobRoleLabels,
@@ -124,12 +129,88 @@ def reduce_to_published_roles(lf: pl.LazyFrame) -> pl.LazyFrame:
     return lf
 
 
-def pivot_job_role_cols_to_rows():
+def pivot_job_role_cols_to_rows(lf: pl.LazyFrame) -> pl.LazyFrame:
+    """Reshapes wide per-job-role columns into one row per job role.
+
+    Must run after relabel_job_role_columns: that step has already enforced
+    every job role column's prefix is one of the 15 known
+    PublishedJobRoleLabels values, which is what lets this function trust
+    published_job_role_labels as its column-discovery source rather than
+    pattern-matching raw codes.
+
+    Uses a struct-per-label -> concat_list -> explode -> unnest reshape (no
+    joins, no group_by) - proven in prior production testing to hold ~14GB
+    peak RSS at ~6.6M-row/210-col scale, versus an immediate OOM for an
+    unpivot()+join alternative at the same scale.
+
+    Grain columns (establishment_id, job_role_label) are cast to
+    Categorical/Enum here, not left as String - required to avoid the OOM
+    previously hit in this exact reshape's downstream grain-uniqueness
+    check at ~370M output rows, confirmed to be caused by hashing/grouping
+    String grain columns at that cardinality.
+
+    Args:
+        lf (pl.LazyFrame): LazyFrame with columns already relabelled to
+            {published_label}_{suffix} shape.
+
+    Returns:
+        pl.LazyFrame: long-format LazyFrame with columns establishment_id,
+            ascwds_workplace_import_date, job_role_label, employees,
+            starters, leavers, vacancies. One row per label per input row
+            (dense - includes all-null metric rows).
+
+    Raises:
+        ValueError: if none of the expected {label}_{suffix} columns are
+            found in the input schema (schema-regression guard).
     """
-    Placeholder function to pivot job role columns into rows to create column
-    for job role number and columns for emps, starters, leavers and vacancies.
-    """
-    pass
+    metric_suffixes = {
+        SLVCols.employees: "emp",
+        SLVCols.starters: "strt",
+        SLVCols.leavers: "stop",
+        SLVCols.vacancies: "vacy",
+    }
+    schema_cols = set(lf.collect_schema().names())
+
+    if not any(
+        f"{label}_{suffix}" in schema_cols
+        for label in published_job_role_labels
+        for suffix in metric_suffixes.values()
+    ):
+        raise ValueError(
+            "No published job role columns found to pivot - expected columns "
+            "named '{label}_{suffix}'. Has relabel_job_role_columns run yet?"
+        )
+
+    label_structs = [
+        pl.struct(
+            pl.lit(label).alias(SLVCols.job_role_label),
+            *[
+                pl.col(f"{label}_{suffix}").alias(metric)
+                for metric, suffix in metric_suffixes.items()
+            ],
+        )
+        for label in published_job_role_labels
+    ]
+
+    return (
+        lf.select(
+            AWPClean.establishment_id,
+            AWPClean.ascwds_workplace_import_date,
+            pl.concat_list(label_structs).alias("_job_role_struct_list"),
+        )
+        .explode("_job_role_struct_list")
+        .unnest("_job_role_struct_list")
+        .with_columns(
+            pl.col(AWPClean.establishment_id).cast(CatColType.EstablishmentCatType),
+            pl.col(SLVCols.job_role_label).cast(
+                CatColType.PublishedJobRoleLabelEnumType
+            ),
+            pl.col(SLVCols.employees).cast(pl.Int16),
+            pl.col(SLVCols.starters).cast(pl.Int16),
+            pl.col(SLVCols.leavers).cast(pl.Int16),
+            pl.col(SLVCols.vacancies).cast(pl.Int16),
+        )
+    )
 
 
 def relabel_job_role_columns(lf: pl.LazyFrame) -> pl.LazyFrame:

--- a/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/validate_00_prepare.py
+++ b/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/validate_00_prepare.py
@@ -26,11 +26,6 @@ COMPARE_COLS_TO_IMPORT = [
     AWPClean.location_id,
 ]
 
-PUBLISHED_JOB_ROLE_LABELS_VALUES = (
-    SLVPrepareCategoricalValues.published_job_role_labels_column_values
-)
-PUBLISHED_JOB_ROLE_LABELS = PUBLISHED_JOB_ROLE_LABELS_VALUES.categorical_values
-
 
 def no_leftover_raw_job_role_code_columns(df: pl.DataFrame) -> bool:
     """Checks that no jrNN{suffix}-coded job role columns remain in df.
@@ -85,7 +80,9 @@ def main(
         )
     )
     # Each pre-pivot row explodes into one row per published job role label.
-    expected_row_count = compare_df.height * len(PUBLISHED_JOB_ROLE_LABELS)
+    expected_row_count = compare_df.height * len(
+        SLVPrepareCategoricalValues.published_job_role_labels_column_values.categorical_values
+    )
 
     validation = (
         pb.Validate(
@@ -115,19 +112,20 @@ def main(
             brief="Primary key (establishment_id, ascwds_workplace_import_date, "
             "job_role_label) should be unique",
         )
+        # categorical
         .col_vals_in_set(
             SLVCols.job_role_label,
-            PUBLISHED_JOB_ROLE_LABELS,
+            SLVPrepareCategoricalValues.published_job_role_labels_column_values.categorical_values,
         )
+        # distinct values
         .specially(
             vl.is_unique_count_equal(
                 SLVCols.job_role_label,
-                PUBLISHED_JOB_ROLE_LABELS_VALUES.count_of_categorical_values,
+                SLVPrepareCategoricalValues.published_job_role_labels_column_values.count_of_categorical_values,
             ),
             brief=f"{SLVCols.job_role_label} should have exactly "
-            f"{PUBLISHED_JOB_ROLE_LABELS_VALUES.count_of_categorical_values} distinct values",
-        )
-        .interrogate()
+            f"{SLVPrepareCategoricalValues.published_job_role_labels_column_values.count_of_categorical_values} distinct values",
+        ).interrogate()
     )
     vl.write_reports(validation, bucket_name, reports_path)
 

--- a/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/validate_00_prepare.py
+++ b/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/validate_00_prepare.py
@@ -15,7 +15,10 @@ from polars_utils.validation.constants import GLOBAL_ACTIONS, GLOBAL_THRESHOLDS
 from utils.column_names.cleaned_data_files.ascwds_workplace_cleaned import (
     AscwdsWorkplaceCleanedColumns as AWPClean,
 )
-from utils.column_values.categorical_column_values import PublishedJobRoleLabels
+from utils.column_names.slv_job_role_columns import SLVJobRoleColumns as SLVCols
+from utils.column_values.categorical_columns_by_dataset import (
+    SLVPrepareCategoricalValues,
+)
 
 COMPARE_COLS_TO_IMPORT = [
     AWPClean.establishment_id,
@@ -23,7 +26,10 @@ COMPARE_COLS_TO_IMPORT = [
     AWPClean.location_id,
 ]
 
-PUBLISHED_JOB_ROLE_LABELS = PublishedJobRoleLabels("job_role_label").categorical_values
+PUBLISHED_JOB_ROLE_LABELS_VALUES = (
+    SLVPrepareCategoricalValues.published_job_role_labels_column_values
+)
+PUBLISHED_JOB_ROLE_LABELS = PUBLISHED_JOB_ROLE_LABELS_VALUES.categorical_values
 
 
 def no_leftover_raw_job_role_code_columns(df: pl.DataFrame) -> bool:
@@ -41,26 +47,6 @@ def no_leftover_raw_job_role_code_columns(df: pl.DataFrame) -> bool:
         bool: True if no columns match the raw jrNN{suffix} code shape
     """
     return not any(pUtils.JOB_ROLE_COLUMN_PATTERN.match(col) for col in df.columns)
-
-
-def has_all_published_job_role_label_columns(df: pl.DataFrame) -> bool:
-    """Checks that every published job role label has a corresponding column in df.
-
-    Compares against the exact label portion of each column (everything
-    before its trailing `_{suffix}`), not a prefix match - several labels
-    share a prefix (`other`, `other_managers`, `other_regulated_professions`,
-    `other_direct_care`), so a `startswith` check would let a sibling label's
-    column mask a missing one.
-
-    Args:
-        df (pl.DataFrame): the dataframe to check
-
-    Returns:
-        bool: True if every published job role label has at least one
-            matching column
-    """
-    column_labels = {col.rsplit("_", 1)[0] for col in df.columns}
-    return all(label in column_labels for label in PUBLISHED_JOB_ROLE_LABELS)
 
 
 def main(
@@ -98,7 +84,8 @@ def main(
             )
         )
     )
-    expected_row_count = compare_df.height
+    # Each pre-pivot row explodes into one row per published job role label.
+    expected_row_count = compare_df.height * len(PUBLISHED_JOB_ROLE_LABELS)
 
     validation = (
         pb.Validate(
@@ -118,9 +105,27 @@ def main(
             no_leftover_raw_job_role_code_columns,
             brief="No leftover jrNN-coded job role columns should remain after relabelling",
         )
+        # job role pivot grain
+        .rows_distinct(
+            columns_subset=[
+                AWPClean.establishment_id,
+                AWPClean.ascwds_workplace_import_date,
+                SLVCols.job_role_label,
+            ],
+            brief="Primary key (establishment_id, ascwds_workplace_import_date, "
+            "job_role_label) should be unique",
+        )
+        .col_vals_in_set(
+            SLVCols.job_role_label,
+            PUBLISHED_JOB_ROLE_LABELS,
+        )
         .specially(
-            has_all_published_job_role_label_columns,
-            brief="Job role columns should be present, named after their published labels",
+            vl.is_unique_count_equal(
+                SLVCols.job_role_label,
+                PUBLISHED_JOB_ROLE_LABELS_VALUES.count_of_categorical_values,
+            ),
+            brief=f"{SLVCols.job_role_label} should have exactly "
+            f"{PUBLISHED_JOB_ROLE_LABELS_VALUES.count_of_categorical_values} distinct values",
         )
         .interrogate()
     )

--- a/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/validate_00_prepare.py
+++ b/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/validate_00_prepare.py
@@ -1,7 +1,6 @@
 import sys
 
 import pointblank as pb
-import polars as pl
 
 from polars_utils import utils
 from polars_utils.filtering_utils import (

--- a/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/validate_00_prepare.py
+++ b/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/validate_00_prepare.py
@@ -79,7 +79,7 @@ def main(
             )
         )
     )
-    # Each pre-pivot row explodes into one row per published job role label.
+    # Each pre-reshape row explodes into one row per published job role label.
     expected_row_count = compare_df.height * len(
         SLVPrepareCategoricalValues.published_job_role_labels_column_values.categorical_values
     )
@@ -102,7 +102,7 @@ def main(
             no_leftover_raw_job_role_code_columns,
             brief="No leftover jrNN-coded job role columns should remain after relabelling",
         )
-        # job role pivot grain
+        # job role reshape grain
         .rows_distinct(
             columns_subset=[
                 AWPClean.establishment_id,

--- a/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/validate_00_prepare.py
+++ b/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/fargate/validate_00_prepare.py
@@ -3,7 +3,6 @@ import sys
 import pointblank as pb
 import polars as pl
 
-import projects._07_workforce_characteristics._01_starters_leavers_vacancies.fargate.utils.prepare_utils as pUtils
 from polars_utils import utils
 from polars_utils.filtering_utils import (
     earliest_file_per_month_filter_expr,
@@ -25,23 +24,6 @@ COMPARE_COLS_TO_IMPORT = [
     AWPClean.ascwds_workplace_import_date,
     AWPClean.location_id,
 ]
-
-
-def no_leftover_raw_job_role_code_columns(df: pl.DataFrame) -> bool:
-    """Checks that no jrNN{suffix}-coded job role columns remain in df.
-
-    Reuses pUtils.JOB_ROLE_COLUMN_PATTERN (the same pattern
-    relabel_job_role_columns matches on) rather than a separate, narrower
-    pattern here - keeps the two in lockstep so a new suffix can't slip past
-    this check just because it wasn't listed twice.
-
-    Args:
-        df (pl.DataFrame): the dataframe to check
-
-    Returns:
-        bool: True if no columns match the raw jrNN{suffix} code shape
-    """
-    return not any(pUtils.JOB_ROLE_COLUMN_PATTERN.match(col) for col in df.columns)
 
 
 def main(
@@ -96,11 +78,6 @@ def main(
         .row_count_match(
             expected_row_count,
             brief=f"Expects {expected_row_count} rows",
-        )
-        # job role relabelling
-        .specially(
-            no_leftover_raw_job_role_code_columns,
-            brief="No leftover jrNN-coded job role columns should remain after relabelling",
         )
         # job role reshape grain
         .rows_distinct(

--- a/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/tests/fargate/test_00_prepare.py
+++ b/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/tests/fargate/test_00_prepare.py
@@ -16,7 +16,7 @@ class TestPrepare:
 
     @patch(f"{PATCH_PATH}.utils.sink_to_parquet")
     @patch(f"{PATCH_PATH}.pUtils.relabel_job_role_columns")
-    @patch(f"{PATCH_PATH}.pUtils.pivot_job_role_cols_to_rows")
+    @patch(f"{PATCH_PATH}.pUtils.reshape_job_role_cols_to_rows")
     @patch(f"{PATCH_PATH}.pUtils.reduce_to_published_roles")
     @patch(f"{PATCH_PATH}.earliest_file_per_month_filter_expr")
     @patch(f"{PATCH_PATH}.reduced_data_filter_expr")
@@ -29,7 +29,7 @@ class TestPrepare:
         reduced_data_filter_expr_mock: Mock,
         earliest_file_per_month_filter_expr_mock: Mock,
         reduce_to_published_roles_mock: Mock,
-        pivot_job_role_cols_to_rows_mock: Mock,
+        reshape_job_role_cols_to_rows_mock: Mock,
         relabel_job_role_columns_mock: Mock,
         sink_to_parquet_mock: Mock,
     ):
@@ -81,10 +81,10 @@ class TestPrepare:
         relabel_job_role_columns_mock.assert_called_once_with(merged_jr_cols_lf)
         relabelled_lf = relabel_job_role_columns_mock.return_value
 
-        pivot_job_role_cols_to_rows_mock.assert_called_once_with(relabelled_lf)
-        pivoted_lf = pivot_job_role_cols_to_rows_mock.return_value
+        reshape_job_role_cols_to_rows_mock.assert_called_once_with(relabelled_lf)
+        reshaped_lf = reshape_job_role_cols_to_rows_mock.return_value
 
         sink_to_parquet_mock.assert_called_once_with(
-            lazy_df=pivoted_lf,
+            lazy_df=reshaped_lf,
             output_path=self.PREPARED_DATA_DESTINATION,
         )

--- a/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/tests/fargate/test_00_prepare.py
+++ b/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/tests/fargate/test_00_prepare.py
@@ -77,13 +77,14 @@ class TestPrepare:
 
         reduce_to_published_roles_mock.assert_called_once_with(dropped_totals_lf)
         merged_jr_cols_lf = reduce_to_published_roles_mock.return_value
-        # TODO: Uncomment when pivot_job_role_cols_to_rows is implemented.
-        # pivot_job_role_cols_to_rows_mock.assert_called_once()
 
         relabel_job_role_columns_mock.assert_called_once_with(merged_jr_cols_lf)
         relabelled_lf = relabel_job_role_columns_mock.return_value
 
+        pivot_job_role_cols_to_rows_mock.assert_called_once_with(relabelled_lf)
+        pivoted_lf = pivot_job_role_cols_to_rows_mock.return_value
+
         sink_to_parquet_mock.assert_called_once_with(
-            lazy_df=relabelled_lf,
+            lazy_df=pivoted_lf,
             output_path=self.PREPARED_DATA_DESTINATION,
         )

--- a/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/tests/fargate/test_01_merge.py
+++ b/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/tests/fargate/test_01_merge.py
@@ -16,12 +16,10 @@ class TestMain:
     @patch(f"{PATCH_PATH}.mUtils.apply_employment_status_magic_numbers")
     @patch(f"{PATCH_PATH}.mUtils.join_datasets")
     @patch(f"{PATCH_PATH}.pl.scan_csv")
-    @patch(f"{PATCH_PATH}.expr.is_slv_job_role_column")
     @patch(f"{PATCH_PATH}.utils.scan_parquet")
     def test_main_runs(
         self,
         scan_parquet_mock: Mock,
-        is_slv_job_role_column_mock: Mock,
         scan_csv_mock: Mock,
         join_datasets_mock: Mock,
         apply_employment_status_magic_numbers_mock: Mock,
@@ -48,7 +46,6 @@ class TestMain:
         scan_parquet_mock.assert_has_calls(scan_calls)
 
         # TODO: Uncomment these assertions when the placeholder functions are implemented
-        is_slv_job_role_column_mock.assert_called_once()
         # join_datasets_mock.assert_called_once()
         # apply_employment_status_magic_numbers_mock.assert_called_once()
 

--- a/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/tests/fargate/test_validate_00_prepare.py
+++ b/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/tests/fargate/test_validate_00_prepare.py
@@ -10,6 +10,9 @@ from utils.column_names.cleaned_data_files.ascwds_workplace_cleaned import (
     AscwdsWorkplaceCleanedColumns as AWPClean,
 )
 from utils.column_names.slv_job_role_columns import SLVJobRoleColumns as SLVCols
+from utils.column_values.categorical_columns_by_dataset import (
+    SLVPrepareCategoricalValues,
+)
 
 PATCH_PATH = "projects._07_workforce_characteristics._01_starters_leavers_vacancies.fargate.validate_00_prepare"
 
@@ -28,7 +31,7 @@ class TestMain:
         }
         source_rows = [
             ("1-001", date(2026, 1, 1), label, 1, 1, 1, 1)
-            for label in job.PUBLISHED_JOB_ROLE_LABELS
+            for label in SLVPrepareCategoricalValues.published_job_role_labels_column_values.categorical_values
         ]
         self.source_df = pl.DataFrame(source_rows, source_schema, orient="row")
 
@@ -99,29 +102,6 @@ class TestMain:
             assert (
                 assertion in assertion_types_present
             ), f"{assertion} not found in validation report"
-
-    @patch(f"{PATCH_PATH}.vl.write_reports")
-    @patch(f"{PATCH_PATH}.utils.read_parquet")
-    def test_expected_row_count_is_multiplied_by_published_label_count(
-        self,
-        mock_read_parquet: Mock,
-        mock_write_reports: Mock,
-    ):
-        # Only 1-001 survives the compare-side reduction filters (see setup's comment),
-        # so each published label contributes exactly one exploded row for it.
-        mock_read_parquet.side_effect = [self.source_df, self.compare_df]
-
-        job.main("bucket", "my/source/", "my/compare/", "my/reports/")
-
-        validation_arg = mock_write_reports.call_args[0][0]
-        report_json = json.loads(validation_arg.get_json_report())
-        row_count_match_item = next(
-            item for item in report_json if item["assertion_type"] == "row_count_match"
-        )
-
-        assert row_count_match_item["values"]["count"] == len(
-            job.PUBLISHED_JOB_ROLE_LABELS
-        )
 
 
 class TestNoLeftoverRawJobRoleCodeColumns:

--- a/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/tests/fargate/test_validate_00_prepare.py
+++ b/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/tests/fargate/test_validate_00_prepare.py
@@ -1,27 +1,35 @@
 import json
-import unittest
 from datetime import date
 from unittest.mock import Mock, call, patch
 
 import polars as pl
+import pytest
 
 import projects._07_workforce_characteristics._01_starters_leavers_vacancies.fargate.validate_00_prepare as job
 from utils.column_names.cleaned_data_files.ascwds_workplace_cleaned import (
     AscwdsWorkplaceCleanedColumns as AWPClean,
 )
+from utils.column_names.slv_job_role_columns import SLVJobRoleColumns as SLVCols
 
 PATCH_PATH = "projects._07_workforce_characteristics._01_starters_leavers_vacancies.fargate.validate_00_prepare"
 
 
-class ValidatePreparedSLVDataTests(unittest.TestCase):
-    def setUp(self) -> None:
+class TestMain:
+    @pytest.fixture(autouse=True)
+    def setup(self):
         source_schema = {
-            AWPClean.location_id: pl.String,
             AWPClean.establishment_id: pl.String,
+            AWPClean.ascwds_workplace_import_date: pl.Date,
+            SLVCols.job_role_label: pl.String,
+            SLVCols.employees: pl.Int64,
+            SLVCols.starters: pl.Int64,
+            SLVCols.leavers: pl.Int64,
+            SLVCols.vacancies: pl.Int64,
         }
         source_rows = [
-            ("Loc-001", "1-001"),
-        ]  # fmt: skip
+            ("1-001", date(2026, 1, 1), label, 1, 1, 1, 1)
+            for label in job.PUBLISHED_JOB_ROLE_LABELS
+        ]
         self.source_df = pl.DataFrame(source_rows, source_schema, orient="row")
 
         # The compare frame is the unreduced cleaned ASCWDS data, so it carries rows
@@ -52,7 +60,7 @@ class ValidatePreparedSLVDataTests(unittest.TestCase):
         mock_read_parquet.side_effect = [self.source_df, self.compare_df]
         job.main("bucket", "my/source/", "my/compare/", "my/reports/")
 
-        self.assertEqual(mock_read_parquet.call_count, 2)
+        assert mock_read_parquet.call_count == 2
         mock_read_parquet.assert_has_calls(
             [
                 call(source="s3://bucket/my/source/"),
@@ -83,14 +91,37 @@ class ValidatePreparedSLVDataTests(unittest.TestCase):
         expected_assertions = {
             "row_count_match",
             "specially",
+            "rows_distinct",
+            "col_vals_in_set",
         }
 
         for assertion in expected_assertions:
-            self.assertIn(
-                assertion,
-                assertion_types_present,
-                f"{assertion} not found in validation report",
-            )
+            assert (
+                assertion in assertion_types_present
+            ), f"{assertion} not found in validation report"
+
+    @patch(f"{PATCH_PATH}.vl.write_reports")
+    @patch(f"{PATCH_PATH}.utils.read_parquet")
+    def test_expected_row_count_is_multiplied_by_published_label_count(
+        self,
+        mock_read_parquet: Mock,
+        mock_write_reports: Mock,
+    ):
+        # Only 1-001 survives the compare-side reduction filters (see setup's comment),
+        # so each published label contributes exactly one exploded row for it.
+        mock_read_parquet.side_effect = [self.source_df, self.compare_df]
+
+        job.main("bucket", "my/source/", "my/compare/", "my/reports/")
+
+        validation_arg = mock_write_reports.call_args[0][0]
+        report_json = json.loads(validation_arg.get_json_report())
+        row_count_match_item = next(
+            item for item in report_json if item["assertion_type"] == "row_count_match"
+        )
+
+        assert row_count_match_item["values"]["count"] == len(
+            job.PUBLISHED_JOB_ROLE_LABELS
+        )
 
 
 class TestNoLeftoverRawJobRoleCodeColumns:
@@ -103,26 +134,3 @@ class TestNoLeftoverRawJobRoleCodeColumns:
         df = pl.DataFrame(schema={"jr01emp": pl.Int64})
 
         assert not job.no_leftover_raw_job_role_code_columns(df)
-
-
-class TestHasAllPublishedJobRoleLabelColumns:
-    def test_true_when_every_published_label_has_a_column(self):
-        columns = [f"{label}_emp" for label in job.PUBLISHED_JOB_ROLE_LABELS]
-        df = pl.DataFrame(schema={col: pl.Int64 for col in columns})
-
-        assert job.has_all_published_job_role_label_columns(df)
-
-    def test_false_when_missing_label_shares_a_prefix_with_present_siblings(self):
-        # "other", "other_managers", "other_regulated_professions", and
-        # "other_direct_care" all share the "other_" prefix - pins that a
-        # missing "other" column isn't masked by its siblings being present.
-        present_labels = [
-            label for label in job.PUBLISHED_JOB_ROLE_LABELS if label != "other"
-        ]
-        df = pl.DataFrame(schema={f"{label}_emp": pl.Int64 for label in present_labels})
-
-        assert not job.has_all_published_job_role_label_columns(df)
-
-
-if __name__ == "__main__":
-    unittest.main(warnings="ignore")

--- a/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/tests/fargate/test_validate_00_prepare.py
+++ b/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/tests/fargate/test_validate_00_prepare.py
@@ -102,15 +102,3 @@ class TestMain:
             assert (
                 assertion in assertion_types_present
             ), f"{assertion} not found in validation report"
-
-
-class TestNoLeftoverRawJobRoleCodeColumns:
-    def test_true_when_no_raw_job_role_code_columns_remain(self):
-        df = pl.DataFrame(schema={AWPClean.establishment_id: pl.String})
-
-        assert job.no_leftover_raw_job_role_code_columns(df)
-
-    def test_false_when_a_raw_jrNN_column_remains(self):
-        df = pl.DataFrame(schema={"jr01emp": pl.Int64})
-
-        assert not job.no_leftover_raw_job_role_code_columns(df)

--- a/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/tests/fargate/utils/test_prepare_utils.py
+++ b/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/tests/fargate/utils/test_prepare_utils.py
@@ -94,19 +94,6 @@ class TestReshapeJobRoleColsToRows:
 
         pl_testing.assert_frame_equal(returned_lf, expected_lf, check_row_order=False)
 
-    def test_output_has_expected_dtypes(self):
-        case = Data.reshape_job_role_cols_to_rows_test_cases[0]
-        test_lf = pl.LazyFrame(case.input_data)
-
-        returned_schema = job.reshape_job_role_cols_to_rows(test_lf).collect_schema()
-
-        assert returned_schema[AWPClean.establishment_id] == CatColType.EstablishmentCatType  # fmt: skip
-        assert returned_schema[SLVCols.job_role_label] == CatColType.PublishedJobRoleLabelEnumType  # fmt: skip
-        assert returned_schema[SLVCols.employees] == pl.Int16
-        assert returned_schema[SLVCols.starters] == pl.Int16
-        assert returned_schema[SLVCols.leavers] == pl.Int16
-        assert returned_schema[SLVCols.vacancies] == pl.Int16
-
 
 class TestRelabelJobRoleColumns:
     @pytest.mark.parametrize(

--- a/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/tests/fargate/utils/test_prepare_utils.py
+++ b/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/tests/fargate/utils/test_prepare_utils.py
@@ -107,17 +107,6 @@ class TestPivotJobRoleColsToRows:
         assert returned_schema[SLVCols.leavers] == pl.Int16
         assert returned_schema[SLVCols.vacancies] == pl.Int16
 
-    def test_raises_value_error_when_no_job_role_columns_found(self):
-        test_lf = pl.LazyFrame(
-            {
-                AWPClean.establishment_id: ["1"],
-                AWPClean.ascwds_workplace_import_date: [None],
-            }
-        )
-
-        with pytest.raises(ValueError):
-            job.pivot_job_role_cols_to_rows(test_lf)
-
 
 class TestRelabelJobRoleColumns:
     @pytest.mark.parametrize(

--- a/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/tests/fargate/utils/test_prepare_utils.py
+++ b/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/tests/fargate/utils/test_prepare_utils.py
@@ -3,9 +3,14 @@ import polars.testing as pl_testing
 import pytest
 
 import projects._07_workforce_characteristics._01_starters_leavers_vacancies.fargate.utils.prepare_utils as job
+from polars_utils.column_types import CategoricalColumnTypes as CatColType
 from projects._07_workforce_characteristics.unittest_data.polars_slv_test_data import (
     TestPrepareUtilsData as Data,
 )
+from utils.column_names.cleaned_data_files.ascwds_workplace_cleaned import (
+    AscwdsWorkplaceCleanedColumns as AWPClean,
+)
+from utils.column_names.slv_job_role_columns import SLVJobRoleColumns as SLVCols
 from utils.column_values.categorical_column_values import PublishedJobRoleLabels
 
 PATCH_PATH = "projects._07_workforce_characteristics._01_starters_leavers_vacancies.fargate.utils.prepare_utils"
@@ -65,8 +70,53 @@ class TestJobRoleCodeDerivation:
 
 
 class TestPivotJobRoleColsToRows:
-    def test_pivot_job_role_cols_to_rows(self):
-        pass
+    @pytest.mark.parametrize(
+        "case",
+        [
+            pytest.param(case, id=case.id)
+            for case in Data.pivot_job_role_cols_to_rows_test_cases
+        ],
+    )
+    def test_pivot_job_role_cols_to_rows(self, case):
+        test_lf = pl.LazyFrame(case.input_data)
+        expected_lf = pl.LazyFrame(case.expected_data).with_columns(
+            pl.col(AWPClean.establishment_id).cast(CatColType.EstablishmentCatType),
+            pl.col(SLVCols.job_role_label).cast(
+                CatColType.PublishedJobRoleLabelEnumType
+            ),
+            pl.col(SLVCols.employees).cast(pl.Int16),
+            pl.col(SLVCols.starters).cast(pl.Int16),
+            pl.col(SLVCols.leavers).cast(pl.Int16),
+            pl.col(SLVCols.vacancies).cast(pl.Int16),
+        )
+
+        returned_lf = job.pivot_job_role_cols_to_rows(test_lf)
+
+        pl_testing.assert_frame_equal(returned_lf, expected_lf, check_row_order=False)
+
+    def test_output_has_expected_dtypes(self):
+        case = Data.pivot_job_role_cols_to_rows_test_cases[0]
+        test_lf = pl.LazyFrame(case.input_data)
+
+        returned_schema = job.pivot_job_role_cols_to_rows(test_lf).collect_schema()
+
+        assert returned_schema[AWPClean.establishment_id] == CatColType.EstablishmentCatType  # fmt: skip
+        assert returned_schema[SLVCols.job_role_label] == CatColType.PublishedJobRoleLabelEnumType  # fmt: skip
+        assert returned_schema[SLVCols.employees] == pl.Int16
+        assert returned_schema[SLVCols.starters] == pl.Int16
+        assert returned_schema[SLVCols.leavers] == pl.Int16
+        assert returned_schema[SLVCols.vacancies] == pl.Int16
+
+    def test_raises_value_error_when_no_job_role_columns_found(self):
+        test_lf = pl.LazyFrame(
+            {
+                AWPClean.establishment_id: ["1"],
+                AWPClean.ascwds_workplace_import_date: [None],
+            }
+        )
+
+        with pytest.raises(ValueError):
+            job.pivot_job_role_cols_to_rows(test_lf)
 
 
 class TestRelabelJobRoleColumns:

--- a/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/tests/fargate/utils/test_prepare_utils.py
+++ b/projects/_07_workforce_characteristics/_01_starters_leavers_vacancies/tests/fargate/utils/test_prepare_utils.py
@@ -69,15 +69,15 @@ class TestJobRoleCodeDerivation:
         )
 
 
-class TestPivotJobRoleColsToRows:
+class TestReshapeJobRoleColsToRows:
     @pytest.mark.parametrize(
         "case",
         [
             pytest.param(case, id=case.id)
-            for case in Data.pivot_job_role_cols_to_rows_test_cases
+            for case in Data.reshape_job_role_cols_to_rows_test_cases
         ],
     )
-    def test_pivot_job_role_cols_to_rows(self, case):
+    def test_reshape_job_role_cols_to_rows(self, case):
         test_lf = pl.LazyFrame(case.input_data)
         expected_lf = pl.LazyFrame(case.expected_data).with_columns(
             pl.col(AWPClean.establishment_id).cast(CatColType.EstablishmentCatType),
@@ -90,15 +90,15 @@ class TestPivotJobRoleColsToRows:
             pl.col(SLVCols.vacancies).cast(pl.Int16),
         )
 
-        returned_lf = job.pivot_job_role_cols_to_rows(test_lf)
+        returned_lf = job.reshape_job_role_cols_to_rows(test_lf)
 
         pl_testing.assert_frame_equal(returned_lf, expected_lf, check_row_order=False)
 
     def test_output_has_expected_dtypes(self):
-        case = Data.pivot_job_role_cols_to_rows_test_cases[0]
+        case = Data.reshape_job_role_cols_to_rows_test_cases[0]
         test_lf = pl.LazyFrame(case.input_data)
 
-        returned_schema = job.pivot_job_role_cols_to_rows(test_lf).collect_schema()
+        returned_schema = job.reshape_job_role_cols_to_rows(test_lf).collect_schema()
 
         assert returned_schema[AWPClean.establishment_id] == CatColType.EstablishmentCatType  # fmt: skip
         assert returned_schema[SLVCols.job_role_label] == CatColType.PublishedJobRoleLabelEnumType  # fmt: skip

--- a/projects/_07_workforce_characteristics/unittest_data/polars_slv_test_data.py
+++ b/projects/_07_workforce_characteristics/unittest_data/polars_slv_test_data.py
@@ -1,9 +1,11 @@
 from dataclasses import dataclass
+from datetime import date
 from typing import Any
 
 from utils.column_names.cleaned_data_files.ascwds_workplace_cleaned import (
     AscwdsWorkplaceCleanedColumns as AWPClean,
 )
+from utils.column_names.slv_job_role_columns import SLVJobRoleColumns as SLVCols
 from utils.column_values.categorical_column_values import PublishedJobRoleLabels
 
 
@@ -22,7 +24,75 @@ class RelabelJobRoleColumnsTestCase:
 
 
 @dataclass
+class PivotJobRoleColsToRowsTestCase:
+    id: str
+    input_data: dict[str, Any]
+    expected_data: dict[str, Any]
+
+
+# All 15 published labels, in PublishedJobRoleLabels' own field order. The pivot
+# unconditionally references every label's 4 metric columns (trusting that the raw
+# ASC-WDS schema always declares them), so any functional test case needs the full set.
+_ALL_PUBLISHED_LABELS = [
+    PublishedJobRoleLabels.senior_management,
+    PublishedJobRoleLabels.registered_manager,
+    PublishedJobRoleLabels.social_worker,
+    PublishedJobRoleLabels.senior_care_worker,
+    PublishedJobRoleLabels.care_worker,
+    PublishedJobRoleLabels.community_support_and_outreach,
+    PublishedJobRoleLabels.occupational_therapist,
+    PublishedJobRoleLabels.registered_nurse,
+    PublishedJobRoleLabels.allied_health_professional,
+    PublishedJobRoleLabels.deputy_manager,
+    PublishedJobRoleLabels.support_worker,
+    PublishedJobRoleLabels.other_managers,
+    PublishedJobRoleLabels.other_regulated_professions,
+    PublishedJobRoleLabels.other_direct_care,
+    PublishedJobRoleLabels.other,
+]
+_ALL_NULL_LABEL = PublishedJobRoleLabels.other  # exercises the dense-null-row case
+
+
+def _build_pivot_job_role_cols_to_rows_case() -> PivotJobRoleColsToRowsTestCase:
+    establishment_id = "1"
+    import_date = date(2024, 1, 1)
+
+    input_data = {
+        AWPClean.establishment_id: [establishment_id],
+        AWPClean.ascwds_workplace_import_date: [import_date],
+    }
+    expected_rows = []
+    for i, label in enumerate(_ALL_PUBLISHED_LABELS):
+        if label == _ALL_NULL_LABEL:
+            metrics = (None, None, None, None)
+        else:
+            metrics = (i + 1, i + 2, i + 3, i + 4)
+        for suffix, metric in zip(("emp", "strt", "stop", "vacy"), metrics):
+            input_data[f"{label}_{suffix}"] = [metric]
+        expected_rows.append((label, *metrics))
+
+    expected_data = {
+        AWPClean.establishment_id: [establishment_id] * len(expected_rows),
+        AWPClean.ascwds_workplace_import_date: [import_date] * len(expected_rows),
+        SLVCols.job_role_label: [row[0] for row in expected_rows],
+        SLVCols.employees: [row[1] for row in expected_rows],
+        SLVCols.starters: [row[2] for row in expected_rows],
+        SLVCols.leavers: [row[3] for row in expected_rows],
+        SLVCols.vacancies: [row[4] for row in expected_rows],
+    }
+    return PivotJobRoleColsToRowsTestCase(
+        id="reshapes_all_labels_and_keeps_dense_row_when_a_labels_metrics_are_all_null",
+        input_data=input_data,
+        expected_data=expected_data,
+    )
+
+
+@dataclass
 class TestPrepareUtilsData:
+    pivot_job_role_cols_to_rows_test_cases = [
+        _build_pivot_job_role_cols_to_rows_case(),
+    ]
+
     reduce_to_published_roles_test_cases = [
         ReduceToPublishedRolesTestCase(
             id="leaves_published_role_untouched",

--- a/projects/_07_workforce_characteristics/unittest_data/polars_slv_test_data.py
+++ b/projects/_07_workforce_characteristics/unittest_data/polars_slv_test_data.py
@@ -24,13 +24,13 @@ class RelabelJobRoleColumnsTestCase:
 
 
 @dataclass
-class PivotJobRoleColsToRowsTestCase:
+class ReshapeJobRoleColsToRowsTestCase:
     id: str
     input_data: dict[str, Any]
     expected_data: dict[str, Any]
 
 
-# All 15 published labels, in PublishedJobRoleLabels' own field order. The pivot
+# All 15 published labels, in PublishedJobRoleLabels' own field order. The reshape
 # unconditionally references every label's 4 metric columns (trusting that the raw
 # ASC-WDS schema always declares them), so any functional test case needs the full set.
 _ALL_PUBLISHED_LABELS = [
@@ -53,7 +53,7 @@ _ALL_PUBLISHED_LABELS = [
 _ALL_NULL_LABEL = PublishedJobRoleLabels.other  # exercises the dense-null-row case
 
 
-def _build_pivot_job_role_cols_to_rows_case() -> PivotJobRoleColsToRowsTestCase:
+def _build_reshape_job_role_cols_to_rows_case() -> ReshapeJobRoleColsToRowsTestCase:
     establishment_id = "1"
     import_date = date(2024, 1, 1)
 
@@ -80,7 +80,7 @@ def _build_pivot_job_role_cols_to_rows_case() -> PivotJobRoleColsToRowsTestCase:
         SLVCols.leavers: [row[3] for row in expected_rows],
         SLVCols.vacancies: [row[4] for row in expected_rows],
     }
-    return PivotJobRoleColsToRowsTestCase(
+    return ReshapeJobRoleColsToRowsTestCase(
         id="reshapes_all_labels_and_keeps_dense_row_when_a_labels_metrics_are_all_null",
         input_data=input_data,
         expected_data=expected_data,
@@ -89,8 +89,8 @@ def _build_pivot_job_role_cols_to_rows_case() -> PivotJobRoleColsToRowsTestCase:
 
 @dataclass
 class TestPrepareUtilsData:
-    pivot_job_role_cols_to_rows_test_cases = [
-        _build_pivot_job_role_cols_to_rows_case(),
+    reshape_job_role_cols_to_rows_test_cases = [
+        _build_reshape_job_role_cols_to_rows_case(),
     ]
 
     reduce_to_published_roles_test_cases = [

--- a/projects/_07_workforce_characteristics/unittest_data/polars_slv_test_data.py
+++ b/projects/_07_workforce_characteristics/unittest_data/polars_slv_test_data.py
@@ -30,67 +30,212 @@ class ReshapeJobRoleColsToRowsTestCase:
     expected_data: dict[str, Any]
 
 
-# All 15 published labels, in PublishedJobRoleLabels' own field order. The reshape
-# unconditionally references every label's 4 metric columns (trusting that the raw
-# ASC-WDS schema always declares them), so any functional test case needs the full set.
-_ALL_PUBLISHED_LABELS = [
-    PublishedJobRoleLabels.senior_management,
-    PublishedJobRoleLabels.registered_manager,
-    PublishedJobRoleLabels.social_worker,
-    PublishedJobRoleLabels.senior_care_worker,
-    PublishedJobRoleLabels.care_worker,
-    PublishedJobRoleLabels.community_support_and_outreach,
-    PublishedJobRoleLabels.occupational_therapist,
-    PublishedJobRoleLabels.registered_nurse,
-    PublishedJobRoleLabels.allied_health_professional,
-    PublishedJobRoleLabels.deputy_manager,
-    PublishedJobRoleLabels.support_worker,
-    PublishedJobRoleLabels.other_managers,
-    PublishedJobRoleLabels.other_regulated_professions,
-    PublishedJobRoleLabels.other_direct_care,
-    PublishedJobRoleLabels.other,
-]
-_ALL_NULL_LABEL = PublishedJobRoleLabels.other  # exercises the dense-null-row case
+# The reshape unconditionally references every one of the 15 published labels' 4
+# metric columns (trusting that the raw ASC-WDS schema always declares them), so
+# every case below carries the full set - `other`'s columns are all-null in the
+# single-row case, to also exercise the dense-null-row behaviour.
+_reshape_single_row_case = ReshapeJobRoleColsToRowsTestCase(
+    id="reshapes_all_labels_and_keeps_dense_row_when_a_labels_metrics_are_all_null",
+    input_data={
+        AWPClean.establishment_id: ["1"],
+        AWPClean.ascwds_workplace_import_date: [date(2024, 1, 1)],
+        f"{PublishedJobRoleLabels.senior_management}_emp": [1],
+        f"{PublishedJobRoleLabels.senior_management}_strt": [2],
+        f"{PublishedJobRoleLabels.senior_management}_stop": [3],
+        f"{PublishedJobRoleLabels.senior_management}_vacy": [4],
+        f"{PublishedJobRoleLabels.registered_manager}_emp": [2],
+        f"{PublishedJobRoleLabels.registered_manager}_strt": [3],
+        f"{PublishedJobRoleLabels.registered_manager}_stop": [4],
+        f"{PublishedJobRoleLabels.registered_manager}_vacy": [5],
+        f"{PublishedJobRoleLabels.social_worker}_emp": [3],
+        f"{PublishedJobRoleLabels.social_worker}_strt": [4],
+        f"{PublishedJobRoleLabels.social_worker}_stop": [5],
+        f"{PublishedJobRoleLabels.social_worker}_vacy": [6],
+        f"{PublishedJobRoleLabels.senior_care_worker}_emp": [4],
+        f"{PublishedJobRoleLabels.senior_care_worker}_strt": [5],
+        f"{PublishedJobRoleLabels.senior_care_worker}_stop": [6],
+        f"{PublishedJobRoleLabels.senior_care_worker}_vacy": [7],
+        f"{PublishedJobRoleLabels.care_worker}_emp": [5],
+        f"{PublishedJobRoleLabels.care_worker}_strt": [6],
+        f"{PublishedJobRoleLabels.care_worker}_stop": [7],
+        f"{PublishedJobRoleLabels.care_worker}_vacy": [8],
+        f"{PublishedJobRoleLabels.community_support_and_outreach}_emp": [6],
+        f"{PublishedJobRoleLabels.community_support_and_outreach}_strt": [7],
+        f"{PublishedJobRoleLabels.community_support_and_outreach}_stop": [8],
+        f"{PublishedJobRoleLabels.community_support_and_outreach}_vacy": [9],
+        f"{PublishedJobRoleLabels.occupational_therapist}_emp": [7],
+        f"{PublishedJobRoleLabels.occupational_therapist}_strt": [8],
+        f"{PublishedJobRoleLabels.occupational_therapist}_stop": [9],
+        f"{PublishedJobRoleLabels.occupational_therapist}_vacy": [10],
+        f"{PublishedJobRoleLabels.registered_nurse}_emp": [8],
+        f"{PublishedJobRoleLabels.registered_nurse}_strt": [9],
+        f"{PublishedJobRoleLabels.registered_nurse}_stop": [10],
+        f"{PublishedJobRoleLabels.registered_nurse}_vacy": [11],
+        f"{PublishedJobRoleLabels.allied_health_professional}_emp": [9],
+        f"{PublishedJobRoleLabels.allied_health_professional}_strt": [10],
+        f"{PublishedJobRoleLabels.allied_health_professional}_stop": [11],
+        f"{PublishedJobRoleLabels.allied_health_professional}_vacy": [12],
+        f"{PublishedJobRoleLabels.deputy_manager}_emp": [10],
+        f"{PublishedJobRoleLabels.deputy_manager}_strt": [11],
+        f"{PublishedJobRoleLabels.deputy_manager}_stop": [12],
+        f"{PublishedJobRoleLabels.deputy_manager}_vacy": [13],
+        f"{PublishedJobRoleLabels.support_worker}_emp": [11],
+        f"{PublishedJobRoleLabels.support_worker}_strt": [12],
+        f"{PublishedJobRoleLabels.support_worker}_stop": [13],
+        f"{PublishedJobRoleLabels.support_worker}_vacy": [14],
+        f"{PublishedJobRoleLabels.other_managers}_emp": [12],
+        f"{PublishedJobRoleLabels.other_managers}_strt": [13],
+        f"{PublishedJobRoleLabels.other_managers}_stop": [14],
+        f"{PublishedJobRoleLabels.other_managers}_vacy": [15],
+        f"{PublishedJobRoleLabels.other_regulated_professions}_emp": [13],
+        f"{PublishedJobRoleLabels.other_regulated_professions}_strt": [14],
+        f"{PublishedJobRoleLabels.other_regulated_professions}_stop": [15],
+        f"{PublishedJobRoleLabels.other_regulated_professions}_vacy": [16],
+        f"{PublishedJobRoleLabels.other_direct_care}_emp": [14],
+        f"{PublishedJobRoleLabels.other_direct_care}_strt": [15],
+        f"{PublishedJobRoleLabels.other_direct_care}_stop": [16],
+        f"{PublishedJobRoleLabels.other_direct_care}_vacy": [17],
+        f"{PublishedJobRoleLabels.other}_emp": [None],
+        f"{PublishedJobRoleLabels.other}_strt": [None],
+        f"{PublishedJobRoleLabels.other}_stop": [None],
+        f"{PublishedJobRoleLabels.other}_vacy": [None],
+    },
+    expected_data={
+        AWPClean.establishment_id: ["1"] * 15,
+        AWPClean.ascwds_workplace_import_date: [date(2024, 1, 1)] * 15,
+        SLVCols.job_role_label: [
+            PublishedJobRoleLabels.senior_management,
+            PublishedJobRoleLabels.registered_manager,
+            PublishedJobRoleLabels.social_worker,
+            PublishedJobRoleLabels.senior_care_worker,
+            PublishedJobRoleLabels.care_worker,
+            PublishedJobRoleLabels.community_support_and_outreach,
+            PublishedJobRoleLabels.occupational_therapist,
+            PublishedJobRoleLabels.registered_nurse,
+            PublishedJobRoleLabels.allied_health_professional,
+            PublishedJobRoleLabels.deputy_manager,
+            PublishedJobRoleLabels.support_worker,
+            PublishedJobRoleLabels.other_managers,
+            PublishedJobRoleLabels.other_regulated_professions,
+            PublishedJobRoleLabels.other_direct_care,
+            PublishedJobRoleLabels.other,
+        ],
+        SLVCols.employees: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, None],
+        SLVCols.starters: [2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, None],
+        SLVCols.leavers: [3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, None],
+        SLVCols.vacancies: [4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, None],
+    },
+)
 
-
-def _build_reshape_job_role_cols_to_rows_case() -> ReshapeJobRoleColsToRowsTestCase:
-    establishment_id = "1"
-    import_date = date(2024, 1, 1)
-
-    input_data = {
-        AWPClean.establishment_id: [establishment_id],
-        AWPClean.ascwds_workplace_import_date: [import_date],
-    }
-    expected_rows = []
-    for i, label in enumerate(_ALL_PUBLISHED_LABELS):
-        if label == _ALL_NULL_LABEL:
-            metrics = (None, None, None, None)
-        else:
-            metrics = (i + 1, i + 2, i + 3, i + 4)
-        for suffix, metric in zip(("emp", "strt", "stop", "vacy"), metrics):
-            input_data[f"{label}_{suffix}"] = [metric]
-        expected_rows.append((label, *metrics))
-
-    expected_data = {
-        AWPClean.establishment_id: [establishment_id] * len(expected_rows),
-        AWPClean.ascwds_workplace_import_date: [import_date] * len(expected_rows),
-        SLVCols.job_role_label: [row[0] for row in expected_rows],
-        SLVCols.employees: [row[1] for row in expected_rows],
-        SLVCols.starters: [row[2] for row in expected_rows],
-        SLVCols.leavers: [row[3] for row in expected_rows],
-        SLVCols.vacancies: [row[4] for row in expected_rows],
-    }
-    return ReshapeJobRoleColsToRowsTestCase(
-        id="reshapes_all_labels_and_keeps_dense_row_when_a_labels_metrics_are_all_null",
-        input_data=input_data,
-        expected_data=expected_data,
-    )
+# Two source rows, each with its own distinct value per label (row A = the label's
+# position 1-15, row B = 100 + that position), so a grain-pairing bug (a value
+# leaking or shuffling onto the wrong establishment/date after the explode) would
+# show up as a mismatched row rather than passing by coincidence.
+_reshape_multi_row_case = ReshapeJobRoleColsToRowsTestCase(
+    id="keeps_grain_columns_paired_with_their_own_row_across_multiple_source_rows",
+    input_data={
+        AWPClean.establishment_id: ["10", "20"],
+        AWPClean.ascwds_workplace_import_date: [date(2024, 2, 1), date(2024, 3, 1)],
+        f"{PublishedJobRoleLabels.senior_management}_emp": [1, 101],
+        f"{PublishedJobRoleLabels.senior_management}_strt": [1, 101],
+        f"{PublishedJobRoleLabels.senior_management}_stop": [1, 101],
+        f"{PublishedJobRoleLabels.senior_management}_vacy": [1, 101],
+        f"{PublishedJobRoleLabels.registered_manager}_emp": [2, 102],
+        f"{PublishedJobRoleLabels.registered_manager}_strt": [2, 102],
+        f"{PublishedJobRoleLabels.registered_manager}_stop": [2, 102],
+        f"{PublishedJobRoleLabels.registered_manager}_vacy": [2, 102],
+        f"{PublishedJobRoleLabels.social_worker}_emp": [3, 103],
+        f"{PublishedJobRoleLabels.social_worker}_strt": [3, 103],
+        f"{PublishedJobRoleLabels.social_worker}_stop": [3, 103],
+        f"{PublishedJobRoleLabels.social_worker}_vacy": [3, 103],
+        f"{PublishedJobRoleLabels.senior_care_worker}_emp": [4, 104],
+        f"{PublishedJobRoleLabels.senior_care_worker}_strt": [4, 104],
+        f"{PublishedJobRoleLabels.senior_care_worker}_stop": [4, 104],
+        f"{PublishedJobRoleLabels.senior_care_worker}_vacy": [4, 104],
+        f"{PublishedJobRoleLabels.care_worker}_emp": [5, 105],
+        f"{PublishedJobRoleLabels.care_worker}_strt": [5, 105],
+        f"{PublishedJobRoleLabels.care_worker}_stop": [5, 105],
+        f"{PublishedJobRoleLabels.care_worker}_vacy": [5, 105],
+        f"{PublishedJobRoleLabels.community_support_and_outreach}_emp": [6, 106],
+        f"{PublishedJobRoleLabels.community_support_and_outreach}_strt": [6, 106],
+        f"{PublishedJobRoleLabels.community_support_and_outreach}_stop": [6, 106],
+        f"{PublishedJobRoleLabels.community_support_and_outreach}_vacy": [6, 106],
+        f"{PublishedJobRoleLabels.occupational_therapist}_emp": [7, 107],
+        f"{PublishedJobRoleLabels.occupational_therapist}_strt": [7, 107],
+        f"{PublishedJobRoleLabels.occupational_therapist}_stop": [7, 107],
+        f"{PublishedJobRoleLabels.occupational_therapist}_vacy": [7, 107],
+        f"{PublishedJobRoleLabels.registered_nurse}_emp": [8, 108],
+        f"{PublishedJobRoleLabels.registered_nurse}_strt": [8, 108],
+        f"{PublishedJobRoleLabels.registered_nurse}_stop": [8, 108],
+        f"{PublishedJobRoleLabels.registered_nurse}_vacy": [8, 108],
+        f"{PublishedJobRoleLabels.allied_health_professional}_emp": [9, 109],
+        f"{PublishedJobRoleLabels.allied_health_professional}_strt": [9, 109],
+        f"{PublishedJobRoleLabels.allied_health_professional}_stop": [9, 109],
+        f"{PublishedJobRoleLabels.allied_health_professional}_vacy": [9, 109],
+        f"{PublishedJobRoleLabels.deputy_manager}_emp": [10, 110],
+        f"{PublishedJobRoleLabels.deputy_manager}_strt": [10, 110],
+        f"{PublishedJobRoleLabels.deputy_manager}_stop": [10, 110],
+        f"{PublishedJobRoleLabels.deputy_manager}_vacy": [10, 110],
+        f"{PublishedJobRoleLabels.support_worker}_emp": [11, 111],
+        f"{PublishedJobRoleLabels.support_worker}_strt": [11, 111],
+        f"{PublishedJobRoleLabels.support_worker}_stop": [11, 111],
+        f"{PublishedJobRoleLabels.support_worker}_vacy": [11, 111],
+        f"{PublishedJobRoleLabels.other_managers}_emp": [12, 112],
+        f"{PublishedJobRoleLabels.other_managers}_strt": [12, 112],
+        f"{PublishedJobRoleLabels.other_managers}_stop": [12, 112],
+        f"{PublishedJobRoleLabels.other_managers}_vacy": [12, 112],
+        f"{PublishedJobRoleLabels.other_regulated_professions}_emp": [13, 113],
+        f"{PublishedJobRoleLabels.other_regulated_professions}_strt": [13, 113],
+        f"{PublishedJobRoleLabels.other_regulated_professions}_stop": [13, 113],
+        f"{PublishedJobRoleLabels.other_regulated_professions}_vacy": [13, 113],
+        f"{PublishedJobRoleLabels.other_direct_care}_emp": [14, 114],
+        f"{PublishedJobRoleLabels.other_direct_care}_strt": [14, 114],
+        f"{PublishedJobRoleLabels.other_direct_care}_stop": [14, 114],
+        f"{PublishedJobRoleLabels.other_direct_care}_vacy": [14, 114],
+        f"{PublishedJobRoleLabels.other}_emp": [15, 115],
+        f"{PublishedJobRoleLabels.other}_strt": [15, 115],
+        f"{PublishedJobRoleLabels.other}_stop": [15, 115],
+        f"{PublishedJobRoleLabels.other}_vacy": [15, 115],
+    },
+    expected_data={
+        AWPClean.establishment_id: ["10"] * 15 + ["20"] * 15,
+        AWPClean.ascwds_workplace_import_date: [date(2024, 2, 1)] * 15
+        + [date(2024, 3, 1)] * 15,
+        SLVCols.job_role_label: [
+            PublishedJobRoleLabels.senior_management,
+            PublishedJobRoleLabels.registered_manager,
+            PublishedJobRoleLabels.social_worker,
+            PublishedJobRoleLabels.senior_care_worker,
+            PublishedJobRoleLabels.care_worker,
+            PublishedJobRoleLabels.community_support_and_outreach,
+            PublishedJobRoleLabels.occupational_therapist,
+            PublishedJobRoleLabels.registered_nurse,
+            PublishedJobRoleLabels.allied_health_professional,
+            PublishedJobRoleLabels.deputy_manager,
+            PublishedJobRoleLabels.support_worker,
+            PublishedJobRoleLabels.other_managers,
+            PublishedJobRoleLabels.other_regulated_professions,
+            PublishedJobRoleLabels.other_direct_care,
+            PublishedJobRoleLabels.other,
+        ]
+        * 2,
+        SLVCols.employees: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]
+        + [101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115],
+        SLVCols.starters: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]
+        + [101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115],
+        SLVCols.leavers: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]
+        + [101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115],
+        SLVCols.vacancies: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]
+        + [101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115],
+    },
+)
 
 
 @dataclass
 class TestPrepareUtilsData:
     reshape_job_role_cols_to_rows_test_cases = [
-        _build_reshape_job_role_cols_to_rows_case(),
+        _reshape_single_row_case,
+        _reshape_multi_row_case,
     ]
 
     reduce_to_published_roles_test_cases = [

--- a/tests/test_polars_utils_data.py
+++ b/tests/test_polars_utils_data.py
@@ -25,6 +25,7 @@ from utils.column_values.categorical_column_values import (
 )
 from utils.column_values.categorical_columns_by_dataset import (
     EstimatedIndCQCFilledPostsByJobRoleCategoricalValues as CatVals,
+    SLVPrepareCategoricalValues,
 )
 
 
@@ -463,6 +464,13 @@ class ColumnTypesData:
             actual=CatColType.JobGroupEnumType,
             expected=pl.Enum(
                 CatVals.main_job_group_labels_column_values.categorical_values
+            ),
+        ),
+        CategoricalColumnTypeCase(
+            id="published_job_role_label_enum_type_matches_published_job_role_labels_values",
+            actual=CatColType.PublishedJobRoleLabelEnumType,
+            expected=pl.Enum(
+                SLVPrepareCategoricalValues.published_job_role_labels_column_values.categorical_values
             ),
         ),
         CategoricalColumnTypeCase(

--- a/utils/column_names/slv_job_role_columns.py
+++ b/utils/column_names/slv_job_role_columns.py
@@ -1,0 +1,10 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class SLVJobRoleColumns:
+    job_role_label: str = "job_role_label"
+    employees: str = "employees"
+    starters: str = "starters"
+    leavers: str = "leavers"
+    vacancies: str = "vacancies"


### PR DESCRIPTION
## Description
Trello ticket [#1814](https://trello.com/c/SL6hUcbc/1814-l-pivot-6-pivot-job-role-columns-to-rows)

Implements `reshape_job_role_cols_to_rows()` in the SLV prepare job, reshaping the wide per-published-job-role `{label}_{emp,strt,stop,vacy}` columns into one row per `(establishment_id, ascwds_workplace_import_date, job_role_label)`. Updates `_01_merge.py` to read the new fixed-shape output directly (no longer needs a column selector), and reworks `validate_00_prepare.py`'s checks (grain-uniqueness, distinct-value/row-count checks) to match the new long-format output.

## Testing
- [x] Unit tests passing
- [x] Successful [Step Function run](https://eu-west-2.console.aws.amazon.com/states/home?region=eu-west-2#/v2/executions/details/arn:aws:states:eu-west-2:856699698263:execution:1814-slv-reshape-Ind-CQC-SLV:d4550652-5b99-4e08-a9fe-296155a7524e)
- [x] Outputs checked in Athena (Example output attached to trello ticket)

## Checklist (delete if not relevant)
- [x] Unit tests added/amended
- [x] Docstrings added/updated
- [x] Updated CHANGELOG
- [x] Code reviewed by AI
- [x] Moved Trello ticket to PR column

## Reviewer checklist
- [ ] PR solves the Trello ticket requirements
- [ ] Outputs appear reasonable and understandable
- [ ] The overall approach is appropriate and not over-engineered
- [ ] No obvious scalability, performance or interdependency concerns
- [ ] Tests appropriately cover the main behaviour/edge cases
- [ ] Naming and structure are broadly understandable and consistent
- [ ] Docstrings are sufficient for future maintenance
- [ ] Docstrings cover non-obvious behaviour