### PR TITLE
1863 - Migrate _06_estimate_filled_posts remaining PySpark jobs to Polars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,8 @@ All notable changes to this project will be documented in this file.
 
 - Reworked `reduce_to_published_roles` in the SLV prepare job to derive which raw ASC-WDS job role codes are published versus fold into an 'other' group from the team's own `PublishedJobRoleLabels`/job-group definitions, instead of a hand-maintained mapping dict that needed manual upkeep whenever ASC-WDS's raw job role codes changed.
 
+- Completed the Polars migration of functions within `estimate_ind_cqc_filled_posts.py`.
+
 ### Improved
 - Reduced CircleCI credit usage by removing `no-cache = true` from all `docker-bake.hcl` image targets, so the already-enabled Docker layer caching actually takes effect instead of every image rebuilding from scratch on every push.
 

--- a/projects/_03_independent_cqc/_06_estimate_filled_posts/fargate/estimate_ind_cqc_filled_posts.py
+++ b/projects/_03_independent_cqc/_06_estimate_filled_posts/fargate/estimate_ind_cqc_filled_posts.py
@@ -1,9 +1,13 @@
 from polars_utils import utils
+from projects._03_independent_cqc._06_estimate_filled_posts.fargate.utils.models.estimate_non_res_ct_filled_posts import (
+    estimate_non_res_capacity_tracker_filled_posts,
+)
 from projects._03_independent_cqc._06_estimate_filled_posts.fargate.utils.models.non_res_with_and_without_dormancy_combined import (
     combine_non_res_with_and_without_dormancy_models,
 )
 from projects._03_independent_cqc._06_estimate_filled_posts.fargate.utils.models.utils import (
     enrich_with_model_predictions,
+    set_min_value,
 )
 from projects._03_independent_cqc.utils.imputation.imputation import model_imputation
 from utils.column_names.ind_cqc_pipeline_columns import IndCqcColumns as IndCQC
@@ -97,24 +101,23 @@ def main(
 
     lf = combine_non_res_with_and_without_dormancy_models(lf)
 
-    # Uncommented these call when ascwds_pir_merged has been converted to polars.
-    # lf = model_imputation(
-    #     lf,
-    #     IndCQC.ascwds_pir_merged,
-    #     IndCQC.care_home_model,
-    #     IndCQC.imputed_posts_care_home_model,
-    #     care_home=True,
-    #     extrapolation_method="nominal",
-    # )
+    lf = model_imputation(
+        lf,
+        IndCQC.ascwds_pir_merged,
+        IndCQC.care_home_model,
+        IndCQC.imputed_posts_care_home_model,
+        care_home=True,
+        extrapolation_method="nominal",
+    )
 
-    # lf = model_imputation(
-    #     lf,
-    #     IndCQC.ascwds_pir_merged,
-    #     IndCQC.non_res_combined_model,
-    #     IndCQC.imputed_posts_non_res_combined_model,
-    #     care_home=False,
-    #     extrapolation_method="nominal",
-    # )
+    lf = model_imputation(
+        lf,
+        IndCQC.ascwds_pir_merged,
+        IndCQC.non_res_combined_model,
+        IndCQC.imputed_posts_non_res_combined_model,
+        care_home=False,
+        extrapolation_method="nominal",
+    )
 
     lf = model_imputation(
         lf,
@@ -125,11 +128,23 @@ def main(
         extrapolation_method="nominal",
     )
 
-    # merge_columns_in_order
+    value_expr, source_expr = utils.coalesce_with_source_labels(
+        cols=[
+            IndCQC.ascwds_pir_merged,
+            IndCQC.imputed_posts_care_home_model,
+            IndCQC.care_home_model,
+            IndCQC.imputed_posts_non_res_combined_model,
+            IndCQC.imputed_pir_filled_posts_model,
+            IndCQC.non_res_combined_model,
+            IndCQC.posts_rolling_average_model,
+        ],
+        name=IndCQC.estimate_filled_posts,
+    )
+    lf = lf.with_columns([value_expr, source_expr])
 
-    # set_min_value
+    lf = set_min_value(lf, IndCQC.estimate_filled_posts, 1.0)
 
-    # estimate_non_res_capacity_tracker_filled_posts
+    lf = estimate_non_res_capacity_tracker_filled_posts(lf)
 
     utils.sink_to_parquet(
         lf,

--- a/projects/_03_independent_cqc/_06_estimate_filled_posts/fargate/utils/models/utils.py
+++ b/projects/_03_independent_cqc/_06_estimate_filled_posts/fargate/utils/models/utils.py
@@ -44,6 +44,25 @@ def enrich_with_model_predictions(
     return ind_cqc_with_predictions_lf
 
 
+def set_min_value(
+    lf: pl.LazyFrame, col_name: str, min_value: float | None = 1.0
+) -> pl.LazyFrame:
+    """
+    Clips values in the specified column to a minimum, leaving nulls untouched.
+
+    Args:
+        lf (pl.LazyFrame): A LazyFrame containing the specified column.
+        col_name (str): The name of the column to set the minimum value for.
+        min_value (float | None): The minimum value allowed in the specified
+            column. If None, no minimum is applied.
+
+    Returns:
+        pl.LazyFrame: The LazyFrame with the specified column clipped to the
+        minimum value.
+    """
+    return lf.with_columns(pl.col(col_name).clip(lower_bound=min_value))
+
+
 def join_model_predictions(
     lf: pl.LazyFrame,
     predictions_lf: pl.LazyFrame,

--- a/projects/_03_independent_cqc/_06_estimate_filled_posts/tests/fargate/test_estimate_ind_cqc_filled_posts.py
+++ b/projects/_03_independent_cqc/_06_estimate_filled_posts/tests/fargate/test_estimate_ind_cqc_filled_posts.py
@@ -14,6 +14,9 @@ class EstimateIndCQCFilledPostsTests(unittest.TestCase):
     mock_data = Mock(name="data")
 
     @patch(f"{PATCH_PATH}.utils.sink_to_parquet")
+    @patch(f"{PATCH_PATH}.estimate_non_res_capacity_tracker_filled_posts")
+    @patch(f"{PATCH_PATH}.set_min_value")
+    @patch(f"{PATCH_PATH}.utils.coalesce_with_source_labels")
     @patch(f"{PATCH_PATH}.model_imputation")
     @patch(f"{PATCH_PATH}.combine_non_res_with_and_without_dormancy_models")
     @patch(f"{PATCH_PATH}.enrich_with_model_predictions")
@@ -24,8 +27,12 @@ class EstimateIndCQCFilledPostsTests(unittest.TestCase):
         enrich_with_model_predictions_mock: Mock,
         combine_non_res_with_and_without_dormancy_models_mcok: Mock,
         model_imputation: Mock,
+        coalesce_with_source_labels_mock: Mock,
+        set_min_value_mock: Mock,
+        estimate_non_res_capacity_tracker_filled_posts_mock: Mock,
         sink_to_parquet_mock: Mock,
     ):
+        coalesce_with_source_labels_mock.return_value = (Mock(), Mock())
 
         job.main(
             self.TEST_BUCKET_NAME,
@@ -39,7 +46,12 @@ class EstimateIndCQCFilledPostsTests(unittest.TestCase):
         )
         self.assertEqual(enrich_with_model_predictions_mock.call_count, 3)
         combine_non_res_with_and_without_dormancy_models_mcok.assert_called_once()
-        self.assertEqual(model_imputation.call_count, 1)
+        self.assertEqual(model_imputation.call_count, 3)
+        coalesce_with_source_labels_mock.assert_called_once()
+        set_min_value_mock.assert_called_once_with(
+            ANY, job.IndCQC.estimate_filled_posts, 1.0
+        )
+        estimate_non_res_capacity_tracker_filled_posts_mock.assert_called_once()
         sink_to_parquet_mock.assert_called_once_with(
             ANY,
             self.TEST_DESTINATION,

--- a/projects/_03_independent_cqc/_06_estimate_filled_posts/tests/fargate/utils/models/test_estimate_ind_cqc_filled_posts_models_utils.py
+++ b/projects/_03_independent_cqc/_06_estimate_filled_posts/tests/fargate/utils/models/test_estimate_ind_cqc_filled_posts_models_utils.py
@@ -3,6 +3,7 @@ from unittest.mock import ANY, Mock, patch
 
 import polars as pl
 import polars.testing as pl_testing
+import pytest
 
 from projects._03_independent_cqc._06_estimate_filled_posts.fargate.utils.models import (
     utils as job,
@@ -13,6 +14,7 @@ from projects._03_independent_cqc.unittest_data.polars_ind_cqc_test_file_data im
 from projects._03_independent_cqc.unittest_data.polars_ind_cqc_test_file_schemas import (
     EstimateFilledPostsModelsUtils as Schemas,
 )
+from utils.column_names.ind_cqc_pipeline_columns import IndCqcColumns as IndCqc
 
 PATCH_PATH: str = (
     "projects._03_independent_cqc._06_estimate_filled_posts.fargate.utils.models.utils"
@@ -137,6 +139,26 @@ class EnrichWithModelPredictionsTest(unittest.TestCase):
         pl_testing.assert_frame_equal(
             returned_lf, self.expected_enriched_non_res_lf, check_row_order=False
         )
+
+
+class TestSetMinValue:
+    @pytest.mark.parametrize(
+        "prediction, min_value, expected_prediction",
+        [case.as_pytest_param() for case in Data.set_min_value_test_cases],
+    )
+    def test_function_returns_expected_value(
+        self, prediction, min_value, expected_prediction
+    ):
+        test_lf = pl.LazyFrame(
+            [(prediction,)], Schemas.set_min_value_schema, orient="row"
+        )
+        expected_lf = pl.LazyFrame(
+            [(expected_prediction,)], Schemas.set_min_value_schema, orient="row"
+        )
+
+        returned_lf = job.set_min_value(test_lf, IndCqc.prediction, min_value)
+
+        pl_testing.assert_frame_equal(returned_lf, expected_lf)
 
 
 class JoinModelPredictionsTests(unittest.TestCase):

--- a/projects/_03_independent_cqc/_06_estimate_filled_posts/utils/models/utils.py
+++ b/projects/_03_independent_cqc/_06_estimate_filled_posts/utils/models/utils.py
@@ -45,6 +45,7 @@ def enrich_with_model_predictions(
     return ind_cqc_with_predictions_df
 
 
+# converted to polars -> projects\_03_independent_cqc\_06_estimate_filled_posts\fargate\utils\models\utils.py
 def set_min_value(df: DataFrame, col_name: str, min_value: float = 1.0) -> DataFrame:
     """
     The function takes the greatest value between the existing value and the specified min_value which defaults to 1.0.

--- a/projects/_03_independent_cqc/unittest_data/polars_ind_cqc_test_file_data.py
+++ b/projects/_03_independent_cqc/unittest_data/polars_ind_cqc_test_file_data.py
@@ -1719,7 +1719,60 @@ class NullLongitudinalOutliersData:
 
 
 @dataclass
+class SetMinValueTestCase:
+    id: str
+    prediction: Optional[float]
+    min_value: Optional[float]
+    expected_prediction: Optional[float]
+
+    def as_pytest_param(self):
+        """Return test case as pytest ParameterSet."""
+        return pytest.param(
+            self.prediction, self.min_value, self.expected_prediction, id=self.id
+        )
+
+
+@dataclass
 class EstimateFilledPostsModelsUtils:
+    set_min_value_test_cases = [
+        SetMinValueTestCase(
+            id="replaces_value_below_min_value",
+            prediction=-7.5,
+            min_value=2.0,
+            expected_prediction=2.0,
+        ),
+        SetMinValueTestCase(
+            id="replaces_value_with_default_min_value_when_not_set",
+            prediction=0.5,
+            min_value=1.0,
+            expected_prediction=1.0,
+        ),
+        SetMinValueTestCase(
+            id="replaces_value_with_greatest_when_min_value_is_negative",
+            prediction=-7.5,
+            min_value=-5.0,
+            expected_prediction=-5.0,
+        ),
+        SetMinValueTestCase(
+            id="does_not_replace_value_when_min_value_is_none",
+            prediction=1.5,
+            min_value=None,
+            expected_prediction=1.5,
+        ),
+        SetMinValueTestCase(
+            id="does_not_replace_value_above_min_value",
+            prediction=1.5,
+            min_value=1.0,
+            expected_prediction=1.5,
+        ),
+        SetMinValueTestCase(
+            id="does_not_replace_null_prediction",
+            prediction=None,
+            min_value=1.0,
+            expected_prediction=None,
+        ),
+    ]
+
     enrich_model_ind_cqc_rows = [
         ("1-001", date(2025, 1, 1), CareHome.not_care_home, None),
         ("1-002", date(2025, 1, 1), CareHome.not_care_home, None),

--- a/projects/_03_independent_cqc/unittest_data/polars_ind_cqc_test_file_schemas.py
+++ b/projects/_03_independent_cqc/unittest_data/polars_ind_cqc_test_file_schemas.py
@@ -1263,6 +1263,12 @@ class NullLongitudinalOutliersSchema:
 
 @dataclass
 class EstimateFilledPostsModelsUtils:
+    set_min_value_schema = pl.Schema(
+        {
+            IndCQC.prediction: pl.Float64,
+        }
+    )
+
     enrich_model_ind_cqc_schema = pl.Schema(
         {
             IndCQC.location_id: pl.String,


### PR DESCRIPTION
## Description
Trello ticket [#1863](https://trello.com/c/Hq4Ndr6A/1863-migrate-06estimatefilledposts-remaining-pyspark-jobs-to-polars)

Completed the Polars migration of functions within `estimate_ind_cqc_filled_posts.py`.

## Testing
- [x] Unit tests passing
- [x] Successful [Step Function run](https://eu-west-2.console.aws.amazon.com/states/home?region=eu-west-2#/v2/executions/details/arn:aws:states:eu-west-2:856699698263:execution:1863-efp-polars-Ind-CQC-Filled-Post-Estimates:a7ca6230-d292-4a3f-b3cb-5e033d31992c)
- [x] Outputs checked in Athena - I compared the outputs (pyspark vs polars) as well

## Checklist (delete if not relevant)
- [x] Unit tests added/amended
- [x] Docstrings added/updated
- [x] Updated CHANGELOG
- [x] Code reviewed by AI
- [x] Moved Trello ticket to PR column

## Reviewer checklist
- [ ] PR solves the Trello ticket requirements
- [ ] Outputs appear reasonable and understandable
- [ ] The overall approach is appropriate and not over-engineered
- [ ] No obvious scalability, performance or interdependency concerns
- [ ] Tests appropriately cover the main behaviour/edge cases
- [ ] Naming and structure are broadly understandable and consistent
- [ ] Docstrings are sufficient for future maintenance
- [ ] Docstrings cover non-obvious behaviour
