### PR TITLE
1868 - Fix ModuleNotFoundError breaking PySpark Glue ingestion jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -285,10 +285,6 @@ jobs:
             aws s3 sync "s3://sfc-main-datasets/domain=ind_cqc_filled_posts/dataset=ind_cqc_07_01_merge_metadata_job_roles/" "s3://$BRANCH_DATASET_BUCKET/domain=ind_cqc_filled_posts/dataset=main_ind_cqc_07_01_merge_metadata_job_roles/" --delete
             aws s3 sync "s3://sfc-main-datasets/domain=workforce_characteristics/dataset=empstat_rates/" "s3://$BRANCH_DATASET_BUCKET/domain=workforce_characteristics/dataset=empstat_rates/" --delete
       - run:
-          name: Copy raw ASCWDS data for manual Step Function testing
-          command: |
-            aws s3 sync "s3://sfc-data-engineering-raw/domain=ASCWDS/dataset=workplace/" "s3://$BRANCH_DATASET_BUCKET/domain=raw/" --delete
-      - run:
           name: Copy models to non-prod dataset
           command: |
             aws s3 sync "s3://sfc-main-pipeline-resources/models/" "s3://$BRANCH_RESOURCES_BUCKET/models/"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -285,6 +285,10 @@ jobs:
             aws s3 sync "s3://sfc-main-datasets/domain=ind_cqc_filled_posts/dataset=ind_cqc_07_01_merge_metadata_job_roles/" "s3://$BRANCH_DATASET_BUCKET/domain=ind_cqc_filled_posts/dataset=main_ind_cqc_07_01_merge_metadata_job_roles/" --delete
             aws s3 sync "s3://sfc-main-datasets/domain=workforce_characteristics/dataset=empstat_rates/" "s3://$BRANCH_DATASET_BUCKET/domain=workforce_characteristics/dataset=empstat_rates/" --delete
       - run:
+          name: Copy raw ASCWDS data for manual Step Function testing
+          command: |
+            aws s3 sync "s3://sfc-data-engineering-raw/domain=ASCWDS/dataset=workplace/" "s3://$BRANCH_DATASET_BUCKET/domain=raw/" --delete
+      - run:
           name: Copy models to non-prod dataset
           command: |
             aws s3 sync "s3://sfc-main-pipeline-resources/models/" "s3://$BRANCH_RESOURCES_BUCKET/models/"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,8 @@ All notable changes to this project will be documented in this file.
 
 - Added missing error notifications for the CQC/ASC-WDS orchestrator and crawler-refresh steps in three ingestion pipelines, and a bounded timeout for the ASC-WDS worker/workplace file-arrival polling loops.
 
+- Fixed a broken import in the shared ingestion utils that caused the ASC-WDS, Capacity Tracker, CQC PIR, and ONS PySpark Glue ingestion jobs to fail with `ModuleNotFoundError: No module named 'polars'`.
+
 ## [v2026.06.0] - 15/07/2026
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,7 +87,7 @@ All notable changes to this project will be documented in this file.
 
 - Added missing error notifications for the CQC/ASC-WDS orchestrator and crawler-refresh steps in three ingestion pipelines, and a bounded timeout for the ASC-WDS worker/workplace file-arrival polling loops.
 
-- Fixed a broken import in the shared ingestion utils that caused the ASC-WDS, Capacity Tracker, CQC PIR, and ONS PySpark Glue ingestion jobs to fail with `ModuleNotFoundError: No module named 'polars'`.
+- Fixed a broken import in the shared ingestion utils that caused the ASC-WDS, Capacity Tracker, CQC PIR, and ONS PySpark Glue ingestion jobs to fail with `ModuleNotFoundError: No module named 'polars'`. Inlined the affected `split_s3_uri` helper instead of importing it, so this file no longer depends on PySpark/pydeequ either.
 
 ## [v2026.06.0] - 15/07/2026
 

--- a/projects/_01_ingest/utils/utils.py
+++ b/projects/_01_ingest/utils/utils.py
@@ -3,7 +3,7 @@ from typing import Any
 
 import boto3
 
-from polars_utils.utils import split_s3_uri
+from utils.utils import split_s3_uri
 
 TWO_MB = 2000000
 

--- a/projects/_01_ingest/utils/utils.py
+++ b/projects/_01_ingest/utils/utils.py
@@ -3,8 +3,6 @@ from typing import Any
 
 import boto3
 
-from utils.utils import split_s3_uri
-
 TWO_MB = 2000000
 
 
@@ -117,6 +115,21 @@ def construct_s3_uri(bucket_name: str, key: str) -> str:
     """
     trimmed_bucket_name = bucket_name.strip()
     return f"s3://{trimmed_bucket_name}/{key}"
+
+
+# converted to polars -> polars_utils.utils.py
+def split_s3_uri(uri: str) -> tuple[str, str]:
+    """
+    Converts a given string of an s3 uri into its bucket and key names
+
+    Args:
+        uri (str): The s3 uri to be split.
+
+    Returns:
+        tuple[str, str]: A tuple of the bucket and key substrings from the s3 uri.
+    """
+    bucket, prefix = uri.replace("s3://", "").split("/", 1)
+    return bucket, prefix
 
 
 def construct_destination_path(destination: str, key: str) -> str:


### PR DESCRIPTION
## Description
Trello ticket [#1868](add link)

The ASC-WDS Glue ingestion job was failing in production with `ModuleNotFoundError: No module named 'polars'`. Root cause: `projects/_01_ingest/utils/utils.py` (imported by all four legacy PySpark Glue ingestion jobs — ASC-WDS, Capacity Tracker, CQC PIR, ONS) imported `split_s3_uri` from `polars_utils.utils`, which does `import polars` at module level — unavailable in the Glue PySpark runtime. This broke all four jobs, not just ASC-WDS.

Fix: inlined `split_s3_uri`'s two-line body directly into `projects/_01_ingest/utils/utils.py` instead of importing it from either `polars_utils` or the repo-wide `utils.utils` (which would have introduced a pyspark/pydeequ dependency for the same reason, in the opposite direction). This keeps the file dependency-free, as it was before the regression.

A full repo audit confirmed this was the only incorrect `split_s3_uri` import — no other Glue job or the CQC ingestion pipeline (already Polars/Fargate) is affected.

## Testing
- [x] Unit tests passing
- [ ] Successful [Step Function run](add link) - not possible to run in branch - permissions issues
- [ ] Outputs checked in Athena

- `uv run pytest projects/_01_ingest/tests/utils/test_utils.py` — 14 passed.
- Confirmed `projects._01_ingest.utils.utils` now imports cleanly with `polars`, `pyspark`, and `pydeequ` all blocked from `sys.modules` (simulating the Glue runtime it broke in).
- Manually triggered `Ingest-ASCWDS` against a real file in the branch's non-prod environment: it got past the previously-failing import and reached the parquet write step (proving the `ModuleNotFoundError` is fixed), then hit an unrelated `PATH_ALREADY_EXISTS` caused by the branch's dataset bucket doubling as both source and destination in this test setup (no separate raw bucket / cross-account access from non-prod) — not a defect in this change. 

## Checklist (delete if not relevant)
- [ ] Unit tests added/amended
- [x] Docstrings added/updated
- [x] Updated CHANGELOG
- [x] Code reviewed by AI
- [ ] Moved Trello ticket to PR column

## Reviewer checklist
- [ ] PR solves the Trello ticket requirements
- [ ] Outputs appear reasonable and understandable
- [ ] The overall approach is appropriate and not over-engineered
- [ ] No obvious scalability, performance or interdependency concerns
- [ ] Tests appropriately cover the main behaviour/edge cases
- [ ] Naming and structure are broadly understandable and consistent
- [ ] Docstrings are sufficient for future maintenance
- [ ] Docstrings cover non-obvious behaviour
