### PR TITLE
1865 - Migrate _06_estimate_filled_posts validation to pointblank

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,8 @@ All notable changes to this project will be documented in this file.
 
 - Completed the Polars migration of functions within `estimate_ind_cqc_filled_posts.py`.
 
+- Updated pointblank validation for the estimates job within the Ind CQC pipeline, and added the custom validation rules that hadn't been converted from PySpark yet.
+
 ### Improved
 - Reduced CircleCI credit usage by removing `no-cache = true` from all `docker-bake.hcl` image targets, so the already-enabled Docker layer caching actually takes effect instead of every image rebuilding from scratch on every push.
 

--- a/projects/_03_independent_cqc/_06_estimate_filled_posts/fargate/utils/validation_utils.py
+++ b/projects/_03_independent_cqc/_06_estimate_filled_posts/fargate/utils/validation_utils.py
@@ -1,0 +1,133 @@
+import polars as pl
+
+from utils.column_names.ind_cqc_pipeline_columns import IndCqcColumns
+from utils.column_values.categorical_column_values import (
+    CareHome,
+    PrimaryServiceType,
+    PrimaryServiceTypeSecondLevel,
+    Services,
+)
+
+
+def care_home_matches_primary_service_type_expr() -> pl.Expr:
+    """
+    The data in care_home and primary_service_type should be related: a
+    non-care-home location must have a non-residential primary service type,
+    and a care home must have one of the two care-home primary service types.
+
+    Returns:
+        pl.Expr: a boolean expression, true where care_home and
+        primary_service_type are consistent.
+    """
+    return (
+        (
+            pl.col(IndCqcColumns.care_home).eq(CareHome.not_care_home)
+            & pl.col(IndCqcColumns.primary_service_type).eq(
+                PrimaryServiceType.non_residential
+            )
+        )
+        | (
+            pl.col(IndCqcColumns.care_home).eq(CareHome.care_home)
+            & pl.col(IndCqcColumns.primary_service_type).eq(
+                PrimaryServiceType.care_home_with_nursing
+            )
+        )
+        | (
+            pl.col(IndCqcColumns.care_home).eq(CareHome.care_home)
+            & pl.col(IndCqcColumns.primary_service_type).eq(
+                PrimaryServiceType.care_home_only
+            )
+        )
+    )
+
+
+def _services_offered_consistency_expr(
+    second_level_value: str,
+    required_service: str,
+    excluded_services: list[str],
+) -> pl.Expr:
+    """
+    Shared engine for the services_offered consistency rules: if
+    primary_service_type_second_level equals second_level_value,
+    services_offered must contain required_service and must not contain any
+    of excluded_services. Rows where second_level_value doesn't apply always
+    pass.
+
+    Args:
+        second_level_value (str): the primary_service_type_second_level value
+            the rule applies to.
+        required_service (str): the services_offered value required when the
+            rule applies.
+        excluded_services (list[str]): services_offered values that must not
+            be present when the rule applies.
+
+    Returns:
+        pl.Expr: a boolean expression, true where the rule holds or does not
+        apply.
+    """
+    applies = pl.col(IndCqcColumns.primary_service_type_second_level).eq(
+        second_level_value
+    )
+    services_offered = pl.col(IndCqcColumns.services_offered)
+    contains_required = services_offered.list.contains(required_service)
+    excludes_others = (
+        ~pl.any_horizontal(
+            [services_offered.list.contains(service) for service in excluded_services]
+        )
+        if excluded_services
+        else pl.lit(True)
+    )
+    return ~applies | (applies & contains_required & excludes_others)
+
+
+def shared_lives_services_offered_expr() -> pl.Expr:
+    """
+    If primary_service_type_second_level is 'Shared Lives', services_offered
+    must contain 'Shared Lives'.
+
+    Returns:
+        pl.Expr: a boolean expression, true where the rule holds or does not
+        apply.
+    """
+    return _services_offered_consistency_expr(
+        PrimaryServiceTypeSecondLevel.shared_lives,
+        Services.shared_lives,
+        excluded_services=[],
+    )
+
+
+def care_home_with_nursing_services_offered_expr() -> pl.Expr:
+    """
+    If primary_service_type_second_level is 'Care home with nursing',
+    services_offered must contain 'Care home service with nursing' and must
+    not contain 'Shared Lives'.
+
+    Returns:
+        pl.Expr: a boolean expression, true where the rule holds or does not
+        apply.
+    """
+    return _services_offered_consistency_expr(
+        PrimaryServiceTypeSecondLevel.care_home_with_nursing,
+        Services.care_home_service_with_nursing,
+        excluded_services=[Services.shared_lives],
+    )
+
+
+def care_home_without_nursing_services_offered_expr() -> pl.Expr:
+    """
+    If primary_service_type_second_level is 'Care home without nursing',
+    services_offered must contain 'Care home service without nursing' and
+    must not contain 'Shared Lives' or 'Care home service with nursing'.
+
+    Returns:
+        pl.Expr: a boolean expression, true where the rule holds or does not
+        apply.
+    """
+    return _services_offered_consistency_expr(
+        PrimaryServiceTypeSecondLevel.care_home_only,
+        Services.care_home_service_without_nursing,
+        excluded_services=[
+            Services.shared_lives,
+            Services.care_home_service_with_nursing,
+        ],
+    )

--- a/projects/_03_independent_cqc/_06_estimate_filled_posts/fargate/validate_estimated_ind_cqc_filled_posts_data.py
+++ b/projects/_03_independent_cqc/_06_estimate_filled_posts/fargate/validate_estimated_ind_cqc_filled_posts_data.py
@@ -1,11 +1,16 @@
 import sys
 
 import pointblank as pb
+import polars as pl
+import polars.selectors as cs
 
 from polars_utils import utils
 from polars_utils.expressions import str_length_cols
 from polars_utils.validation import actions as vl
 from polars_utils.validation.constants import GLOBAL_ACTIONS, GLOBAL_THRESHOLDS
+from projects._03_independent_cqc._06_estimate_filled_posts.fargate.utils import (
+    validation_utils as vUtils,
+)
 from utils.column_names.ind_cqc_pipeline_columns import IndCqcColumns
 from utils.column_values.categorical_columns_by_dataset import (
     EstimatedIndCQCFilledPostsCategoricalValues as CatValues,
@@ -32,10 +37,14 @@ def main(
         compare_path (str): path to a dataset to compare against for expected size
     """
 
-    source_df = utils.read_parquet(
-        f"s3://{bucket_name}/{source_path}", exclude_complex_types=True
-    ).with_columns(
-        str_length_cols([IndCqcColumns.location_id]),
+    raw_source_df = utils.read_parquet(
+        f"s3://{bucket_name}/{source_path}"
+    ).with_columns(str_length_cols([IndCqcColumns.location_id]))
+    # services_offered (a List column) is needed by 3 of the custom business rules
+    # below, so it's kept even though other Struct/List columns are excluded as
+    # pointblank cannot validate them directly.
+    source_df = raw_source_df.select(
+        ~cs.by_dtype(pl.Struct, pl.List) | cs.by_name(IndCqcColumns.services_offered)
     )
     compare_df = utils.read_parquet(
         f"s3://{bucket_name}/{compare_path}",
@@ -68,8 +77,8 @@ def main(
                 IndCqcColumns.current_ons_import_date,
                 IndCqcColumns.current_cssr,
                 IndCqcColumns.current_region,
-                #         IndCqcColumns.estimate_filled_posts,
-                #         IndCqcColumns.estimate_filled_posts_source,
+                IndCqcColumns.estimate_filled_posts,
+                IndCqcColumns.estimate_filled_posts_source,
             ]
         )
         # index columns
@@ -82,11 +91,16 @@ def main(
         # between (inclusive)
         .col_vals_between(IndCqcColumns.ascwds_filled_posts, 1.0, 3000.0, na_pass=True)
         .col_vals_between(IndCqcColumns.ascwds_pir_merged, 1.0, 3000.0, na_pass=True)
-        # .col_vals_between(IndCqcColumns.care_home_model, -100.0, 3000.0)
-        # .col_vals_between(
-        #     IndCqcColumns.imputed_posts_non_res_combined_model, -100.0, 3000.0
-        # )
-        # .col_vals_between(IndCqcColumns.estimate_filled_posts, 1.0, 3000.0)
+        .col_vals_between(IndCqcColumns.care_home_model, -100.0, 3000.0, na_pass=True)
+        .col_vals_between(
+            IndCqcColumns.imputed_posts_non_res_combined_model,
+            -100.0,
+            3000.0,
+            na_pass=True,
+        )
+        .col_vals_between(
+            IndCqcColumns.estimate_filled_posts, 1.0, 3000.0, na_pass=True
+        )
         .col_vals_between(
             IndCqcColumns.non_res_with_dormancy_model, -100.0, 3000.0, na_pass=True
         )
@@ -97,7 +111,9 @@ def main(
         .col_vals_between(
             IndCqcColumns.pir_people_directly_employed_dedup, 1, 3000, na_pass=True
         )
-        # .col_vals_between(IndCqcColumns.imputed_pir_filled_posts_model, -100.0, 3000.0)
+        .col_vals_between(
+            IndCqcColumns.imputed_pir_filled_posts_model, -100.0, 3000.0, na_pass=True
+        )
         .col_vals_between(IndCqcColumns.posts_rolling_average_model, 1.0, 3000.0)
         # categorical
         .col_vals_in_set(
@@ -127,10 +143,10 @@ def main(
                 None,
             ],
         )
-        # .col_vals_in_set(
-        #     IndCqcColumns.estimate_filled_posts_source,
-        #     CatValues.estimate_filled_posts_source_column_values.categorical_values,
-        # )
+        .col_vals_in_set(
+            IndCqcColumns.estimate_filled_posts_source,
+            CatValues.estimate_filled_posts_source_column_values.categorical_values,
+        )
         # distinct values
         .specially(
             vl.is_unique_count_equal(
@@ -174,17 +190,30 @@ def main(
             ),
             brief=f"{IndCqcColumns.ascwds_filled_posts_source} needs to be one of {CatValues.ascwds_filled_posts_source_column_values.categorical_values}",
         )
-        # .specially(
-        #     vl.is_unique_count_equal(
-        #         IndCqcColumns.estimate_filled_posts_source,
-        #         CatValues.estimate_filled_posts_source_column_values.count_of_categorical_values,
-        #     ),
-        #     brief=f"{IndCqcColumns.estimate_filled_posts_source} needs to be one of {CatValues.estimate_filled_posts_source_column_values.categorical_values}",
-        # )
-        # TODO - Add custom validation rule that the data in carehome and primary_service_type should be related.
-        # TODO - Add custom validation rule that primary_service_type_second_level correctly allocates shared lives.
-        # TODO - Add custom validation rule that primary_service_type_second_level correctly allocates care homes with nursing.
-        # TODO - Add custom validation rule that primary_service_type_second_level correctly allocates care homes without nursing.
+        .specially(
+            vl.is_unique_count_equal(
+                IndCqcColumns.estimate_filled_posts_source,
+                CatValues.estimate_filled_posts_source_column_values.count_of_categorical_values,
+            ),
+            brief=f"{IndCqcColumns.estimate_filled_posts_source} needs to be one of {CatValues.estimate_filled_posts_source_column_values.categorical_values}",
+        )
+        # custom business rules
+        .col_vals_expr(
+            vUtils.care_home_matches_primary_service_type_expr(),
+            brief="care_home and primary_service_type should be related.",
+        )
+        .col_vals_expr(
+            vUtils.shared_lives_services_offered_expr(),
+            brief="If primary_service_type_second_level is 'Shared Lives', services_offered must contain 'Shared Lives'.",
+        )
+        .col_vals_expr(
+            vUtils.care_home_with_nursing_services_offered_expr(),
+            brief="If primary_service_type_second_level is 'Care home with nursing', services_offered must contain 'Care home service with nursing' and must not contain 'Shared Lives'.",
+        )
+        .col_vals_expr(
+            vUtils.care_home_without_nursing_services_offered_expr(),
+            brief="If primary_service_type_second_level is 'Care home without nursing', services_offered must contain 'Care home service without nursing' and must not contain 'Shared Lives' or 'Care home service with nursing'.",
+        )
         .interrogate()
     )
     vl.write_reports(validation, bucket_name, reports_path)

--- a/projects/_03_independent_cqc/_06_estimate_filled_posts/tests/fargate/test_validate_estimated_ind_cqc_filled_posts_data.py
+++ b/projects/_03_independent_cqc/_06_estimate_filled_posts/tests/fargate/test_validate_estimated_ind_cqc_filled_posts_data.py
@@ -42,7 +42,7 @@ class ValidateEstimatedIndCQCFilledPostsDataTests(unittest.TestCase):
 
         mock_read_parquet.assert_has_calls(
             [
-                call("s3://bucket/my/dataset/", exclude_complex_types=True),
+                call("s3://bucket/my/dataset/"),
                 call(
                     "s3://bucket/other/dataset/",
                     selected_columns=job.imputed_ind_cqc_cols_to_import,
@@ -76,6 +76,7 @@ class ValidateEstimatedIndCQCFilledPostsDataTests(unittest.TestCase):
             "col_vals_between",
             "col_vals_in_set",
             "specially",
+            "col_vals_expr",
         }
 
         for assertion in expected_assertions:

--- a/projects/_03_independent_cqc/_06_estimate_filled_posts/tests/fargate/utils/test_validation_utils.py
+++ b/projects/_03_independent_cqc/_06_estimate_filled_posts/tests/fargate/utils/test_validation_utils.py
@@ -1,0 +1,106 @@
+import polars as pl
+import pytest
+
+import projects._03_independent_cqc._06_estimate_filled_posts.fargate.utils.validation_utils as job
+from projects._03_independent_cqc.unittest_data.polars_ind_cqc_test_file_data import (
+    ValidationUtilsData as Data,
+)
+from utils.column_names.ind_cqc_pipeline_columns import IndCqcColumns as IndCQC
+
+
+class TestCareHomeMatchesPrimaryServiceTypeExpr:
+    @pytest.mark.parametrize(
+        "care_home, primary_service_type, expected",
+        [
+            case.as_pytest_param()
+            for case in Data.care_home_matches_primary_service_type_test_cases
+        ],
+    )
+    def test_function_returns_expected_value(
+        self, care_home, primary_service_type, expected
+    ):
+        df = pl.DataFrame(
+            {
+                IndCQC.care_home: [care_home],
+                IndCQC.primary_service_type: [primary_service_type],
+            }
+        )
+
+        result = df.select(job.care_home_matches_primary_service_type_expr())
+
+        assert result.item() is expected
+
+
+class TestSharedLivesServicesOfferedExpr:
+    @pytest.mark.parametrize(
+        "primary_service_type_second_level, services_offered, expected",
+        [
+            case.as_pytest_param()
+            for case in Data.shared_lives_services_offered_test_cases
+        ],
+    )
+    def test_function_returns_expected_value(
+        self, primary_service_type_second_level, services_offered, expected
+    ):
+        df = pl.DataFrame(
+            {
+                IndCQC.primary_service_type_second_level: [
+                    primary_service_type_second_level
+                ],
+                IndCQC.services_offered: [services_offered],
+            }
+        )
+
+        result = df.select(job.shared_lives_services_offered_expr())
+
+        assert result.item() is expected
+
+
+class TestCareHomeWithNursingServicesOfferedExpr:
+    @pytest.mark.parametrize(
+        "primary_service_type_second_level, services_offered, expected",
+        [
+            case.as_pytest_param()
+            for case in Data.care_home_with_nursing_services_offered_test_cases
+        ],
+    )
+    def test_function_returns_expected_value(
+        self, primary_service_type_second_level, services_offered, expected
+    ):
+        df = pl.DataFrame(
+            {
+                IndCQC.primary_service_type_second_level: [
+                    primary_service_type_second_level
+                ],
+                IndCQC.services_offered: [services_offered],
+            }
+        )
+
+        result = df.select(job.care_home_with_nursing_services_offered_expr())
+
+        assert result.item() is expected
+
+
+class TestCareHomeWithoutNursingServicesOfferedExpr:
+    @pytest.mark.parametrize(
+        "primary_service_type_second_level, services_offered, expected",
+        [
+            case.as_pytest_param()
+            for case in Data.care_home_without_nursing_services_offered_test_cases
+        ],
+    )
+    def test_function_returns_expected_value(
+        self, primary_service_type_second_level, services_offered, expected
+    ):
+        df = pl.DataFrame(
+            {
+                IndCQC.primary_service_type_second_level: [
+                    primary_service_type_second_level
+                ],
+                IndCQC.services_offered: [services_offered],
+            }
+        )
+
+        result = df.select(job.care_home_without_nursing_services_offered_expr())
+
+        assert result.item() is expected

--- a/projects/_03_independent_cqc/unittest_data/polars_ind_cqc_test_file_data.py
+++ b/projects/_03_independent_cqc/unittest_data/polars_ind_cqc_test_file_data.py
@@ -18,8 +18,10 @@ from utils.column_values.categorical_column_values import (
     JobRoleFilteringRule,
     MainJobRoleLabels,
     PrimaryServiceType,
+    PrimaryServiceTypeSecondLevel,
     Region,
     Sector,
+    Services,
 )
 
 
@@ -466,11 +468,153 @@ class ValidateEstimatedIndCQCFilledPostsData:
     ]
 
     estimated_ind_cqc_filled_posts_rows = [
-        ("1-000000001", date(2024, 1, 1), date(2024, 1, 1), "Y", Sector.independent, 5, PrimaryServiceType.care_home_only, PrimaryServiceType.care_home_only, date(2024, 1, 1), "cssr", "region", 5, 5, 5, "source", 5.0, 5.0, 5, 5.0, 5.0, "source", 5.0, 5.0, 5.0, 5.0, 5.0, 5.0),
-        ("1-000000002", date(2024, 1, 1), date(2024, 1, 1), "Y", Sector.independent, 5, PrimaryServiceType.care_home_only, PrimaryServiceType.care_home_only, date(2024, 1, 1), "cssr", "region", 5, 5, 5, "source", 5.0, 5.0, 5, 5.0, 5.0, "source", 5.0, 5.0, 5.0, 5.0, 5.0, 5.0),
-        ("1-000000001", date(2024, 1, 9), date(2024, 1, 1), "Y", Sector.independent, 5, PrimaryServiceType.care_home_only, PrimaryServiceType.care_home_only, date(2024, 1, 1), "cssr", "region", 5, 5, 5, "source", 5.0, 5.0, 5, 5.0, 5.0, "source", 5.0, 5.0, 5.0, 5.0, 5.0, 5.0),
-        ("1-000000002", date(2024, 1, 9), date(2024, 1, 1), "Y", Sector.independent, 5, PrimaryServiceType.care_home_only, PrimaryServiceType.care_home_only, date(2024, 1, 1), "cssr", "region", 5, 5, 5, "source", 5.0, 5.0, 5, 5.0, 5.0, "source", 5.0, 5.0, 5.0, 5.0, 5.0, 5.0),
+        ("1-000000001", date(2024, 1, 1), date(2024, 1, 1), "Y", Sector.independent, 5, PrimaryServiceType.care_home_only, PrimaryServiceType.care_home_only, date(2024, 1, 1), "cssr", "region", 5, 5, 5, "source", 5.0, 5.0, 5, 5.0, 5.0, "source", 5.0, 5.0, 5.0, 5.0, 5.0, 5.0, [Services.care_home_service_without_nursing]),
+        ("1-000000002", date(2024, 1, 1), date(2024, 1, 1), "Y", Sector.independent, 5, PrimaryServiceType.care_home_only, PrimaryServiceType.care_home_only, date(2024, 1, 1), "cssr", "region", 5, 5, 5, "source", 5.0, 5.0, 5, 5.0, 5.0, "source", 5.0, 5.0, 5.0, 5.0, 5.0, 5.0, [Services.care_home_service_without_nursing]),
+        ("1-000000001", date(2024, 1, 9), date(2024, 1, 1), "Y", Sector.independent, 5, PrimaryServiceType.care_home_only, PrimaryServiceType.care_home_only, date(2024, 1, 1), "cssr", "region", 5, 5, 5, "source", 5.0, 5.0, 5, 5.0, 5.0, "source", 5.0, 5.0, 5.0, 5.0, 5.0, 5.0, [Services.care_home_service_without_nursing]),
+        ("1-000000002", date(2024, 1, 9), date(2024, 1, 1), "Y", Sector.independent, 5, PrimaryServiceType.care_home_only, PrimaryServiceType.care_home_only, date(2024, 1, 1), "cssr", "region", 5, 5, 5, "source", 5.0, 5.0, 5, 5.0, 5.0, "source", 5.0, 5.0, 5.0, 5.0, 5.0, 5.0, [Services.care_home_service_without_nursing]),
     ] # fmt: skip
+
+
+@dataclass
+class CareHomeMatchesPrimaryServiceTypeTestCase:
+    id: str
+    care_home: str
+    primary_service_type: str
+    expected: bool
+
+    def as_pytest_param(self):
+        """Return test case as pytest ParameterSet."""
+        return pytest.param(
+            self.care_home, self.primary_service_type, self.expected, id=self.id
+        )
+
+
+@dataclass
+class ServicesOfferedRuleTestCase:
+    id: str
+    primary_service_type_second_level: str
+    services_offered: list
+    expected: bool
+
+    def as_pytest_param(self):
+        """Return test case as pytest ParameterSet."""
+        return pytest.param(
+            self.primary_service_type_second_level,
+            self.services_offered,
+            self.expected,
+            id=self.id,
+        )
+
+
+@dataclass
+class ValidationUtilsData:
+    care_home_matches_primary_service_type_test_cases = [
+        CareHomeMatchesPrimaryServiceTypeTestCase(
+            id="not_care_home_and_non_residential_is_valid",
+            care_home=CareHome.not_care_home,
+            primary_service_type=PrimaryServiceType.non_residential,
+            expected=True,
+        ),
+        CareHomeMatchesPrimaryServiceTypeTestCase(
+            id="care_home_and_care_home_with_nursing_is_valid",
+            care_home=CareHome.care_home,
+            primary_service_type=PrimaryServiceType.care_home_with_nursing,
+            expected=True,
+        ),
+        CareHomeMatchesPrimaryServiceTypeTestCase(
+            id="care_home_and_care_home_only_is_valid",
+            care_home=CareHome.care_home,
+            primary_service_type=PrimaryServiceType.care_home_only,
+            expected=True,
+        ),
+        CareHomeMatchesPrimaryServiceTypeTestCase(
+            id="care_home_and_non_residential_is_invalid",
+            care_home=CareHome.care_home,
+            primary_service_type=PrimaryServiceType.non_residential,
+            expected=False,
+        ),
+    ]
+
+    shared_lives_services_offered_test_cases = [
+        ServicesOfferedRuleTestCase(
+            id="rule_does_not_apply_when_not_shared_lives",
+            primary_service_type_second_level=PrimaryServiceTypeSecondLevel.care_home_only,
+            services_offered=[Services.care_home_service_without_nursing],
+            expected=True,
+        ),
+        ServicesOfferedRuleTestCase(
+            id="valid_when_shared_lives_and_services_offered_contains_shared_lives",
+            primary_service_type_second_level=PrimaryServiceTypeSecondLevel.shared_lives,
+            services_offered=[Services.shared_lives],
+            expected=True,
+        ),
+        ServicesOfferedRuleTestCase(
+            id="invalid_when_shared_lives_and_services_offered_missing_shared_lives",
+            primary_service_type_second_level=PrimaryServiceTypeSecondLevel.shared_lives,
+            services_offered=[Services.care_home_service_without_nursing],
+            expected=False,
+        ),
+    ]
+
+    care_home_with_nursing_services_offered_test_cases = [
+        ServicesOfferedRuleTestCase(
+            id="rule_does_not_apply_when_not_care_home_with_nursing",
+            primary_service_type_second_level=PrimaryServiceTypeSecondLevel.care_home_only,
+            services_offered=[Services.care_home_service_without_nursing],
+            expected=True,
+        ),
+        ServicesOfferedRuleTestCase(
+            id="valid_when_services_offered_contains_nursing_and_not_shared_lives",
+            primary_service_type_second_level=PrimaryServiceTypeSecondLevel.care_home_with_nursing,
+            services_offered=[Services.care_home_service_with_nursing],
+            expected=True,
+        ),
+        ServicesOfferedRuleTestCase(
+            id="invalid_when_services_offered_missing_nursing",
+            primary_service_type_second_level=PrimaryServiceTypeSecondLevel.care_home_with_nursing,
+            services_offered=[Services.care_home_service_without_nursing],
+            expected=False,
+        ),
+        ServicesOfferedRuleTestCase(
+            id="invalid_when_services_offered_also_contains_shared_lives",
+            primary_service_type_second_level=PrimaryServiceTypeSecondLevel.care_home_with_nursing,
+            services_offered=[
+                Services.care_home_service_with_nursing,
+                Services.shared_lives,
+            ],
+            expected=False,
+        ),
+    ]
+
+    care_home_without_nursing_services_offered_test_cases = [
+        ServicesOfferedRuleTestCase(
+            id="rule_does_not_apply_when_not_care_home_without_nursing",
+            primary_service_type_second_level=PrimaryServiceTypeSecondLevel.care_home_with_nursing,
+            services_offered=[Services.care_home_service_with_nursing],
+            expected=True,
+        ),
+        ServicesOfferedRuleTestCase(
+            id="valid_when_services_offered_contains_only_without_nursing",
+            primary_service_type_second_level=PrimaryServiceTypeSecondLevel.care_home_only,
+            services_offered=[Services.care_home_service_without_nursing],
+            expected=True,
+        ),
+        ServicesOfferedRuleTestCase(
+            id="invalid_when_services_offered_missing_without_nursing",
+            primary_service_type_second_level=PrimaryServiceTypeSecondLevel.care_home_only,
+            services_offered=[Services.shared_lives],
+            expected=False,
+        ),
+        ServicesOfferedRuleTestCase(
+            id="invalid_when_services_offered_also_contains_with_nursing",
+            primary_service_type_second_level=PrimaryServiceTypeSecondLevel.care_home_only,
+            services_offered=[
+                Services.care_home_service_without_nursing,
+                Services.care_home_service_with_nursing,
+            ],
+            expected=False,
+        ),
+    ]
 
 
 @dataclass

--- a/projects/_03_independent_cqc/unittest_data/polars_ind_cqc_test_file_schemas.py
+++ b/projects/_03_independent_cqc/unittest_data/polars_ind_cqc_test_file_schemas.py
@@ -596,6 +596,7 @@ class ValidateEstimatedIndCQCFilledPostsSchemas:
             (IndCQC.non_res_with_dormancy_model, pl.Float64()),
             (IndCQC.non_res_without_dormancy_model, pl.Float64()),
             (IndCQC.imputed_pir_filled_posts_model, pl.Float64()),
+            (IndCQC.services_offered, pl.List(pl.String())),
         ]
     )
 


### PR DESCRIPTION
## Description
Trello ticket [#1865](https://trello.com/c/RaVVdhX9/1865-migrate-06estimatefilledposts-validation-to-pointblank)

Updated pointblank validation for the estimates job within the Ind CQC pipeline, and added the custom validation rules that hadn't been converted from PySpark yet.

## Testing
- [x] Unit tests passing
- [x] Successful [Step Function run](https://eu-west-2.console.aws.amazon.com/states/home?region=eu-west-2#/v2/executions/details/arn:aws:states:eu-west-2:856699698263:execution:1865-pb-validate-Ind-CQC-Filled-Post-Estimates:f5e1e1ab-23af-4f72-b2eb-f0b8176be903)
- [ ] Outputs checked in Athena

[Add any additional testing information here - add screenshot if relevant]

## Checklist (delete if not relevant)
- [ ] Unit tests added/amended
- [ ] Docstrings added/updated
- [ ] Updated CHANGELOG
- [ ] Code reviewed by AI
- [ ] Moved Trello ticket to PR column

## Reviewer checklist
- [ ] PR solves the Trello ticket requirements
- [ ] Outputs appear reasonable and understandable
- [ ] The overall approach is appropriate and not over-engineered
- [ ] No obvious scalability, performance or interdependency concerns
- [ ] Tests appropriately cover the main behaviour/edge cases
- [ ] Naming and structure are broadly understandable and consistent
- [ ] Docstrings are sufficient for future maintenance
- [ ] Docstrings cover non-obvious behaviour
