### PR TITLE
1873 - Replace groupby-agg-explode-join broadcasts with .over() in job role impute utils

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -281,6 +281,7 @@ jobs:
             aws s3 sync "s3://sfc-main-datasets/domain=capacity_tracker/dataset=capacity_tracker_non_residential_cleaned/" "s3://$BRANCH_DATASET_BUCKET/domain=capacity_tracker/dataset=capacity_tracker_non_residential_cleaned/" --delete
             aws s3 sync "s3://sfc-main-datasets/domain=CQC/dataset=pir_cleaned/" "s3://$BRANCH_DATASET_BUCKET/domain=CQC/dataset=pir_cleaned/" --delete
             aws s3 sync "s3://sfc-main-datasets/domain=ind_cqc_filled_posts/dataset=ind_cqc_06_estimated_filled_posts/" "s3://$BRANCH_DATASET_BUCKET/domain=ind_cqc_filled_posts/dataset=main_ind_cqc_06_estimated_filled_posts/" --delete
+            aws s3 sync "s3://sfc-main-datasets/domain=ind_cqc_filled_posts/dataset=ind_cqc_07_03_impute_job_roles/" "s3://$BRANCH_DATASET_BUCKET/domain=ind_cqc_filled_posts/dataset=main_ind_cqc_07_03_impute_job_roles/" --delete
             aws s3 sync "s3://sfc-main-datasets/domain=ind_cqc_filled_posts/dataset=ind_cqc_07_04_estimate_job_roles/" "s3://$BRANCH_DATASET_BUCKET/domain=ind_cqc_filled_posts/dataset=main_ind_cqc_07_04_estimate_job_roles/" --delete
             aws s3 sync "s3://sfc-main-datasets/domain=ind_cqc_filled_posts/dataset=ind_cqc_07_01_merge_metadata_job_roles/" "s3://$BRANCH_DATASET_BUCKET/domain=ind_cqc_filled_posts/dataset=main_ind_cqc_07_01_merge_metadata_job_roles/" --delete
             aws s3 sync "s3://sfc-main-datasets/domain=workforce_characteristics/dataset=empstat_rates/" "s3://$BRANCH_DATASET_BUCKET/domain=workforce_characteristics/dataset=empstat_rates/" --delete

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -281,7 +281,6 @@ jobs:
             aws s3 sync "s3://sfc-main-datasets/domain=capacity_tracker/dataset=capacity_tracker_non_residential_cleaned/" "s3://$BRANCH_DATASET_BUCKET/domain=capacity_tracker/dataset=capacity_tracker_non_residential_cleaned/" --delete
             aws s3 sync "s3://sfc-main-datasets/domain=CQC/dataset=pir_cleaned/" "s3://$BRANCH_DATASET_BUCKET/domain=CQC/dataset=pir_cleaned/" --delete
             aws s3 sync "s3://sfc-main-datasets/domain=ind_cqc_filled_posts/dataset=ind_cqc_06_estimated_filled_posts/" "s3://$BRANCH_DATASET_BUCKET/domain=ind_cqc_filled_posts/dataset=main_ind_cqc_06_estimated_filled_posts/" --delete
-            aws s3 sync "s3://sfc-main-datasets/domain=ind_cqc_filled_posts/dataset=ind_cqc_07_03_impute_job_roles/" "s3://$BRANCH_DATASET_BUCKET/domain=ind_cqc_filled_posts/dataset=main_ind_cqc_07_03_impute_job_roles/" --delete
             aws s3 sync "s3://sfc-main-datasets/domain=ind_cqc_filled_posts/dataset=ind_cqc_07_04_estimate_job_roles/" "s3://$BRANCH_DATASET_BUCKET/domain=ind_cqc_filled_posts/dataset=main_ind_cqc_07_04_estimate_job_roles/" --delete
             aws s3 sync "s3://sfc-main-datasets/domain=ind_cqc_filled_posts/dataset=ind_cqc_07_01_merge_metadata_job_roles/" "s3://$BRANCH_DATASET_BUCKET/domain=ind_cqc_filled_posts/dataset=main_ind_cqc_07_01_merge_metadata_job_roles/" --delete
             aws s3 sync "s3://sfc-main-datasets/domain=workforce_characteristics/dataset=empstat_rates/" "s3://$BRANCH_DATASET_BUCKET/domain=workforce_characteristics/dataset=empstat_rates/" --delete

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,7 +68,7 @@ All notable changes to this project will be documented in this file.
 - Reworked `reduce_to_published_roles` in the SLV prepare job to derive which raw ASC-WDS job role codes are published versus fold into an 'other' group from the team's own `PublishedJobRoleLabels`/job-group definitions, instead of a hand-maintained mapping dict that needed manual upkeep whenever ASC-WDS's raw job role codes changed.
 
 ### Improved
-- Replaced groupby-agg-explode-join broadcasts with `.over()` in the job role imputation utils, reducing peak memory in the Estimate Filled Posts by Job Role imputation step.
+- Replaced groupby-agg-explode-join broadcasts with `.over()` in the job role imputation utils, reducing peak memory in the Estimate Filled Posts by Job Role imputation step. The frame is now explicitly sorted by location, job role, and date beforehand, so imputed ratios broadcast onto the correct rows regardless of source row order.
 
 - Reduced CircleCI credit usage by removing `no-cache = true` from all `docker-bake.hcl` image targets, so the already-enabled Docker layer caching actually takes effect instead of every image rebuilding from scratch on every push.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,8 @@ All notable changes to this project will be documented in this file.
 - Reworked `reduce_to_published_roles` in the SLV prepare job to derive which raw ASC-WDS job role codes are published versus fold into an 'other' group from the team's own `PublishedJobRoleLabels`/job-group definitions, instead of a hand-maintained mapping dict that needed manual upkeep whenever ASC-WDS's raw job role codes changed.
 
 ### Improved
+- Replaced groupby-agg-explode-join broadcasts with `.over()` in the job role imputation utils, reducing peak memory in the Estimate Filled Posts by Job Role imputation step.
+
 - Reduced CircleCI credit usage by removing `no-cache = true` from all `docker-bake.hcl` image targets, so the already-enabled Docker layer caching actually takes effect instead of every image rebuilding from scratch on every push.
 
 - Added dependency caching (`uv` and Spark/Ivy JARs, keyed on `uv.lock`) to the CircleCI `test` job, saving ~10-13s per run on the `install dependencies` and `Fetch Spark JARs` steps versus no caching at all, measured directly across cache-hit and forced cache-miss runs including restore/save overhead.

--- a/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/utils/impute_utils.py
+++ b/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/utils/impute_utils.py
@@ -13,8 +13,10 @@ def create_imputed_ascwds_job_role_counts(
     """
     Impute job role ratios by interpolation forward fill and backward fill.
 
-    Uses groupby-agg-explode pattern to keep processing within polars streaming
-    engine.
+    Broadcasts the imputed ratio back onto every row with `.over()` rather than a
+    groupby-agg-explode-join: a join that broadcasts a computed value onto every row
+    costs more peak memory than `.over()`'s in-place fallback (see the `over-vs-join`
+    skill).
 
     Args:
         estimated_job_role_posts_lf(pl.LazyFrame): dataset to impute
@@ -37,26 +39,12 @@ def create_imputed_ascwds_job_role_counts(
         .interpolate()
         .forward_fill()
         .backward_fill()
+        .over(impute_groups)
         .alias(IndCQC.imputed_ascwds_job_role_ratios)
     )
 
-    impute_agg_lf = (
-        # polars_streaming: groupby-agg-explode workaround; should be .over() when window functions support streaming
-        estimated_job_role_posts_lf.group_by(impute_groups)
-        .agg(
-            # Sort the join key in the same manner as the imputed values.
-            pl.col(IndCQC.id_per_locationid_import_date_job_role).sort_by(order_key),
-            imputed_ratios,
-        )
-        .explode(
-            IndCQC.id_per_locationid_import_date_job_role,
-            IndCQC.imputed_ascwds_job_role_ratios,
-        )
-        .drop(impute_groups)
-    )
-
-    estimated_job_role_posts_lf = estimated_job_role_posts_lf.join(
-        impute_agg_lf, on=IndCQC.id_per_locationid_import_date_job_role, how="left"
+    estimated_job_role_posts_lf = estimated_job_role_posts_lf.with_columns(
+        imputed_ratios
     )
 
     estimated_job_role_posts_lf = estimated_job_role_posts_lf.with_columns(
@@ -74,9 +62,11 @@ def get_percent_share_ratios(
     groups: Optional[list[str]] = None,
 ) -> pl.LazyFrame:
     """
-    Calculate ratios over location and date using groupby-agg-explode pattern.
+    Calculate ratios over location and date, broadcasting via `.over()`.
 
-    Using groupby-agg-explode ensures it can be processed with the streaming engine.
+    `.over()` computes and writes its result in place; the equivalent groupby-agg-
+    explode-join would cost more peak memory for the same reason a join-based
+    `.over()` replacement does (see the `over-vs-join` skill).
 
     Args:
         estimated_job_role_posts_lf(pl.LazyFrame): dataset to calculate ratios over. Must contain location_id and cqc_location_import_date_columns for grouping
@@ -90,23 +80,8 @@ def get_percent_share_ratios(
     if groups is None:
         groups = [IndCQC.location_id, IndCQC.cqc_location_import_date]
 
-    # Groupby-agg-explode on only necessary subset, before joining back on id_per_locationid_import_date_job_role.
-    # polars_streaming: groupby-agg-explode workaround; could be replaced with .over() and simpler join when window functions support streaming
-    ratios_agg_lf = (
-        estimated_job_role_posts_lf.group_by(groups)
-        .agg(
-            pl.col(
-                IndCQC.id_per_locationid_import_date_job_role
-            ),  # Keep to align during explode
-            percentage_share(input_col).cast(pl.Float32).alias(output_col),
-        )
-        .explode(IndCQC.id_per_locationid_import_date_job_role, output_col)
-        # Drop groups to prevent duplicate columns after join.
-        .drop(groups)
-    )
-
-    return estimated_job_role_posts_lf.join(
-        ratios_agg_lf, on=IndCQC.id_per_locationid_import_date_job_role, how="left"
+    return estimated_job_role_posts_lf.with_columns(
+        percentage_share(input_col).cast(pl.Float32).over(groups).alias(output_col)
     )
 
 

--- a/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/utils/impute_utils.py
+++ b/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/utils/impute_utils.py
@@ -11,12 +11,12 @@ def create_imputed_ascwds_job_role_counts(
     estimated_job_role_posts_lf: pl.LazyFrame,
 ) -> pl.LazyFrame:
     """
-    Impute job role ratios by interpolation forward fill and backward fill.
+    Impute job role ratios per location and job role by interpolation, forward fill,
+    and backward fill, then broadcast the result back onto every row with `.over()`.
 
-    Broadcasts the imputed ratio back onto every row with `.over()` rather than a
-    groupby-agg-explode-join: a join that broadcasts a computed value onto every row
-    costs more peak memory than `.over()`'s in-place fallback (see the `over-vs-join`
-    skill).
+    The frame is sorted by (location_id, job_role, date) before the `.over()` call,
+    since its default mapping strategy writes results back in original row order and
+    would otherwise misassign values on unsorted input.
 
     Args:
         estimated_job_role_posts_lf(pl.LazyFrame): dataset to impute
@@ -35,7 +35,6 @@ def create_imputed_ascwds_job_role_counts(
 
     imputed_ratios = (
         pl.col(IndCQC.ascwds_job_role_ratios)
-        .sort_by(order_key)
         .interpolate()
         .forward_fill()
         .backward_fill()
@@ -43,9 +42,10 @@ def create_imputed_ascwds_job_role_counts(
         .alias(IndCQC.imputed_ascwds_job_role_ratios)
     )
 
-    estimated_job_role_posts_lf = estimated_job_role_posts_lf.with_columns(
-        imputed_ratios
-    )
+    # Must be sorted before the .over() call above — see docstring.
+    estimated_job_role_posts_lf = estimated_job_role_posts_lf.sort(
+        *impute_groups, order_key
+    ).with_columns(imputed_ratios)
 
     estimated_job_role_posts_lf = estimated_job_role_posts_lf.with_columns(
         pl.col(IndCQC.estimate_filled_posts)

--- a/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/tests/fargate/utils/test_impute_utils.py
+++ b/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/tests/fargate/utils/test_impute_utils.py
@@ -40,6 +40,36 @@ class TestCreateImputedASCWDSJobRoleCounts:
         pl_testing.assert_frame_equal(returned_lf, expected_lf, rel_tol=0.0001)
 
 
+class TestCreateImputedASCWDSJobRoleCountsRowOrder:
+    def test_result_correct_when_source_rows_not_sorted_by_date(self):
+        expected_lf = pl.LazyFrame(
+            data=[
+                ("1", "1", "job_role_a", date(2026, 1, 1), 1, 1.0, 1.0, 1.0, 1.0),
+                ("2", "1", "job_role_a", date(2026, 1, 2), None, 2.0, None, 0.7, 1.4),
+                ("3", "1", "job_role_a", date(2026, 1, 3), 4, 4.0, 0.4, 0.4, 1.6),
+                ("4", "1", "job_role_b", date(2026, 1, 1), None, 1.0, None, 1.0, 1.0),
+                ("5", "1", "job_role_b", date(2026, 1, 2), 2, 2.0, 1.0, 1.0, 2.0),
+                ("6", "1", "job_role_b", date(2026, 1, 3), 6, 6.0, 0.6, 0.6, 3.6),
+            ],
+            schema=Schemas.create_imputed_ascwds_job_role_counts_expected_schema,
+            orient="row",
+        )
+        # Rows arrive out of date order within a group (e.g. as read back from
+        # Athena), which is what previously exposed the sort_by-inside-.over() bug:
+        # results got broadcast onto the wrong rows unless the source happened to
+        # already be sorted by date within each group.
+        input_lf = expected_lf.drop(
+            IndCQC.ascwds_job_role_ratios,
+            IndCQC.imputed_ascwds_job_role_ratios,
+            IndCQC.imputed_ascwds_job_role_counts,
+        ).sort(IndCQC.cqc_location_import_date, descending=True)
+
+        returned_lf = job.create_imputed_ascwds_job_role_counts(input_lf).sort(
+            IndCQC.id_per_locationid_import_date_job_role
+        )
+        pl_testing.assert_frame_equal(returned_lf, expected_lf, rel_tol=0.0001)
+
+
 class TestGetPercentageShareRatios:
     def test_over_groups(self):
         expected_lf = pl.LazyFrame(


### PR DESCRIPTION
## Description
Trello ticket [#1873](https://trello.com/c/dcoshNNJ/1873-make-job-role-impute-more-efficient)

Reviewed `impute_utils.py` for efficiency. Two functions (`create_imputed_ascwds_job_role_counts`, `get_percent_share_ratios`) used a groupby→agg→explode→join pattern to broadcast a per-group computed value back onto every row — a leftover streaming-engine workaround. Per the repo's `over-vs-join` finding, a join that broadcasts a value onto every row costs more peak memory than `.over()`'s in-place fallback, so both functions were rewritten to use `.over()` directly (matching the same idiom already used in `primary_service_rate_of_change.py`). The rolling-ratio and size-group functions in the same file were reviewed and left unchanged — the rolling ratio genuinely benefits from pre-aggregation before its expensive windowed computation, and the size-group expression is a small fixed branch chain with no real perf concern.

Impute job ran in 1m45 compared to 2m in main - this will be more impactful when further functionality is added to the job. 

Peak memory is ~3-4x lower than main's join-based version on a 5.76M-row synthetic benchmark (109MB vs 371MB when pre-sorted, 19MB vs 455MB when shuffled), at the cost of some extra time when input isn't pre-sorted (3.1s vs 1.5s in the same benchmark).

## Testing
- [x] Unit tests passing
- [x] Successful [Step Function run](https://eu-west-2.console.aws.amazon.com/states/home?region=eu-west-2#/v2/executions/details/arn:aws:states:eu-west-2:856699698263:execution:1873-impute-perf-Ind-CQC-Filled-Post-Estimates-By-Role:04d5e10a-1759-42ff-a5c2-f0e1dbe4a5a0) (crawler failed as I'd set it going manually so it was already running when triggered, not a genuine issue)
- [x] Outputs checked in Athena - returns zero differences when compared to main

## Checklist (delete if not relevant)
- [x] Unit tests added/amended
- [x] Docstrings added/updated
- [x] Updated CHANGELOG
- [x] Code reviewed by AI
- [x] Moved Trello ticket to PR column