### PR TITLE
1861 - Part 2 of 2 - Uncommented impute function calls and added .collect().lazy() calls to split execution plan.

### DIFF
--- a/projects/_03_independent_cqc/_03_impute/fargate/impute_ind_cqc_ascwds_and_pir.py
+++ b/projects/_03_independent_cqc/_03_impute/fargate/impute_ind_cqc_ascwds_and_pir.py
@@ -86,23 +86,47 @@ def main(cleaned_ind_cqc_source: str, destination: str) -> None:
         extrapolation_method="ratio",
     )
 
-    # model_calculate_rolling_average - posts_rolling_average_model
+    # Collect here: model_imputation's unique()+join+concat pattern (used
+    # twice above) is non-streaming. Without this, it fuses into one huge
+    # execution alongside everything else in the pipeline and OOMs on the
+    # production 60GB task.
+    lf = lf.collect().lazy()
 
-    # create_banded_bed_count_column
+    lf = lf.with_columns(
+        calculate_rolling_average(
+            IndCQC.imputed_filled_post_model,
+            f"{NumericalValues.number_of_days_in_window}d",
+            [IndCQC.primary_service_type],
+        ).alias(IndCQC.posts_rolling_average_model)
+    )
 
-    # model_calculate_rolling_average - banded_bed_ratio_rolling_average_model
+    lf = cUtils.create_banded_bed_count_column(
+        lf,
+        IndCQC.number_of_beds_banded_for_rolling_avg,
+        [0, 1, 10, 15, 20, 25, 50, float("Inf")],
+    )
 
-    # convert_care_home_ratios_to_posts - unhash after `model_calculate_rolling_average` converted
-    # lf = lf.with_columns(
-    #     pl.when(is_care_home())
-    #     .then(
-    #         pl.col(IndCQC.banded_bed_ratio_rolling_average_model)
-    #         * pl.col(IndCQC.number_of_beds)
-    #     )
-    #     .otherwise(pl.col(IndCQC.posts_rolling_average_model))
-    #     .cast(pl.Float32)
-    #     .alias(IndCQC.posts_rolling_average_model)
-    # )
+    lf = lf.with_columns(
+        calculate_rolling_average(
+            IndCQC.imputed_filled_posts_per_bed_ratio_model,
+            f"{NumericalValues.number_of_days_in_window}d",
+            [
+                IndCQC.primary_service_type,
+                IndCQC.number_of_beds_banded_for_rolling_avg,
+            ],
+        ).alias(IndCQC.banded_bed_ratio_rolling_average_model)
+    )
+
+    lf = lf.with_columns(
+        pl.when(is_care_home())
+        .then(
+            pl.col(IndCQC.banded_bed_ratio_rolling_average_model)
+            * pl.col(IndCQC.number_of_beds)
+        )
+        .otherwise(pl.col(IndCQC.posts_rolling_average_model))
+        .cast(pl.Float32)
+        .alias(IndCQC.posts_rolling_average_model)
+    )
 
     lf = lf.with_columns(
         pl.when(is_care_home())
@@ -137,6 +161,11 @@ def main(cleaned_ind_cqc_source: str, destination: str) -> None:
         care_home=False,
         extrapolation_method="ratio",
     )
+
+    # Collect here for the same reason as above - the second pair of
+    # model_imputation calls has the same non-streaming unique()+join+concat
+    # cost and would otherwise fuse into the final sink_to_parquet execution.
+    lf = lf.collect().lazy()
 
     lf = lf.with_columns(
         utils.nullify_ct_values_previous_to_first_submission(


### PR DESCRIPTION
## Description
Trello ticket [1861](https://trello.com/c/93gsR9c4)

This is second PR for 1861.

This PR has uncommented polars function calls in imputation job. This caused oom error and required two fixes.

Fix 1 - Refactored calculated_rolling_average
Fix 2 - Added .collect().lazy() calls to the job

This PR only applies the second fix.

Fix 2 - Added .collect().lazy() calls to the job to break up the execution plan. Even with fix 1 memory still spiked over 60GB limit.

But during testing, running each function one after the other by calling .collect().lazy() made the job succeed. Since a big memory user was model_interpolation, these are now followed by collect calls to split the job into three parts.

This branch still fails to run because the rolling average refactor is not in it from part 1.

## Testing
- [x] Unit tests passing
- [ ] Successful [Step Function run](add link)
- [ ] Outputs checked in Athena

See Trello ticket for Athena query.

## Checklist (delete if not relevant)
- [ ] Unit tests added/amended
- [ ] Docstrings added/updated
- [ ] Updated CHANGELOG
- [ ] Code reviewed by AI
- [ ] Moved Trello ticket to PR column

## Reviewer checklist
- [ ] PR solves the Trello ticket requirements
- [ ] Outputs appear reasonable and understandable
- [ ] The overall approach is appropriate and not over-engineered
- [ ] No obvious scalability, performance or interdependency concerns
- [ ] Tests appropriately cover the main behaviour/edge cases
- [ ] Naming and structure are broadly understandable and consistent
- [ ] Docstrings are sufficient for future maintenance
- [ ] Docstrings cover non-obvious behaviour
