### PR TITLE
1876 - Add validation that job role rolling ratios sum to 1 across roles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Added
+- Added a validation check that `ascwds_job_role_rolling_ratio` sums to 1 across job roles within each primary service type, size group and import date group.
+
 - Joined job role estimates with metadata (on `id_per_locationid_import_date`) in the SLV merge job.
 
 - Added `new-ticket`, `commit-push`, and `open-pr` Claude Code skills to run the ticket workflow (branch → SPEC → commits → PR) consistently, and an output-style guideline in CLAUDE.md. Trimmed the existing skills to cross-reference CLAUDE.md/PR templates instead of restating them, and updated remaining `pipenv` mentions to their `uv` equivalents.

--- a/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/validate_03_impute.py
+++ b/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/fargate/validate_03_impute.py
@@ -100,6 +100,30 @@ def count_nulls(df: pl.DataFrame) -> pl.DataFrame:
     )
 
 
+def sum_rolling_ratios_across_job_roles(df: pl.DataFrame) -> pl.DataFrame:
+    """
+    Helper function to total the rolling ratio across job roles within each
+    group.
+
+    Reduces to one row per job role first, since every workplace in a group
+    shares a ratio.
+    """
+
+    group_columns = [
+        IndCqcColumns.primary_service_type,
+        IndCqcColumns.estimate_filled_posts_size_group,
+        IndCqcColumns.cqc_location_import_date,
+    ]
+
+    return (
+        df.unique(
+            subset=group_columns + [IndCqcColumns.main_job_role_clean_labelled],
+        )
+        .group_by(group_columns)
+        .agg(pl.col(IndCqcColumns.ascwds_job_role_rolling_ratio).sum())
+    )
+
+
 def main(
     bucket_name: str, source_path: str, compare_path: str, reports_path: str
 ) -> None:
@@ -322,6 +346,13 @@ def other_validation(
             right=1,
             na_pass=True,
             brief="ascwds_job_role_ratios, imputed_ascwds_job_role_ratios and ascwds_job_role_rolling_ratio should be between 0 and 1 where present",
+        )
+        .col_vals_between(
+            pre=sum_rolling_ratios_across_job_roles,
+            columns=IndCqcColumns.ascwds_job_role_rolling_ratio,
+            left=0.999,
+            right=1.001,
+            brief="ascwds_job_role_rolling_ratio should sum to 1 across job roles within each primary service type, size group and import date",
         )
         # Date plausibility
         .col_vals_ge(

--- a/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/tests/fargate/test_validate_03_impute.py
+++ b/projects/_03_independent_cqc/_07_estimate_filled_posts_by_job_role/tests/fargate/test_validate_03_impute.py
@@ -163,5 +163,59 @@ class ValidateJobRoleEstimatesTests(unittest.TestCase):
         )
 
 
+class TestSumRollingRatiosAcrossJobRoles:
+    schema = {
+        IndCqcColumns.primary_service_type: pl.String,
+        IndCqcColumns.estimate_filled_posts_size_group: pl.String,
+        IndCqcColumns.cqc_location_import_date: pl.Date,
+        IndCqcColumns.main_job_role_clean_labelled: pl.String,
+        IndCqcColumns.location_id: pl.String,
+        IndCqcColumns.ascwds_job_role_rolling_ratio: pl.Float32,
+    }
+
+    def totals_for(self, rows: list[tuple]) -> list:
+        df = pl.DataFrame(rows, self.schema, orient="row")
+        return (
+            job.sum_rolling_ratios_across_job_roles(df)
+            .get_column(IndCqcColumns.ascwds_job_role_rolling_ratio)
+            .to_list()
+        )
+
+    def test_workplaces_sharing_a_group_are_counted_once(self):
+        # The total is per group, not per row.
+        rows = [
+            ("non-residential", "NR 1 to 24", date(2026, 1, 1), "care_worker", loc, 0.3)
+            for loc in ("1-001", "1-002")
+        ] + [
+            (
+                "non-residential",
+                "NR 1 to 24",
+                date(2026, 1, 1),
+                "registered_nurse",
+                loc,
+                0.7,
+            )
+            for loc in ("1-001", "1-002")
+        ]
+        assert self.totals_for(rows) == [1.0]
+
+    def test_job_roles_sharing_a_ratio_both_count(self):
+        # Deduplicating on the ratio would collapse these to 0.5.
+        rows = [
+            ("non-residential", "NR 1 to 24", date(2026, 1, 1), "care_worker", "1-001", 0.5),
+            ("non-residential", "NR 1 to 24", date(2026, 1, 1), "registered_nurse", "1-001", 0.5),
+        ]  # fmt: skip
+        assert self.totals_for(rows) == [1.0]
+
+    def test_groups_are_totalled_independently(self):
+        rows = [
+            ("non-residential", "NR 1 to 24", date(2026, 1, 1), "care_worker", "1-001", 0.4),
+            ("non-residential", "NR 1 to 24", date(2026, 1, 1), "registered_nurse", "1-001", 0.6),
+            ("non-residential", "NR 1 to 24", date(2026, 2, 1), "care_worker", "1-001", 0.2),
+            ("non-residential", "NR 1 to 24", date(2026, 2, 1), "registered_nurse", "1-001", 0.8),
+        ]  # fmt: skip
+        assert sorted(self.totals_for(rows)) == [1.0, 1.0]
+
+
 if __name__ == "__main__":
     unittest.main(warnings="ignore")


### PR DESCRIPTION
## Description
Trello ticket [#1876](https://trello.com/c/SBTVXm5J/1876-add-validation-check-that-jr-ratios-sum-to-1)

Adds a validation check that ascwds_job_role_rolling_ratio sums to 1 across job roles within each primary_service_type / size_group / import_date group, via a new sum_rolling_ratios_across_job_roles helper.

## Testing
- [x] Unit tests passing
- [x] Successful Step Function run ([add link](https://eu-west-2.console.aws.amazon.com/states/home?region=eu-west-2#/v2/executions/details/arn:aws:states:eu-west-2:856699698263:execution:1876-jr-ratio-val-Ind-CQC-Filled-Post-Estimates-By-Role:3af711af-9e25-4a4f-a5a7-964e3af7fab8))

## Checklist
- [x] Unit tests added/amended
- [x] Docstrings added/updated
- [x] Updated CHANGELOG
- [x] Code reviewed by AI
- [x] Moved Trello ticket to PR column